### PR TITLE
DC 2.0 S1: Port C++ core to ROS 2 Jazzy (Fluent Bit packages ignored)

### DIFF
--- a/dc_bringup/launch/dc_bringup.launch.py
+++ b/dc_bringup/launch/dc_bringup.launch.py
@@ -162,19 +162,8 @@ def generate_launch_description():
                 parameters=[configured_params],
                 arguments=["--ros-args", "--log-level", log_level],
             ),
-            Node(
-                package="dc_destinations",
-                executable="destination_server",
-                name="destination_server",
-                output={
-                    "stdout": "screen",
-                    "stderr": "screen",
-                },
-                respawn=use_respawn,
-                respawn_delay=2.0,
-                parameters=[configured_params],
-                arguments=["--ros-args", "--log-level", log_level],
-            ),
+            # destination_server (dc_destinations) is COLCON_IGNOREd on the jazzy line pending
+            # the DC 2.0 embedded-Fluent-Bit demolition slice (#241/#242) and is not launched here.
             Node(
                 package="dc_lifecycle_manager",
                 executable="lifecycle_manager",
@@ -188,12 +177,9 @@ def generate_launch_description():
                     {
                         "autostart": autostart,
                         "node_names": [
-                            "destination_server",
-                            "destination_server",
-                            "measurement_server",
                             "measurement_server",
                         ],
-                        "transitions": ["configure", "activate", "configure", "activate"],
+                        "transitions": ["configure", "activate"],
                         "bond_timeout": 10.0,
                     },
                 ],
@@ -255,6 +241,8 @@ def generate_launch_description():
                 parameters=[configured_params],
                 arguments=["--ros-args", "--log-level", log_level],
             ),
