### PR TITLE
fix: non blocking measurement subscriber

### DIFF
--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -429,8 +429,9 @@ public:
     }
 
     data_pub_ = node->create_publisher<dc_interfaces::msg::StringStamped>(topic_output_, 1);
-    collect_timer_ =
-        node->create_wall_timer(std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); });
+    client_cb_group_ = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+    collect_timer_ = node->create_wall_timer(
+        std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); }, client_cb_group_);
 
     RCLCPP_INFO(logger_, "Done configuring %s", measurement_name_.c_str());
 
@@ -494,6 +495,7 @@ protected:
   bool enabled_{ true };
   bool debug_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
+  rclcpp::CallbackGroup::SharedPtr client_cb_group_;
 
   // Publish data
   int polling_interval_;


### PR DESCRIPTION
# Initial discussions
<!-- If there was -->

- [ ] Github issue: <!-- Reference it with # -->

# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [ ] Other


# What I did
<!-- A clear and concise description of what the change does.
If you are fixing an issue, add a sentence as:

resolves #ISSUE_NUMBER

This will automatically close the issue when this PR gets merged.
-->
If map was not publshed, the whole node would hang because it would wait the map saving timeout.
This create a group per measurement and does not block when one measurement hangs

# How I did it
by using a reentrant callback group

# I am not sure about

# How I tested
by starting the node with the map measurement and others. nothing was blocked

# I'm not a dummy, so I've checked these

- [X] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [X] 💯 I tested locally and it is working
- [X] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
