### PR TITLE
conf: set include_measurement_name to true by default

### DIFF
--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -154,7 +154,7 @@ bool MeasurementServer::loadMeasurementPlugins()
     measurement_init_max_measurements_[i] =
         dc_util::get_int_type_param(node, measurement_ids_[i], "init_max_measurements", 0);
     measurement_include_measurement_name_[i] =
-        dc_util::get_bool_type_param(node, measurement_ids_[i], "include_measurement_name", false);
+        dc_util::get_bool_type_param(node, measurement_ids_[i], "include_measurement_name", true);
     measurement_include_measurement_plugin_[i] =
         dc_util::get_bool_type_param(node, measurement_ids_[i], "include_measurement_plugin", false);
     measurement_remote_keys_[i] =


### PR DESCRIPTION
# Initial discussions
<!-- If there was -->

- [ ] Github issue: <!-- Reference it with # -->

# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [X] Other: configuration


# What I did
<!-- A clear and concise description of what the change does.
If you are fixing an issue, add a sentence as:

resolves #ISSUE_NUMBER

This will automatically close the issue when this PR gets merged.
-->
Set include_measurement_name to true by default since it is used most of the time

# How I did it

# I am not sure about

# How I tested

# I'm not a dummy, so I've checked these

- [ ] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [ ] 💯 I tested locally and it is working
- [ ] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
