### PR TITLE
DC 2.0 S4: Config renderer + PostgreSQL blessed destination

### DIFF
--- a/dc_bridge/Cargo.lock
+++ b/dc_bridge/Cargo.lock
@@ -148,6 +148,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,10 +171,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "block2"
@@ -201,6 +227,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +251,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,10 +277,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
 
 [[package]]
 name = "ctrlc"
@@ -239,12 +318,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "dc_bridge"
 version = "0.1.0"
 dependencies = [
  "ctrlc",
  "dc_bridge_core",
  "dc_interfaces",
+ "postgres",
  "rclrs",
  "rosidl_runtime_rs",
  "serde_json",
@@ -272,6 +361,18 @@ dependencies = [
  "sensor_msgs",
  "service_msgs",
  "std_msgs",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer",
+ "const-oid",
+ "crypto-common",
+ "ctutils",
 ]
 
 [[package]]
@@ -334,6 +435,12 @@ dependencies = [
  "event-listener 5.4.1",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -460,6 +567,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
 ]
 
 [[package]]
@@ -485,6 +593,24 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "indexmap"
@@ -548,10 +674,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -563,10 +707,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys",
+]
 
 [[package]]
 name = "nix"
@@ -599,10 +764,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
 
 [[package]]
 name = "once_cell"
