### PR TITLE
feat: can nest and flatten sample 

### DIFF
--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -60,10 +60,10 @@ public:
             const bool& include_measurement_plugin, const int& condition_max_measurements,
             const std::vector<std::string>& if_all_conditions, const std::vector<std::string>& if_any_conditions,
             const std::vector<std::string>& if_none_conditions, const std::vector<std::string>& remote_keys,
-            const std::vector<std::string>& remote_prefixes, const std::string& save_local_base_path,
-            const std::string& all_base_path, const std::string& all_base_path_expanded,
-            const std::string& save_local_base_path_expanded, const std::string& run_id, const bool& run_id_enabled,
-            const std::vector<json>& custom_params) = 0;
+            const std::vector<std::string>& remote_prefixes, const bool& nest, const bool& flatten,
+            const std::string& save_local_base_path, const std::string& all_base_path,
+            const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
+            const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_params) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -122,6 +122,8 @@ protected:
   std::vector<std::vector<std::string>> measurement_if_none_conditions_;
   std::vector<std::vector<std::string>> measurement_remote_keys_;
   std::vector<std::vector<std::string>> measurement_remote_prefixes_;
+  std::vector<bool> measurement_nested_;
+  std::vector<bool> measurement_flatten_;
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;
   std::string all_base_path_;

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -173,6 +173,8 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   measurement_include_measurement_plugin_.resize(measurement_ids_.size());
   measurement_remote_keys_.resize(measurement_ids_.size());
   measurement_remote_prefixes_.resize(measurement_ids_.size());
+  measurement_nested_.resize(measurement_ids_.size());
+  measurement_flatten_.resize(measurement_ids_.size());
 
   measurement_if_all_conditions_.resize(measurement_ids_.size());
   measurement_if_any_conditions_.resize(measurement_ids_.size());
@@ -252,6 +254,8 @@ bool MeasurementServer::loadMeasurementPlugins()
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "remote_keys", std::vector<std::string>());
     measurement_remote_prefixes_[i] =
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "remote_prefixes", std::vector<std::string>());
+    measurement_nested_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "nested", false);
+    measurement_flatten_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "flatten", false);
 
     measurement_if_all_conditions_[i] =
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_all_conditions", std::vector<std::string>());
@@ -277,7 +281,8 @@ bool MeasurementServer::loadMeasurementPlugins()
                              << ", Include measurement name: " << measurement_include_measurement_name_[i]
                              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
                              << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
-                             << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i])
+                             << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i]) << ", Nest: "
+                             << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
                              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
                              << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
                              << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
@@ -292,8 +297,9 @@ bool MeasurementServer::loadMeasurementPlugins()
           measurement_init_collect_[i], measurement_init_max_measurements_[i], measurement_include_measurement_name_[i],
           measurement_include_measurement_plugin_[i], measurement_condition_max_measurements_[i],
           measurement_if_all_conditions_[i], measurement_if_any_conditions_[i], measurement_if_none_conditions_[i],
-          measurement_remote_keys_[i], measurement_remote_prefixes_[i], save_local_base_path_, all_base_path_,
-          all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_params_);
+          measurement_remote_keys_[i], measurement_remote_prefixes_[i], measurement_nested_[i], measurement_flatten_[i],
+          save_local_base_path_, all_base_path_, all_base_path_expanded_, save_local_base_path_expanded_, run_id_,
+          run_id_enabled_, custom_params_);
     }
     catch (const pluginlib::PluginlibException& ex)
     {


### PR DESCRIPTION
# Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Test (add, remove, modify test(s))
- [ ] Other


# What I did
Can nest sample with sample:
if sample was {"a":1, "b": 2}, it will become { "measurement_name": {"a":1, "b": 2}}

Can flatten samples
if sample was {"a":1, "b": { "c": 2}}, it will become {"/a":1, "/b/c": 2}}

# How I did it
For flattening, i use flatten from nlohmann library.
For nesting, I create a new json and assign the content of the old one as value to the measurement name key of the new one.

I also added a key flattened and nested, so plugins can know about it. In the future, we should have a metadata json inside the sample that we can easily filter out.

Simultaneously, the logic of conditions was not well done when publishing, this has been fixed

# I am not sure about

# How I tested

# I'm not a dummy, so I've checked these

- [X] 📑 I documented correctly following our [guidelines](./CONTRIBUTING.md)
- [X] 💯 I tested locally and it is working
- [X] 🟢 My code does not fail neither code linting checks nor unit test.

Thank you!
