### PR TITLE
fix: same_as_previous condition does not crash with empty json

### DIFF
--- a/dc_measurements/plugins/conditions/same_as_previous.cpp
+++ b/dc_measurements/plugins/conditions/same_as_previous.cpp
@@ -25,6 +25,10 @@ void SameAsPrevious::onConfigure()
 bool SameAsPrevious::getState(dc_interfaces::msg::StringStamped msg)
 {
   json data_json = json::parse(msg.data);
+  if (data_json.empty())
+  {
+    return false;
+  }
   data_json.erase("tags");
   previous_keys_hash_ = keys_hash_;
 


### PR DESCRIPTION
# Initial discussions
<!-- If there was -->

- [ ] Github issue: <!-- Reference it with # -->

# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [ ] Other


# What I did
<!-- A clear and concise description of what the change does.
If you are fixing an issue, add a sentence as:

resolves #ISSUE_NUMBER

This will automatically close the issue when this PR gets merged.
-->
If measurement was empty, it would throw
```
#[component_container_isolated-1] [ERROR] [1683132567.273777058] []: Caught exception in callback for transition 13
        # [component_container_isolated-1] [ERROR] [1683132567.273795216] []: Original error: [json.exception.type_error.307] cannot use erase() with null
        # [component_container_isolated-1] [WARN] [1683132567.273824588] []: Error occurred while doing error handling.
```

# How I did it

# I am not sure about

# How I tested
by running the node without a map published and no error appeared
 
# I'm not a dummy, so I've checked these

- [X] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [X] 💯 I tested locally and it is working
- [X] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
