### PR TITLE
fix: when getting command, strip 0 unicode

### DIFF
--- a/dc_measurements/plugins/measurements/system/linux_parser.cpp
+++ b/dc_measurements/plugins/measurements/system/linux_parser.cpp
@@ -10,6 +10,8 @@
 #include <tuple>
 #include <vector>
 
+#include "dc_util/string_utils.hpp"
+
 using std::stof;
 using std::stol;
 using std::string;
@@ -272,6 +274,11 @@ vector<long> LinuxParser::PidStat(int pid)
   return result;
 }
 
+void stripNullUnicode(std::string& str)
+{
+  str.erase(std::remove_if(str.begin(), str.end(), [](char c) { return c == 0; }), str.end());
+}
+
 /********* LinuxParser::Command *******
  *  Returns the invoking command for the provided process ID.
  *  Inputs: Process ID int.
@@ -309,7 +316,7 @@ string LinuxParser::Command(int pid)
     }
     fs.close();
   }
-  // FIXME There are some unicode characters in here (space \u0000 to replace)
+  stripNullUnicode(command);
   return command;
 }
 


### PR DESCRIPTION
# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [ ] Other


# What I did
the command string could not be passed to postgresql because it had a \u000 in it. this fixes it

# How I did it
remove this character from the string

# I am not sure about

# How I tested

# I'm not a dummy, so I've checked these

- [X] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [X] 💯 I tested locally and it is working
- [X] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
