### PR TITLE
DC 2.0 S2: vector_vendor — pinned Vector binary at build time

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -33,3 +33,47 @@
   acceptance criteria.
 - CI/Docker (`.github/workflows/`, `docker/*/Dockerfile`) intentionally left targeting `humble`
   — out of scope here per the earlier decision to handle Jazzy CI separately (#249).
+
+### #243 - DC 2.0 S2: vector_vendor — pinned Vector binary at build time
+
+- Added a new `vector_vendor` ament package (ADR-0002) with a `CMakeLists.txt` that: detects
+  `x86_64`/`aarch64` via `CMAKE_SYSTEM_PROCESSOR`, downloads the matching official static Vector
+  binary tarball (`vector-<version>-<arch>-unknown-linux-musl.tar.gz`) from the GitHub releases
+  page, verifies it against a per-architecture SHA-256 pinned in the file via `file(DOWNLOAD
+  ... EXPECTED_HASH SHA256=...)` (fails loudly — `FATAL_ERROR` — on mismatch, no silent
+  fallback), extracts it, checks `vector --version` matches the pinned version, and installs the
+  binary to `lib/vector_vendor/vector`.
+- Pinned Vector `0.57.0` (latest stable release as of writing), with real checksums fetched from
+  upstream's own `SHA256SUMS` file for both `x86_64` and `aarch64` musl static tarballs. Bumping
+  the version means changing `VECTOR_VERSION` plus the two `VECTOR_SHA256_*` lines at the top of
+  the file.
+- Added the documented override: a `vector_path` CMake cache variable (settable via `colcon
+  build --cmake-args -Dvector_path=/path/to/vector`, or via a `VECTOR_PATH` environment variable
+  picked up as the cache default) that skips the download entirely and vendors a
+  system-installed binary instead — for air-gapped builds or distro packages.
+- `package.xml` follows the `format="3"` / 4-space-indent / `0.1.0` convention used by the other
+  new Jazzy-line packages (`dc_core`, `dc_bringup`), rather than mirroring legacy
+  `fluent_bit_vendor` (`format="2"`, version `2.0.0`) — `vector_vendor` isn't a `dc_*` package so
+  the `ros2_ws_same_versions` pre-commit hook (which pins all `dc_.*` packages to one version)
+  doesn't apply to it either way.
+- **Verified without `colcon`/`ament_cmake`** (not installed in this sandbox, and the ROS 2
+  install disk-space issue from #242 is still unresolved): copied the file into a bare
+  `project()`-only CMakeLists and ran real `cmake -S/-B` + `cmake --install` end to end against
+  the live GitHub releases endpoint (internet access is available here). Confirmed: (1) the
+  happy path downloads, checksum-verifies, extracts, and installs a runnable `vector 0.57.0`
+  binary; (2) a deliberately corrupted pinned checksum fails the configure step with a clear
+  hash-mismatch error; (3) both the `-Dvector_path=...` cmake-arg and the `VECTOR_PATH`
+  environment variable skip the download and install the given binary directly. All four
+  scriptable acceptance criteria are covered by this; a real `colcon build` of `vector_vendor`
+  is still needed once CI/a machine with `ament_cmake` is available to close the loop formally.
+- Ran `pre-commit` (with `build-doc`, `poetry-requirements`, `pycln` skipped, same as #242, since
+  the disk-heavy doc build and the two broken tool-environment hooks are unrelated to this
+  change) — all hooks that touched the new files passed (`black`, `check-xml`,
+  `ros2_ws_same_versions`, `ros2_ws_set_metadata`, codespell, etc.).
+- **Aside, not part of this task**: this worktree has no `CONTEXT.md` or `docs/adr/` even
+  though `CLAUDE.md` and issue #241 both point at them — they exist only as **untracked** files
+  in the main repo checkout (`/home/dbensoussan/dev/ros2_data_collection/{CONTEXT.md,docs/adr/}`)
+  from an earlier session, never committed, so `git worktree` checkouts (including this one)
+  don't see them. Read ADR-0002 and `CONTEXT.md` from that location to inform this
+  implementation. Worth committing them to the repo in a follow-up so future worktrees/agents
+  don't have to know to look there.

--- a/vector_vendor/CMakeLists.txt
+++ b/vector_vendor/CMakeLists.txt
@@ -1,0 +1,111 @@
+cmake_minimum_required(VERSION 3.18)
+project(vector_vendor)
+
+find_package(ament_cmake REQUIRED)
+
+# Bumping Vector is a single-line change: update the version and the checksum
+# for every supported architecture below (see ADR-0002).
+set(VECTOR_VERSION "0.57.0")
+set(VECTOR_SHA256_x86_64 "b04fafcffcbeb3d43cbba587583dbe3338b24dd34256b3967fb15d137aff75f2")
+set(VECTOR_SHA256_aarch64 "81cec5343e49985351e13f76ae3d550d7b0f0ac64fd4d88c07e3873bdfdf100a")
+
+# Override: point vector_path at a system-installed Vector binary to skip the
+# download entirely (air-gapped builds, distro packages). May be set as a
+# colcon cmake-arg (--cmake-args -Dvector_path=/usr/bin/vector) or via the
+# VECTOR_PATH environment variable.
+if(NOT DEFINED vector_path AND DEFINED ENV{VECTOR_PATH})
+  set(vector_path "$ENV{VECTOR_PATH}")
+endif()
+set(vector_path "${vector_path}" CACHE FILEPATH
+  "Path to a system-installed Vector binary. When set, vector_vendor vendors \
+this binary instead of downloading one.")
+
+if(vector_path)
+  if(NOT EXISTS "${vector_path}")
+    message(FATAL_ERROR "vector_vendor: vector_path='${vector_path}' does not exist")
+  endif()
+  set(_vector_binary "${vector_path}")
+else()
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
+    set(_vector_arch "x86_64")
+  elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64|ARM64)$")
+    set(_vector_arch "aarch64")
+  else()
+    message(FATAL_ERROR
+      "vector_vendor: unsupported architecture '${CMAKE_SYSTEM_PROCESSOR}'; "
+      "set vector_path to a system-installed Vector binary instead")
+  endif()
+
+  set(_vector_sha256 "${VECTOR_SHA256_${_vector_arch}}")
+  if(NOT _vector_sha256)
+    message(FATAL_ERROR "vector_vendor: no pinned checksum for architecture '${_vector_arch}'")
+  endif()
+
+  set(_vector_tarball_name "vector-${VECTOR_VERSION}-${_vector_arch}-unknown-linux-musl.tar.gz")
+  set(_vector_url "https://github.com/vectordotdev/vector/releases/download/v${VECTOR_VERSION}/${_vector_tarball_name}")
+  set(_vector_download_dir "${CMAKE_CURRENT_BINARY_DIR}/download")
+  set(_vector_tarball "${_vector_download_dir}/${_vector_tarball_name}")
+
+  file(MAKE_DIRECTORY "${_vector_download_dir}")
+
+  set(_need_download TRUE)
+  if(EXISTS "${_vector_tarball}")
+    file(SHA256 "${_vector_tarball}" _cached_sha256)
+    if(_cached_sha256 STREQUAL _vector_sha256)
+      set(_need_download FALSE)
+    endif()
+  endif()
+
+  if(_need_download)
+    message(STATUS "vector_vendor: downloading ${_vector_url}")
+    file(DOWNLOAD "${_vector_url}" "${_vector_tarball}"
+      EXPECTED_HASH SHA256=${_vector_sha256}
+      TLS_VERIFY ON
+      STATUS _download_status
+    )
+    list(GET _download_status 0 _download_code)
+    if(NOT _download_code EQUAL 0)
+      list(GET _download_status 1 _download_message)
+      file(REMOVE "${_vector_tarball}")
+      message(FATAL_ERROR
+        "vector_vendor: failed to download Vector ${VECTOR_VERSION} for "
+        "${_vector_arch}: ${_download_message}")
+    endif()
+  endif()
+
+  set(_vector_extract_dir "${CMAKE_CURRENT_BINARY_DIR}/extract")
+  file(REMOVE_RECURSE "${_vector_extract_dir}")
+  file(MAKE_DIRECTORY "${_vector_extract_dir}")
+  file(ARCHIVE_EXTRACT INPUT "${_vector_tarball}" DESTINATION "${_vector_extract_dir}")
+
+  file(GLOB _vector_binary_candidates "${_vector_extract_dir}/*/bin/vector")
+  list(LENGTH _vector_binary_candidates _vector_binary_candidate_count)
+  if(NOT _vector_binary_candidate_count EQUAL 1)
+    message(FATAL_ERROR
+      "vector_vendor: expected exactly one extracted vector binary in "
+      "${_vector_extract_dir}, found ${_vector_binary_candidate_count}")
+  endif()
+  list(GET _vector_binary_candidates 0 _vector_binary)
+
+  execute_process(
+    COMMAND "${_vector_binary}" --version
+    OUTPUT_VARIABLE _vector_version_output
+    RESULT_VARIABLE _vector_version_result
+  )
+  if(NOT _vector_version_result EQUAL 0)
+    message(FATAL_ERROR "vector_vendor: '${_vector_binary} --version' failed")
+  endif()
+  if(NOT _vector_version_output MATCHES "vector ${VECTOR_VERSION} ")
+    message(FATAL_ERROR
+      "vector_vendor: downloaded Vector reports version '${_vector_version_output}', "
+      "expected ${VECTOR_VERSION}")
+  endif()
+endif()
+
+install(
+  PROGRAMS "${_vector_binary}"
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME vector
+)
+
+ament_package()

--- a/vector_vendor/package.xml
+++ b/vector_vendor/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+    <name>vector_vendor</name>
+    <version>0.1.0</version>
+    <description>Vendor package that downloads a checksum-pinned prebuilt Vector binary at build time (ADR-0002), or vendors a system-installed Vector via the vector_path override.</description>
+    <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
+    <license>MPL-2.0</license>
+
+    <buildtool_depend>ament_cmake</buildtool_depend>
+
+    <export>
+        <build_type>ament_cmake</build_type>
+    </export>
+</package>


### PR DESCRIPTION
## Summary

- Adds the `vector_vendor` ament package (ADR-0002): downloads the official prebuilt static Vector binary at build time, pinned to an exact version with SHA-256 checksum verification, auto-detecting x86_64 vs arm64. Nobody compiles Vector.
- Pins Vector `0.57.0`, with real checksums for both `x86_64` and `aarch64` musl static tarballs pulled from upstream's `SHA256SUMS`. Bumping the version is a two-line change at the top of `CMakeLists.txt` (`VECTOR_VERSION` + the matching `VECTOR_SHA256_*` line(s)).
- Documented override: a `vector_path` CMake cache variable, settable via `colcon build --cmake-args -Dvector_path=/path/to/vector` or the `VECTOR_PATH` environment variable, skips the download and vendors a system-installed binary instead — for air-gapped builds and distro packages.
- The download fails loudly (`FATAL_ERROR`) on a checksum mismatch, with no silent fallback.

## Verification

`colcon`/`ament_cmake` aren't available in this sandbox (same pre-existing disk-space constraint noted for #242), so `CMakeLists.txt` was verified with a standalone `cmake -S/-B` + `cmake --install` against the real GitHub releases endpoint:

- Happy path: downloads, checksum-verifies, extracts, and installs a runnable `vector 0.57.0` binary (`vector --version` matches the pinned version).
- A deliberately corrupted pinned checksum fails the configure step with a clear hash-mismatch error.
- Both the `-Dvector_path=...` cmake-arg and the `VECTOR_PATH` env var skip the download and install the given binary directly.

`pre-commit` passed on all hooks touching the changed files (`build-doc`, `poetry-requirements`, `pycln` skipped — same disk-heavy/broken-locally hooks skipped in #242, unrelated to this change).

A real `colcon build --packages-select vector_vendor` on a machine with `ament_cmake` is still needed to close the loop formally.

## Test plan

- [ ] `colcon build --packages-select vector_vendor` succeeds and installs a runnable `vector` binary matching the pinned version
- [ ] `colcon build --packages-select vector_vendor --cmake-args -Dvector_path=<system vector>` skips the download and vendors the given binary
- [ ] Checksum mismatch (e.g. temporarily corrupt a pinned hash) fails the build loudly

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P7AtFt45hfBDpGycnBXpVB