@@ -615,6 +798,54 @@ name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -654,6 +885,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "futures-util",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -678,6 +952,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rclrs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +986,15 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -756,6 +1056,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sensor_msgs"
@@ -828,10 +1134,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "std_msgs"
@@ -848,6 +1187,17 @@ dependencies = [
  "builtin_interfaces",
  "rosidl_runtime_rs",
  "service_msgs",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -893,12 +1243,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
+ "bytes",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "socket2",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -908,6 +1304,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -954,10 +1364,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "uuid"
@@ -984,6 +1421,39 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1042,6 +1512,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1566,12 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zmij"

--- a/dc_bridge/Cargo.toml
+++ b/dc_bridge/Cargo.toml
@@ -31,6 +31,12 @@ dc_interfaces = "*"
 std_msgs = "*"
 std_srvs = "*"
 
+[dev-dependencies]
+# Used only by tests/end_to_end.rs's Postgres-backed test to verify a forwarded Record
+# actually lands in the database; not a runtime dependency of the dc_bridge binary
+# itself (Vector, not dc_bridge, talks to Postgres in production).
+postgres = "0.19"
+
 # The Jazzy build recipe (README.md) sources the rosidl_rust code generator from its git
 # main branch, which emits idiomatic-message conversions (Sequence<T> -> Vec<T> for
 # unbounded primitive arrays, e.g. dc_interfaces' DrawImage.srv `uint16[] color`) that

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -9,11 +9,11 @@ Shipper → output end-to-end, with a console sink standing in for real Destinat
 
 - **`dc_bridge_core/`** — the ROS-independent core: `Forwarder` (msgpack framing, socket
   lifecycle, reconnection, backpressure), `Supervisor` (generic process respawn),
-  `Readiness` (TCP-accept probe), `config` (topic → Fluent Forward tag), and
-  `vector_config` (renders the minimal Vector config, locates the vendored binary). It's
-  a standalone crate with its own `Cargo.toml` (declaring `[workspace]` so it never gets
-  swept into the outer package's workspace) and zero ROS dependencies, so it builds and
-  tests with plain Cargo:
+  `Readiness` (TCP-accept probe), `config` (topic → Fluent Forward tag), `vector_config`
+  (locates the vendored binary), and `render` (ADR-0003's config renderer — see below).
+  It's a standalone crate with its own `Cargo.toml` (declaring `[workspace]` so it never
+  gets swept into the outer package's workspace) and zero ROS dependencies, so it builds
+  and tests with plain Cargo:
 
   ```sh
   cd dc_bridge/dc_bridge_core
@@ -24,13 +24,15 @@ Shipper → output end-to-end, with a console sink standing in for real Destinat
   were verified in a sandbox with no ROS 2 or ros2_rust install available — no `colcon`
   or `rclrs` toolchain is required to run these tests.
 
-- **`src/main.rs`** — the actual ROS node. It declares parameters (`topics`,
-  `vector_forward_host`, `vector_forward_port`, `vector_binary`), starts the Supervisor
-  against the vendored `vector_vendor` binary, subscribes to each configured topic,
-  exposes a `~/ready` (`std_srvs/Trigger`) readiness service, and installs a SIGINT/
-  SIGTERM handler that stops Vector before exiting (see "Runtime flow" below — rclrs
-  doesn't do this on its own). It depends on `rclrs`, `dc_interfaces`, `std_msgs`, and
-  `std_srvs`, all only resolvable inside a colcon workspace (see below).
+- **`src/main.rs`** — the actual ROS node. It declares `shipper.*`/`destinations`/
+  `<name>.*` parameters (ADR-0003's config contract — see below), `vector_forward_host`,
+  `vector_forward_port`, and `vector_binary`; renders the full Vector config via
+  `dc_bridge_core::render` and hands it to the Supervisor (which supervises the vendored
+  `vector_vendor` binary); subscribes to the union of every configured Destination's
+  `inputs` topics; exposes a `~/ready` (`std_srvs/Trigger`) readiness service; and
+  installs a SIGINT/SIGTERM handler that stops Vector before exiting (see "Runtime flow"
+  below — rclrs doesn't do this on its own). It depends on `rclrs`, `dc_interfaces`,
+  `std_msgs`, and `std_srvs`, all only resolvable inside a colcon workspace (see below).
 
 - **`tests/end_to_end.rs`** — a `colcon test`-integrated integration test (colcon-ros-cargo
   runs `cargo test` + `cargo fmt --check` for `ament_cargo` packages, same as any other
@@ -39,6 +41,71 @@ Shipper → output end-to-end, with a console sink standing in for real Destinat
   and asserting the supervised Vector process actually stops when dc_bridge receives
   SIGTERM. This is what caught the signal-handling bug below — manual verification alone
   had missed it.
+
+## Config renderer (ADR-0003)
+
+`dc_bridge_core::render` is a pure, I/O-free module (`src/render.rs`) mapping ROS
+parameters to a complete Vector configuration. Given the unified-destinations config
+contract:
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["pgsql"]
+    pgsql:
+      type: postgres            # blessed types: postgres | s3 | file | console
+      receives: records          # records (default) | files
+      inputs: ["/dc/group/robot"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "$DC_PG_PASSWORD"   # env expansion, consistent with existing $HOME usage
+      database: "dc"
+      table: "dc"
+      time_key: "date"
+      time_format: "double"      # double | iso8601
+```
+
+it renders: the Fluent Forward source; one `remap` (VRL) transform that normalizes each
+blessed destination's timestamp field into `time_key` per `time_format` — `double`
+(Unix epoch seconds as a float) or `iso8601` (`%Y-%m-%dT%H:%M:%S%.9f`), replacing the
+Humble-era chained Lua filters (`dc_destinations/include/dc_destinations/
+flb_destination.hpp` on the `humble` branch); one `route` transform named `dc`, giving
+every Destination a stable output at `dc.<name>` (the passthrough contract other
+`custom_sinks` snippets are meant to consume, per ADR-0003) — the route's branch
+condition and the normalize transform's per-destination `if` both match on the same
+Fluent Forward tag `TopicConfig` derives from that Destination's `inputs` topics; a disk
+buffer (`shipper.data_dir`, minimum ~256 MiB per Vector's own `postgres` sink
+constraint) per sink; and the sink itself. Only `postgres` is implemented; `s3`, `file`,
+`console` are reserved blessed-type names that reject clearly (`RenderError::
+UnsupportedType`) until their own issues land.
+
+Two layers, both pure and gold-file-tested (`src/render.rs`'s `#[cfg(test)]` module,
+comparing against checked-in fixtures under `tests/fixtures/render/*.toml` via parsed
+`toml::Table` equality so incidental formatting differences don't make the tests
+brittle):
+
+- `destination_from_raw` / `PostgresParams::from_raw` validate the flat, stringly-typed
+  values ROS parameters naturally give (`<name>.type`, `<name>.host`, …) into typed
+  config — every "invalid-parameter rejection" acceptance criterion (unknown `type`,
+  bad `time_format`/`receives`, missing required field, out-of-range `port`, empty
+  `inputs`/`destinations`, duplicate/invalid destination names, an undersized disk
+  buffer) is a `RenderError` variant with its own test.
+- `render` turns already-validated `RenderConfig` into the Vector TOML text above.
+
+`expand_env` (also pure — it takes an injected lookup function rather than reading the
+real environment) implements the `$NAME`/`${NAME}` expansion `shipper.data_dir` and
+each destination's `password` use; `main.rs` is the only place that calls it with
+`std::env::var`.
+
+Run just these tests (no ROS, Vector, or Postgres needed):
+
+```sh
+cd dc_bridge/dc_bridge_core
+cargo test render::
+```
 
 ## Verified in a real ROS 2 Jazzy + ros2_rust environment
 

--- a/dc_bridge/dc_bridge_core/src/lib.rs
+++ b/dc_bridge/dc_bridge_core/src/lib.rs
@@ -5,10 +5,16 @@
 pub mod config;
 pub mod forwarder;
 pub mod readiness;
+pub mod render;
 pub mod supervisor;
 pub mod vector_config;
 
 pub use config::{BridgeConfig, TopicConfig};
 pub use forwarder::{Forwarder, ForwarderConfig, ForwarderError, Record};
 pub use readiness::Readiness;
+pub use render::{
+    destination_from_raw, expand_env, render as render_vector_config, Destination, DestinationKind,
+    PostgresParams, RawPostgresParams, Receives, RenderConfig, RenderError, TimeFormat,
+    MIN_DISK_BUFFER_BYTES, ROUTE_TRANSFORM_ID,
+};
 pub use supervisor::{Supervisor, SupervisorConfig};

--- a/dc_bridge/dc_bridge_core/src/render.rs
+++ b/dc_bridge/dc_bridge_core/src/render.rs
@@ -1,0 +1,794 @@
+//! Config renderer (ADR-0003): a pure, I/O-free mapping from Bridge/Destination
+//! parameters to a complete Vector configuration. Given a fully-resolved [`RenderConfig`],
+//! [`render`] produces Vector TOML with: the Fluent Forward source, one VRL transform
+//! that normalizes each blessed destination's timestamp field (replacing the Humble-era
+//! chained Lua filters — see `dc_destinations/include/dc_destinations/flb_destination.hpp`
+//! on the `humble` branch), one `route` transform exposing a stable `dc.<tag>` output per
+//! Destination (the passthrough contract from ADR-0003), disk-buffer settings, and the
+//! blessed sinks themselves (only `postgres` is implemented; `s3`/`file`/`console` are
+//! reserved names that reject clearly until their own issues land).
+//!
+//! Two layers, both pure and independently testable:
+//! - [`destination_from_raw`] / [`PostgresParams::from_raw`] turn the flat, stringly-typed
+//!   values ROS parameters naturally give us into validated, typed config — this is where
+//!   "invalid-parameter rejection with clear error messages" lives.
+//! - [`render`] turns already-validated, typed [`RenderConfig`] into Vector TOML text.
+//!
+//! [`expand_env`] handles the `$HOME`/`$DC_PG_PASSWORD`-style expansion the config
+//! contract uses for `shipper.data_dir` and destination passwords; it takes an injected
+//! lookup function rather than reading the real environment, so it stays pure too.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::net::SocketAddr;
+use toml::value::Table;
+use toml::Value;
+
+use crate::config::TopicConfig;
+
+const SOURCE_ID: &str = "dc_bridge_in";
+const NORMALIZE_TRANSFORM_ID: &str = "dc_bridge_normalize";
+/// The stable public route-transform id ADR-0003 fixes: each Destination's output is
+/// addressable as `dc.<name>`, the name passthrough `custom_sinks` snippets consume.
+pub const ROUTE_TRANSFORM_ID: &str = "dc";
+/// Vector rejects a disk buffer's `max_size` below this (~256 MiB); see the `postgres`
+/// sink reference docs.
+pub const MIN_DISK_BUFFER_BYTES: u64 = 268_435_488;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RenderConfig {
+    pub forward_addr: SocketAddr,
+    pub data_dir: String,
+    pub buffer_max_bytes: u64,
+    pub destinations: Vec<Destination>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Destination {
+    pub name: String,
+    pub receives: Receives,
+    /// ROS topic names feeding this Destination; the Fluent Forward tag each one is
+    /// routed under is derived the same way `TopicConfig` derives it for subscriptions.
+    pub inputs: Vec<String>,
+    pub kind: DestinationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Receives {
+    Records,
+    Files,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum DestinationKind {
+    Postgres(PostgresParams),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeFormat {
+    Double,
+    Iso8601,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PostgresParams {
+    pub host: String,
+    pub port: u16,
+    pub user: String,
+    pub password: String,
+    pub database: String,
+    pub table: String,
+    pub time_key: String,
+    pub time_format: TimeFormat,
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum RenderError {
+    #[error("shipper.data_dir must not be empty")]
+    EmptyDataDir,
+    #[error("no destinations configured; add at least one entry to the `destinations` parameter")]
+    NoDestinations,
+    #[error(
+        "destination '{0}': name must start with a letter and contain only letters, digits, or underscores"
+    )]
+    InvalidDestinationName(String),
+    #[error("duplicate destination name '{0}'")]
+    DuplicateDestination(String),
+    #[error("destination '{0}': `inputs` must not be empty")]
+    EmptyInputs(String),
+    #[error(
+        "destination '{0}': type '{1}' is not a blessed destination type (supported: postgres; s3, file, console are reserved names not yet implemented)"
+    )]
+    UnsupportedType(String, String),
+    #[error("destination '{0}': receives '{1}' is invalid (expected 'records' or 'files')")]
+    InvalidReceives(String, String),
+    #[error("destination '{0}': `receives: files` is not yet supported (only `records`)")]
+    FilesNotSupported(String),
+    #[error("destination '{0}': time_format '{1}' is invalid (expected 'double' or 'iso8601')")]
+    InvalidTimeFormat(String, String),
+    #[error("destination '{0}': missing required field `{1}`")]
+    MissingField(String, String),
+    #[error("destination '{0}': port {1} is out of range (expected 1-65535)")]
+    InvalidPort(String, i64),
+    #[error(
+        "shipper.buffer_max_bytes ({0}) is below Vector's disk-buffer minimum of {MIN_DISK_BUFFER_BYTES} bytes"
+    )]
+    BufferTooSmall(u64),
+    #[error("failed to serialize the rendered config: {0}")]
+    Serialize(String),
+}
+
+/// Raw, flat Postgres parameters as ROS would declare them (`<name>.host`, `<name>.port`,
+/// …). `None` means "not declared"; empty strings are treated the same as `None` so an
+/// accidentally-blank YAML value still gets a clear "missing field" error rather than a
+/// silently broken connection string.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RawPostgresParams<'a> {
+    pub host: Option<&'a str>,
+    pub port: Option<i64>,
+    pub user: Option<&'a str>,
+    pub password: Option<&'a str>,
+    pub database: Option<&'a str>,
+    pub table: Option<&'a str>,
+    pub time_key: Option<&'a str>,
+    pub time_format: Option<&'a str>,
+}
+
+impl PostgresParams {
+    pub fn from_raw(name: &str, raw: RawPostgresParams) -> Result<Self, RenderError> {
+        let required = |value: Option<&str>, field: &str| {
+            value
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .ok_or_else(|| RenderError::MissingField(name.to_string(), field.to_string()))
+        };
+
+        let user = required(raw.user, "user")?;
+        let password = required(raw.password, "password")?;
+        let database = required(raw.database, "database")?;
+        let table = required(raw.table, "table")?;
+
+        let host = raw
+            .host
+            .filter(|s| !s.is_empty())
+            .unwrap_or("127.0.0.1")
+            .to_string();
+        let port_raw = raw.port.unwrap_or(5432);
+        let port = u16::try_from(port_raw)
+            .ok()
+            .filter(|p| *p != 0)
+            .ok_or_else(|| RenderError::InvalidPort(name.to_string(), port_raw))?;
+        let time_key = raw
+            .time_key
+            .filter(|s| !s.is_empty())
+            .unwrap_or("date")
+            .to_string();
+        let time_format = match raw
+            .time_format
+            .filter(|s| !s.is_empty())
+            .unwrap_or("double")
+        {
+            "double" => TimeFormat::Double,
+            "iso8601" => TimeFormat::Iso8601,
+            other => {
+                return Err(RenderError::InvalidTimeFormat(
+                    name.to_string(),
+                    other.to_string(),
+                ))
+            }
+        };
+
+        Ok(PostgresParams {
+            host,
+            port,
+            user,
+            password,
+            database,
+            table,
+            time_key,
+            time_format,
+        })
+    }
+}
+
+/// Validates and builds one [`Destination`] from the flat parameters ROS would declare
+/// for it. `type_str`/`receives_str` come straight from the `<name>.type` /
+/// `<name>.receives` parameters.
+pub fn destination_from_raw(
+    name: &str,
+    type_str: &str,
+    receives_str: &str,
+    inputs: Vec<String>,
+    postgres: RawPostgresParams,
+) -> Result<Destination, RenderError> {
+    let receives = match receives_str {
+        "records" => Receives::Records,
+        "files" => Receives::Files,
+        other => {
+            return Err(RenderError::InvalidReceives(
+                name.to_string(),
+                other.to_string(),
+            ))
+        }
+    };
+    if receives != Receives::Records {
+        return Err(RenderError::FilesNotSupported(name.to_string()));
+    }
+
+    let kind = match type_str {
+        "postgres" => DestinationKind::Postgres(PostgresParams::from_raw(name, postgres)?),
+        other => {
+            return Err(RenderError::UnsupportedType(
+                name.to_string(),
+                other.to_string(),
+            ))
+        }
+    };
+
+    Ok(Destination {
+        name: name.to_string(),
+        receives,
+        inputs,
+        kind,
+    })
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+#[error("undefined environment variable '{0}' referenced in '{1}'")]
+pub struct ExpandError(String, String);
+
+/// Expands `$NAME` and `${NAME}` references in `input` using `lookup`, matching the DC
+/// config contract's `$HOME`/`$DC_PG_PASSWORD`-style expansion. Takes an injected lookup
+/// function (rather than reading the real environment) so it stays pure and deterministic
+/// under test; callers pass `std::env::var` (or similar) in production.
+pub fn expand_env(
+    input: &str,
+    lookup: impl Fn(&str) -> Option<String>,
+) -> Result<String, ExpandError> {
+    let chars: Vec<char> = input.chars().collect();
+    let mut out = String::new();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+            if let Some(rel_end) = chars[i + 2..].iter().position(|&c| c == '}') {
+                let end = i + 2 + rel_end;
+                let name: String = chars[i + 2..end].iter().collect();
+                let value =
+                    lookup(&name).ok_or_else(|| ExpandError(name.clone(), input.to_string()))?;
+                out.push_str(&value);
+                i = end + 1;
+                continue;
+            }
+        } else if chars[i] == '$'
+            && i + 1 < chars.len()
+            && (chars[i + 1].is_ascii_alphabetic() || chars[i + 1] == '_')
+        {
+            let start = i + 1;
+            let mut end = start;
+            while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_') {
+                end += 1;
+            }
+            let name: String = chars[start..end].iter().collect();
+            let value =
+                lookup(&name).ok_or_else(|| ExpandError(name.clone(), input.to_string()))?;
+            out.push_str(&value);
+            i = end;
+            continue;
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    Ok(out)
+}
+
+fn is_valid_destination_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    matches!(chars.next(), Some(c) if c.is_ascii_alphabetic())
+        && chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+fn validate(config: &RenderConfig) -> Result<(), RenderError> {
+    if config.data_dir.trim().is_empty() {
+        return Err(RenderError::EmptyDataDir);
+    }
+    if config.destinations.is_empty() {
+        return Err(RenderError::NoDestinations);
+    }
+    if config.buffer_max_bytes < MIN_DISK_BUFFER_BYTES {
+        return Err(RenderError::BufferTooSmall(config.buffer_max_bytes));
+    }
+
+    let mut seen = HashSet::new();
+    for dest in &config.destinations {
+        if !is_valid_destination_name(&dest.name) {
+            return Err(RenderError::InvalidDestinationName(dest.name.clone()));
+        }
+        if !seen.insert(dest.name.as_str()) {
+            return Err(RenderError::DuplicateDestination(dest.name.clone()));
+        }
+        if dest.inputs.is_empty() {
+            return Err(RenderError::EmptyInputs(dest.name.clone()));
+        }
+        if dest.receives != Receives::Records {
+            return Err(RenderError::FilesNotSupported(dest.name.clone()));
+        }
+    }
+    Ok(())
+}
+
+/// The Fluent Forward tags a Destination's `inputs` topics are subscribed/forwarded
+/// under — the same derivation `TopicConfig` uses, kept in lock-step so the rendered
+/// `route`/`remap` conditions actually match what the Bridge forwards.
+fn derived_tags(inputs: &[String]) -> Vec<String> {
+    inputs
+        .iter()
+        .map(|topic| TopicConfig::new(topic.clone(), None).tag)
+        .collect()
+}
+
+/// A VRL `includes([...], .tag)` condition matching any of `tags`.
+fn tag_condition(tags: &[String]) -> String {
+    let quoted: Vec<String> = tags.iter().map(|t| format!("{:?}", t)).collect();
+    format!("includes([{}], .tag)", quoted.join(", "))
+}
+
+fn render_normalize_source(config: &RenderConfig) -> String {
+    let mut out = String::new();
+    for dest in &config.destinations {
+        let DestinationKind::Postgres(pg) = &dest.kind;
+        let cond = tag_condition(&derived_tags(&dest.inputs));
+        writeln!(out, "if {cond} {{").unwrap();
+        match pg.time_format {
+            TimeFormat::Double => writeln!(
+                out,
+                "  .{key} = to_float(to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")) / 1000000000.0",
+                key = pg.time_key
+            )
+            .unwrap(),
+            TimeFormat::Iso8601 => writeln!(
+                out,
+                "  .{key} = format_timestamp!(.timestamp, format: \"%Y-%m-%dT%H:%M:%S%.9f\")",
+                key = pg.time_key
+            )
+            .unwrap(),
+        }
+        out.push_str("}\n");
+    }
+    out
+}
+
+/// Percent-encodes a postgres URI userinfo component (user/password) byte-by-byte, so
+/// arbitrary credential characters (`@`, `:`, `/`, `%`, non-ASCII…) can't corrupt the
+/// `postgres://user:password@host:port/db` endpoint string Vector's `postgres` sink parses.
+fn percent_encode_userinfo(value: &str) -> String {
+    let mut out = String::new();
+    for byte in value.bytes() {
+        let c = byte as char;
+        if c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | '_' | '~') {
+            out.push(c);
+        } else {
+            write!(out, "%{byte:02X}").unwrap();
+        }
+    }
+    out
+}
+
+fn render_sink(config: &RenderConfig, dest: &Destination) -> Table {
+    let DestinationKind::Postgres(pg) = &dest.kind;
+    let mut sink = Table::new();
+    sink.insert("type".into(), Value::String("postgres".into()));
+    sink.insert(
+        "inputs".into(),
+        Value::Array(vec![Value::String(format!(
+            "{ROUTE_TRANSFORM_ID}.{}",
+            dest.name
+        ))]),
+    );
+    sink.insert(
+        "endpoint".into(),
+        Value::String(format!(
+            "postgres://{}:{}@{}:{}/{}",
+            percent_encode_userinfo(&pg.user),
+            percent_encode_userinfo(&pg.password),
+            pg.host,
+            pg.port,
+            pg.database,
+        )),
+    );
+    sink.insert("table".into(), Value::String(pg.table.clone()));
+
+    let mut buffer = Table::new();
+    buffer.insert("type".into(), Value::String("disk".into()));
+    buffer.insert(
+        "max_size".into(),
+        Value::Integer(config.buffer_max_bytes as i64),
+    );
+    sink.insert("buffer".into(), Value::Table(buffer));
+
+    sink
+}
+
+/// Renders `config` into a complete Vector TOML configuration. Pure: no file, network,
+/// ROS, or Vector-process I/O — every input is already resolved (env expansion, if any,
+/// must happen before this is called; see [`expand_env`]).
+pub fn render(config: &RenderConfig) -> Result<String, RenderError> {
+    validate(config)?;
+
+    let mut root = Table::new();
+    root.insert("data_dir".into(), Value::String(config.data_dir.clone()));
+
+    let mut source = Table::new();
+    source.insert("type".into(), Value::String("fluent".into()));
+    source.insert(
+        "address".into(),
+        Value::String(config.forward_addr.to_string()),
+    );
+    let mut sources = Table::new();
+    sources.insert(SOURCE_ID.into(), Value::Table(source));
+    root.insert("sources".into(), Value::Table(sources));
+
+    let mut normalize = Table::new();
+    normalize.insert("type".into(), Value::String("remap".into()));
+    normalize.insert(
+        "inputs".into(),
+        Value::Array(vec![Value::String(SOURCE_ID.into())]),
+    );
+    normalize.insert(
+        "source".into(),
+        Value::String(render_normalize_source(config)),
+    );
+
+    let mut route_branches = Table::new();
+    for dest in &config.destinations {
+        let mut branch = Table::new();
+        branch.insert("type".into(), Value::String("vrl".into()));
+        branch.insert(
+            "source".into(),
+            Value::String(tag_condition(&derived_tags(&dest.inputs))),
+        );
+        route_branches.insert(dest.name.clone(), Value::Table(branch));
+    }
+    let mut route = Table::new();
+    route.insert("type".into(), Value::String("route".into()));
+    route.insert(
+        "inputs".into(),
+        Value::Array(vec![Value::String(NORMALIZE_TRANSFORM_ID.into())]),
+    );
+    // Every Record the Bridge forwards belongs to some Destination's `inputs`, so an
+    // unmatched branch should never fire in practice; discard rather than expose an
+    // `_unmatched` output nothing is meant to consume.
+    route.insert("reroute_unmatched".into(), Value::Boolean(false));
+    route.insert("route".into(), Value::Table(route_branches));
+
+    let mut transforms = Table::new();
+    transforms.insert(NORMALIZE_TRANSFORM_ID.into(), Value::Table(normalize));
+    transforms.insert(ROUTE_TRANSFORM_ID.into(), Value::Table(route));
+    root.insert("transforms".into(), Value::Table(transforms));
+
+    let mut sinks = Table::new();
+    for dest in &config.destinations {
+        sinks.insert(dest.name.clone(), Value::Table(render_sink(config, dest)));
+    }
+    root.insert("sinks".into(), Value::Table(sinks));
+
+    toml::to_string_pretty(&Value::Table(root)).map_err(|e| RenderError::Serialize(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn postgres_destination(name: &str, inputs: &[&str], time_format: TimeFormat) -> Destination {
+        Destination {
+            name: name.to_string(),
+            receives: Receives::Records,
+            inputs: inputs.iter().map(|s| s.to_string()).collect(),
+            kind: DestinationKind::Postgres(PostgresParams {
+                host: "127.0.0.1".to_string(),
+                port: 5432,
+                user: "dc".to_string(),
+                password: "hunter2".to_string(),
+                database: "dc".to_string(),
+                table: "dc".to_string(),
+                time_key: "date".to_string(),
+                time_format,
+            }),
+        }
+    }
+
+    fn basic_config(time_format: TimeFormat) -> RenderConfig {
+        RenderConfig {
+            forward_addr: "127.0.0.1:24224".parse().unwrap(),
+            data_dir: "/home/dc/.dc/buffer".to_string(),
+            buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
+            destinations: vec![postgres_destination(
+                "pgsql",
+                &["/dc/group/robot"],
+                time_format,
+            )],
+        }
+    }
+
+    fn parsed(output: &str) -> toml::Table {
+        output.parse().expect("rendered config must be valid TOML")
+    }
+
+    #[test]
+    fn renders_source_transform_route_and_sink_for_a_single_postgres_destination() {
+        let rendered = render(&basic_config(TimeFormat::Double)).unwrap();
+        let parsed_matches = parsed(&rendered);
+        insta_free_assert(
+            &parsed_matches,
+            include_str!("../tests/fixtures/render/basic_double.toml"),
+        );
+    }
+
+    #[test]
+    fn iso8601_time_format_renders_a_format_timestamp_call() {
+        let rendered = render(&basic_config(TimeFormat::Iso8601)).unwrap();
+        let parsed_matches = parsed(&rendered);
+        insta_free_assert(
+            &parsed_matches,
+            include_str!("../tests/fixtures/render/iso8601.toml"),
+        );
+    }
+
+    #[test]
+    fn multiple_destinations_each_get_their_own_dc_dot_tag_route_and_sink() {
+        let config = RenderConfig {
+            forward_addr: "127.0.0.1:24224".parse().unwrap(),
+            data_dir: "/home/dc/.dc/buffer".to_string(),
+            buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
+            destinations: vec![
+                postgres_destination("pgsql", &["/dc/group/robot"], TimeFormat::Double),
+                postgres_destination(
+                    "pgsql_archive",
+                    &["/dc/measurement/uptime"],
+                    TimeFormat::Iso8601,
+                ),
+            ],
+        };
+        let rendered = render(&config).unwrap();
+        let parsed_matches = parsed(&rendered);
+        insta_free_assert(
+            &parsed_matches,
+            include_str!("../tests/fixtures/render/multiple_destinations.toml"),
+        );
+    }
+
+    /// Gold-file comparison via parsed `toml::Table` equality rather than raw string
+    /// equality, so incidental key-ordering/formatting differences in `toml`'s
+    /// pretty-printer don't make these tests brittle.
+    fn insta_free_assert(actual: &toml::Table, expected_fixture: &str) {
+        let expected: toml::Table = expected_fixture
+            .parse()
+            .expect("fixture file must be valid TOML");
+        assert_eq!(actual, &expected);
+    }
+
+    #[test]
+    fn tag_routes_are_rendered_under_dc_dot_name_exactly() {
+        let rendered = render(&basic_config(TimeFormat::Double)).unwrap();
+        let parsed = parsed(&rendered);
+        let sink = parsed["sinks"]["pgsql"].as_table().unwrap();
+        assert_eq!(
+            sink["inputs"].as_array().unwrap(),
+            &[Value::String("dc.pgsql".to_string())]
+        );
+        let route = parsed["transforms"]["dc"].as_table().unwrap();
+        assert!(route["route"].as_table().unwrap().contains_key("pgsql"));
+    }
+
+    #[test]
+    fn rejects_empty_destinations() {
+        let config = RenderConfig {
+            forward_addr: "127.0.0.1:24224".parse().unwrap(),
+            data_dir: "/home/dc/.dc/buffer".to_string(),
+            buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
+            destinations: vec![],
+        };
+        assert_eq!(render(&config), Err(RenderError::NoDestinations));
+    }
+
+    #[test]
+    fn rejects_empty_data_dir() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.data_dir = "".to_string();
+        assert_eq!(render(&config), Err(RenderError::EmptyDataDir));
+    }
+
+    #[test]
+    fn rejects_a_too_small_disk_buffer() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.buffer_max_bytes = 1024;
+        assert_eq!(render(&config), Err(RenderError::BufferTooSmall(1024)));
+    }
+
+    #[test]
+    fn rejects_empty_inputs() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.destinations[0].inputs = vec![];
+        assert_eq!(
+            render(&config),
+            Err(RenderError::EmptyInputs("pgsql".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_destination_names() {
+        let mut config = basic_config(TimeFormat::Double);
+        let dup = config.destinations[0].clone();
+        config.destinations.push(dup);
+        assert_eq!(
+            render(&config),
+            Err(RenderError::DuplicateDestination("pgsql".to_string()))
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_destination_names() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.destinations[0].name = "pg-sql!".to_string();
+        assert_eq!(
+            render(&config),
+            Err(RenderError::InvalidDestinationName("pg-sql!".to_string()))
+        );
+    }
+
+    #[test]
+    fn destination_from_raw_rejects_an_unsupported_blessed_type() {
+        let err = destination_from_raw(
+            "archive",
+            "mongodb",
+            "records",
+            vec!["/dc/group/robot".to_string()],
+            RawPostgresParams::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::UnsupportedType("archive".to_string(), "mongodb".to_string())
+        );
+    }
+
+    #[test]
+    fn destination_from_raw_rejects_receives_files_clearly_for_now() {
+        let err = destination_from_raw(
+            "archive",
+            "postgres",
+            "files",
+            vec!["/dc/measurement/map".to_string()],
+            RawPostgresParams::default(),
+        )
+        .unwrap_err();
+        assert_eq!(err, RenderError::FilesNotSupported("archive".to_string()));
+    }
+
+    #[test]
+    fn destination_from_raw_rejects_an_invalid_receives_value() {
+        let err = destination_from_raw(
+            "archive",
+            "postgres",
+            "bogus",
+            vec!["/dc/measurement/map".to_string()],
+            RawPostgresParams::default(),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::InvalidReceives("archive".to_string(), "bogus".to_string())
+        );
+    }
+
+    #[test]
+    fn postgres_from_raw_rejects_missing_required_fields() {
+        let err = PostgresParams::from_raw(
+            "pgsql",
+            RawPostgresParams {
+                user: Some("dc"),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::MissingField("pgsql".to_string(), "password".to_string())
+        );
+    }
+
+    #[test]
+    fn postgres_from_raw_rejects_an_invalid_time_format() {
+        let err = PostgresParams::from_raw(
+            "pgsql",
+            RawPostgresParams {
+                user: Some("dc"),
+                password: Some("secret"),
+                database: Some("dc"),
+                table: Some("dc"),
+                time_format: Some("rfc2822"),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::InvalidTimeFormat("pgsql".to_string(), "rfc2822".to_string())
+        );
+    }
+
+    #[test]
+    fn postgres_from_raw_rejects_an_out_of_range_port() {
+        let err = PostgresParams::from_raw(
+            "pgsql",
+            RawPostgresParams {
+                user: Some("dc"),
+                password: Some("secret"),
+                database: Some("dc"),
+                table: Some("dc"),
+                port: Some(70000),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, RenderError::InvalidPort("pgsql".to_string(), 70000));
+    }
+
+    #[test]
+    fn postgres_from_raw_applies_documented_defaults() {
+        let params = PostgresParams::from_raw(
+            "pgsql",
+            RawPostgresParams {
+                user: Some("dc"),
+                password: Some("secret"),
+                database: Some("dc"),
+                table: Some("dc"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(params.host, "127.0.0.1");
+        assert_eq!(params.port, 5432);
+        assert_eq!(params.time_key, "date");
+        assert_eq!(params.time_format, TimeFormat::Double);
+    }
+
+    #[test]
+    fn expand_env_substitutes_dollar_name_and_braced_form() {
+        let mut env = HashMap::new();
+        env.insert("HOME".to_string(), "/home/dc".to_string());
+        env.insert("DC_PG_PASSWORD".to_string(), "s3cr3t".to_string());
+
+        assert_eq!(
+            expand_env("$HOME/.dc/buffer", |k| env.get(k).cloned()),
+            Ok("/home/dc/.dc/buffer".to_string())
+        );
+        assert_eq!(
+            expand_env("${DC_PG_PASSWORD}", |k| env.get(k).cloned()),
+            Ok("s3cr3t".to_string())
+        );
+    }
+
+    #[test]
+    fn expand_env_rejects_an_undefined_variable() {
+        let result = expand_env("$MISSING", |_| None);
+        assert_eq!(
+            result,
+            Err(ExpandError("MISSING".to_string(), "$MISSING".to_string()))
+        );
+    }
+
+    #[test]
+    fn percent_encodes_special_characters_in_credentials() {
+        let mut config = basic_config(TimeFormat::Double);
+        let DestinationKind::Postgres(pg) = &mut config.destinations[0].kind;
+        pg.password = "p@ss/w:rd%".to_string();
+        let rendered = render(&config).unwrap();
+        let parsed = parsed(&rendered);
+        let endpoint = parsed["sinks"]["pgsql"]["endpoint"].as_str().unwrap();
+        assert_eq!(
+            endpoint,
+            "postgres://dc:p%40ss%2Fw%3Ard%25@127.0.0.1:5432/dc"
+        );
+    }
+}

--- a/dc_bridge/dc_bridge_core/src/supervisor.rs
+++ b/dc_bridge/dc_bridge_core/src/supervisor.rs
@@ -33,6 +33,16 @@ pub struct Supervisor {
     config: SupervisorConfig,
     child: Option<Child>,
     last_exit: Option<Instant>,
+    /// Set by [`Supervisor::stop`]; once true, [`Supervisor::poll_restart`] refuses to
+    /// respawn. Without this, a caller that stops the supervised process (e.g.
+    /// `main.rs`'s SIGTERM handler, which explicitly kills Vector before exiting) races
+    /// the background thread that also calls `poll_restart` in a loop: `stop` sets
+    /// `child` to `None`, and if the next `poll_restart` tick lands before the process
+    /// actually exits, it reads that same `None` as "the process died, respawn it" and
+    /// spawns a brand-new, now-permanently-orphaned Vector — reproduced by hand (a
+    /// direct `kill -TERM` on a real, running `dc_bridge` left a freshly-spawned Vector
+    /// child reparented to init once dc_bridge itself had exited).
+    stopped: bool,
 }
 
 impl Supervisor {
@@ -41,6 +51,7 @@ impl Supervisor {
             config,
             child: None,
             last_exit: None,
+            stopped: false,
         }
     }
 
@@ -60,8 +71,13 @@ impl Supervisor {
     }
 
     /// Checks whether the supervised process has exited and, if so, restarts it
-    /// (subject to `restart_backoff`). Returns `Ok(true)` if a restart happened.
+    /// (subject to `restart_backoff`). Returns `Ok(true)` if a restart happened. A
+    /// no-op, returning `Ok(false)`, once [`Supervisor::stop`] has been called — see
+    /// the `stopped` field doc for the respawn-after-stop race this prevents.
     pub fn poll_restart(&mut self) -> io::Result<bool> {
+        if self.stopped {
+            return Ok(false);
+        }
         let exited = match &mut self.child {
             Some(child) => child.try_wait()?.is_some(),
             None => true,
@@ -81,7 +97,11 @@ impl Supervisor {
         Ok(true)
     }
 
+    /// Stops the supervised process and permanently disables future respawns from
+    /// `poll_restart` (there is no corresponding "un-stop": a `Supervisor` is only ever
+    /// stopped once, right before the owning process exits).
     pub fn stop(&mut self) {
+        self.stopped = true;
         if let Some(mut child) = self.child.take() {
             let _ = child.kill();
             let _ = child.wait();

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/basic_double.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/basic_double.toml
@@ -1,0 +1,34 @@
+data_dir = "/home/dc/.dc/buffer"
+
+[sinks.pgsql]
+endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+inputs = ["dc.pgsql"]
+table = "dc"
+type = "postgres"
+
+[sinks.pgsql.buffer]
+max_size = 268435488
+type = "disk"
+
+[sources.dc_bridge_in]
+address = "127.0.0.1:24224"
+type = "fluent"
+
+[transforms.dc]
+inputs = ["dc_bridge_normalize"]
+reroute_unmatched = false
+type = "route"
+
+[transforms.dc.route.pgsql]
+source = 'includes(["dc.group.robot"], .tag)'
+type = "vrl"
+
+[transforms.dc_bridge_normalize]
+inputs = ["dc_bridge_in"]
+source = """
+if includes(["dc.group.robot"], .tag) {
+  .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+}
+"""
+type = "remap"
+

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/iso8601.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/iso8601.toml
@@ -1,0 +1,34 @@
+data_dir = "/home/dc/.dc/buffer"
+
+[sinks.pgsql]
+endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+inputs = ["dc.pgsql"]
+table = "dc"
+type = "postgres"
+
+[sinks.pgsql.buffer]
+max_size = 268435488
+type = "disk"
+
+[sources.dc_bridge_in]
+address = "127.0.0.1:24224"
+type = "fluent"
+
+[transforms.dc]
+inputs = ["dc_bridge_normalize"]
+reroute_unmatched = false
+type = "route"
+
+[transforms.dc.route.pgsql]
+source = 'includes(["dc.group.robot"], .tag)'
+type = "vrl"
+
+[transforms.dc_bridge_normalize]
+inputs = ["dc_bridge_in"]
+source = """
+if includes(["dc.group.robot"], .tag) {
+  .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
+}
+"""
+type = "remap"
+

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/multiple_destinations.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/multiple_destinations.toml
@@ -1,0 +1,51 @@
+data_dir = "/home/dc/.dc/buffer"
+
+[sinks.pgsql]
+endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+inputs = ["dc.pgsql"]
+table = "dc"
+type = "postgres"
+
+[sinks.pgsql.buffer]
+max_size = 268435488
+type = "disk"
+
+[sinks.pgsql_archive]
+endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+inputs = ["dc.pgsql_archive"]
+table = "dc"
+type = "postgres"
+
+[sinks.pgsql_archive.buffer]
+max_size = 268435488
+type = "disk"
+
+[sources.dc_bridge_in]
+address = "127.0.0.1:24224"
+type = "fluent"
+
+[transforms.dc]
+inputs = ["dc_bridge_normalize"]
+reroute_unmatched = false
+type = "route"
+
+[transforms.dc.route.pgsql]
+source = 'includes(["dc.group.robot"], .tag)'
+type = "vrl"
+
+[transforms.dc.route.pgsql_archive]
+source = 'includes(["dc.measurement.uptime"], .tag)'
+type = "vrl"
+
+[transforms.dc_bridge_normalize]
+inputs = ["dc_bridge_in"]
+source = """
+if includes(["dc.group.robot"], .tag) {
+  .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+}
+if includes(["dc.measurement.uptime"], .tag) {
+  .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
+}
+"""
+type = "remap"
+

--- a/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
+++ b/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
@@ -50,3 +50,34 @@ fn respects_restart_backoff_between_respawn_attempts() {
     // Second exit is within the (60s) backoff window, so no respawn should happen yet.
     assert!(!supervisor.poll_restart().unwrap());
 }
+
+/// Regression test for a real race hit in a live Docker verification pass (see the
+/// `stopped` field doc on `Supervisor`): `main.rs`'s SIGTERM handler calls `stop()`
+/// then exits, while a background thread independently calls `poll_restart()` in a
+/// loop. If `stop()` didn't permanently disable future respawns, a `poll_restart` tick
+/// landing right after `stop()` reads the just-cleared `child` as "the process died"
+/// and spawns a brand-new, now-permanently-orphaned replacement.
+#[test]
+fn poll_restart_never_respawns_after_stop() {
+    let mut supervisor = Supervisor::new(SupervisorConfig {
+        program: "sh".into(),
+        args: vec!["-c".to_string(), "sleep 5".to_string()],
+        restart_backoff: Duration::from_millis(0),
+    });
+
+    supervisor.start().unwrap();
+    assert!(supervisor.is_running());
+
+    supervisor.stop();
+    assert!(!supervisor.is_running());
+
+    // Simulate the background restart thread's next tick(s) racing right behind
+    // `stop()`, exactly as they do in `main.rs`.
+    for _ in 0..5 {
+        assert!(
+            !supervisor.poll_restart().unwrap(),
+            "poll_restart must never respawn once the supervisor has been stopped"
+        );
+    }
+    assert!(!supervisor.is_running());
+}

--- a/dc_bridge/src/main.rs
+++ b/dc_bridge/src/main.rs
@@ -3,6 +3,14 @@
 //! topic subscriptions and a readiness service. Only buildable inside a colcon workspace
 //! with the ros2_rust (`rclrs`) toolchain — see dc_bridge/README.md.
 //!
+//! Vector's own configuration (the Fluent Forward source, the timestamp/Tag-normalizing
+//! VRL transform, the `dc.<name>` route per Destination, and the blessed sinks
+//! themselves) is produced by `dc_bridge_core::render` (ADR-0003) from the `shipper` and
+//! `destinations` parameters below — this node's job is just to declare those
+//! parameters, expand the `$HOME`/`$DC_PG_PASSWORD`-style env references the config
+//! contract uses, and hand the result to the Supervisor. The set of topics subscribed
+//! is derived from every configured Destination's `inputs`, not a separate parameter.
+//!
 //! Built, run, and `colcon test`-covered (see tests/end_to_end.rs) in a real ROS 2
 //! Jazzy + ros2_rust Docker environment: the node locates and supervises the vendored
 //! Vector binary, the `~/ready` service answers correctly, a `StringStamped` Record
@@ -10,13 +18,17 @@
 //! Vector process stops when dc_bridge receives SIGINT/SIGTERM. See dc_bridge/README.md
 //! for the verification recipe and the three real bugs it caught.
 
+use dc_bridge_core::render::{
+    destination_from_raw, expand_env, render as render_vector_config, RawPostgresParams,
+    RenderConfig, MIN_DISK_BUFFER_BYTES,
+};
 use dc_bridge_core::{readiness, vector_config};
 use dc_bridge_core::{
-    BridgeConfig, Forwarder, ForwarderConfig, Readiness, Record, Supervisor, SupervisorConfig,
-    TopicConfig,
+    Forwarder, ForwarderConfig, Readiness, Record, Supervisor, SupervisorConfig, TopicConfig,
 };
 use dc_interfaces::msg::StringStamped;
 use rclrs::{CreateBasicExecutor, RclrsErrorFilter};
+use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
@@ -30,11 +42,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // rclrs's ParameterVariant is only implemented for Arc<str>/Arc<[Arc<str>]> (not
     // String/Vec<String>), so parameters are declared in those types and converted.
-    let topics: Arc<[Arc<str>]> = node
-        .declare_parameter("topics")
-        .default(Arc::from(Vec::<Arc<str>>::new()))
-        .mandatory()?
-        .get();
     let vector_host: Arc<str> = node
         .declare_parameter("vector_forward_host")
         .default(Arc::from("127.0.0.1"))
@@ -50,15 +57,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .default(Arc::from(""))
         .mandatory()?
         .get();
+    let forward_addr: SocketAddr = format!("{}:{}", vector_host, vector_port).parse()?;
 
-    let config = BridgeConfig {
-        topics: topics
-            .iter()
-            .map(|t| TopicConfig::new(t.to_string(), None))
-            .collect(),
-        vector_forward_addr: format!("{}:{}", vector_host, vector_port),
-    };
-    let forward_addr: SocketAddr = config.vector_forward_addr.parse()?;
+    let render_config = build_render_config(&node, forward_addr)?;
+    let rendered_vector_config = render_vector_config(&render_config)?;
 
     let vector_binary = if !vector_binary_override.is_empty() {
         PathBuf::from(vector_binary_override.to_string())
@@ -69,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
 
     let vector_config_path = std::env::temp_dir().join("dc_bridge_vector.toml");
-    std::fs::write(&vector_config_path, vector_config::render(forward_addr))?;
+    std::fs::write(&vector_config_path, rendered_vector_config)?;
 
     let supervisor = Arc::new(Mutex::new(Supervisor::new(SupervisorConfig::vector(
         vector_binary,
@@ -106,9 +108,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         forward_addr,
     ))));
 
+    // Every Destination's `inputs` topic is subscribed to exactly once, even if more
+    // than one Destination consumes it.
+    let mut subscribed_topics = BTreeSet::new();
+    for destination in &render_config.destinations {
+        for topic in &destination.inputs {
+            subscribed_topics.insert(topic.clone());
+        }
+    }
+
     // Held so subscriptions aren't dropped once out of scope; the node keeps them alive.
     let mut _subscriptions = Vec::new();
-    for topic_config in config.topics {
+    for topic in subscribed_topics {
+        let topic_config = TopicConfig::new(topic, None);
         let forwarder = forwarder.clone();
         let tag = topic_config.tag.clone();
         let subscription =
@@ -141,6 +153,130 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     executor.spin(rclrs::SpinOptions::default()).first_error()?;
     Ok(())
+}
+
+/// Declares the `shipper`/`destinations` parameters (ADR-0003's config contract) and
+/// builds the [`RenderConfig`] the config renderer needs. `$NAME`/`${NAME}` references in
+/// `shipper.data_dir` and each Postgres destination's `password` are expanded against the
+/// real process environment (`std::env::var`) here — `dc_bridge_core::render` itself
+/// never touches the environment, so it stays pure and testable without ROS or Vector.
+fn build_render_config(
+    node: &rclrs::Node,
+    forward_addr: SocketAddr,
+) -> Result<RenderConfig, Box<dyn std::error::Error>> {
+    let data_dir_raw: Arc<str> = node
+        .declare_parameter("shipper.data_dir")
+        .default(Arc::from("$HOME/.dc/buffer"))
+        .mandatory()?
+        .get();
+    let data_dir = expand_env(&data_dir_raw, |name| std::env::var(name).ok())?;
+
+    let buffer_max_bytes: i64 = node
+        .declare_parameter("shipper.buffer_max_bytes")
+        .default(MIN_DISK_BUFFER_BYTES as i64)
+        .mandatory()?
+        .get();
+
+    let destination_names: Arc<[Arc<str>]> = node
+        .declare_parameter("destinations")
+        .default(Arc::from(Vec::<Arc<str>>::new()))
+        .mandatory()?
+        .get();
+
+    let mut destinations = Vec::with_capacity(destination_names.len());
+    for name in destination_names.iter() {
+        destinations.push(declare_destination(node, name)?);
+    }
+
+    Ok(RenderConfig {
+        forward_addr,
+        data_dir,
+        buffer_max_bytes: buffer_max_bytes.max(0) as u64,
+        destinations,
+    })
+}
+
+/// Declares every `<name>.*` parameter one Destination needs and validates them into a
+/// typed `Destination` via `dc_bridge_core::render::destination_from_raw` — this is
+/// where an invalid `type`/`receives`/`time_format`, or a missing required Postgres
+/// field, turns into the clear startup error the acceptance criteria call for, rather
+/// than a confusing failure deep inside Vector.
+fn declare_destination(
+    node: &rclrs::Node,
+    name: &str,
+) -> Result<dc_bridge_core::render::Destination, Box<dyn std::error::Error>> {
+    let type_str: Arc<str> = node
+        .declare_parameter(format!("{name}.type"))
+        .default(Arc::from(""))
+        .mandatory()?
+        .get();
+    let receives_str: Arc<str> = node
+        .declare_parameter(format!("{name}.receives"))
+        .default(Arc::from("records"))
+        .mandatory()?
+        .get();
+    let inputs: Arc<[Arc<str>]> = node
+        .declare_parameter(format!("{name}.inputs"))
+        .default(Arc::from(Vec::<Arc<str>>::new()))
+        .mandatory()?
+        .get();
+
+    let host: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.host"))
+        .optional()?
+        .get();
+    let port: Option<i64> = node
+        .declare_parameter(format!("{name}.port"))
+        .optional()?
+        .get();
+    let user: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.user"))
+        .optional()?
+        .get();
+    let password_raw: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.password"))
+        .optional()?
+        .get();
+    let database: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.database"))
+        .optional()?
+        .get();
+    let table: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.table"))
+        .optional()?
+        .get();
+    let time_key: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.time_key"))
+        .optional()?
+        .get();
+    let time_format: Option<Arc<str>> = node
+        .declare_parameter(format!("{name}.time_format"))
+        .optional()?
+        .get();
+
+    let password = password_raw
+        .map(|p| expand_env(&p, |var| std::env::var(var).ok()))
+        .transpose()?;
+
+    let postgres = RawPostgresParams {
+        host: host.as_deref(),
+        port,
+        user: user.as_deref(),
+        password: password.as_deref(),
+        database: database.as_deref(),
+        table: table.as_deref(),
+        time_key: time_key.as_deref(),
+        time_format: time_format.as_deref(),
+    };
+
+    let inputs: Vec<String> = inputs.iter().map(|s| s.to_string()).collect();
+    Ok(destination_from_raw(
+        name,
+        &type_str,
+        &receives_str,
+        inputs,
+        postgres,
+    )?)
 }
 
 fn header_stamp_to_system_time(header: &std_msgs::msg::Header) -> SystemTime {

--- a/dc_bridge/tests/end_to_end.rs
+++ b/dc_bridge/tests/end_to_end.rs
@@ -1,65 +1,277 @@
-//! End-to-end workflow test for the actual ROS node: spawns the real `dc_bridge` binary
+//! End-to-end workflow tests for the actual ROS node: spawns the real `dc_bridge` binary
 //! (which locates and supervises the real vendored Vector binary), waits for the
 //! readiness service to report true, publishes a Record on a subscribed topic, and
-//! asserts it reaches Vector's console sink — automating the manual verification done
-//! for #244 (see dc_bridge/README.md) as a real `colcon test` / `cargo test`.
+//! asserts the pipeline behaves as expected — automating the manual verification done
+//! for #244/#245 (see dc_bridge/README.md) as a real `colcon test` / `cargo test`.
 //!
 //! Requires a sourced ROS 2 + rclrs environment (this is what `colcon test
 //! --packages-select dc_bridge` runs under the hood, via colcon-ros-cargo's
 //! `AmentCargoTestTask`, which is just `cargo test`); it cannot run in a plain sandbox.
+//!
+//! Since the config renderer (ADR-0003) only produces blessed-Destination sinks
+//! (`postgres` today — no more bare `console` sink to grep stdout for), every test here
+//! configures dc_bridge with one `postgres`-type destination. Two tests only need Vector
+//! to have started successfully (readiness, shutdown behavior) and work against a
+//! Postgres endpoint that need not actually be reachable; the third test verifies a
+//! Record actually lands in a real Postgres row, and skips itself with a clear message
+//! when no Postgres is reachable at the configured address, since `cargo test`/`colcon
+//! test` must still pass cleanly on machines with no Postgres container running.
 
 use dc_interfaces::msg::StringStamped;
+use postgres::{Client, NoTls};
 use rclrs::{CreateBasicExecutor, RclrsErrorFilter, SpinOptions};
-use std::io::{BufRead, BufReader};
+use std::net::{SocketAddr, TcpStream};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std_srvs::srv::{Trigger, Trigger_Request, Trigger_Response};
 
-/// Both tests in this file identify the Vector process they spawned by matching its
-/// install path system-wide (see `vector_pid`), since it's a grandchild of the test, not
-/// directly reachable via `Child`. That match can't distinguish between the two tests'
-/// own Vector instances, so they must not run concurrently (`cargo test` parallelizes
-/// tests within a binary by default).
+/// All three tests in this file identify the Vector process they spawned by matching
+/// its install path system-wide or as a direct child (see `vector_child_of`), since it's
+/// a grandchild of the test, not directly reachable via `Child`. That match can't
+/// distinguish between different tests' own Vector instances, so they must not run
+/// concurrently (`cargo test` parallelizes tests within a binary by default).
 static PROCESS_LOCK: Mutex<()> = Mutex::new(());
 
-#[test]
-fn published_record_reaches_vectors_console_sink() {
-    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    let bin = env!("CARGO_BIN_EXE_dc_bridge");
-    let mut child = Command::new(bin)
-        .args(["--ros-args", "-p", "topics:=[\"/dc/measurement/uptime\"]"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .expect("failed to spawn the dc_bridge binary under test");
+/// The Postgres address every test's rendered config points at. Matches
+/// `tools/infrastructure/docker/docker-compose.postgresql.yaml` and
+/// `dc_bringup/params/dc_params.yaml`'s `pgsql` destination.
+const PG_HOST: &str = "127.0.0.1";
+const PG_PORT: u16 = 5432;
+const PG_USER: &str = "dc";
+const PG_PASSWORD: &str = "password";
+const PG_DATABASE: &str = "dc";
+const PG_TABLE: &str = "dc";
 
-    let captured = Arc::new(Mutex::new(String::new()));
-    {
-        let stdout = child.stdout.take().expect("child stdout was not piped");
-        let captured = captured.clone();
-        std::thread::spawn(move || {
-            for line in BufReader::new(stdout).lines().map_while(Result::ok) {
-                let mut captured = captured.lock().unwrap();
-                captured.push_str(&line);
-                captured.push('\n');
+/// A fresh, unique directory per spawned `dc_bridge`, so the disk buffer Vector writes
+/// to (`shipper.data_dir`) never survives across test invocations. Vector's `Child::kill`
+/// (see `Supervisor::stop`) sends SIGKILL, so a supervised Vector never gets to flush its
+/// buffer gracefully; without a unique `data_dir` per spawn, a later test run's Vector
+/// process finds the previous run's unflushed, disk-buffered records still on disk and
+/// redelivers them on startup — a stale row lands in Postgres carrying an *older* run's
+/// timestamp but the *same* hardcoded marker value, which was observed to intermittently
+/// fail `published_record_lands_in_postgres_when_reachable`'s plausibility assertion
+/// before this was isolated per spawn.
+fn unique_data_dir() -> String {
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    std::env::temp_dir()
+        .join(format!("dc_bridge_e2e_test_{}_{n}", std::process::id()))
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// `--ros-args -p ...` flags declaring one `pgsql` postgres destination subscribed to
+/// `/dc/measurement/uptime`, matching `dc_bringup/params/dc_params.yaml`'s config
+/// contract (ADR-0003), plus a fresh `shipper.data_dir` (see `unique_data_dir`). Valid
+/// whether or not a real Postgres is listening at `PG_HOST:PG_PORT` — Vector's Fluent
+/// source (and therefore dc_bridge's readiness probe) starts independently of downstream
+/// sink connectivity.
+fn postgres_destination_args() -> Vec<String> {
+    [
+        "--ros-args",
+        "-p",
+        &format!("shipper.data_dir:={}", unique_data_dir()),
+        "-p",
+        "destinations:=[\"pgsql\"]",
+        "-p",
+        "pgsql.type:=postgres",
+        "-p",
+        "pgsql.inputs:=[\"/dc/measurement/uptime\"]",
+        "-p",
+        &format!("pgsql.host:={PG_HOST}"),
+        "-p",
+        &format!("pgsql.port:={PG_PORT}"),
+        "-p",
+        &format!("pgsql.user:={PG_USER}"),
+        "-p",
+        &format!("pgsql.password:={PG_PASSWORD}"),
+        "-p",
+        &format!("pgsql.database:={PG_DATABASE}"),
+        "-p",
+        &format!("pgsql.table:={PG_TABLE}"),
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn spawn_dc_bridge(extra_args: &[String], stdout: Stdio, stderr: Stdio) -> std::process::Child {
+    let bin = env!("CARGO_BIN_EXE_dc_bridge");
+    let mut args = postgres_destination_args();
+    args.extend(extra_args.iter().cloned());
+    Command::new(bin)
+        .args(args)
+        .stdout(stdout)
+        .stderr(stderr)
+        .spawn()
+        .expect("failed to spawn the dc_bridge binary under test")
+}
+
+/// Polls dc_bridge's `~/ready` service (a TCP-accept probe against Vector's Fluent
+/// Forward port — independent of any downstream sink's connectivity) until it reports
+/// `true` or `deadline` passes.
+fn wait_for_ready(deadline: Instant) -> bool {
+    let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
+    let mut executor = context.create_basic_executor();
+    // ROS node names may only contain alphanumerics/underscores; `ThreadId`'s `Debug`
+    // output (e.g. `ThreadId(2)`) violates that, so a nanosecond timestamp is used for
+    // uniqueness instead.
+    let node = executor
+        .create_node(&format!(
+            "dc_bridge_end_to_end_test_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+        .expect("failed to create the test node");
+    let ready_client = node
+        .create_client::<Trigger>("/dc_bridge/ready")
+        .expect("failed to create a client for /dc_bridge/ready");
+
+    let ready = Arc::new(Mutex::new(false));
+    while !*ready.lock().unwrap() && Instant::now() < deadline {
+        let ready = ready.clone();
+        let ready_client = ready_client.clone();
+        let promise = executor.commands().run(async move {
+            if ready_client.notify_on_service_ready().await.is_err() {
+                return;
+            }
+            let response: Result<Trigger_Response, _> = ready_client
+                .call(&Trigger_Request::default())
+                .unwrap()
+                .await;
+            if let Ok(response) = response {
+                *ready.lock().unwrap() = response.success;
             }
         });
+        let _ = executor
+            .spin(
+                SpinOptions::new()
+                    .until_promise_resolved(promise)
+                    .timeout(Duration::from_secs(2)),
+            )
+            .first_error();
     }
-    {
-        // Drained (not asserted on) so the child never blocks on a full stderr pipe.
-        let stderr = child.stderr.take().expect("child stderr was not piped");
-        std::thread::spawn(
-            move || {
-                for _line in BufReader::new(stderr).lines().map_while(Result::ok) {}
-            },
+    let is_ready = *ready.lock().unwrap();
+    is_ready
+}
+
+/// Since the config renderer only produces blessed-Destination sinks (ADR-0003) — no
+/// bare `console` sink to grep dc_bridge's stdout for anymore — this proves the
+/// rendered `postgres` sink config is accepted by the real Vector binary and Vector
+/// actually starts serving the Fluent source, without requiring a reachable Postgres:
+/// `~/ready` only probes the Fluent Forward port, which Vector accepts on regardless of
+/// downstream sink connectivity.
+#[test]
+fn dc_bridge_becomes_ready_with_a_configured_postgres_destination() {
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut child = spawn_dc_bridge(&[], Stdio::null(), Stdio::null());
+
+    let ready = wait_for_ready(Instant::now() + Duration::from_secs(30));
+    terminate(&mut child);
+
+    assert!(
+        ready,
+        "dc_bridge's readiness service never reported ready within 30s with a \
+         postgres-type destination configured"
+    );
+}
+
+/// rclrs has no signal handling yet, so `executor.spin()` never returns on its own;
+/// dc_bridge installs its own SIGINT/SIGTERM handler specifically to stop the Vector
+/// process it supervises before exiting (see main.rs). Without it, Vector would be
+/// orphaned and keep running after every normal shutdown (Ctrl-C, `ros2 launch`,
+/// `kill <pid>`), not just a SIGKILL (which no userspace handler can catch anyway).
+#[test]
+fn stops_the_supervised_vector_process_on_sigterm() {
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let mut child = spawn_dc_bridge(&[], Stdio::null(), Stdio::null());
+    let dc_bridge_pid = child.id();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut vector_pid = vector_child_of(dc_bridge_pid);
+    while vector_pid.is_none() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        vector_pid = vector_child_of(dc_bridge_pid);
+    }
+    let vector_pid = vector_pid
+        .expect("expected dc_bridge to have spawned a Vector child process before shutdown");
+
+    terminate(&mut child);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while is_running(vector_pid) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    assert!(
+        !is_running(vector_pid),
+        "expected dc_bridge's supervised Vector process (pid {vector_pid}) to be stopped \
+         after it received SIGTERM, but it's still running"
+    );
+}
+
+/// A quick TCP-connect probe (not a real Postgres handshake) for whether something is
+/// listening at `PG_HOST:PG_PORT` — used to skip the Postgres-backed test below with a
+/// clear message on machines with no Postgres container running, rather than making
+/// `cargo test`/`colcon test` hard-fail without one (a live Postgres, e.g. via
+/// `tools/infrastructure/docker/docker-compose.postgresql.yaml`, isn't available in
+/// every environment this runs in).
+fn postgres_reachable() -> bool {
+    let addr: SocketAddr = format!("{PG_HOST}:{PG_PORT}")
+        .parse()
+        .expect("PG_HOST:PG_PORT must parse as a socket address");
+    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+}
+
+/// Exercises the full path end-to-end against a real Postgres: spawns dc_bridge with a
+/// `postgres`-type `pgsql` destination, publishes a `StringStamped` Record on its
+/// `inputs` topic, and asserts the row actually lands in the target table with `date`
+/// populated as a plausible Unix-epoch-seconds float and `uptime_s` equal to the
+/// published value — the same demo documented in dc_bridge/README.md, automated.
+#[test]
+fn published_record_lands_in_postgres_when_reachable() {
+    if !postgres_reachable() {
+        eprintln!(
+            "skipping published_record_lands_in_postgres_when_reachable: no Postgres \
+             reachable at {PG_HOST}:{PG_PORT}; start \
+             tools/infrastructure/docker/docker-compose.postgresql.yaml (or an \
+             equivalent postgres:13 container with user/password 'dc'/'password') to \
+             run this test"
         );
+        return;
     }
+
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let mut db = Client::connect(
+        &format!(
+            "host={PG_HOST} port={PG_PORT} user={PG_USER} password={PG_PASSWORD} \
+             dbname={PG_DATABASE}"
+        ),
+        NoTls,
+    )
+    .expect("failed to connect to the test Postgres instance");
+    db.execute(&format!("DELETE FROM {PG_TABLE}"), &[])
+        .expect("failed to clear the target table before the test");
+
+    // A distinctive marker so this assertion can't pass on a stale row left over from a
+    // previous run or a concurrent demo hitting the same table.
+    const MARKER_UPTIME_S: i32 = 918_273;
+
+    let before = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
+
+    let mut child = spawn_dc_bridge(&[], Stdio::null(), Stdio::null());
 
     let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
     let mut executor = context.create_basic_executor();
     let node = executor
-        .create_node("dc_bridge_end_to_end_test")
+        .create_node("dc_bridge_end_to_end_pg_test")
         .expect("failed to create the test node");
     let ready_client = node
         .create_client::<Trigger>("/dc_bridge/ready")
@@ -69,8 +281,8 @@ fn published_record_reaches_vectors_console_sink() {
         .expect("failed to create a publisher on /dc/measurement/uptime");
 
     let ready = Arc::new(Mutex::new(false));
-    let deadline = Instant::now() + Duration::from_secs(30);
-    while !*ready.lock().unwrap() && Instant::now() < deadline {
+    let ready_deadline = Instant::now() + Duration::from_secs(30);
+    while !*ready.lock().unwrap() && Instant::now() < ready_deadline {
         let ready = ready.clone();
         let ready_client = ready_client.clone();
         let promise = executor.commands().run(async move {
@@ -98,70 +310,55 @@ fn published_record_reaches_vectors_console_sink() {
         "dc_bridge's readiness service never reported ready within 30s"
     );
 
+    // A default (zeroed) `header.stamp`, as a bare `StringStamped::default()` would
+    // have, forwards as the Unix epoch — `date` would then always be `0`, useless for
+    // the plausibility assertion below. Set a real stamp, as any actual Measurement
+    // publisher would.
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
     let mut message = StringStamped::default();
-    message.data = r#"{"uptime_s": 42}"#.to_string();
-    let publish_deadline = Instant::now() + Duration::from_secs(5);
+    message.header.stamp.sec = now.as_secs() as i32;
+    message.header.stamp.nanosec = now.subsec_nanos();
+    message.data = format!(r#"{{"uptime_s": {MARKER_UPTIME_S}}}"#);
+
+    let mut row: Option<(f64, i32)> = None;
+    let publish_deadline = Instant::now() + Duration::from_secs(20);
     while Instant::now() < publish_deadline {
         publisher
             .publish(&message)
             .expect("failed to publish the test Record");
-        if captured.lock().unwrap().contains("uptime_s") {
+        std::thread::sleep(Duration::from_millis(300));
+        let rows = db
+            .query(
+                &format!("SELECT date, uptime_s FROM {PG_TABLE} WHERE uptime_s = $1"),
+                &[&MARKER_UPTIME_S],
+            )
+            .expect("failed to query the target table");
+        if let Some(r) = rows.into_iter().next() {
+            row = Some((r.get(0), r.get(1)));
             break;
         }
-        std::thread::sleep(Duration::from_millis(200));
     }
 
-    let output = captured.lock().unwrap().clone();
-    terminate(&mut child);
-
-    assert!(
-        output.contains("\"tag\":\"dc.measurement.uptime\""),
-        "expected the Record forwarded with its topic-derived Fluent Forward tag on \
-         Vector's console sink; captured dc_bridge output:\n{output}"
-    );
-    assert!(
-        output.contains("\"uptime_s\":42"),
-        "expected the Record's JSON payload to reach Vector's console sink; captured \
-         dc_bridge output:\n{output}"
-    );
-}
-
-/// rclrs has no signal handling yet, so `executor.spin()` never returns on its own;
-/// dc_bridge installs its own SIGINT/SIGTERM handler specifically to stop the Vector
-/// process it supervises before exiting (see main.rs). Without it, Vector would be
-/// orphaned and keep running after every normal shutdown (Ctrl-C, `ros2 launch`,
-/// `kill <pid>`), not just a SIGKILL (which no userspace handler can catch anyway).
-#[test]
-fn stops_the_supervised_vector_process_on_sigterm() {
-    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-    let bin = env!("CARGO_BIN_EXE_dc_bridge");
-    let mut child = Command::new(bin)
-        .args(["--ros-args", "-p", "topics:=[\"/dc/measurement/uptime\"]"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("failed to spawn the dc_bridge binary under test");
-    let dc_bridge_pid = child.id();
-
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let mut vector_pid = vector_child_of(dc_bridge_pid);
-    while vector_pid.is_none() && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(100));
-        vector_pid = vector_child_of(dc_bridge_pid);
-    }
-    let vector_pid = vector_pid
-        .expect("expected dc_bridge to have spawned a Vector child process before shutdown");
+    let after = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
 
     terminate(&mut child);
 
-    let deadline = Instant::now() + Duration::from_secs(5);
-    while is_running(vector_pid) && Instant::now() < deadline {
-        std::thread::sleep(Duration::from_millis(100));
-    }
+    let (date, uptime_s) = row.unwrap_or_else(|| {
+        panic!(
+            "expected a row with uptime_s = {MARKER_UPTIME_S} to land in Postgres \
+             within 20s of publishing, but none appeared"
+        )
+    });
+    assert_eq!(uptime_s, MARKER_UPTIME_S);
     assert!(
-        !is_running(vector_pid),
-        "expected dc_bridge's supervised Vector process (pid {vector_pid}) to be stopped \
-         after it received SIGTERM, but it's still running"
+        date >= before - 1.0 && date <= after + 1.0,
+        "expected `date` ({date}) to be a plausible Unix-epoch-seconds timestamp \
+         between {before} and {after}"
     );
 }
 

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -8,6 +8,23 @@ measurement_server:
 
 dc_bridge:
   ros__parameters:
-    topics: ["/dc/measurement/uptime"]
+    # ADR-0003 config contract: the config renderer (dc_bridge_core::render) turns
+    # `shipper`/`destinations` into a complete Vector config. `pgsql` here matches
+    # tools/infrastructure/docker/docker-compose.postgresql.yaml's credentials.
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["pgsql"]
+    pgsql:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc"
+      time_key: "date"
+      time_format: "double"
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224

--- a/progress.txt
+++ b/progress.txt
@@ -261,3 +261,112 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
 - `dc_bridge/README.md` and the `main.rs` module doc comment updated to describe the
   test file, the three real bugs found in this environment (adding the Vector-orphaning
   one to the two from the original pass), and the shutdown behavior.
+
+### #245 - DC 2.0 S4: Config renderer + PostgreSQL blessed destination
+
+- Added `dc_bridge_core::render` (`dc_bridge/dc_bridge_core/src/render.rs`, new module):
+  a pure, I/O-free config renderer (ADR-0003) mapping the unified `shipper`/
+  `destinations` ROS parameter contract to a complete Vector TOML config — a `fluent`
+  source; one `remap` (VRL) transform that normalizes each blessed destination's
+  timestamp into its `time_key` per `time_format` (`double` = Unix epoch seconds as an
+  f64, `iso8601` = `%Y-%m-%dT%H:%M:%S%.9f`), replacing the Humble-era chained Lua filters
+  (`dc_destinations/include/dc_destinations/flb_destination.hpp` on `humble`); one
+  `route` transform literally named `dc`, so Vector's own `<transform_id>.<route_id>`
+  addressing convention gives every Destination a stable `dc.<name>` output for free
+  (ADR-0003's passthrough contract) — verified this addressing scheme, and the VRL
+  itself, against the real vendored Vector 0.57.0 binary (`vector vrl`, `vector validate
+  --no-environment`) before writing any Rust; a disk buffer (`shipper.data_dir`,
+  Vector's own documented ~256 MiB `postgres`-sink minimum, `MIN_DISK_BUFFER_BYTES`); and
+  a `postgres`-type sink per destination (`postgres://user:pass@host:port/db`, with
+  byte-wise percent-encoding of user/password so arbitrary credential characters can't
+  corrupt the URI). Only `postgres` is implemented; `s3`/`file`/`console` are reserved
+  blessed-type names that reject clearly (`RenderError::UnsupportedType`) until their
+  own issues land.
+- Two pure, independently-testable layers: `destination_from_raw`/
+  `PostgresParams::from_raw` validate the flat, stringly-typed values ROS parameters
+  naturally give (`<name>.type`, `<name>.host`, …) into typed config — this is where
+  every "invalid-parameter rejection" acceptance criterion (unknown `type`, bad
+  `time_format`/`receives`, missing required field, out-of-range port, empty
+  `inputs`/`destinations`, duplicate/invalid destination names, an undersized disk
+  buffer) becomes a `RenderError` variant with its own test; `render` turns an
+  already-validated `RenderConfig` into the Vector TOML text. `expand_env` implements
+  the `$NAME`/`${NAME}` expansion `shipper.data_dir` and each destination's `password`
+  use, via an injected lookup closure rather than reading the real environment, so it
+  stays pure/deterministic under test.
+- 36 new tests in `dc_bridge_core` (37 after the Supervisor fix below), including
+  gold-file tests comparing rendered TOML — parsed as `toml::Table` so incidental
+  formatting differences don't make them brittle — against checked-in fixtures under
+  `dc_bridge/dc_bridge_core/tests/fixtures/render/*.toml` (`basic_double.toml`,
+  `iso8601.toml`, `multiple_destinations.toml`), generated from the renderer's own real
+  output (not hand-typed) so they can't silently drift from what the code actually
+  produces. All pass with plain `cargo test` (no ROS/Vector/Postgres needed); `cargo
+  clippy --all-targets -- -D warnings` and `cargo fmt --check` are clean.
+- Wired into `dc_bridge/src/main.rs`: declares `shipper.data_dir`,
+  `shipper.buffer_max_bytes`, `destinations` (a list of names), and per-destination
+  `<name>.type`/`<name>.receives`/`<name>.inputs`/`<name>.host`/`<name>.port`/
+  `<name>.user`/`<name>.password`/`<name>.database`/`<name>.table`/`<name>.time_key`/
+  `<name>.time_format` parameters; builds a `RenderConfig` (expanding `$HOME`/
+  `$DC_PG_PASSWORD`-style references against the real environment via `expand_env`),
+  renders it, and writes the result as Vector's config instead of the old tracer-bullet
+  `vector_config::render`. The flat `topics` parameter is gone — the Bridge now
+  subscribes to the union of every configured Destination's `inputs` topics instead.
+- Updated `dc_bringup/params/dc_params.yaml`'s `dc_bridge` block to the new `shipper`/
+  `destinations`/`pgsql` shape, pointed at `tools/infrastructure/docker/
+  docker-compose.postgresql.yaml`'s existing Postgres service (user/password/database
+  `dc`/`password`/`dc`) so the bringup demo exercises the real blessed-destination path
+  end-to-end rather than the old bare console sink. No launch-file changes were needed —
+  `dc_bringup.launch.py` already wires `dc_bridge` purely through the params file.
+- **Verified in a real ROS 2 Jazzy + ros2_rust + Postgres environment** (same Docker
+  recipe as #244, reused from that pass): `colcon build --packages-up-to dc_bridge`
+  succeeded on the first attempt with **zero changes needed to `main.rs`** — the `rclrs`
+  parameter API (`.declare_parameter(...).default(...).mandatory()?.get()` /
+  `.optional()?.get()`, `Arc<str>`/`Arc<[Arc<str>]>` types) was used correctly the first
+  time. Ran the real demo against a live Postgres 13 (`docker-compose.postgresql.yaml`'s
+  credentials, table `dc(date double precision, uptime_s integer)`): `~/ready` answered
+  `success=True`, and `ros2 topic pub --once /dc/measurement/uptime
+  dc_interfaces/msg/StringStamped "{data: '{\"uptime_s\": 42}'}"` produced a real row
+  (`date=0, uptime_s=42` — `date=0` is expected, since `ros2 topic pub` doesn't set a
+  real `header.stamp`, same caveat as the #244 console demo).
+- **Found and fixed one real bug this environment caught, in `dc_bridge_core`'s
+  `Supervisor` (not in the new renderer/main.rs code)**: `Supervisor::stop()` clears its
+  `child` and kills the process, but the background thread `main.rs` spawns also calls
+  `poll_restart()` in a loop; without a `stopped` flag, a `poll_restart` tick landing
+  right after `stop()` read the just-cleared `child` as "the process crashed" and
+  respawned a **brand-new Vector**, which then got orphaned the instant `dc_bridge`
+  itself exited right after (the SIGTERM handler calls `stop()` then
+  `std::process::exit`). Reproduced by hand twice with a direct `kill -TERM` on a live
+  process before the fix, confirmed gone after. Fixed by adding a `stopped: bool` field
+  that `poll_restart` checks and short-circuits on; added a regression test,
+  `poll_restart_never_respawns_after_stop`, in
+  `dc_bridge/dc_bridge_core/tests/supervisor_tests.rs`.
+- Rewrote `dc_bridge/tests/end_to_end.rs` (the old bare-console-sink test had nothing
+  left to assert against, since the renderer now only produces blessed-Destination
+  sinks) into three `colcon test`-integrated tests: readiness with a postgres
+  destination configured (proves Vector accepts the rendered sink config and starts,
+  without needing Postgres reachable — `~/ready` only probes the Fluent port);
+  SIGTERM-stops-the-supervised-Vector (unchanged behavior, updated to the new params);
+  and a Postgres-backed test that publishes a Record with a distinctive marker value and
+  asserts the row lands with a plausible `date` and correct value, but TCP-probes
+  `127.0.0.1:5432` first and skips itself with a clear printed message if nothing's
+  listening, so `colcon test`/`cargo test` still passes cleanly on machines with no
+  Postgres container running (explicitly confirmed both ways: stopped Postgres and
+  reran — skip message printed, suite still `3 passed`; restarted Postgres and reran —
+  all 3 passed including the DB assertion). Added `postgres = "0.19"` as a
+  `dc_bridge`-only dev-dependency (Vector, not `dc_bridge` itself, talks to Postgres in
+  production). Iterating against the real environment caught and fixed three more small
+  bugs specific to this test file (a ROS-node-naming collision from using `ThreadId`'s
+  `Debug` output, which contains characters ROS node names reject; a test message
+  defaulting `header.stamp` to zero, making the `date` plausibility assertion trivially
+  pass/fail meaninglessly; and real cross-run flakiness from every test sharing one
+  `shipper.data_dir` — since `Supervisor::stop` uses `SIGKILL`, a run's unflushed
+  disk-buffered rows survived and got redelivered by the *next* run's Vector, fixed by
+  giving every spawned `dc_bridge` a fresh `shipper.data_dir`). `colcon test
+  --packages-select dc_bridge` then passed 3/3 across 17 consecutive runs with zero
+  leftover live processes each time. `cargo clippy --all-targets -- -D warnings` and
+  `cargo fmt --check` are clean for both `dc_bridge_core` and `dc_bridge`.
+- **Not done / left for follow-up**: `s3`/`file`/`console` blessed destination types
+  (reserved names only, per this issue's scope — PostgreSQL was the one required to
+  land end-to-end); a documented/reusable dev container for this Jazzy+ros2_rust+Rust
+  toolchain (every DC 2.0 Rust-package slice so far — #242, #243, #244, and this one —
+  has rebuilt the same ad hoc Docker environment from scratch in-session, with nothing
+  checked into the repo to reuse it; worth its own follow-up issue).


### PR DESCRIPTION
## Summary

- Adds `dc_bridge_core::render` (ADR-0003): a pure, I/O-free config renderer mapping the unified `shipper`/`destinations` ROS parameter contract to a complete Vector config — the Fluent Forward source, one VRL transform normalizing each blessed destination's timestamp (`double` | `iso8601`, replacing the Humble-era chained Lua filters), a `route` transform giving every Destination a stable `dc.<name>` passthrough output, a disk buffer, and a `postgres` sink per destination. `s3`/`file`/`console` are reserved blessed-type names that reject clearly until their own issues land.
- Wires this into `dc_bridge/src/main.rs` (replacing the old flat `topics` parameter and tracer-bullet console-only config) and updates `dc_bringup`'s example params to the new contract, pointed at the repo's existing `docker-compose.postgresql.yaml` service.
- Verified against a real ROS 2 Jazzy + ros2_rust build (`colcon build`, zero changes needed to `main.rs`) and a live dockerized PostgreSQL — a published Record lands correctly in Postgres, `~/ready` still works.
- Found and fixed a real `Supervisor` bug in that environment: `stop()` didn't prevent the background restart-poller from racing in and respawning a brand-new, now-orphaned Vector process right as `dc_bridge` exited. Added a regression test.
- Rewrote the `colcon test`-integrated integration suite (`dc_bridge/tests/end_to_end.rs`) for the new blessed-sink-only config: readiness, SIGTERM shutdown, and a Postgres-backed record-lands-in-db test that skips cleanly (with a printed message) when no Postgres is reachable, so `colcon test` still passes on machines without one running.

## Test plan

- [x] `cargo test` in `dc_bridge/dc_bridge_core` — 37 passing (gold-file tests for the renderer, plus the new Supervisor regression test), no ROS/Vector/Postgres needed
- [x] `cargo clippy --all-targets -- -D warnings` / `cargo fmt --check` clean for `dc_bridge_core` and `dc_bridge`
- [x] `colcon build --packages-up-to dc_bridge` succeeds in a real Jazzy + ros2_rust environment
- [x] `colcon test --packages-select dc_bridge` — 3/3 passing across 17 consecutive runs, zero leftover processes
- [x] Manual demo: `ros2 topic pub` on `/dc/measurement/uptime` → row lands in a live Postgres with correct `date`/`uptime_s`; `~/ready` reports `success=True`
- [x] Confirmed the Postgres-backed test skips cleanly (with a clear message) when Postgres isn't running, and re-engages when it is

Closes #245

https://claude.ai/code/session_014UQjwWPjWyWtpFXTeJStWa