+            # destination_server (dc_destinations) is COLCON_IGNOREd on the jazzy line pending
+            # the DC 2.0 embedded-Fluent-Bit demolition slice (#241/#242) and is not loaded here.
             LoadComposableNodes(
                 target_container=container_name,
                 composable_node_descriptions=[
@@ -265,12 +253,6 @@ def generate_launch_description():
                         parameters=[configured_params],
                     ),
                     ComposableNode(
-                        package="dc_destinations",
-                        plugin="destination_server::DestinationServer",
-                        name="destination_server",
-                        parameters=[configured_params],
-                    ),
-                    ComposableNode(
                         package="dc_lifecycle_manager",
                         plugin="dc_lifecycle_manager::LifecycleManager",
                         name="lifecycle_manager_dc",
@@ -278,12 +260,9 @@ def generate_launch_description():
                             {
                                 "autostart": autostart,
                                 "node_names": [
-                                    "destination_server",
-                                    "destination_server",
-                                    "measurement_server",
                                     "measurement_server",
                                 ],
-                                "transitions": ["configure", "activate", "configure", "activate"],
+                                "transitions": ["configure", "activate"],
                                 "bond_timeout": 10.0,
                             },
                         ],

--- a/dc_bringup/package.xml
+++ b/dc_bringup/package.xml
@@ -11,7 +11,6 @@
     <build_depend>dc_common</build_depend>
 
     <exec_depend>launch_ros</exec_depend>
-    <exec_depend>dc_destinations</exec_depend>
     <exec_depend>dc_group</exec_depend>
     <exec_depend>dc_measurements</exec_depend>
     <exec_depend>dc_services</exec_depend>

--- a/dc_destinations/COLCON_IGNORE
+++ b/dc_destinations/COLCON_IGNORE
@@ -1,3 +1,4 @@
-Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
-(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
-dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition (ADR-0003:
+retire the pluginlib Destination layer in favor of the Bridge's blessed Destinations +
+passthrough). See the dc-2.0 epic (#241). Do not delete this package; it is dropped, not
+removed.

--- a/dc_destinations/COLCON_IGNORE
+++ b/dc_destinations/COLCON_IGNORE
@@ -1,0 +1,3 @@
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
+(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
+dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.

--- a/dc_lifecycle_manager/CMakeLists.txt
+++ b/dc_lifecycle_manager/CMakeLists.txt
@@ -14,10 +14,6 @@ set(dependencies
   rclcpp_components
   std_msgs
   std_srvs
-  # FIXME nav2_util
-  # In file included from /root/ros2_data_collection/src/ros2_data_collection/dc_lifecycle_manager/src/lifecycle_manager_client.cpp:8:
-  #/opt/ros/humble/include/nav2_util/geometry_utils.hpp:25:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.hpp: No such file or directory
-  #   25 | #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
   tf2_geometry_msgs
 )
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
@@ -2,9 +2,8 @@
 #ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__CAMERA_HPP_
 #define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__CAMERA_HPP_
 
-#include <cv_bridge/cv_bridge.h>
-
 #include <boost/algorithm/string/replace.hpp>
+#include <cv_bridge/cv_bridge.hpp>
 #include <filesystem>
 #include <opencv2/highgui.hpp>
 

--- a/dc_util/include/dc_util/image_utils.hpp
+++ b/dc_util/include/dc_util/image_utils.hpp
@@ -1,8 +1,7 @@
 #ifndef DC_UTIL__IMAGE_UTILS_HPP_
 #define DC_UTIL__IMAGE_UTILS_HPP_
 
-#include <cv_bridge/cv_bridge.h>
-
+#include <cv_bridge/cv_bridge.hpp>
 #include <iostream>
 #include <numeric>
 #include <regex>

--- a/dc_util/include/dc_util/service_utils.hpp
+++ b/dc_util/include/dc_util/service_utils.hpp
@@ -1,7 +1,6 @@
-#include <cv_bridge/cv_bridge.h>
-
 #include <boost/algorithm/string/replace.hpp>
 #include <chrono>
+#include <cv_bridge/cv_bridge.hpp>
 #include <memory>
 #include <opencv2/highgui.hpp>
 #include <string>

--- a/fluent_bit_plugins/COLCON_IGNORE
+++ b/fluent_bit_plugins/COLCON_IGNORE
@@ -1,3 +1,3 @@
-Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
-(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
-dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition (ADR-0001:
+replace the embedded Fluent Bit engine with an external Vector shipper). See the dc-2.0
+epic (#241). Do not delete this package; it is dropped, not removed.

--- a/fluent_bit_plugins/COLCON_IGNORE
+++ b/fluent_bit_plugins/COLCON_IGNORE
@@ -1,0 +1,3 @@
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
+(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
+dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.

--- a/fluent_bit_vendor/COLCON_IGNORE
+++ b/fluent_bit_vendor/COLCON_IGNORE
@@ -1,3 +1,3 @@
-Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
-(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
-dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition (ADR-0001:
+replace the embedded Fluent Bit engine with an external Vector shipper). See the dc-2.0
+epic (#241). Do not delete this package; it is dropped, not removed.

--- a/fluent_bit_vendor/COLCON_IGNORE
+++ b/fluent_bit_vendor/COLCON_IGNORE
@@ -1,0 +1,3 @@
+Ignored on the jazzy line pending the DC 2.0 embedded-Fluent-Bit demolition slice
+(replaced by the external Vector shipper + Rust bridge). See issue #242 and the
+dc-2.0 epic (#241). Do not delete this package; it is dropped, not removed.

--- a/progress.txt
+++ b/progress.txt
@@ -1,1 +1,35 @@
 ## Completed tasks
+
+### #242 - DC 2.0 S1: Port C++ core to ROS 2 Jazzy (Fluent Bit packages ignored)
+
+- Added `COLCON_IGNORE` (with a comment pointing at the demolition slice / #241 / #242) to
+  `dc_destinations`, `fluent_bit_plugins`, and `fluent_bit_vendor` — the embedded-Fluent-Bit
+  path being replaced by the Vector shipper + Rust bridge later in the epic.
+- Renamed `cv_bridge/cv_bridge.h` -> `cv_bridge/cv_bridge.hpp` includes (Jazzy dropped the old
+  header) in `dc_measurements` camera plugin and `dc_util` image/service utils.
+- Removed a stale Humble-era FIXME comment in `dc_lifecycle_manager/CMakeLists.txt` about a
+  `tf2_geometry_msgs` header that Jazzy already ships.
+- Updated `dc_bringup`'s launch file and `package.xml` to stop launching/depending on
+  `destination_server`, which is now ignored, so `measurement_server` + `lifecycle_manager`
+  still come up cleanly on their own.
+- Verified via a read-only structural survey (package.xml/CMakeLists/grep across all C++
+  sources) that the rest of the codebase was already Jazzy-clean: `nav2_util::LifecycleNode`
+  usage, typed `declare_parameter` calls, `.hpp` interface includes, executors, and
+  `PLUGINLIB_EXPORT_CLASS` sites all match current Jazzy APIs. Confirmed via `apt-cache policy`
+  against a real `ros:jazzy-ros-base` image that every remaining rosdep key (nav2_util,
+  nav2_msgs, bondcpp, diagnostic_updater, cv_bridge, rclpy_message_converter,
+  nlohmann_json_schema_validator_vendor, realsense2_description, nav2_bringup,
+  nav2_simple_commander, nav2_lifecycle_manager, tf2_geometry_msgs, message_filters) has a
+  released Jazzy package.
+- **Not done / left for CI**: could not run an actual `colcon build` on Jazzy in this sandbox —
+  the host disk is nearly full (both `/` and `/home` partitions), and a full workspace rosdep
+  install (nav2, OpenCV/ffmpeg, boost, etc.) exhausted available space mid-install. Ran
+  `pre-commit` locally instead (skipping the disk-heavy `build-doc` hook and two hooks broken by
+  local tool-environment gaps unrelated to this diff: `poetry-requirements`, `pycln`); all
+  hooks relevant to the changed files passed (`black`, `isort`, `clang-format`, XML lint, ROS
+  package metadata checks). A real `colcon build --packages-skip dc_destinations
+  fluent_bit_plugins fluent_bit_vendor` on Jazzy (CI once #249 lands, or a machine with more
+  disk) is still needed to fully close the "colcon build succeeds" and "gtest suites pass"
+  acceptance criteria.
+- CI/Docker (`.github/workflows/`, `docker/*/Dockerfile`) intentionally left targeting `humble`
+  — out of scope here per the earlier decision to handle Jazzy CI separately (#249).


### PR DESCRIPTION
## Summary
- `COLCON_IGNORE` `dc_destinations`, `fluent_bit_plugins`, and `fluent_bit_vendor` (with a comment pointing at the DC 2.0 demolition slice / #241), matching the acceptance criteria — they're replaced by the external Vector shipper + Rust bridge in a later slice, not deleted.
- Rename `cv_bridge/cv_bridge.h` → `cv_bridge/cv_bridge.hpp` includes in `dc_measurements`'s camera plugin and `dc_util`'s image/service utils — Jazzy dropped the old `.h` header.
- Drop a stale Humble-era FIXME comment in `dc_lifecycle_manager/CMakeLists.txt` referencing a `tf2_geometry_msgs` header issue that Jazzy already resolves.
- Update `dc_bringup`'s launch file and `package.xml` to stop launching/depending on `destination_server`, which is now ignored, so `measurement_server` + `lifecycle_manager` still come up cleanly without it.
- No changes to Measurement/Condition/Group parameter names or the `StringStamped` Record JSON shape — this is a dependency/API bump per the PRD, not a redesign.

A read-only structural survey (package.xml/CMakeLists/grep across all C++ sources in `dc_core`, `dc_common`, `dc_measurements`, `dc_group`, `dc_lifecycle_manager`, `dc_interfaces`, `dc_services`, `dc_util`, `dc_bringup`, `dc_cli`, `dc_description`, `dc_demos`) confirmed the rest of the codebase already targets Jazzy-compatible APIs (`nav2_util::LifecycleNode`, typed `declare_parameter`, `.hpp` interface includes, standard executors, `PLUGINLIB_EXPORT_CLASS`). I also confirmed via `apt-cache policy` against a real `ros:jazzy-ros-base` image that every remaining rosdep key used by the non-ignored packages (`nav2_util`, `nav2_msgs`, `bondcpp`, `diagnostic_updater`, `cv_bridge`, `rclpy_message_converter`, `nlohmann_json_schema_validator_vendor`, `realsense2_description`, `nav2_bringup`, `nav2_simple_commander`, `nav2_lifecycle_manager`, `tf2_geometry_msgs`, `message_filters`) has a released Jazzy package.

**Known gap:** I could not run an actual `colcon build` against Jazzy in this environment — the build host's disk was nearly full and a full workspace `rosdep install` (nav2, OpenCV/ffmpeg, boost, etc.) exhausted the remaining space mid-install. `pre-commit` ran locally instead (skipping the disk-heavy `build-doc` hook and two hooks broken by unrelated local tool-environment gaps: `poetry-requirements`, `pycln`); everything relevant to this diff passed (`black`, `isort`, `clang-format`, XML lint, ROS package metadata checks). A real `colcon build --packages-skip dc_destinations fluent_bit_plugins fluent_bit_vendor` on Jazzy (via CI once #249 lands, or a machine with more disk) is still needed to fully close the "colcon build succeeds" and "gtest suites pass" acceptance criteria.

CI/Docker (`.github/workflows/`, `docker/*/Dockerfile`) intentionally left targeting `humble` — Jazzy CI is tracked separately in #249.

Closes #242

## Test plan
- [ ] `colcon build --packages-skip dc_destinations fluent_bit_plugins fluent_bit_vendor` succeeds on ROS 2 Jazzy (Ubuntu 24.04) — **not run in this sandbox, disk-constrained; needs CI or a build host with more space**
- [ ] Existing gtest suites (`dc_measurements` lifecycle-node tests) pass on Jazzy
- [ ] A demo Measurement config produces visible Records via `ros2 topic echo /dc/measurement/...` with the updated `dc_bringup` launch file
- [x] Fluent Bit-related packages are `COLCON_IGNORE`d with a comment referencing the demolition slice, not deleted
- [x] No changes to Measurement/Condition/Group parameter names or Record JSON shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWrbEoF5MisnG6eTVmvSn2