### PR TITLE
fix+doc: docker exec command did not load environment

### DIFF
--- a/doc/src/dc/setup.md
+++ b/doc/src/dc/setup.md
@@ -60,12 +60,12 @@ $ xhost +
 Then start the container:
 
 ```bash
-$ docker compose up
+$ docker compose up -d
 ```
 
 And get in the container with:
 ```bash
-$ docker exec -it ros2-data-collection bash
+$ docker exec -it ros2-data-collection /ros_entrypoint.sh bash
 ```
 
 ## Build from source

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -23,11 +23,11 @@ services:
       - ${HOME}/.Xauthority:/root/.Xauthority
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /var/run/docker.sock:/var/run/docker.sock
-      - ${PWD}:/root/ws/src/ros2_data_collection
+      - ${PWD}:/root/ros2_data_collection/src/ros2_data_collection
     network_mode: "host"
     logging: *x-logging
     restart: *x-restart
     stop_grace_period: *x-stop-grace-period
     runtime: nvidia
     command: tail -F anything
-    working_dir: /root/ws
+    working_dir: /root/ros2_data_collection


### PR DESCRIPTION
# Initial discussions
- [X] Github issue: #140 

# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [ ] Other


# What I did
resolves #140

# How I did it
1. Fix the workspace path, /root/ws was wrong
2. update the documentation to explain how to source the workspace properly

# I am not sure about
If there is a way to load the entrypoint with docker exec without passing it everytime

# How I tested
1. `docker compose up` in terminal 1
2. `docker exec -it ros2-data-collection2 /ros_entrypoint.sh bash`
3. Type `ros2` and see the command is loaded
4. Type `ros2 launch dc_demos uptime_stdout.launch.py` and see it can run

# I'm not a dummy, so I've checked these

- [X] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [X] 💯 I tested locally and it is working
- [X] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
