### PR TITLE
DC 2.0 S5: S3/file/console blessed destinations + dc.<tag> passthrough contract

### DIFF
--- a/dc_bridge/Cargo.lock
+++ b/dc_bridge/Cargo.lock
@@ -1592,6 +1592,10 @@ name = "composition_interfaces"
 version = "2.0.4"
 
 [[patch.unused]]
+name = "dc_bridge"
+version = "0.1.0"
+
+[[patch.unused]]
 name = "diagnostic_msgs"
 version = "5.3.8"
 

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -40,15 +40,18 @@ via the public per-Tag `dc.<tag>` routes documented in `doc/src/dc/destinations.
   runs `cargo test` + `cargo fmt --check` for `ament_cargo` packages, same as any other
   Cargo package) that spawn the *real* `dc_bridge` binary and `rclrs`-drive a test
   client against it: readiness with a postgres destination; the supervised Vector
-  process stopping on SIGTERM; a Record landing as a real Postgres row (skips when no
-  Postgres listens at 127.0.0.1:5432); a Record landing as an object in an
-  S3-compatible store's bucket configured purely via ROS params (verified against
-  RustFS, the recommended self-hosted store now that MinIO's community edition is
-  archived upstream; skips when nothing listens at 127.0.0.1:9000); a
-  `custom_config_files` snippet shipping Records to an un-blessed `http` sink by
-  consuming the public `dc.<tag>` route (self-contained — the test plays the HTTP
-  server); and a colliding snippet failing dc_bridge startup loudly. This file is what
-  caught the signal-handling bug below — manual verification alone had missed it.
+  process stopping on SIGTERM; a Record landing as a real Postgres row; a Record
+  landing as an object in an S3-compatible store's bucket configured purely via ROS
+  params (verified against RustFS, the recommended self-hosted store now that MinIO's
+  community edition is archived upstream); a `custom_config_files` snippet shipping
+  Records to an un-blessed `http` sink by consuming the public `dc.<tag>` route
+  (self-contained — the test plays the HTTP server); and a colliding snippet failing
+  dc_bridge startup loudly. The store-backed tests **require** a Postgres at
+  127.0.0.1:5432 and an S3-compatible store at 127.0.0.1:9000 and hard-fail
+  immediately with setup instructions when they're missing — they deliberately never
+  skip, since libtest swallows passing tests' output and a skipped run is
+  indistinguishable from a verified one. This file is what caught the signal-handling
+  bug below — manual verification alone had missed it.
 
 ## Config renderer (ADR-0003)
 

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -41,8 +41,10 @@ via the public per-Tag `dc.<tag>` routes documented in `doc/src/dc/destinations.
   Cargo package) that spawn the *real* `dc_bridge` binary and `rclrs`-drive a test
   client against it: readiness with a postgres destination; the supervised Vector
   process stopping on SIGTERM; a Record landing as a real Postgres row (skips when no
-  Postgres listens at 127.0.0.1:5432); a Record landing as an object in a MinIO bucket
-  configured purely via ROS params (skips when no MinIO listens at 127.0.0.1:9000); a
+  Postgres listens at 127.0.0.1:5432); a Record landing as an object in an
+  S3-compatible store's bucket configured purely via ROS params (verified against
+  RustFS, the recommended self-hosted store now that MinIO's community edition is
+  archived upstream; skips when nothing listens at 127.0.0.1:9000); a
   `custom_config_files` snippet shipping Records to an un-blessed `http` sink by
   consuming the public `dc.<tag>` route (self-contained — the test plays the HTTP
   server); and a colliding snippet failing dc_bridge startup loudly. This file is what
@@ -84,7 +86,7 @@ stable public output at `dc.<tag>` (ADR-0003's passthrough contract, documented 
 in `doc/src/dc/destinations.md`) that blessed sinks and `custom_config_files` snippets
 alike consume; a disk buffer (`shipper.data_dir`, minimum ~256 MiB per Vector's own
 `postgres` sink constraint) per persistent sink; and the sinks themselves. All four
-blessed types are implemented: `postgres`, `s3` (AWS or MinIO-style custom `endpoint`),
+blessed types are implemented: `postgres`, `s3` (AWS, or a RustFS/MinIO-style custom `endpoint`),
 `file`, and `console` (no disk buffer — it's a debugging sink).
 
 Two layers, both pure and gold-file-tested (`src/render.rs`'s `#[cfg(test)]` module,

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -2,8 +2,10 @@
 
 The Bridge (ADRs 0001/0004/0006): a Rust (`rclrs`) node that subscribes to `dc_interfaces/msg/StringStamped`
 Record topics and forwards every Record to the Vector shipper over the Fluent Forward
-protocol. This package is the DC 2.0 tracer bullet proving Measurement → Bridge →
-Shipper → output end-to-end, with a console sink standing in for real Destinations.
+protocol. It renders Vector's configuration from ROS parameters for the blessed
+Destination set (`postgres`, `s3`, `file`, `console` — ADR-0003) and passes raw Vector
+snippets (`custom_config_files`) through for everything else in Vector's sink catalog,
+via the public per-Tag `dc.<tag>` routes documented in `doc/src/dc/destinations.md`.
 
 ## Layout
 
@@ -34,13 +36,17 @@ Shipper → output end-to-end, with a console sink standing in for real Destinat
   below — rclrs doesn't do this on its own). It depends on `rclrs`, `dc_interfaces`,
   `std_msgs`, and `std_srvs`, all only resolvable inside a colcon workspace (see below).
 
-- **`tests/end_to_end.rs`** — a `colcon test`-integrated integration test (colcon-ros-cargo
+- **`tests/end_to_end.rs`** — `colcon test`-integrated integration tests (colcon-ros-cargo
   runs `cargo test` + `cargo fmt --check` for `ament_cargo` packages, same as any other
-  Cargo package) that spawns the *real* `dc_bridge` binary and `rclrs`-drives a test
-  client against it: publishing a Record and asserting it reaches Vector's console sink,
-  and asserting the supervised Vector process actually stops when dc_bridge receives
-  SIGTERM. This is what caught the signal-handling bug below — manual verification alone
-  had missed it.
+  Cargo package) that spawn the *real* `dc_bridge` binary and `rclrs`-drive a test
+  client against it: readiness with a postgres destination; the supervised Vector
+  process stopping on SIGTERM; a Record landing as a real Postgres row (skips when no
+  Postgres listens at 127.0.0.1:5432); a Record landing as an object in a MinIO bucket
+  configured purely via ROS params (skips when no MinIO listens at 127.0.0.1:9000); a
+  `custom_config_files` snippet shipping Records to an un-blessed `http` sink by
+  consuming the public `dc.<tag>` route (self-contained — the test plays the HTTP
+  server); and a colliding snippet failing dc_bridge startup loudly. This file is what
+  caught the signal-handling bug below — manual verification alone had missed it.
 
 ## Config renderer (ADR-0003)
 
@@ -72,33 +78,42 @@ it renders: the Fluent Forward source; one `remap` (VRL) transform that normaliz
 blessed destination's timestamp field into `time_key` per `time_format` — `double`
 (Unix epoch seconds as a float) or `iso8601` (`%Y-%m-%dT%H:%M:%S%.9f`), replacing the
 Humble-era chained Lua filters (`dc_destinations/include/dc_destinations/
-flb_destination.hpp` on the `humble` branch); one `route` transform named `dc`, giving
-every Destination a stable output at `dc.<name>` (the passthrough contract other
-`custom_sinks` snippets are meant to consume, per ADR-0003) — the route's branch
-condition and the normalize transform's per-destination `if` both match on the same
-Fluent Forward tag `TopicConfig` derives from that Destination's `inputs` topics; a disk
-buffer (`shipper.data_dir`, minimum ~256 MiB per Vector's own `postgres` sink
-constraint) per sink; and the sink itself. Only `postgres` is implemented; `s3`, `file`,
-`console` are reserved blessed-type names that reject clearly (`RenderError::
-UnsupportedType`) until their own issues land.
+flb_destination.hpp` on the `humble` branch); one `route` transform named `dc` with one
+branch per distinct Tag across every Destination's `inputs`, so each Tag's Records get a
+stable public output at `dc.<tag>` (ADR-0003's passthrough contract, documented as API
+in `doc/src/dc/destinations.md`) that blessed sinks and `custom_config_files` snippets
+alike consume; a disk buffer (`shipper.data_dir`, minimum ~256 MiB per Vector's own
+`postgres` sink constraint) per persistent sink; and the sinks themselves. All four
+blessed types are implemented: `postgres`, `s3` (AWS or MinIO-style custom `endpoint`),
+`file`, and `console` (no disk buffer — it's a debugging sink).
 
 Two layers, both pure and gold-file-tested (`src/render.rs`'s `#[cfg(test)]` module,
 comparing against checked-in fixtures under `tests/fixtures/render/*.toml` via parsed
 `toml::Table` equality so incidental formatting differences don't make the tests
-brittle):
+brittle — every fixture is also `vector validate`d against the real pinned binary
+whenever it changes):
 
-- `destination_from_raw` / `PostgresParams::from_raw` validate the flat, stringly-typed
-  values ROS parameters naturally give (`<name>.type`, `<name>.host`, …) into typed
-  config — every "invalid-parameter rejection" acceptance criterion (unknown `type`,
-  bad `time_format`/`receives`, missing required field, out-of-range `port`, empty
-  `inputs`/`destinations`, duplicate/invalid destination names, an undersized disk
-  buffer) is a `RenderError` variant with its own test.
+- `destination_from_raw` (with the per-type `*Params::from_raw` constructors) validates
+  the flat, stringly-typed values ROS parameters naturally give (`<name>.type`,
+  `<name>.host`, …) into typed config — every "invalid-parameter rejection" acceptance
+  criterion (unknown `type`, bad `time_format`/`receives`, missing required field, half
+  an S3 credential pair, out-of-range `port`, empty `inputs`/`destinations`,
+  duplicate/invalid/reserved destination names, an undersized disk buffer) is a
+  `RenderError` variant with its own test.
 - `render` turns already-validated `RenderConfig` into the Vector TOML text above.
 
+`validate_custom_config_files` (also pure) checks the passthrough side: every
+`custom_config_files` snippet must parse as TOML, define at least one component, and
+not claim a component id owned by the rendered config or another snippet — so a bad
+snippet fails loudly at Bridge startup with an error naming the file. As a backstop,
+`main.rs` also runs `vector validate --no-environment` over the merged `--config` set
+(catching e.g. a snippet consuming a `dc.<tag>` route no Destination subscribes) before
+the Supervisor ever starts Vector.
+
 `expand_env` (also pure — it takes an injected lookup function rather than reading the
-real environment) implements the `$NAME`/`${NAME}` expansion `shipper.data_dir` and
-each destination's `password` use; `main.rs` is the only place that calls it with
-`std::env::var`.
+real environment) implements the `$NAME`/`${NAME}` expansion `shipper.data_dir`,
+destination credentials (`password`, `secret_access_key`), and `custom_config_files`
+paths use; `main.rs` is the only place that calls it with `std::env::var`.
 
 Run just these tests (no ROS, Vector, or Postgres needed):
 
@@ -150,6 +165,13 @@ process-supervision behavior under signals):
   explicit `ctrlc` handler (the `termination` feature, not just default SIGINT) that
   stops Vector before exiting. SIGKILL still can't be caught by any userspace handler —
   that part is an inherent, unavoidable Unix limit, not specific to this.
+- **Vector orphaned by a SIGTERM during startup**: the handler above used to be
+  installed only *after* `Supervisor::start()`, so a signal landing in between (hit
+  intermittently by `stops_the_supervised_vector_process_on_sigterm` once the startup
+  sequence also grew a `vector validate` step) killed dc_bridge via the OS default and
+  left the just-spawned Vector running. Fixed by installing the handler before the
+  first `start()` and making `Supervisor::start` a no-op after `stop()`, so the handler
+  can fire at any point of the startup sequence without leaking a process.
 
 ## Building via colcon (cargo integration)
 

--- a/dc_bridge/dc_bridge_core/src/lib.rs
+++ b/dc_bridge/dc_bridge_core/src/lib.rs
@@ -13,8 +13,9 @@ pub use config::{BridgeConfig, TopicConfig};
 pub use forwarder::{Forwarder, ForwarderConfig, ForwarderError, Record};
 pub use readiness::Readiness;
 pub use render::{
-    destination_from_raw, expand_env, render as render_vector_config, Destination, DestinationKind,
-    PostgresParams, RawPostgresParams, Receives, RenderConfig, RenderError, TimeFormat,
-    MIN_DISK_BUFFER_BYTES, ROUTE_TRANSFORM_ID,
+    destination_from_raw, expand_env, render as render_vector_config, route_output_for_tag,
+    validate_custom_config_files, CustomConfigFile, Destination, DestinationKind, FileParams,
+    PostgresParams, RawDestinationParams, Receives, RenderConfig, RenderError, S3Auth, S3Params,
+    TimeFormat, MIN_DISK_BUFFER_BYTES, ROUTE_TRANSFORM_ID,
 };
 pub use supervisor::{Supervisor, SupervisorConfig};

--- a/dc_bridge/dc_bridge_core/src/render.rs
+++ b/dc_bridge/dc_bridge_core/src/render.rs
@@ -3,22 +3,28 @@
 //! [`render`] produces Vector TOML with: the Fluent Forward source, one VRL transform
 //! that normalizes each blessed destination's timestamp field (replacing the Humble-era
 //! chained Lua filters — see `dc_destinations/include/dc_destinations/flb_destination.hpp`
-//! on the `humble` branch), one `route` transform exposing a stable `dc.<tag>` output per
-//! Destination (the passthrough contract from ADR-0003), disk-buffer settings, and the
-//! blessed sinks themselves (only `postgres` is implemented; `s3`/`file`/`console` are
-//! reserved names that reject clearly until their own issues land).
+//! on the `humble` branch), one `route` transform exposing the public per-Tag routes
+//! (the passthrough contract from ADR-0003 — see [`route_output_for_tag`]), disk-buffer
+//! settings, and the blessed sinks themselves (`postgres`, `s3`, `file`, `console`).
 //!
 //! Two layers, both pure and independently testable:
-//! - [`destination_from_raw`] / [`PostgresParams::from_raw`] turn the flat, stringly-typed
-//!   values ROS parameters naturally give us into validated, typed config — this is where
-//!   "invalid-parameter rejection with clear error messages" lives.
+//! - [`destination_from_raw`] (with the per-type `*Params::from_raw` constructors) turns
+//!   the flat, stringly-typed values ROS parameters naturally give us into validated,
+//!   typed config — this is where "invalid-parameter rejection with clear error
+//!   messages" lives.
 //! - [`render`] turns already-validated, typed [`RenderConfig`] into Vector TOML text.
 //!
+//! [`validate_custom_config_files`] checks the passthrough side of ADR-0003: raw Vector
+//! config snippets (the `custom_config_files` parameter) must parse and must not claim
+//! component ids the rendered config already owns — so a bad snippet fails loudly at
+//! Bridge startup instead of crash-looping the supervised Vector.
+//!
 //! [`expand_env`] handles the `$HOME`/`$DC_PG_PASSWORD`-style expansion the config
-//! contract uses for `shipper.data_dir` and destination passwords; it takes an injected
-//! lookup function rather than reading the real environment, so it stays pure too.
+//! contract uses for `shipper.data_dir` and destination credentials; it takes an
+//! injected lookup function rather than reading the real environment, so it stays pure
+//! too.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::fmt::Write as _;
 use std::net::SocketAddr;
 use toml::value::Table;
@@ -28,12 +34,25 @@ use crate::config::TopicConfig;
 
 const SOURCE_ID: &str = "dc_bridge_in";
 const NORMALIZE_TRANSFORM_ID: &str = "dc_bridge_normalize";
-/// The stable public route-transform id ADR-0003 fixes: each Destination's output is
-/// addressable as `dc.<name>`, the name passthrough `custom_sinks` snippets consume.
+/// The stable public route-transform id ADR-0003 fixes: combined with Vector's
+/// `<transform_id>.<route_id>` addressing convention it makes every Tag's Records
+/// addressable as `dc.<tag>` — see [`route_output_for_tag`].
 pub const ROUTE_TRANSFORM_ID: &str = "dc";
+/// Component ids the rendered config owns; Destination names and passthrough snippets
+/// must not claim them.
+const RESERVED_COMPONENT_IDS: [&str; 3] = [SOURCE_ID, NORMALIZE_TRANSFORM_ID, ROUTE_TRANSFORM_ID];
 /// Vector rejects a disk buffer's `max_size` below this (~256 MiB); see the `postgres`
 /// sink reference docs.
 pub const MIN_DISK_BUFFER_BYTES: u64 = 268_435_488;
+
+/// The public Shipper route name a Tag's Records are exposed under — ADR-0003's
+/// passthrough contract, documented as API in `doc/src/dc/destinations.md`. The Tag for
+/// topic `/dc/measurement/uptime` is `dc.measurement.uptime`, so its route is
+/// `dc.dc.measurement.uptime`: the leading `dc.` names the route transform, the rest is
+/// the Tag verbatim.
+pub fn route_output_for_tag(tag: &str) -> String {
+    format!("{ROUTE_TRANSFORM_ID}.{tag}")
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct RenderConfig {
@@ -50,6 +69,9 @@ pub struct Destination {
     /// ROS topic names feeding this Destination; the Fluent Forward tag each one is
     /// routed under is derived the same way `TopicConfig` derives it for subscriptions.
     pub inputs: Vec<String>,
+    /// Event field the normalized timestamp is written to before routing.
+    pub time_key: String,
+    pub time_format: TimeFormat,
     pub kind: DestinationKind,
 }
 
@@ -62,6 +84,9 @@ pub enum Receives {
 #[derive(Debug, Clone, PartialEq)]
 pub enum DestinationKind {
     Postgres(PostgresParams),
+    S3(S3Params),
+    File(FileParams),
+    Console,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -78,8 +103,37 @@ pub struct PostgresParams {
     pub password: String,
     pub database: String,
     pub table: String,
-    pub time_key: String,
-    pub time_format: TimeFormat,
+}
+
+/// S3-compatible object storage (`type: s3`). With only `bucket` (and usually `region`)
+/// set, credentials come from the ambient AWS environment/instance profile; a
+/// MinIO-style server takes `endpoint`, explicit `access_key_id`/`secret_access_key`,
+/// and (typically) `force_path_style: true`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct S3Params {
+    pub bucket: String,
+    pub region: Option<String>,
+    /// Custom S3-compatible endpoint URL (MinIO, Ceph RGW, …); omit for AWS.
+    pub endpoint: Option<String>,
+    pub key_prefix: Option<String>,
+    pub auth: Option<S3Auth>,
+    pub force_path_style: Option<bool>,
+    /// Maximum seconds a batch buffers before an object is written; omitted, Vector's
+    /// own default (300 s) applies.
+    pub batch_timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct S3Auth {
+    pub access_key_id: String,
+    pub secret_access_key: String,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileParams {
+    /// Output path; Vector template syntax (e.g. `/var/log/dc/records-%Y-%m-%d.log`)
+    /// is passed through untouched.
+    pub path: String,
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -92,12 +146,16 @@ pub enum RenderError {
         "destination '{0}': name must start with a letter and contain only letters, digits, or underscores"
     )]
     InvalidDestinationName(String),
+    #[error(
+        "destination '{0}': name is reserved by the DC-generated Vector config; pick another name"
+    )]
+    ReservedDestinationName(String),
     #[error("duplicate destination name '{0}'")]
     DuplicateDestination(String),
     #[error("destination '{0}': `inputs` must not be empty")]
     EmptyInputs(String),
     #[error(
-        "destination '{0}': type '{1}' is not a blessed destination type (supported: postgres; s3, file, console are reserved names not yet implemented)"
+        "destination '{0}': type '{1}' is not a blessed destination type (supported: postgres, s3, file, console; other Vector sinks are available via `custom_config_files`)"
     )]
     UnsupportedType(String, String),
     #[error("destination '{0}': receives '{1}' is invalid (expected 'records' or 'files')")]
@@ -111,72 +169,85 @@ pub enum RenderError {
     #[error("destination '{0}': port {1} is out of range (expected 1-65535)")]
     InvalidPort(String, i64),
     #[error(
+        "destination '{0}': access_key_id and secret_access_key must be set together (got only one)"
+    )]
+    IncompleteS3Auth(String),
+    #[error("destination '{0}': batch_timeout_secs {1} is invalid (expected a positive integer)")]
+    InvalidBatchTimeout(String, i64),
+    #[error(
         "shipper.buffer_max_bytes ({0}) is below Vector's disk-buffer minimum of {MIN_DISK_BUFFER_BYTES} bytes"
     )]
     BufferTooSmall(u64),
+    #[error("custom config file '{0}' is not valid TOML: {1}")]
+    CustomConfigParse(String, String),
+    #[error(
+        "custom config file '{0}' defines no sources, transforms, sinks, or enrichment tables"
+    )]
+    CustomConfigEmpty(String),
+    #[error(
+        "custom config file '{0}' defines component '{1}', which collides with a component of the DC-generated Vector config"
+    )]
+    CustomConfigReservedCollision(String, String),
+    #[error("custom config files '{0}' and '{1}' both define component '{2}'")]
+    CustomConfigDuplicate(String, String, String),
     #[error("failed to serialize the rendered config: {0}")]
     Serialize(String),
 }
 
-/// Raw, flat Postgres parameters as ROS would declare them (`<name>.host`, `<name>.port`,
-/// …). `None` means "not declared"; empty strings are treated the same as `None` so an
-/// accidentally-blank YAML value still gets a clear "missing field" error rather than a
-/// silently broken connection string.
+/// Raw, flat Destination parameters as ROS would declare them (`<name>.host`,
+/// `<name>.bucket`, …), spanning every blessed type; each type's `from_raw` picks the
+/// fields it needs. `None` means "not declared"; empty strings are treated the same as
+/// `None` so an accidentally-blank YAML value still gets a clear "missing field" error
+/// rather than a silently broken config.
 #[derive(Debug, Clone, Copy, Default)]
-pub struct RawPostgresParams<'a> {
+pub struct RawDestinationParams<'a> {
+    // Shared
+    pub time_key: Option<&'a str>,
+    pub time_format: Option<&'a str>,
+    // postgres
     pub host: Option<&'a str>,
     pub port: Option<i64>,
     pub user: Option<&'a str>,
     pub password: Option<&'a str>,
     pub database: Option<&'a str>,
     pub table: Option<&'a str>,
-    pub time_key: Option<&'a str>,
-    pub time_format: Option<&'a str>,
+    // s3
+    pub bucket: Option<&'a str>,
+    pub region: Option<&'a str>,
+    pub endpoint: Option<&'a str>,
+    pub key_prefix: Option<&'a str>,
+    pub access_key_id: Option<&'a str>,
+    pub secret_access_key: Option<&'a str>,
+    pub force_path_style: Option<bool>,
+    pub batch_timeout_secs: Option<i64>,
+    // file
+    pub path: Option<&'a str>,
+}
+
+fn required(name: &str, value: Option<&str>, field: &str) -> Result<String, RenderError> {
+    value
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .ok_or_else(|| RenderError::MissingField(name.to_string(), field.to_string()))
+}
+
+fn optional(value: Option<&str>) -> Option<String> {
+    value.filter(|s| !s.is_empty()).map(str::to_string)
 }
 
 impl PostgresParams {
-    pub fn from_raw(name: &str, raw: RawPostgresParams) -> Result<Self, RenderError> {
-        let required = |value: Option<&str>, field: &str| {
-            value
-                .filter(|s| !s.is_empty())
-                .map(str::to_string)
-                .ok_or_else(|| RenderError::MissingField(name.to_string(), field.to_string()))
-        };
+    pub fn from_raw(name: &str, raw: &RawDestinationParams) -> Result<Self, RenderError> {
+        let user = required(name, raw.user, "user")?;
+        let password = required(name, raw.password, "password")?;
+        let database = required(name, raw.database, "database")?;
+        let table = required(name, raw.table, "table")?;
 
-        let user = required(raw.user, "user")?;
-        let password = required(raw.password, "password")?;
-        let database = required(raw.database, "database")?;
-        let table = required(raw.table, "table")?;
-
-        let host = raw
-            .host
-            .filter(|s| !s.is_empty())
-            .unwrap_or("127.0.0.1")
-            .to_string();
+        let host = optional(raw.host).unwrap_or_else(|| "127.0.0.1".to_string());
         let port_raw = raw.port.unwrap_or(5432);
         let port = u16::try_from(port_raw)
             .ok()
             .filter(|p| *p != 0)
             .ok_or_else(|| RenderError::InvalidPort(name.to_string(), port_raw))?;
-        let time_key = raw
-            .time_key
-            .filter(|s| !s.is_empty())
-            .unwrap_or("date")
-            .to_string();
-        let time_format = match raw
-            .time_format
-            .filter(|s| !s.is_empty())
-            .unwrap_or("double")
-        {
-            "double" => TimeFormat::Double,
-            "iso8601" => TimeFormat::Iso8601,
-            other => {
-                return Err(RenderError::InvalidTimeFormat(
-                    name.to_string(),
-                    other.to_string(),
-                ))
-            }
-        };
 
         Ok(PostgresParams {
             host,
@@ -185,8 +256,47 @@ impl PostgresParams {
             password,
             database,
             table,
-            time_key,
-            time_format,
+        })
+    }
+}
+
+impl S3Params {
+    pub fn from_raw(name: &str, raw: &RawDestinationParams) -> Result<Self, RenderError> {
+        let bucket = required(name, raw.bucket, "bucket")?;
+        let auth = match (optional(raw.access_key_id), optional(raw.secret_access_key)) {
+            (Some(access_key_id), Some(secret_access_key)) => Some(S3Auth {
+                access_key_id,
+                secret_access_key,
+            }),
+            (None, None) => None,
+            _ => return Err(RenderError::IncompleteS3Auth(name.to_string())),
+        };
+        let batch_timeout_secs = raw
+            .batch_timeout_secs
+            .map(|secs| {
+                u64::try_from(secs)
+                    .ok()
+                    .filter(|s| *s > 0)
+                    .ok_or(RenderError::InvalidBatchTimeout(name.to_string(), secs))
+            })
+            .transpose()?;
+
+        Ok(S3Params {
+            bucket,
+            region: optional(raw.region),
+            endpoint: optional(raw.endpoint),
+            key_prefix: optional(raw.key_prefix),
+            auth,
+            force_path_style: raw.force_path_style,
+            batch_timeout_secs,
+        })
+    }
+}
+
+impl FileParams {
+    pub fn from_raw(name: &str, raw: &RawDestinationParams) -> Result<Self, RenderError> {
+        Ok(FileParams {
+            path: required(name, raw.path, "path")?,
         })
     }
 }
@@ -199,7 +309,7 @@ pub fn destination_from_raw(
     type_str: &str,
     receives_str: &str,
     inputs: Vec<String>,
-    postgres: RawPostgresParams,
+    raw: RawDestinationParams,
 ) -> Result<Destination, RenderError> {
     let receives = match receives_str {
         "records" => Receives::Records,
@@ -215,8 +325,27 @@ pub fn destination_from_raw(
         return Err(RenderError::FilesNotSupported(name.to_string()));
     }
 
+    let time_key = optional(raw.time_key).unwrap_or_else(|| "date".to_string());
+    let time_format = match raw
+        .time_format
+        .filter(|s| !s.is_empty())
+        .unwrap_or("double")
+    {
+        "double" => TimeFormat::Double,
+        "iso8601" => TimeFormat::Iso8601,
+        other => {
+            return Err(RenderError::InvalidTimeFormat(
+                name.to_string(),
+                other.to_string(),
+            ))
+        }
+    };
+
     let kind = match type_str {
-        "postgres" => DestinationKind::Postgres(PostgresParams::from_raw(name, postgres)?),
+        "postgres" => DestinationKind::Postgres(PostgresParams::from_raw(name, &raw)?),
+        "s3" => DestinationKind::S3(S3Params::from_raw(name, &raw)?),
+        "file" => DestinationKind::File(FileParams::from_raw(name, &raw)?),
+        "console" => DestinationKind::Console,
         other => {
             return Err(RenderError::UnsupportedType(
                 name.to_string(),
@@ -229,6 +358,8 @@ pub fn destination_from_raw(
         name: name.to_string(),
         receives,
         inputs,
+        time_key,
+        time_format,
         kind,
     })
 }
@@ -303,6 +434,9 @@ fn validate(config: &RenderConfig) -> Result<(), RenderError> {
         if !is_valid_destination_name(&dest.name) {
             return Err(RenderError::InvalidDestinationName(dest.name.clone()));
         }
+        if RESERVED_COMPONENT_IDS.contains(&dest.name.as_str()) {
+            return Err(RenderError::ReservedDestinationName(dest.name.clone()));
+        }
         if !seen.insert(dest.name.as_str()) {
             return Err(RenderError::DuplicateDestination(dest.name.clone()));
         }
@@ -316,10 +450,81 @@ fn validate(config: &RenderConfig) -> Result<(), RenderError> {
     Ok(())
 }
 
+/// The component ids the rendered config claims for itself: the fixed
+/// source/transform ids plus one sink per Destination.
+fn rendered_component_ids(config: &RenderConfig) -> BTreeSet<String> {
+    RESERVED_COMPONENT_IDS
+        .iter()
+        .map(|id| id.to_string())
+        .chain(config.destinations.iter().map(|d| d.name.clone()))
+        .collect()
+}
+
+/// One raw Vector config snippet from the `custom_config_files` parameter: `path` is
+/// only used in error messages, `content` is the file's TOML text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomConfigFile {
+    pub path: String,
+    pub content: String,
+}
+
+/// Validates passthrough snippets (ADR-0003) against the rendered config: each must be
+/// valid TOML, define at least one component, and no component id may collide with the
+/// DC-generated config or another snippet — Vector would reject the merged config
+/// anyway, but this turns it into a clear Bridge startup error naming the offending
+/// file instead of a supervised-Vector crash loop.
+pub fn validate_custom_config_files(
+    config: &RenderConfig,
+    files: &[CustomConfigFile],
+) -> Result<(), RenderError> {
+    let mut owners: BTreeMap<String, Option<String>> = rendered_component_ids(config)
+        .into_iter()
+        .map(|id| (id, None))
+        .collect();
+
+    for file in files {
+        let parsed: Table = file.content.parse().map_err(|e: toml::de::Error| {
+            RenderError::CustomConfigParse(file.path.clone(), e.to_string())
+        })?;
+
+        let mut component_ids = Vec::new();
+        for section in ["sources", "transforms", "sinks", "enrichment_tables"] {
+            if let Some(Value::Table(components)) = parsed.get(section) {
+                component_ids.extend(components.keys().cloned());
+            }
+        }
+        if component_ids.is_empty() {
+            return Err(RenderError::CustomConfigEmpty(file.path.clone()));
+        }
+
+        for id in component_ids {
+            match owners.get(&id) {
+                Some(None) => {
+                    return Err(RenderError::CustomConfigReservedCollision(
+                        file.path.clone(),
+                        id,
+                    ))
+                }
+                Some(Some(other_path)) => {
+                    return Err(RenderError::CustomConfigDuplicate(
+                        other_path.clone(),
+                        file.path.clone(),
+                        id,
+                    ))
+                }
+                None => {
+                    owners.insert(id, Some(file.path.clone()));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// The Fluent Forward tags a Destination's `inputs` topics are subscribed/forwarded
 /// under — the same derivation `TopicConfig` uses, kept in lock-step so the rendered
 /// `route`/`remap` conditions actually match what the Bridge forwards.
-fn derived_tags(inputs: &[String]) -> Vec<String> {
+fn derived_tags(inputs: &[String]) -> BTreeSet<String> {
     inputs
         .iter()
         .map(|topic| TopicConfig::new(topic.clone(), None).tag)
@@ -327,7 +532,7 @@ fn derived_tags(inputs: &[String]) -> Vec<String> {
 }
 
 /// A VRL `includes([...], .tag)` condition matching any of `tags`.
-fn tag_condition(tags: &[String]) -> String {
+fn tag_condition(tags: &BTreeSet<String>) -> String {
     let quoted: Vec<String> = tags.iter().map(|t| format!("{:?}", t)).collect();
     format!("includes([{}], .tag)", quoted.join(", "))
 }
@@ -335,20 +540,19 @@ fn tag_condition(tags: &[String]) -> String {
 fn render_normalize_source(config: &RenderConfig) -> String {
     let mut out = String::new();
     for dest in &config.destinations {
-        let DestinationKind::Postgres(pg) = &dest.kind;
         let cond = tag_condition(&derived_tags(&dest.inputs));
         writeln!(out, "if {cond} {{").unwrap();
-        match pg.time_format {
+        match dest.time_format {
             TimeFormat::Double => writeln!(
                 out,
                 "  .{key} = to_float(to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")) / 1000000000.0",
-                key = pg.time_key
+                key = dest.time_key
             )
             .unwrap(),
             TimeFormat::Iso8601 => writeln!(
                 out,
                 "  .{key} = format_timestamp!(.timestamp, format: \"%Y-%m-%dT%H:%M:%S%.9f\")",
-                key = pg.time_key
+                key = dest.time_key
             )
             .unwrap(),
         }
@@ -373,38 +577,102 @@ fn percent_encode_userinfo(value: &str) -> String {
     out
 }
 
-fn render_sink(config: &RenderConfig, dest: &Destination) -> Table {
-    let DestinationKind::Postgres(pg) = &dest.kind;
-    let mut sink = Table::new();
-    sink.insert("type".into(), Value::String("postgres".into()));
-    sink.insert(
-        "inputs".into(),
-        Value::Array(vec![Value::String(format!(
-            "{ROUTE_TRANSFORM_ID}.{}",
-            dest.name
-        ))]),
-    );
-    sink.insert(
-        "endpoint".into(),
-        Value::String(format!(
-            "postgres://{}:{}@{}:{}/{}",
-            percent_encode_userinfo(&pg.user),
-            percent_encode_userinfo(&pg.password),
-            pg.host,
-            pg.port,
-            pg.database,
-        )),
-    );
-    sink.insert("table".into(), Value::String(pg.table.clone()));
+/// The `dc.<tag>` route outputs feeding a Destination's sink — one per distinct Tag of
+/// its `inputs` topics.
+fn sink_inputs(dest: &Destination) -> Value {
+    Value::Array(
+        derived_tags(&dest.inputs)
+            .iter()
+            .map(|tag| Value::String(route_output_for_tag(tag)))
+            .collect(),
+    )
+}
 
+fn disk_buffer(config: &RenderConfig) -> Value {
     let mut buffer = Table::new();
     buffer.insert("type".into(), Value::String("disk".into()));
     buffer.insert(
         "max_size".into(),
         Value::Integer(config.buffer_max_bytes as i64),
     );
-    sink.insert("buffer".into(), Value::Table(buffer));
+    Value::Table(buffer)
+}
 
+fn json_encoding() -> Value {
+    let mut encoding = Table::new();
+    encoding.insert("codec".into(), Value::String("json".into()));
+    Value::Table(encoding)
+}
+
+fn render_sink(config: &RenderConfig, dest: &Destination) -> Table {
+    let mut sink = Table::new();
+    sink.insert("inputs".into(), sink_inputs(dest));
+    match &dest.kind {
+        DestinationKind::Postgres(pg) => {
+            sink.insert("type".into(), Value::String("postgres".into()));
+            sink.insert(
+                "endpoint".into(),
+                Value::String(format!(
+                    "postgres://{}:{}@{}:{}/{}",
+                    percent_encode_userinfo(&pg.user),
+                    percent_encode_userinfo(&pg.password),
+                    pg.host,
+                    pg.port,
+                    pg.database,
+                )),
+            );
+            sink.insert("table".into(), Value::String(pg.table.clone()));
+            sink.insert("buffer".into(), disk_buffer(config));
+        }
+        DestinationKind::S3(s3) => {
+            sink.insert("type".into(), Value::String("aws_s3".into()));
+            sink.insert("bucket".into(), Value::String(s3.bucket.clone()));
+            if let Some(region) = &s3.region {
+                sink.insert("region".into(), Value::String(region.clone()));
+            }
+            if let Some(endpoint) = &s3.endpoint {
+                sink.insert("endpoint".into(), Value::String(endpoint.clone()));
+            }
+            if let Some(key_prefix) = &s3.key_prefix {
+                sink.insert("key_prefix".into(), Value::String(key_prefix.clone()));
+            }
+            if let Some(force_path_style) = s3.force_path_style {
+                sink.insert("force_path_style".into(), Value::Boolean(force_path_style));
+            }
+            if let Some(auth) = &s3.auth {
+                let mut auth_table = Table::new();
+                auth_table.insert(
+                    "access_key_id".into(),
+                    Value::String(auth.access_key_id.clone()),
+                );
+                auth_table.insert(
+                    "secret_access_key".into(),
+                    Value::String(auth.secret_access_key.clone()),
+                );
+                sink.insert("auth".into(), Value::Table(auth_table));
+            }
+            if let Some(timeout) = s3.batch_timeout_secs {
+                let mut batch = Table::new();
+                batch.insert("timeout_secs".into(), Value::Integer(timeout as i64));
+                sink.insert("batch".into(), Value::Table(batch));
+            }
+            sink.insert("encoding".into(), json_encoding());
+            sink.insert("buffer".into(), disk_buffer(config));
+        }
+        DestinationKind::File(file) => {
+            sink.insert("type".into(), Value::String("file".into()));
+            sink.insert("path".into(), Value::String(file.path.clone()));
+            sink.insert("encoding".into(), json_encoding());
+            sink.insert("buffer".into(), disk_buffer(config));
+        }
+        DestinationKind::Console => {
+            sink.insert("type".into(), Value::String("console".into()));
+            sink.insert("target".into(), Value::String("stdout".into()));
+            sink.insert("encoding".into(), json_encoding());
+            // No disk buffer: console is a debugging sink; the in-memory default is
+            // the right behavior (and a disk buffer would replay old output on start).
+        }
+    }
     sink
 }
 
@@ -438,15 +706,20 @@ pub fn render(config: &RenderConfig) -> Result<String, RenderError> {
         Value::String(render_normalize_source(config)),
     );
 
+    // One route branch per distinct Tag across every Destination's `inputs` — the
+    // public `dc.<tag>` outputs of ADR-0003's passthrough contract. Blessed sinks and
+    // custom snippets alike consume them.
+    let all_tags: BTreeSet<String> = config
+        .destinations
+        .iter()
+        .flat_map(|dest| derived_tags(&dest.inputs))
+        .collect();
     let mut route_branches = Table::new();
-    for dest in &config.destinations {
+    for tag in &all_tags {
         let mut branch = Table::new();
         branch.insert("type".into(), Value::String("vrl".into()));
-        branch.insert(
-            "source".into(),
-            Value::String(tag_condition(&derived_tags(&dest.inputs))),
-        );
-        route_branches.insert(dest.name.clone(), Value::Table(branch));
+        branch.insert("source".into(), Value::String(format!(".tag == {tag:?}")));
+        route_branches.insert(tag.clone(), Value::Table(branch));
     }
     let mut route = Table::new();
     route.insert("type".into(), Value::String("route".into()));
@@ -479,88 +752,59 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn postgres_destination(name: &str, inputs: &[&str], time_format: TimeFormat) -> Destination {
+    fn destination(
+        name: &str,
+        inputs: &[&str],
+        time_format: TimeFormat,
+        kind: DestinationKind,
+    ) -> Destination {
         Destination {
             name: name.to_string(),
             receives: Receives::Records,
             inputs: inputs.iter().map(|s| s.to_string()).collect(),
-            kind: DestinationKind::Postgres(PostgresParams {
-                host: "127.0.0.1".to_string(),
-                port: 5432,
-                user: "dc".to_string(),
-                password: "hunter2".to_string(),
-                database: "dc".to_string(),
-                table: "dc".to_string(),
-                time_key: "date".to_string(),
-                time_format,
-            }),
+            time_key: "date".to_string(),
+            time_format,
+            kind,
         }
     }
 
-    fn basic_config(time_format: TimeFormat) -> RenderConfig {
+    fn postgres_kind() -> DestinationKind {
+        DestinationKind::Postgres(PostgresParams {
+            host: "127.0.0.1".to_string(),
+            port: 5432,
+            user: "dc".to_string(),
+            password: "hunter2".to_string(),
+            database: "dc".to_string(),
+            table: "dc".to_string(),
+        })
+    }
+
+    fn config_with(destinations: Vec<Destination>) -> RenderConfig {
         RenderConfig {
             forward_addr: "127.0.0.1:24224".parse().unwrap(),
             data_dir: "/home/dc/.dc/buffer".to_string(),
             buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
-            destinations: vec![postgres_destination(
-                "pgsql",
-                &["/dc/group/robot"],
-                time_format,
-            )],
+            destinations,
         }
+    }
+
+    fn basic_config(time_format: TimeFormat) -> RenderConfig {
+        config_with(vec![destination(
+            "pgsql",
+            &["/dc/group/robot"],
+            time_format,
+            postgres_kind(),
+        )])
     }
 
     fn parsed(output: &str) -> toml::Table {
         output.parse().expect("rendered config must be valid TOML")
     }
 
-    #[test]
-    fn renders_source_transform_route_and_sink_for_a_single_postgres_destination() {
-        let rendered = render(&basic_config(TimeFormat::Double)).unwrap();
-        let parsed_matches = parsed(&rendered);
-        insta_free_assert(
-            &parsed_matches,
-            include_str!("../tests/fixtures/render/basic_double.toml"),
-        );
-    }
-
-    #[test]
-    fn iso8601_time_format_renders_a_format_timestamp_call() {
-        let rendered = render(&basic_config(TimeFormat::Iso8601)).unwrap();
-        let parsed_matches = parsed(&rendered);
-        insta_free_assert(
-            &parsed_matches,
-            include_str!("../tests/fixtures/render/iso8601.toml"),
-        );
-    }
-
-    #[test]
-    fn multiple_destinations_each_get_their_own_dc_dot_tag_route_and_sink() {
-        let config = RenderConfig {
-            forward_addr: "127.0.0.1:24224".parse().unwrap(),
-            data_dir: "/home/dc/.dc/buffer".to_string(),
-            buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
-            destinations: vec![
-                postgres_destination("pgsql", &["/dc/group/robot"], TimeFormat::Double),
-                postgres_destination(
-                    "pgsql_archive",
-                    &["/dc/measurement/uptime"],
-                    TimeFormat::Iso8601,
-                ),
-            ],
-        };
-        let rendered = render(&config).unwrap();
-        let parsed_matches = parsed(&rendered);
-        insta_free_assert(
-            &parsed_matches,
-            include_str!("../tests/fixtures/render/multiple_destinations.toml"),
-        );
-    }
-
     /// Gold-file comparison via parsed `toml::Table` equality rather than raw string
     /// equality, so incidental key-ordering/formatting differences in `toml`'s
     /// pretty-printer don't make these tests brittle.
-    fn insta_free_assert(actual: &toml::Table, expected_fixture: &str) {
+    fn assert_matches_fixture(actual: &toml::Table, expected_fixture: &str) {
         let expected: toml::Table = expected_fixture
             .parse()
             .expect("fixture file must be valid TOML");
@@ -568,26 +812,187 @@ mod tests {
     }
 
     #[test]
-    fn tag_routes_are_rendered_under_dc_dot_name_exactly() {
+    fn renders_source_transform_route_and_sink_for_a_single_postgres_destination() {
         let rendered = render(&basic_config(TimeFormat::Double)).unwrap();
-        let parsed = parsed(&rendered);
-        let sink = parsed["sinks"]["pgsql"].as_table().unwrap();
-        assert_eq!(
-            sink["inputs"].as_array().unwrap(),
-            &[Value::String("dc.pgsql".to_string())]
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/basic_double.toml"),
         );
-        let route = parsed["transforms"]["dc"].as_table().unwrap();
-        assert!(route["route"].as_table().unwrap().contains_key("pgsql"));
+    }
+
+    #[test]
+    fn iso8601_time_format_renders_a_format_timestamp_call() {
+        let rendered = render(&basic_config(TimeFormat::Iso8601)).unwrap();
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/iso8601.toml"),
+        );
+    }
+
+    #[test]
+    fn multiple_destinations_share_per_tag_routes_and_get_their_own_sinks() {
+        let config = config_with(vec![
+            destination(
+                "pgsql",
+                &["/dc/group/robot"],
+                TimeFormat::Double,
+                postgres_kind(),
+            ),
+            destination(
+                "pgsql_archive",
+                &["/dc/measurement/uptime"],
+                TimeFormat::Iso8601,
+                postgres_kind(),
+            ),
+        ]);
+        let rendered = render(&config).unwrap();
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/multiple_destinations.toml"),
+        );
+    }
+
+    #[test]
+    fn renders_an_s3_destination_with_a_minio_style_custom_endpoint() {
+        let config = config_with(vec![destination(
+            "minio",
+            &["/dc/group/robot", "/dc/measurement/uptime"],
+            TimeFormat::Double,
+            DestinationKind::S3(S3Params {
+                bucket: "dc-records".to_string(),
+                region: Some("us-east-1".to_string()),
+                endpoint: Some("http://127.0.0.1:9000".to_string()),
+                key_prefix: Some("robot1/".to_string()),
+                auth: Some(S3Auth {
+                    access_key_id: "minioadmin".to_string(),
+                    secret_access_key: "minioadmin".to_string(),
+                }),
+                force_path_style: Some(true),
+                batch_timeout_secs: Some(2),
+            }),
+        )]);
+        let rendered = render(&config).unwrap();
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/s3_minio.toml"),
+        );
+    }
+
+    #[test]
+    fn renders_an_aws_s3_destination_with_ambient_credentials() {
+        let config = config_with(vec![destination(
+            "s3_archive",
+            &["/dc/group/robot"],
+            TimeFormat::Iso8601,
+            DestinationKind::S3(S3Params {
+                bucket: "dc-records".to_string(),
+                region: Some("eu-west-1".to_string()),
+                endpoint: None,
+                key_prefix: None,
+                auth: None,
+                force_path_style: None,
+                batch_timeout_secs: None,
+            }),
+        )]);
+        let rendered = render(&config).unwrap();
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/s3_aws.toml"),
+        );
+    }
+
+    #[test]
+    fn renders_file_and_console_destinations() {
+        let config = config_with(vec![
+            destination(
+                "local_log",
+                &["/dc/group/robot"],
+                TimeFormat::Double,
+                DestinationKind::File(FileParams {
+                    path: "/var/log/dc/records-%Y-%m-%d.log".to_string(),
+                }),
+            ),
+            destination(
+                "debug_console",
+                &["/dc/group/robot"],
+                TimeFormat::Double,
+                DestinationKind::Console,
+            ),
+        ]);
+        let rendered = render(&config).unwrap();
+        assert_matches_fixture(
+            &parsed(&rendered),
+            include_str!("../tests/fixtures/render/file_and_console.toml"),
+        );
+    }
+
+    #[test]
+    fn console_sink_has_no_disk_buffer() {
+        let config = config_with(vec![destination(
+            "debug_console",
+            &["/dc/group/robot"],
+            TimeFormat::Double,
+            DestinationKind::Console,
+        )]);
+        let rendered = render(&config).unwrap();
+        let parsed = parsed(&rendered);
+        let sink = parsed["sinks"]["debug_console"].as_table().unwrap();
+        assert!(!sink.contains_key("buffer"));
+    }
+
+    #[test]
+    fn routes_are_per_tag_and_sinks_consume_dc_dot_tag_outputs() {
+        let config = config_with(vec![
+            destination(
+                "pgsql",
+                &["/dc/group/robot", "/dc/measurement/uptime"],
+                TimeFormat::Double,
+                postgres_kind(),
+            ),
+            destination(
+                "debug_console",
+                &["/dc/measurement/uptime"],
+                TimeFormat::Double,
+                DestinationKind::Console,
+            ),
+        ]);
+        let rendered = render(&config).unwrap();
+        let parsed = parsed(&rendered);
+
+        let route = parsed["transforms"]["dc"]["route"].as_table().unwrap();
+        assert_eq!(
+            route.keys().collect::<Vec<_>>(),
+            vec!["dc.group.robot", "dc.measurement.uptime"]
+        );
+
+        let pgsql_inputs = parsed["sinks"]["pgsql"]["inputs"].as_array().unwrap();
+        assert_eq!(
+            pgsql_inputs,
+            &[
+                Value::String("dc.dc.group.robot".to_string()),
+                Value::String("dc.dc.measurement.uptime".to_string()),
+            ]
+        );
+        let console_inputs = parsed["sinks"]["debug_console"]["inputs"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            console_inputs,
+            &[Value::String("dc.dc.measurement.uptime".to_string())]
+        );
+    }
+
+    #[test]
+    fn route_output_for_tag_is_the_documented_public_name() {
+        assert_eq!(
+            route_output_for_tag("dc.measurement.uptime"),
+            "dc.dc.measurement.uptime"
+        );
     }
 
     #[test]
     fn rejects_empty_destinations() {
-        let config = RenderConfig {
-            forward_addr: "127.0.0.1:24224".parse().unwrap(),
-            data_dir: "/home/dc/.dc/buffer".to_string(),
-            buffer_max_bytes: MIN_DISK_BUFFER_BYTES,
-            destinations: vec![],
-        };
+        let config = config_with(vec![]);
         assert_eq!(render(&config), Err(RenderError::NoDestinations));
     }
 
@@ -637,13 +1042,26 @@ mod tests {
     }
 
     #[test]
+    fn rejects_destination_names_reserved_by_the_rendered_config() {
+        for reserved in ["dc", "dc_bridge_in", "dc_bridge_normalize"] {
+            let mut config = basic_config(TimeFormat::Double);
+            config.destinations[0].name = reserved.to_string();
+            assert_eq!(
+                render(&config),
+                Err(RenderError::ReservedDestinationName(reserved.to_string())),
+                "name '{reserved}' must be rejected"
+            );
+        }
+    }
+
+    #[test]
     fn destination_from_raw_rejects_an_unsupported_blessed_type() {
         let err = destination_from_raw(
             "archive",
             "mongodb",
             "records",
             vec!["/dc/group/robot".to_string()],
-            RawPostgresParams::default(),
+            RawDestinationParams::default(),
         )
         .unwrap_err();
         assert_eq!(
@@ -653,13 +1071,56 @@ mod tests {
     }
 
     #[test]
+    fn destination_from_raw_builds_s3_file_and_console_kinds() {
+        let s3 = destination_from_raw(
+            "minio",
+            "s3",
+            "records",
+            vec!["/dc/group/robot".to_string()],
+            RawDestinationParams {
+                bucket: Some("dc-records"),
+                endpoint: Some("http://127.0.0.1:9000"),
+                access_key_id: Some("minioadmin"),
+                secret_access_key: Some("minioadmin"),
+                force_path_style: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(matches!(s3.kind, DestinationKind::S3(_)));
+
+        let file = destination_from_raw(
+            "local_log",
+            "file",
+            "records",
+            vec!["/dc/group/robot".to_string()],
+            RawDestinationParams {
+                path: Some("/var/log/dc/records.log"),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(matches!(file.kind, DestinationKind::File(_)));
+
+        let console = destination_from_raw(
+            "debug_console",
+            "console",
+            "records",
+            vec!["/dc/group/robot".to_string()],
+            RawDestinationParams::default(),
+        )
+        .unwrap();
+        assert_eq!(console.kind, DestinationKind::Console);
+    }
+
+    #[test]
     fn destination_from_raw_rejects_receives_files_clearly_for_now() {
         let err = destination_from_raw(
             "archive",
             "postgres",
             "files",
             vec!["/dc/measurement/map".to_string()],
-            RawPostgresParams::default(),
+            RawDestinationParams::default(),
         )
         .unwrap_err();
         assert_eq!(err, RenderError::FilesNotSupported("archive".to_string()));
@@ -672,7 +1133,7 @@ mod tests {
             "postgres",
             "bogus",
             vec!["/dc/measurement/map".to_string()],
-            RawPostgresParams::default(),
+            RawDestinationParams::default(),
         )
         .unwrap_err();
         assert_eq!(
@@ -682,10 +1143,29 @@ mod tests {
     }
 
     #[test]
+    fn destination_from_raw_rejects_an_invalid_time_format() {
+        let err = destination_from_raw(
+            "debug_console",
+            "console",
+            "records",
+            vec!["/dc/measurement/map".to_string()],
+            RawDestinationParams {
+                time_format: Some("rfc2822"),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::InvalidTimeFormat("debug_console".to_string(), "rfc2822".to_string())
+        );
+    }
+
+    #[test]
     fn postgres_from_raw_rejects_missing_required_fields() {
         let err = PostgresParams::from_raw(
             "pgsql",
-            RawPostgresParams {
+            &RawDestinationParams {
                 user: Some("dc"),
                 ..Default::default()
             },
@@ -698,30 +1178,10 @@ mod tests {
     }
 
     #[test]
-    fn postgres_from_raw_rejects_an_invalid_time_format() {
-        let err = PostgresParams::from_raw(
-            "pgsql",
-            RawPostgresParams {
-                user: Some("dc"),
-                password: Some("secret"),
-                database: Some("dc"),
-                table: Some("dc"),
-                time_format: Some("rfc2822"),
-                ..Default::default()
-            },
-        )
-        .unwrap_err();
-        assert_eq!(
-            err,
-            RenderError::InvalidTimeFormat("pgsql".to_string(), "rfc2822".to_string())
-        );
-    }
-
-    #[test]
     fn postgres_from_raw_rejects_an_out_of_range_port() {
         let err = PostgresParams::from_raw(
             "pgsql",
-            RawPostgresParams {
+            &RawDestinationParams {
                 user: Some("dc"),
                 password: Some("secret"),
                 database: Some("dc"),
@@ -738,7 +1198,7 @@ mod tests {
     fn postgres_from_raw_applies_documented_defaults() {
         let params = PostgresParams::from_raw(
             "pgsql",
-            RawPostgresParams {
+            &RawDestinationParams {
                 user: Some("dc"),
                 password: Some("secret"),
                 database: Some("dc"),
@@ -749,8 +1209,159 @@ mod tests {
         .unwrap();
         assert_eq!(params.host, "127.0.0.1");
         assert_eq!(params.port, 5432);
-        assert_eq!(params.time_key, "date");
-        assert_eq!(params.time_format, TimeFormat::Double);
+    }
+
+    #[test]
+    fn destination_from_raw_applies_time_defaults() {
+        let dest = destination_from_raw(
+            "debug_console",
+            "console",
+            "records",
+            vec!["/dc/group/robot".to_string()],
+            RawDestinationParams::default(),
+        )
+        .unwrap();
+        assert_eq!(dest.time_key, "date");
+        assert_eq!(dest.time_format, TimeFormat::Double);
+    }
+
+    #[test]
+    fn s3_from_raw_rejects_a_missing_bucket() {
+        let err = S3Params::from_raw("minio", &RawDestinationParams::default()).unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::MissingField("minio".to_string(), "bucket".to_string())
+        );
+    }
+
+    #[test]
+    fn s3_from_raw_rejects_half_a_credential_pair() {
+        let err = S3Params::from_raw(
+            "minio",
+            &RawDestinationParams {
+                bucket: Some("dc-records"),
+                access_key_id: Some("minioadmin"),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(err, RenderError::IncompleteS3Auth("minio".to_string()));
+    }
+
+    #[test]
+    fn s3_from_raw_rejects_a_non_positive_batch_timeout() {
+        let err = S3Params::from_raw(
+            "minio",
+            &RawDestinationParams {
+                bucket: Some("dc-records"),
+                batch_timeout_secs: Some(0),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::InvalidBatchTimeout("minio".to_string(), 0)
+        );
+    }
+
+    #[test]
+    fn file_from_raw_rejects_a_missing_path() {
+        let err = FileParams::from_raw("local_log", &RawDestinationParams::default()).unwrap_err();
+        assert_eq!(
+            err,
+            RenderError::MissingField("local_log".to_string(), "path".to_string())
+        );
+    }
+
+    #[test]
+    fn custom_config_files_pass_when_they_define_fresh_components() {
+        let config = basic_config(TimeFormat::Double);
+        let files = vec![CustomConfigFile {
+            path: "/etc/dc/http.toml".to_string(),
+            content: r#"
+[sinks.my_http]
+type = "http"
+inputs = ["dc.dc.group.robot"]
+uri = "http://127.0.0.1:8080/ingest"
+encoding.codec = "json"
+"#
+            .to_string(),
+        }];
+        assert_eq!(validate_custom_config_files(&config, &files), Ok(()));
+    }
+
+    #[test]
+    fn custom_config_files_reject_invalid_toml() {
+        let config = basic_config(TimeFormat::Double);
+        let files = vec![CustomConfigFile {
+            path: "/etc/dc/broken.toml".to_string(),
+            content: "[sinks.broken\ntype =".to_string(),
+        }];
+        assert!(matches!(
+            validate_custom_config_files(&config, &files),
+            Err(RenderError::CustomConfigParse(path, _)) if path == "/etc/dc/broken.toml"
+        ));
+    }
+
+    #[test]
+    fn custom_config_files_reject_an_empty_snippet() {
+        let config = basic_config(TimeFormat::Double);
+        let files = vec![CustomConfigFile {
+            path: "/etc/dc/empty.toml".to_string(),
+            content: "# nothing here\n".to_string(),
+        }];
+        assert_eq!(
+            validate_custom_config_files(&config, &files),
+            Err(RenderError::CustomConfigEmpty(
+                "/etc/dc/empty.toml".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn custom_config_files_reject_collisions_with_rendered_components() {
+        let config = basic_config(TimeFormat::Double);
+        for id in ["pgsql", "dc", "dc_bridge_in", "dc_bridge_normalize"] {
+            let files = vec![CustomConfigFile {
+                path: "/etc/dc/collide.toml".to_string(),
+                content: format!(
+                    "[sinks.{id}]\ntype = \"console\"\ninputs = [\"dc.dc.group.robot\"]\nencoding.codec = \"json\"\n"
+                ),
+            }];
+            assert_eq!(
+                validate_custom_config_files(&config, &files),
+                Err(RenderError::CustomConfigReservedCollision(
+                    "/etc/dc/collide.toml".to_string(),
+                    id.to_string()
+                )),
+                "component id '{id}' must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn custom_config_files_reject_the_same_component_in_two_snippets() {
+        let config = basic_config(TimeFormat::Double);
+        let snippet = |path: &str| CustomConfigFile {
+            path: path.to_string(),
+            content: r#"
+[sinks.my_http]
+type = "http"
+inputs = ["dc.dc.group.robot"]
+uri = "http://127.0.0.1:8080/ingest"
+encoding.codec = "json"
+"#
+            .to_string(),
+        };
+        assert_eq!(
+            validate_custom_config_files(&config, &[snippet("/a.toml"), snippet("/b.toml")]),
+            Err(RenderError::CustomConfigDuplicate(
+                "/a.toml".to_string(),
+                "/b.toml".to_string(),
+                "my_http".to_string()
+            ))
+        );
     }
 
     #[test]
@@ -781,7 +1392,9 @@ mod tests {
     #[test]
     fn percent_encodes_special_characters_in_credentials() {
         let mut config = basic_config(TimeFormat::Double);
-        let DestinationKind::Postgres(pg) = &mut config.destinations[0].kind;
+        let DestinationKind::Postgres(pg) = &mut config.destinations[0].kind else {
+            panic!("basic_config must hold a postgres destination");
+        };
         pg.password = "p@ss/w:rd%".to_string();
         let rendered = render(&config).unwrap();
         let parsed = parsed(&rendered);

--- a/dc_bridge/dc_bridge_core/src/render.rs
+++ b/dc_bridge/dc_bridge_core/src/render.rs
@@ -107,13 +107,15 @@ pub struct PostgresParams {
 
 /// S3-compatible object storage (`type: s3`). With only `bucket` (and usually `region`)
 /// set, credentials come from the ambient AWS environment/instance profile; a
-/// MinIO-style server takes `endpoint`, explicit `access_key_id`/`secret_access_key`,
-/// and (typically) `force_path_style: true`.
+/// self-hosted server (RustFS is the recommended one — MinIO's community edition was
+/// archived upstream in 2026 — but any S3-compatible store works) takes `endpoint`,
+/// explicit `access_key_id`/`secret_access_key`, and (typically)
+/// `force_path_style: true`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct S3Params {
     pub bucket: String,
     pub region: Option<String>,
-    /// Custom S3-compatible endpoint URL (MinIO, Ceph RGW, …); omit for AWS.
+    /// Custom S3-compatible endpoint URL (RustFS, MinIO, Ceph RGW, …); omit for AWS.
     pub endpoint: Option<String>,
     pub key_prefix: Option<String>,
     pub auth: Option<S3Auth>,
@@ -852,10 +854,13 @@ mod tests {
         );
     }
 
+    /// The self-hosted custom-endpoint shape (issue #246's "MinIO-style" acceptance
+    /// criterion — RustFS is the recommended store now that MinIO's community edition
+    /// is archived upstream; the rendered config is identical either way).
     #[test]
-    fn renders_an_s3_destination_with_a_minio_style_custom_endpoint() {
+    fn renders_an_s3_destination_with_a_self_hosted_custom_endpoint() {
         let config = config_with(vec![destination(
-            "minio",
+            "rustfs",
             &["/dc/group/robot", "/dc/measurement/uptime"],
             TimeFormat::Double,
             DestinationKind::S3(S3Params {
@@ -864,8 +869,8 @@ mod tests {
                 endpoint: Some("http://127.0.0.1:9000".to_string()),
                 key_prefix: Some("robot1/".to_string()),
                 auth: Some(S3Auth {
-                    access_key_id: "minioadmin".to_string(),
-                    secret_access_key: "minioadmin".to_string(),
+                    access_key_id: "rustfsadmin".to_string(),
+                    secret_access_key: "rustfsadmin".to_string(),
                 }),
                 force_path_style: Some(true),
                 batch_timeout_secs: Some(2),
@@ -874,7 +879,7 @@ mod tests {
         let rendered = render(&config).unwrap();
         assert_matches_fixture(
             &parsed(&rendered),
-            include_str!("../tests/fixtures/render/s3_minio.toml"),
+            include_str!("../tests/fixtures/render/s3_custom_endpoint.toml"),
         );
     }
 
@@ -1073,15 +1078,15 @@ mod tests {
     #[test]
     fn destination_from_raw_builds_s3_file_and_console_kinds() {
         let s3 = destination_from_raw(
-            "minio",
+            "rustfs",
             "s3",
             "records",
             vec!["/dc/group/robot".to_string()],
             RawDestinationParams {
                 bucket: Some("dc-records"),
                 endpoint: Some("http://127.0.0.1:9000"),
-                access_key_id: Some("minioadmin"),
-                secret_access_key: Some("minioadmin"),
+                access_key_id: Some("rustfsadmin"),
+                secret_access_key: Some("rustfsadmin"),
                 force_path_style: Some(true),
                 ..Default::default()
             },
@@ -1227,31 +1232,31 @@ mod tests {
 
     #[test]
     fn s3_from_raw_rejects_a_missing_bucket() {
-        let err = S3Params::from_raw("minio", &RawDestinationParams::default()).unwrap_err();
+        let err = S3Params::from_raw("rustfs", &RawDestinationParams::default()).unwrap_err();
         assert_eq!(
             err,
-            RenderError::MissingField("minio".to_string(), "bucket".to_string())
+            RenderError::MissingField("rustfs".to_string(), "bucket".to_string())
         );
     }
 
     #[test]
     fn s3_from_raw_rejects_half_a_credential_pair() {
         let err = S3Params::from_raw(
-            "minio",
+            "rustfs",
             &RawDestinationParams {
                 bucket: Some("dc-records"),
-                access_key_id: Some("minioadmin"),
+                access_key_id: Some("rustfsadmin"),
                 ..Default::default()
             },
         )
         .unwrap_err();
-        assert_eq!(err, RenderError::IncompleteS3Auth("minio".to_string()));
+        assert_eq!(err, RenderError::IncompleteS3Auth("rustfs".to_string()));
     }
 
     #[test]
     fn s3_from_raw_rejects_a_non_positive_batch_timeout() {
         let err = S3Params::from_raw(
-            "minio",
+            "rustfs",
             &RawDestinationParams {
                 bucket: Some("dc-records"),
                 batch_timeout_secs: Some(0),
@@ -1261,7 +1266,7 @@ mod tests {
         .unwrap_err();
         assert_eq!(
             err,
-            RenderError::InvalidBatchTimeout("minio".to_string(), 0)
+            RenderError::InvalidBatchTimeout("rustfs".to_string(), 0)
         );
     }
 

--- a/dc_bridge/dc_bridge_core/src/supervisor.rs
+++ b/dc_bridge/dc_bridge_core/src/supervisor.rs
@@ -17,13 +17,15 @@ pub struct SupervisorConfig {
 }
 
 impl SupervisorConfig {
-    pub fn vector(binary: PathBuf, config_path: PathBuf) -> Self {
+    /// `config_paths` is the rendered config plus any `custom_config_files` passthrough
+    /// snippets (ADR-0003) — Vector merges multiple `--config` files natively.
+    pub fn vector(binary: PathBuf, config_paths: impl IntoIterator<Item = PathBuf>) -> Self {
         Self {
             program: binary,
-            args: vec![
-                "--config".to_string(),
-                config_path.to_string_lossy().into_owned(),
-            ],
+            args: config_paths
+                .into_iter()
+                .flat_map(|path| ["--config".to_string(), path.to_string_lossy().into_owned()])
+                .collect(),
             restart_backoff: Duration::from_millis(500),
         }
     }
@@ -55,7 +57,13 @@ impl Supervisor {
         }
     }
 
+    /// Spawns the supervised process. A no-op once [`Supervisor::stop`] has been
+    /// called, so a signal handler installed *before* the first `start()` (as `main.rs`
+    /// does) can never race it into spawning a process nobody will ever stop.
     pub fn start(&mut self) -> io::Result<()> {
+        if self.stopped {
+            return Ok(());
+        }
         let child = Command::new(&self.config.program)
             .args(&self.config.args)
             .spawn()?;

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/file_and_console.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/file_and_console.toml
@@ -1,24 +1,24 @@
 data_dir = "/home/dc/.dc/buffer"
 
-[sinks.pgsql]
-endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+[sinks.debug_console]
 inputs = ["dc.dc.group.robot"]
-table = "dc"
-type = "postgres"
+target = "stdout"
+type = "console"
 
-[sinks.pgsql.buffer]
+[sinks.debug_console.encoding]
+codec = "json"
+
+[sinks.local_log]
+inputs = ["dc.dc.group.robot"]
+path = "/var/log/dc/records-%Y-%m-%d.log"
+type = "file"
+
+[sinks.local_log.buffer]
 max_size = 268435488
 type = "disk"
 
-[sinks.pgsql_archive]
-endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
-inputs = ["dc.dc.measurement.uptime"]
-table = "dc"
-type = "postgres"
-
-[sinks.pgsql_archive.buffer]
-max_size = 268435488
-type = "disk"
+[sinks.local_log.encoding]
+codec = "json"
 
 [sources.dc_bridge_in]
 address = "127.0.0.1:24224"
@@ -33,18 +33,14 @@ type = "route"
 source = '.tag == "dc.group.robot"'
 type = "vrl"
 
-[transforms.dc.route."dc.measurement.uptime"]
-source = '.tag == "dc.measurement.uptime"'
-type = "vrl"
-
 [transforms.dc_bridge_normalize]
 inputs = ["dc_bridge_in"]
 source = """
 if includes(["dc.group.robot"], .tag) {
   .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
 }
-if includes(["dc.measurement.uptime"], .tag) {
-  .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
+if includes(["dc.group.robot"], .tag) {
+  .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
 }
 """
 type = "remap"

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/iso8601.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/iso8601.toml
@@ -2,7 +2,7 @@ data_dir = "/home/dc/.dc/buffer"
 
 [sinks.pgsql]
 endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
-inputs = ["dc.pgsql"]
+inputs = ["dc.dc.group.robot"]
 table = "dc"
 type = "postgres"
 
@@ -19,8 +19,8 @@ inputs = ["dc_bridge_normalize"]
 reroute_unmatched = false
 type = "route"
 
-[transforms.dc.route.pgsql]
-source = 'includes(["dc.group.robot"], .tag)'
+[transforms.dc.route."dc.group.robot"]
+source = '.tag == "dc.group.robot"'
 type = "vrl"
 
 [transforms.dc_bridge_normalize]
@@ -31,4 +31,3 @@ if includes(["dc.group.robot"], .tag) {
 }
 """
 type = "remap"
-

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_aws.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_aws.toml
@@ -1,14 +1,17 @@
 data_dir = "/home/dc/.dc/buffer"
 
-[sinks.pgsql]
-endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
+[sinks.s3_archive]
+bucket = "dc-records"
 inputs = ["dc.dc.group.robot"]
-table = "dc"
-type = "postgres"
+region = "eu-west-1"
+type = "aws_s3"
 
-[sinks.pgsql.buffer]
+[sinks.s3_archive.buffer]
 max_size = 268435488
 type = "disk"
+
+[sinks.s3_archive.encoding]
+codec = "json"
 
 [sources.dc_bridge_in]
 address = "127.0.0.1:24224"
@@ -27,7 +30,7 @@ type = "vrl"
 inputs = ["dc_bridge_in"]
 source = """
 if includes(["dc.group.robot"], .tag) {
-  .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+  .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
 }
 """
 type = "remap"

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_custom_endpoint.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_custom_endpoint.toml
@@ -1,6 +1,6 @@
 data_dir = "/home/dc/.dc/buffer"
 
-[sinks.minio]
+[sinks.rustfs]
 bucket = "dc-records"
 endpoint = "http://127.0.0.1:9000"
 force_path_style = true
@@ -12,18 +12,18 @@ key_prefix = "robot1/"
 region = "us-east-1"
 type = "aws_s3"
 
-[sinks.minio.auth]
-access_key_id = "minioadmin"
-secret_access_key = "minioadmin"
+[sinks.rustfs.auth]
+access_key_id = "rustfsadmin"
+secret_access_key = "rustfsadmin"
 
-[sinks.minio.batch]
+[sinks.rustfs.batch]
 timeout_secs = 2
 
-[sinks.minio.buffer]
+[sinks.rustfs.buffer]
 max_size = 268435488
 type = "disk"
 
-[sinks.minio.encoding]
+[sinks.rustfs.encoding]
 codec = "json"
 
 [sources.dc_bridge_in]

--- a/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_minio.toml
+++ b/dc_bridge/dc_bridge_core/tests/fixtures/render/s3_minio.toml
@@ -1,24 +1,30 @@
 data_dir = "/home/dc/.dc/buffer"
 
-[sinks.pgsql]
-endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
-inputs = ["dc.dc.group.robot"]
-table = "dc"
-type = "postgres"
+[sinks.minio]
+bucket = "dc-records"
+endpoint = "http://127.0.0.1:9000"
+force_path_style = true
+inputs = [
+    "dc.dc.group.robot",
+    "dc.dc.measurement.uptime",
+]
+key_prefix = "robot1/"
+region = "us-east-1"
+type = "aws_s3"
 
-[sinks.pgsql.buffer]
+[sinks.minio.auth]
+access_key_id = "minioadmin"
+secret_access_key = "minioadmin"
+
+[sinks.minio.batch]
+timeout_secs = 2
+
+[sinks.minio.buffer]
 max_size = 268435488
 type = "disk"
 
-[sinks.pgsql_archive]
-endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
-inputs = ["dc.dc.measurement.uptime"]
-table = "dc"
-type = "postgres"
-
-[sinks.pgsql_archive.buffer]
-max_size = 268435488
-type = "disk"
+[sinks.minio.encoding]
+codec = "json"
 
 [sources.dc_bridge_in]
 address = "127.0.0.1:24224"
@@ -40,11 +46,8 @@ type = "vrl"
 [transforms.dc_bridge_normalize]
 inputs = ["dc_bridge_in"]
 source = """
-if includes(["dc.group.robot"], .tag) {
+if includes(["dc.group.robot", "dc.measurement.uptime"], .tag) {
   .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
-}
-if includes(["dc.measurement.uptime"], .tag) {
-  .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
 }
 """
 type = "remap"

--- a/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
+++ b/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
@@ -81,3 +81,26 @@ fn poll_restart_never_respawns_after_stop() {
     }
     assert!(!supervisor.is_running());
 }
+
+/// Companion to the test above, for the startup side of the same class of race:
+/// `main.rs` installs its SIGTERM handler *before* the first `start()`, so a signal
+/// landing during startup calls `stop()` on a supervisor that hasn't spawned anything
+/// yet — a subsequent `start()` must then be a no-op rather than spawning a process
+/// nobody will ever stop (hit for real as an intermittent `colcon test` failure of
+/// `stops_the_supervised_vector_process_on_sigterm` while the startup sequence also
+/// grew a `vector validate` step).
+#[test]
+fn start_never_spawns_after_stop() {
+    let mut supervisor = Supervisor::new(SupervisorConfig {
+        program: "sh".into(),
+        args: vec!["-c".to_string(), "sleep 5".to_string()],
+        restart_backoff: Duration::from_millis(0),
+    });
+
+    supervisor.stop();
+    supervisor.start().unwrap();
+    assert!(
+        !supervisor.is_running(),
+        "start() must not spawn anything once the supervisor has been stopped"
+    );
+}

--- a/dc_bridge/src/main.rs
+++ b/dc_bridge/src/main.rs
@@ -4,12 +4,16 @@
 //! with the ros2_rust (`rclrs`) toolchain — see dc_bridge/README.md.
 //!
 //! Vector's own configuration (the Fluent Forward source, the timestamp/Tag-normalizing
-//! VRL transform, the `dc.<name>` route per Destination, and the blessed sinks
-//! themselves) is produced by `dc_bridge_core::render` (ADR-0003) from the `shipper` and
-//! `destinations` parameters below — this node's job is just to declare those
-//! parameters, expand the `$HOME`/`$DC_PG_PASSWORD`-style env references the config
-//! contract uses, and hand the result to the Supervisor. The set of topics subscribed
-//! is derived from every configured Destination's `inputs`, not a separate parameter.
+//! VRL transform, the public per-Tag `dc.<tag>` routes, and the blessed sinks —
+//! `postgres`, `s3`, `file`, `console`) is produced by `dc_bridge_core::render`
+//! (ADR-0003) from the `shipper` and `destinations` parameters below — this node's job
+//! is just to declare those parameters, expand the `$HOME`/`$DC_PG_PASSWORD`-style env
+//! references the config contract uses, and hand the result to the Supervisor. The set
+//! of topics subscribed is derived from every configured Destination's `inputs`, not a
+//! separate parameter. Raw Vector snippets listed in `custom_config_files` (ADR-0003's
+//! passthrough) are collision-checked, `vector validate`d together with the rendered
+//! config so a bad snippet fails loudly at startup, and passed to Vector as additional
+//! `--config` files.
 //!
 //! Built, run, and `colcon test`-covered (see tests/end_to_end.rs) in a real ROS 2
 //! Jazzy + ros2_rust Docker environment: the node locates and supervises the vendored
@@ -19,8 +23,8 @@
 //! for the verification recipe and the three real bugs it caught.
 
 use dc_bridge_core::render::{
-    destination_from_raw, expand_env, render as render_vector_config, RawPostgresParams,
-    RenderConfig, MIN_DISK_BUFFER_BYTES,
+    destination_from_raw, expand_env, render as render_vector_config, validate_custom_config_files,
+    CustomConfigFile, RawDestinationParams, RenderConfig, MIN_DISK_BUFFER_BYTES,
 };
 use dc_bridge_core::{readiness, vector_config};
 use dc_bridge_core::{
@@ -62,6 +66,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let render_config = build_render_config(&node, forward_addr)?;
     let rendered_vector_config = render_vector_config(&render_config)?;
 
+    // ADR-0003 passthrough: raw Vector config snippets merged natively by Vector via
+    // additional `--config` arguments. Collision-checked against the rendered config
+    // here so a bad snippet is a clear startup error naming the file, not a
+    // supervised-Vector crash loop.
+    let custom_config_paths: Arc<[Arc<str>]> = node
+        .declare_parameter("custom_config_files")
+        .default(Arc::from(Vec::<Arc<str>>::new()))
+        .mandatory()?
+        .get();
+    let mut custom_config_files = Vec::with_capacity(custom_config_paths.len());
+    for path_raw in custom_config_paths.iter() {
+        let path = expand_env(path_raw, |name| std::env::var(name).ok())?;
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("failed to read custom config file '{path}': {e}"))?;
+        custom_config_files.push(CustomConfigFile { path, content });
+    }
+    validate_custom_config_files(&render_config, &custom_config_files)?;
+
     let vector_binary = if !vector_binary_override.is_empty() {
         PathBuf::from(vector_binary_override.to_string())
     } else {
@@ -73,10 +95,38 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vector_config_path = std::env::temp_dir().join("dc_bridge_vector.toml");
     std::fs::write(&vector_config_path, rendered_vector_config)?;
 
+    let vector_config_paths: Vec<PathBuf> = std::iter::once(vector_config_path)
+        .chain(custom_config_files.iter().map(|f| PathBuf::from(&f.path)))
+        .collect();
+
     let supervisor = Arc::new(Mutex::new(Supervisor::new(SupervisorConfig::vector(
-        vector_binary,
-        vector_config_path,
+        vector_binary.clone(),
+        vector_config_paths.clone(),
     ))));
+
+    // rclrs has no signal handling yet (`Context::ok()` unconditionally returns true, so
+    // `executor.spin()` below never returns on its own): without this, dc_bridge exiting
+    // via Ctrl-C, `ros2 launch` shutdown, or a plain SIGTERM would leave the supervised
+    // Vector process running forever, orphaned. SIGKILL still can't be caught (a Unix
+    // limit, not specific to this), but that's now the only path that leaks it.
+    // Installed *before* the Supervisor ever starts Vector: `Supervisor::start` is a
+    // no-op after `stop`, so a signal landing during startup can't race the handler
+    // into leaving an unsupervised Vector behind.
+    {
+        let supervisor = supervisor.clone();
+        ctrlc::set_handler(move || {
+            supervisor.lock().unwrap().stop();
+            std::process::exit(0);
+        })?;
+    }
+
+    // Backstop for anything the pure checks above can't see (e.g. a snippet consuming a
+    // `dc.<tag>` route no configured Destination subscribes, or sink options Vector
+    // itself rejects): run Vector's own validator on the merged config set before
+    // starting the Supervisor, so an invalid config is a loud startup failure instead
+    // of a crash loop.
+    validate_with_vector(&vector_binary, &vector_config_paths)?;
+
     supervisor.lock().unwrap().start()?;
 
     let readiness = Readiness::new();
@@ -89,19 +139,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             readiness.set_ready(ready);
             std::thread::sleep(Duration::from_millis(250));
         });
-    }
-
-    // rclrs has no signal handling yet (`Context::ok()` unconditionally returns true, so
-    // `executor.spin()` below never returns on its own): without this, dc_bridge exiting
-    // via Ctrl-C, `ros2 launch` shutdown, or a plain SIGTERM would leave the supervised
-    // Vector process running forever, orphaned. SIGKILL still can't be caught (a Unix
-    // limit, not specific to this), but that's now the only path that leaks it.
-    {
-        let supervisor = supervisor.clone();
-        ctrlc::set_handler(move || {
-            supervisor.lock().unwrap().stop();
-            std::process::exit(0);
-        })?;
     }
 
     let forwarder = Arc::new(Mutex::new(Forwarder::new(ForwarderConfig::new(
@@ -155,6 +192,31 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Runs `vector validate --no-environment` on the full `--config` set (rendered config
+/// plus passthrough snippets) and turns a failure into a startup error carrying
+/// Vector's own diagnostics. `--no-environment` skips healthchecks and
+/// environment-dependent checks (ports, data_dir, remote endpoints) — this is a config
+/// correctness gate, not a connectivity probe.
+fn validate_with_vector(
+    vector_binary: &std::path::Path,
+    config_paths: &[PathBuf],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = std::process::Command::new(vector_binary)
+        .args(["validate", "--no-environment"])
+        .args(config_paths.iter().map(|p| p.as_os_str()))
+        .output()
+        .map_err(|e| format!("failed to run '{}' validate: {e}", vector_binary.display()))?;
+    if !output.status.success() {
+        return Err(format!(
+            "vector rejected the merged configuration:\n{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        )
+        .into());
+    }
+    Ok(())
+}
+
 /// Declares the `shipper`/`destinations` parameters (ADR-0003's config contract) and
 /// builds the [`RenderConfig`] the config renderer needs. `$NAME`/`${NAME}` references in
 /// `shipper.data_dir` and each Postgres destination's `password` are expanded against the
@@ -196,15 +258,24 @@ fn build_render_config(
     })
 }
 
-/// Declares every `<name>.*` parameter one Destination needs and validates them into a
-/// typed `Destination` via `dc_bridge_core::render::destination_from_raw` — this is
-/// where an invalid `type`/`receives`/`time_format`, or a missing required Postgres
-/// field, turns into the clear startup error the acceptance criteria call for, rather
-/// than a confusing failure deep inside Vector.
+/// Declares every `<name>.*` parameter one Destination might need — the flat union
+/// across all blessed types, mirroring `RawDestinationParams` — and validates them into
+/// a typed `Destination` via `dc_bridge_core::render::destination_from_raw` — this is
+/// where an invalid `type`/`receives`/`time_format`, or a missing required field, turns
+/// into the clear startup error the acceptance criteria call for, rather than a
+/// confusing failure deep inside Vector.
 fn declare_destination(
     node: &rclrs::Node,
     name: &str,
 ) -> Result<dc_bridge_core::render::Destination, Box<dyn std::error::Error>> {
+    let declare_str = |param: &str| -> Result<Option<Arc<str>>, Box<dyn std::error::Error>> {
+        let value: Option<Arc<str>> = node
+            .declare_parameter(format!("{name}.{param}"))
+            .optional()?
+            .get();
+        Ok(value)
+    };
+
     let type_str: Arc<str> = node
         .declare_parameter(format!("{name}.type"))
         .default(Arc::from(""))
@@ -221,52 +292,62 @@ fn declare_destination(
         .mandatory()?
         .get();
 
-    let host: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.host"))
-        .optional()?
-        .get();
+    let time_key = declare_str("time_key")?;
+    let time_format = declare_str("time_format")?;
+    // postgres
+    let host = declare_str("host")?;
     let port: Option<i64> = node
         .declare_parameter(format!("{name}.port"))
         .optional()?
         .get();
-    let user: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.user"))
+    let user = declare_str("user")?;
+    let password_raw = declare_str("password")?;
+    let database = declare_str("database")?;
+    let table = declare_str("table")?;
+    // s3
+    let bucket = declare_str("bucket")?;
+    let region = declare_str("region")?;
+    let endpoint = declare_str("endpoint")?;
+    let key_prefix = declare_str("key_prefix")?;
+    let access_key_id = declare_str("access_key_id")?;
+    let secret_access_key_raw = declare_str("secret_access_key")?;
+    let force_path_style: Option<bool> = node
+        .declare_parameter(format!("{name}.force_path_style"))
         .optional()?
         .get();
-    let password_raw: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.password"))
+    let batch_timeout_secs: Option<i64> = node
+        .declare_parameter(format!("{name}.batch_timeout_secs"))
         .optional()?
         .get();
-    let database: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.database"))
-        .optional()?
-        .get();
-    let table: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.table"))
-        .optional()?
-        .get();
-    let time_key: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.time_key"))
-        .optional()?
-        .get();
-    let time_format: Option<Arc<str>> = node
-        .declare_parameter(format!("{name}.time_format"))
-        .optional()?
-        .get();
+    // file
+    let path = declare_str("path")?;
 
+    // Credentials support `$DC_PG_PASSWORD`-style env references (ADR-0003 contract).
     let password = password_raw
         .map(|p| expand_env(&p, |var| std::env::var(var).ok()))
         .transpose()?;
+    let secret_access_key = secret_access_key_raw
+        .map(|s| expand_env(&s, |var| std::env::var(var).ok()))
+        .transpose()?;
 
-    let postgres = RawPostgresParams {
+    let raw = RawDestinationParams {
+        time_key: time_key.as_deref(),
+        time_format: time_format.as_deref(),
         host: host.as_deref(),
         port,
         user: user.as_deref(),
         password: password.as_deref(),
         database: database.as_deref(),
         table: table.as_deref(),
-        time_key: time_key.as_deref(),
-        time_format: time_format.as_deref(),
+        bucket: bucket.as_deref(),
+        region: region.as_deref(),
+        endpoint: endpoint.as_deref(),
+        key_prefix: key_prefix.as_deref(),
+        access_key_id: access_key_id.as_deref(),
+        secret_access_key: secret_access_key.as_deref(),
+        force_path_style,
+        batch_timeout_secs,
+        path: path.as_deref(),
     };
 
     let inputs: Vec<String> = inputs.iter().map(|s| s.to_string()).collect();
@@ -275,7 +356,7 @@ fn declare_destination(
         &type_str,
         &receives_str,
         inputs,
-        postgres,
+        raw,
     )?)
 }
 

--- a/dc_bridge/tests/end_to_end.rs
+++ b/dc_bridge/tests/end_to_end.rs
@@ -12,8 +12,9 @@
 //! more bare tracer-bullet console sink — most tests here configure dc_bridge with one
 //! `postgres`-type destination. Two tests only need Vector to have started successfully
 //! (readiness, shutdown behavior) and work against a Postgres endpoint that need not
-//! actually be reachable; the Postgres- and MinIO-backed tests verify a Record actually
-//! lands in the real downstream store, and skip themselves with a clear message when
+//! actually be reachable; the Postgres- and S3-store-backed (RustFS) tests verify a
+//! Record actually lands in the real downstream store, and skip themselves with a clear
+//! message when
 //! nothing is listening at the configured address, since `cargo test`/`colcon test`
 //! must still pass cleanly on machines without those containers running. The
 //! passthrough test (`custom_config_files`, ADR-0003) is fully self-contained: the test
@@ -562,32 +563,38 @@ fn colliding_custom_snippet_fails_startup_loudly() {
     );
 }
 
-/// Whether an S3-compatible server answers at 127.0.0.1:9000 (MinIO's default port) —
-/// used to skip the MinIO-backed test below on machines without one running.
-fn minio_reachable() -> bool {
+/// Whether an S3-compatible server answers at 127.0.0.1:9000 (the standard S3 API port
+/// of RustFS/MinIO-style stores) — used to skip the store-backed test below on
+/// machines without one running.
+fn s3_store_reachable() -> bool {
     let addr: SocketAddr = "127.0.0.1:9000"
         .parse()
-        .expect("the MinIO address must parse");
+        .expect("the S3 store address must parse");
     TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
 }
 
-/// Exercises the `s3` blessed destination end-to-end against a real MinIO: dc_bridge is
-/// configured purely via ROS params (custom `endpoint`, explicit credentials,
-/// `force_path_style`, a short `batch_timeout_secs`), a Record is published, and the
-/// test asserts an object containing the marker value lands in the bucket.
+/// Exercises the `s3` blessed destination end-to-end against a real self-hosted
+/// S3-compatible store: dc_bridge is configured purely via ROS params (custom
+/// `endpoint`, explicit credentials, `force_path_style`, a short
+/// `batch_timeout_secs`), a Record is published, and the test asserts an object
+/// containing the marker value lands in the bucket.
 ///
-/// Requires a MinIO at 127.0.0.1:9000 with credentials `minioadmin`/`minioadmin` and an
-/// existing bucket `dc-records` whose anonymous access policy allows public
-/// read/list (`mc anonymous set public`), so the assertion side can use plain
-/// unauthenticated HTTP (via `curl`) instead of a full SigV4 client; objects are
-/// gzip-decoded with `zcat` (Vector's `aws_s3` default compression).
+/// Requires an S3-compatible store at 127.0.0.1:9000 with credentials
+/// `rustfsadmin`/`rustfsadmin` and an existing bucket `dc-records` whose anonymous
+/// access policy allows public read/list (`mc anonymous set public`), so the assertion
+/// side can use plain unauthenticated HTTP (via `curl`) instead of a full SigV4
+/// client; objects are gzip-decoded with `zcat` (Vector's `aws_s3` default
+/// compression). RustFS (`rustfs/rustfs`, whose defaults these are) is the recommended
+/// store — MinIO's community edition was archived upstream in 2026 — and is what this
+/// test was verified against, but the `s3` type (and this test) is store-agnostic.
 #[test]
-fn published_record_reaches_minio_bucket_when_reachable() {
-    if !minio_reachable() {
+fn published_record_reaches_s3_bucket_when_reachable() {
+    if !s3_store_reachable() {
         eprintln!(
-            "skipping published_record_reaches_minio_bucket_when_reachable: nothing \
-             listening at 127.0.0.1:9000; start a MinIO container (minioadmin/minioadmin) \
-             with a public-read bucket 'dc-records' to run this test"
+            "skipping published_record_reaches_s3_bucket_when_reachable: nothing \
+             listening at 127.0.0.1:9000; start an S3-compatible store — e.g. a RustFS \
+             container (rustfsadmin/rustfsadmin) — with a public-read bucket \
+             'dc-records' to run this test"
         );
         return;
     }
@@ -612,27 +619,27 @@ fn published_record_reaches_minio_bucket_when_reachable() {
             "-p".to_string(),
             format!("shipper.data_dir:={}", unique_data_dir()),
             "-p".to_string(),
-            "destinations:=[\"minio\"]".to_string(),
+            "destinations:=[\"rustfs\"]".to_string(),
             "-p".to_string(),
-            "minio.type:=s3".to_string(),
+            "rustfs.type:=s3".to_string(),
             "-p".to_string(),
-            "minio.inputs:=[\"/dc/measurement/uptime\"]".to_string(),
+            "rustfs.inputs:=[\"/dc/measurement/uptime\"]".to_string(),
             "-p".to_string(),
-            "minio.bucket:=dc-records".to_string(),
+            "rustfs.bucket:=dc-records".to_string(),
             "-p".to_string(),
-            "minio.endpoint:=http://127.0.0.1:9000".to_string(),
+            "rustfs.endpoint:=http://127.0.0.1:9000".to_string(),
             "-p".to_string(),
-            "minio.region:=us-east-1".to_string(),
+            "rustfs.region:=us-east-1".to_string(),
             "-p".to_string(),
-            "minio.access_key_id:=minioadmin".to_string(),
+            "rustfs.access_key_id:=rustfsadmin".to_string(),
             "-p".to_string(),
-            "minio.secret_access_key:=minioadmin".to_string(),
+            "rustfs.secret_access_key:=rustfsadmin".to_string(),
             "-p".to_string(),
-            "minio.force_path_style:=true".to_string(),
+            "rustfs.force_path_style:=true".to_string(),
             "-p".to_string(),
-            format!("minio.key_prefix:={prefix}"),
+            format!("rustfs.key_prefix:={prefix}"),
             "-p".to_string(),
-            "minio.batch_timeout_secs:=2".to_string(),
+            "rustfs.batch_timeout_secs:=2".to_string(),
         ],
         Stdio::null(),
         Stdio::null(),
@@ -646,7 +653,7 @@ fn published_record_reaches_minio_bucket_when_reachable() {
     let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
     let executor = context.create_basic_executor();
     let node = executor
-        .create_node("dc_bridge_end_to_end_minio_test")
+        .create_node("dc_bridge_end_to_end_s3_test")
         .expect("failed to create the test node");
     let publisher = node
         .create_publisher::<StringStamped>("/dc/measurement/uptime")
@@ -667,7 +674,7 @@ fn published_record_reaches_minio_bucket_when_reachable() {
             .publish(&message)
             .expect("failed to publish the test Record");
         std::thread::sleep(Duration::from_millis(500));
-        found = minio_prefix_contains_marker(&prefix, &MARKER_UPTIME_S.to_string());
+        found = bucket_prefix_contains_marker(&prefix, &MARKER_UPTIME_S.to_string());
     }
 
     terminate(&mut child);
@@ -681,7 +688,7 @@ fn published_record_reaches_minio_bucket_when_reachable() {
 
 /// Lists `dc-records` objects under `prefix` via anonymous HTTP (`curl`) and returns
 /// whether any of them, gzip-decoded (`zcat`), contains `marker`.
-fn minio_prefix_contains_marker(prefix: &str, marker: &str) -> bool {
+fn bucket_prefix_contains_marker(prefix: &str, marker: &str) -> bool {
     let listing = Command::new("curl")
         .args([
             "-s",

--- a/dc_bridge/tests/end_to_end.rs
+++ b/dc_bridge/tests/end_to_end.rs
@@ -8,14 +8,16 @@
 //! --packages-select dc_bridge` runs under the hood, via colcon-ros-cargo's
 //! `AmentCargoTestTask`, which is just `cargo test`); it cannot run in a plain sandbox.
 //!
-//! Since the config renderer (ADR-0003) only produces blessed-Destination sinks
-//! (`postgres` today — no more bare `console` sink to grep stdout for), every test here
-//! configures dc_bridge with one `postgres`-type destination. Two tests only need Vector
-//! to have started successfully (readiness, shutdown behavior) and work against a
-//! Postgres endpoint that need not actually be reachable; the third test verifies a
-//! Record actually lands in a real Postgres row, and skips itself with a clear message
-//! when no Postgres is reachable at the configured address, since `cargo test`/`colcon
-//! test` must still pass cleanly on machines with no Postgres container running.
+//! Since the config renderer (ADR-0003) only produces blessed-Destination sinks — no
+//! more bare tracer-bullet console sink — most tests here configure dc_bridge with one
+//! `postgres`-type destination. Two tests only need Vector to have started successfully
+//! (readiness, shutdown behavior) and work against a Postgres endpoint that need not
+//! actually be reachable; the Postgres- and MinIO-backed tests verify a Record actually
+//! lands in the real downstream store, and skip themselves with a clear message when
+//! nothing is listening at the configured address, since `cargo test`/`colcon test`
+//! must still pass cleanly on machines without those containers running. The
+//! passthrough test (`custom_config_files`, ADR-0003) is fully self-contained: the test
+//! itself plays the un-blessed HTTP sink's server.
 
 use dc_interfaces::msg::StringStamped;
 use postgres::{Client, NoTls};
@@ -97,9 +99,15 @@ fn postgres_destination_args() -> Vec<String> {
 }
 
 fn spawn_dc_bridge(extra_args: &[String], stdout: Stdio, stderr: Stdio) -> std::process::Child {
-    let bin = env!("CARGO_BIN_EXE_dc_bridge");
     let mut args = postgres_destination_args();
     args.extend(extra_args.iter().cloned());
+    spawn_dc_bridge_with_args(&args, stdout, stderr)
+}
+
+/// Spawns the binary under test with exactly `args` — for tests whose destination
+/// isn't the shared `pgsql` one `postgres_destination_args` declares.
+fn spawn_dc_bridge_with_args(args: &[String], stdout: Stdio, stderr: Stdio) -> std::process::Child {
+    let bin = env!("CARGO_BIN_EXE_dc_bridge");
     Command::new(bin)
         .args(args)
         .stdout(stdout)
@@ -360,6 +368,345 @@ fn published_record_lands_in_postgres_when_reachable() {
         "expected `date` ({date}) to be a plausible Unix-epoch-seconds timestamp \
          between {before} and {after}"
     );
+}
+
+/// ADR-0003's passthrough contract, end to end: a raw Vector snippet listed in
+/// `custom_config_files` ships Records to an un-blessed sink type (`http`) by consuming
+/// the public per-Tag route `dc.dc.measurement.uptime` (`dc.<tag>` for Tag
+/// `dc.measurement.uptime`). The test itself plays the HTTP server on an ephemeral
+/// port, so this runs everywhere — no external container needed.
+#[test]
+fn custom_snippet_ships_records_to_an_http_sink() {
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("failed to bind the test HTTP server socket");
+    let port = listener.local_addr().unwrap().port();
+    let received = Arc::new(Mutex::new(String::new()));
+    {
+        // Answers 200 to everything (including Vector's sink healthcheck) and collects
+        // every request into `received`; detached, dies with the test binary.
+        let received = received.clone();
+        std::thread::spawn(move || {
+            for stream in listener.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let _ = stream.set_read_timeout(Some(Duration::from_millis(500)));
+                let mut request = Vec::new();
+                let mut chunk = [0u8; 4096];
+                loop {
+                    match std::io::Read::read(&mut stream, &mut chunk) {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => {
+                            request.extend_from_slice(&chunk[..n]);
+                            // Stop once the whole body announced by Content-Length has
+                            // arrived (the header separator alone isn't enough — the
+                            // body may land in a later read).
+                            let text = String::from_utf8_lossy(&request);
+                            if let Some((head, body)) = text.split_once("\r\n\r\n") {
+                                let content_length: usize = head
+                                    .lines()
+                                    .find_map(|l| {
+                                        let (k, v) = l.split_once(':')?;
+                                        k.eq_ignore_ascii_case("content-length")
+                                            .then(|| v.trim().parse().ok())?
+                                    })
+                                    .unwrap_or(0);
+                                if body.len() >= content_length {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                received
+                    .lock()
+                    .unwrap()
+                    .push_str(&String::from_utf8_lossy(&request));
+                let _ = std::io::Write::write_all(
+                    &mut stream,
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                );
+            }
+        });
+    }
+
+    let snippet_path = std::env::temp_dir().join(format!(
+        "dc_bridge_e2e_http_snippet_{}.toml",
+        std::process::id()
+    ));
+    std::fs::write(
+        &snippet_path,
+        format!(
+            r#"[sinks.e2e_http]
+type = "http"
+inputs = ["dc.dc.measurement.uptime"]
+uri = "http://127.0.0.1:{port}/ingest"
+encoding.codec = "json"
+batch.timeout_secs = 1
+"#
+        ),
+    )
+    .expect("failed to write the custom config snippet");
+
+    let mut child = spawn_dc_bridge(
+        &[
+            "-p".to_string(),
+            format!("custom_config_files:=[\"{}\"]", snippet_path.display()),
+        ],
+        Stdio::null(),
+        Stdio::null(),
+    );
+    assert!(
+        wait_for_ready(Instant::now() + Duration::from_secs(30)),
+        "dc_bridge's readiness service never reported ready within 30s with a \
+         custom_config_files snippet configured"
+    );
+
+    const MARKER_UPTIME_S: i32 = 653_421;
+    let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
+    let executor = context.create_basic_executor();
+    let node = executor
+        .create_node("dc_bridge_end_to_end_http_test")
+        .expect("failed to create the test node");
+    let publisher = node
+        .create_publisher::<StringStamped>("/dc/measurement/uptime")
+        .expect("failed to create a publisher on /dc/measurement/uptime");
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let mut message = StringStamped::default();
+    message.header.stamp.sec = now.as_secs() as i32;
+    message.header.stamp.nanosec = now.subsec_nanos();
+    message.data = format!(r#"{{"uptime_s": {MARKER_UPTIME_S}}}"#);
+
+    let marker_number = MARKER_UPTIME_S.to_string();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    let mut delivered = false;
+    while !delivered && Instant::now() < deadline {
+        publisher
+            .publish(&message)
+            .expect("failed to publish the test Record");
+        std::thread::sleep(Duration::from_millis(300));
+        delivered = received.lock().unwrap().contains(&marker_number);
+    }
+
+    terminate(&mut child);
+    std::fs::remove_file(&snippet_path).ok();
+
+    assert!(
+        delivered,
+        "expected the custom http-sink snippet to deliver the published Record to the \
+         test HTTP server within 30s, but the marker never arrived; received so far:\n{}",
+        received.lock().unwrap()
+    );
+}
+
+/// "Invalid or colliding custom snippet names fail loudly at startup, not silently":
+/// a snippet claiming a component id the rendered config owns (the `pgsql` sink) must
+/// make dc_bridge itself exit non-zero with a clear error naming the file — not start
+/// up anyway, and not crash-loop the supervised Vector.
+#[test]
+fn colliding_custom_snippet_fails_startup_loudly() {
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    let snippet_path = std::env::temp_dir().join(format!(
+        "dc_bridge_e2e_colliding_snippet_{}.toml",
+        std::process::id()
+    ));
+    std::fs::write(
+        &snippet_path,
+        "[sinks.pgsql]\ntype = \"console\"\ninputs = [\"dc.dc.measurement.uptime\"]\nencoding.codec = \"json\"\n",
+    )
+    .expect("failed to write the colliding snippet");
+
+    let mut child = spawn_dc_bridge(
+        &[
+            "-p".to_string(),
+            format!("custom_config_files:=[\"{}\"]", snippet_path.display()),
+        ],
+        Stdio::null(),
+        Stdio::piped(),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let status = loop {
+        match child.try_wait().expect("failed to poll dc_bridge") {
+            Some(status) => break Some(status),
+            None if Instant::now() >= deadline => break None,
+            None => std::thread::sleep(Duration::from_millis(100)),
+        }
+    };
+    let status = status.unwrap_or_else(|| {
+        terminate(&mut child);
+        std::fs::remove_file(&snippet_path).ok();
+        panic!(
+            "expected dc_bridge to exit at startup when a custom snippet collides with \
+             a rendered component, but it was still running after 20s"
+        );
+    });
+
+    let mut stderr = String::new();
+    if let Some(mut pipe) = child.stderr.take() {
+        let _ = std::io::Read::read_to_string(&mut pipe, &mut stderr);
+    }
+    std::fs::remove_file(&snippet_path).ok();
+
+    assert!(
+        !status.success(),
+        "expected a non-zero exit for a colliding custom snippet, got: {status}"
+    );
+    assert!(
+        stderr.contains("pgsql"),
+        "expected dc_bridge's startup error to name the colliding component; stderr:\n{stderr}"
+    );
+}
+
+/// Whether an S3-compatible server answers at 127.0.0.1:9000 (MinIO's default port) —
+/// used to skip the MinIO-backed test below on machines without one running.
+fn minio_reachable() -> bool {
+    let addr: SocketAddr = "127.0.0.1:9000"
+        .parse()
+        .expect("the MinIO address must parse");
+    TcpStream::connect_timeout(&addr, Duration::from_millis(500)).is_ok()
+}
+
+/// Exercises the `s3` blessed destination end-to-end against a real MinIO: dc_bridge is
+/// configured purely via ROS params (custom `endpoint`, explicit credentials,
+/// `force_path_style`, a short `batch_timeout_secs`), a Record is published, and the
+/// test asserts an object containing the marker value lands in the bucket.
+///
+/// Requires a MinIO at 127.0.0.1:9000 with credentials `minioadmin`/`minioadmin` and an
+/// existing bucket `dc-records` whose anonymous access policy allows public
+/// read/list (`mc anonymous set public`), so the assertion side can use plain
+/// unauthenticated HTTP (via `curl`) instead of a full SigV4 client; objects are
+/// gzip-decoded with `zcat` (Vector's `aws_s3` default compression).
+#[test]
+fn published_record_reaches_minio_bucket_when_reachable() {
+    if !minio_reachable() {
+        eprintln!(
+            "skipping published_record_reaches_minio_bucket_when_reachable: nothing \
+             listening at 127.0.0.1:9000; start a MinIO container (minioadmin/minioadmin) \
+             with a public-read bucket 'dc-records' to run this test"
+        );
+        return;
+    }
+
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    const MARKER_UPTIME_S: i32 = 786_534;
+    // A unique prefix per run, so the assertion below can't match an object left over
+    // from an earlier run against the same long-lived MinIO container.
+    let prefix = format!(
+        "e2e/{}_{}/",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+
+    let mut child = spawn_dc_bridge_with_args(
+        &[
+            "--ros-args".to_string(),
+            "-p".to_string(),
+            format!("shipper.data_dir:={}", unique_data_dir()),
+            "-p".to_string(),
+            "destinations:=[\"minio\"]".to_string(),
+            "-p".to_string(),
+            "minio.type:=s3".to_string(),
+            "-p".to_string(),
+            "minio.inputs:=[\"/dc/measurement/uptime\"]".to_string(),
+            "-p".to_string(),
+            "minio.bucket:=dc-records".to_string(),
+            "-p".to_string(),
+            "minio.endpoint:=http://127.0.0.1:9000".to_string(),
+            "-p".to_string(),
+            "minio.region:=us-east-1".to_string(),
+            "-p".to_string(),
+            "minio.access_key_id:=minioadmin".to_string(),
+            "-p".to_string(),
+            "minio.secret_access_key:=minioadmin".to_string(),
+            "-p".to_string(),
+            "minio.force_path_style:=true".to_string(),
+            "-p".to_string(),
+            format!("minio.key_prefix:={prefix}"),
+            "-p".to_string(),
+            "minio.batch_timeout_secs:=2".to_string(),
+        ],
+        Stdio::null(),
+        Stdio::null(),
+    );
+    assert!(
+        wait_for_ready(Instant::now() + Duration::from_secs(30)),
+        "dc_bridge's readiness service never reported ready within 30s with an s3-type \
+         destination configured"
+    );
+
+    let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
+    let executor = context.create_basic_executor();
+    let node = executor
+        .create_node("dc_bridge_end_to_end_minio_test")
+        .expect("failed to create the test node");
+    let publisher = node
+        .create_publisher::<StringStamped>("/dc/measurement/uptime")
+        .expect("failed to create a publisher on /dc/measurement/uptime");
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let mut message = StringStamped::default();
+    message.header.stamp.sec = now.as_secs() as i32;
+    message.header.stamp.nanosec = now.subsec_nanos();
+    message.data = format!(r#"{{"uptime_s": {MARKER_UPTIME_S}}}"#);
+
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut found = false;
+    while !found && Instant::now() < deadline {
+        publisher
+            .publish(&message)
+            .expect("failed to publish the test Record");
+        std::thread::sleep(Duration::from_millis(500));
+        found = minio_prefix_contains_marker(&prefix, &MARKER_UPTIME_S.to_string());
+    }
+
+    terminate(&mut child);
+
+    assert!(
+        found,
+        "expected an object containing uptime_s = {MARKER_UPTIME_S} under prefix \
+         '{prefix}' of bucket 'dc-records' within 45s of publishing"
+    );
+}
+
+/// Lists `dc-records` objects under `prefix` via anonymous HTTP (`curl`) and returns
+/// whether any of them, gzip-decoded (`zcat`), contains `marker`.
+fn minio_prefix_contains_marker(prefix: &str, marker: &str) -> bool {
+    let listing = Command::new("curl")
+        .args([
+            "-s",
+            &format!("http://127.0.0.1:9000/dc-records?list-type=2&prefix={prefix}"),
+        ])
+        .output()
+        .expect("failed to run curl against MinIO");
+    let listing = String::from_utf8_lossy(&listing.stdout).into_owned();
+    for key in listing
+        .split("<Key>")
+        .skip(1)
+        .filter_map(|part| part.split("</Key>").next())
+    {
+        let object = Command::new("sh")
+            .args([
+                "-c",
+                &format!("curl -s 'http://127.0.0.1:9000/dc-records/{key}' | zcat 2>/dev/null"),
+            ])
+            .output()
+            .expect("failed to fetch an object from MinIO");
+        if String::from_utf8_lossy(&object.stdout).contains(marker) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Sends SIGTERM (dc_bridge's install-hooked signal, not SIGKILL) and waits for exit.

--- a/dc_bridge/tests/end_to_end.rs
+++ b/dc_bridge/tests/end_to_end.rs
@@ -13,10 +13,13 @@
 //! `postgres`-type destination. Two tests only need Vector to have started successfully
 //! (readiness, shutdown behavior) and work against a Postgres endpoint that need not
 //! actually be reachable; the Postgres- and S3-store-backed (RustFS) tests verify a
-//! Record actually lands in the real downstream store, and skip themselves with a clear
-//! message when
-//! nothing is listening at the configured address, since `cargo test`/`colcon test`
-//! must still pass cleanly on machines without those containers running. The
+//! Record actually lands in the real downstream store, and **hard-fail immediately
+//! (with setup instructions) when nothing is listening at the configured address** —
+//! they deliberately never skip. They used to, but libtest swallows passing tests'
+//! output, so a "6 passed" run whose store assertions never executed was
+//! indistinguishable from a real pass — the suite could stay green while the pipeline
+//! was never exercised. Running this suite therefore requires the Postgres and RustFS
+//! containers (see each test's panic message for the one-liners to start them). The
 //! passthrough test (`custom_config_files`, ADR-0003) is fully self-contained: the test
 //! itself plays the un-blessed HTTP sink's server.
 
@@ -53,7 +56,7 @@ const PG_TABLE: &str = "dc";
 /// process finds the previous run's unflushed, disk-buffered records still on disk and
 /// redelivers them on startup — a stale row lands in Postgres carrying an *older* run's
 /// timestamp but the *same* hardcoded marker value, which was observed to intermittently
-/// fail `published_record_lands_in_postgres_when_reachable`'s plausibility assertion
+/// fail `published_record_lands_in_postgres`'s plausibility assertion
 /// before this was isolated per spawn.
 fn unique_data_dir() -> String {
     static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
@@ -223,11 +226,9 @@ fn stops_the_supervised_vector_process_on_sigterm() {
 }
 
 /// A quick TCP-connect probe (not a real Postgres handshake) for whether something is
-/// listening at `PG_HOST:PG_PORT` — used to skip the Postgres-backed test below with a
-/// clear message on machines with no Postgres container running, rather than making
-/// `cargo test`/`colcon test` hard-fail without one (a live Postgres, e.g. via
-/// `tools/infrastructure/docker/docker-compose.postgresql.yaml`, isn't available in
-/// every environment this runs in).
+/// listening at `PG_HOST:PG_PORT` — used to fail the Postgres-backed test below
+/// immediately with setup instructions, instead of a slow, confusing timeout deep in
+/// the pipeline assertions.
 fn postgres_reachable() -> bool {
     let addr: SocketAddr = format!("{PG_HOST}:{PG_PORT}")
         .parse()
@@ -240,18 +241,22 @@ fn postgres_reachable() -> bool {
 /// `inputs` topic, and asserts the row actually lands in the target table with `date`
 /// populated as a plausible Unix-epoch-seconds float and `uptime_s` equal to the
 /// published value — the same demo documented in dc_bridge/README.md, automated.
+///
+/// A live Postgres is REQUIRED: without one this test fails immediately (with setup
+/// instructions) rather than skipping. It used to skip — but libtest swallows a
+/// passing test's output, so a run whose store assertions never executed was
+/// indistinguishable from a real pass, and a change could look verified when the
+/// pipeline was in fact never exercised.
 #[test]
-fn published_record_lands_in_postgres_when_reachable() {
-    if !postgres_reachable() {
-        eprintln!(
-            "skipping published_record_lands_in_postgres_when_reachable: no Postgres \
-             reachable at {PG_HOST}:{PG_PORT}; start \
-             tools/infrastructure/docker/docker-compose.postgresql.yaml (or an \
-             equivalent postgres:13 container with user/password 'dc'/'password') to \
-             run this test"
-        );
-        return;
-    }
+fn published_record_lands_in_postgres() {
+    assert!(
+        postgres_reachable(),
+        "no Postgres reachable at {PG_HOST}:{PG_PORT} — this end-to-end test requires \
+         one and deliberately fails (not skips) without it. Start \
+         tools/infrastructure/docker/docker-compose.postgresql.yaml (or an equivalent \
+         postgres:13 container with user/password 'dc'/'password' and a \
+         'dc (date double precision, uptime_s integer)' table in database 'dc')"
+    );
 
     let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
@@ -564,8 +569,9 @@ fn colliding_custom_snippet_fails_startup_loudly() {
 }
 
 /// Whether an S3-compatible server answers at 127.0.0.1:9000 (the standard S3 API port
-/// of RustFS/MinIO-style stores) — used to skip the store-backed test below on
-/// machines without one running.
+/// of RustFS/MinIO-style stores) — used to fail the store-backed test below
+/// immediately with setup instructions, instead of a slow, confusing timeout in the
+/// bucket-polling loop.
 fn s3_store_reachable() -> bool {
     let addr: SocketAddr = "127.0.0.1:9000"
         .parse()
@@ -579,7 +585,7 @@ fn s3_store_reachable() -> bool {
 /// `batch_timeout_secs`), a Record is published, and the test asserts an object
 /// containing the marker value lands in the bucket.
 ///
-/// Requires an S3-compatible store at 127.0.0.1:9000 with credentials
+/// REQUIRES an S3-compatible store at 127.0.0.1:9000 with credentials
 /// `rustfsadmin`/`rustfsadmin` and an existing bucket `dc-records` whose anonymous
 /// access policy allows public read/list (`mc anonymous set public`), so the assertion
 /// side can use plain unauthenticated HTTP (via `curl`) instead of a full SigV4
@@ -587,17 +593,19 @@ fn s3_store_reachable() -> bool {
 /// compression). RustFS (`rustfs/rustfs`, whose defaults these are) is the recommended
 /// store — MinIO's community edition was archived upstream in 2026 — and is what this
 /// test was verified against, but the `s3` type (and this test) is store-agnostic.
+/// Without a store this test fails immediately (with setup instructions) rather than
+/// skipping — see `published_record_lands_in_postgres` for why skipping was removed.
 #[test]
-fn published_record_reaches_s3_bucket_when_reachable() {
-    if !s3_store_reachable() {
-        eprintln!(
-            "skipping published_record_reaches_s3_bucket_when_reachable: nothing \
-             listening at 127.0.0.1:9000; start an S3-compatible store — e.g. a RustFS \
-             container (rustfsadmin/rustfsadmin) — with a public-read bucket \
-             'dc-records' to run this test"
-        );
-        return;
-    }
+fn published_record_reaches_s3_bucket() {
+    assert!(
+        s3_store_reachable(),
+        "nothing listening at 127.0.0.1:9000 — this end-to-end test requires an \
+         S3-compatible store and deliberately fails (not skips) without one. Start \
+         e.g. a RustFS container (credentials rustfsadmin/rustfsadmin) and create a \
+         public-read bucket: mc alias set local http://127.0.0.1:9000 rustfsadmin \
+         rustfsadmin && mc mb -p local/dc-records && mc anonymous set public \
+         local/dc-records"
+    );
 
     let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -26,5 +26,35 @@ dc_bridge:
       table: "dc"
       time_key: "date"
       time_format: "double"
+    # The other blessed destination types (add the name to `destinations` to enable):
+    #
+    # minio:                      # S3-compatible object storage (MinIO/Ceph/AWS)
+    #   type: s3
+    #   receives: records
+    #   inputs: ["/dc/measurement/uptime"]
+    #   bucket: "dc-records"
+    #   endpoint: "http://127.0.0.1:9000"   # omit for AWS S3
+    #   region: "us-east-1"
+    #   access_key_id: "minioadmin"         # omit both to use ambient AWS credentials
+    #   secret_access_key: "$DC_S3_SECRET"  # $VAR / ${VAR} env references are expanded
+    #   force_path_style: true              # MinIO-style path addressing
+    #   key_prefix: "robot1/"
+    #   batch_timeout_secs: 60              # object write interval; Vector default 300
+    #
+    # local_log:                  # newline-delimited JSON on local disk
+    #   type: file
+    #   receives: records
+    #   inputs: ["/dc/measurement/uptime"]
+    #   path: "/var/log/dc/records-%Y-%m-%d.log"
+    #
+    # debug_console:              # JSON on the Bridge's stdout (debugging)
+    #   type: console
+    #   receives: records
+    #   inputs: ["/dc/measurement/uptime"]
+    #
+    # Any other Vector sink type via the ADR-0003 passthrough: raw Vector config
+    # snippets consuming the public per-Tag `dc.<tag>` routes (see
+    # doc/src/dc/destinations.md for the routing contract).
+    # custom_config_files: ["$HOME/.dc/custom_sinks.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -28,16 +28,16 @@ dc_bridge:
       time_format: "double"
     # The other blessed destination types (add the name to `destinations` to enable):
     #
-    # minio:                      # S3-compatible object storage (MinIO/Ceph/AWS)
-    #   type: s3
-    #   receives: records
+    # rustfs:                     # S3-compatible object storage (self-hosted: RustFS
+    #   type: s3                  # recommended, since MinIO's community edition was
+    #   receives: records         # archived upstream; Ceph and AWS S3 work the same)
     #   inputs: ["/dc/measurement/uptime"]
     #   bucket: "dc-records"
     #   endpoint: "http://127.0.0.1:9000"   # omit for AWS S3
     #   region: "us-east-1"
-    #   access_key_id: "minioadmin"         # omit both to use ambient AWS credentials
+    #   access_key_id: "rustfsadmin"        # omit both to use ambient AWS credentials
     #   secret_access_key: "$DC_S3_SECRET"  # $VAR / ${VAR} env references are expanded
-    #   force_path_style: true              # MinIO-style path addressing
+    #   force_path_style: true              # path-style addressing for self-hosted stores
     #   key_prefix: "robot1/"
     #   batch_timeout_secs: 60              # object write interval; Vector default 300
     #

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -1,5 +1,113 @@
 # Overview
 
+## DC 2.0 (Jazzy): blessed Destinations + passthrough
+
+In the DC 2.0 architecture (ADR-0003, `docs/adr/`), the pluginlib destination-plugin
+layer is retired. The Bridge (`dc_bridge`) renders the external Vector Shipper's
+configuration from plain ROS parameters for a **blessed set** of Destination types —
+`postgres`, `s3`, `file`, `console` — and every other destination in Vector's sink
+catalog is available through the **passthrough**: raw Vector config snippets listed in
+the `custom_config_files` parameter, merged natively by Vector.
+
+### Configuration contract
+
+Every Destination is declared in the `destinations` list of the `dc_bridge` node's
+parameters, with a parameter block named after it (see
+`dc_bringup/params/dc_params.yaml` for a complete commented example):
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"   # Vector's disk-buffer directory
+      # buffer_max_bytes: 268435488  # optional; Vector's disk-buffer minimum
+    destinations: ["pgsql", "minio"]
+    pgsql:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime"]   # ROS topics feeding this Destination
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "$DC_PG_PASSWORD"          # $VAR / ${VAR} env references are expanded
+      database: "dc"
+      table: "dc"
+    minio:
+      type: s3
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      bucket: "dc-records"
+      endpoint: "http://127.0.0.1:9000"    # omit for AWS S3
+      region: "us-east-1"
+      access_key_id: "minioadmin"          # omit both to use ambient AWS credentials
+      secret_access_key: "$DC_S3_SECRET"
+      force_path_style: true               # MinIO-style path addressing
+      key_prefix: "robot1/"
+      batch_timeout_secs: 60               # object write interval; Vector default 300
+```
+
+Common parameters for every blessed type: `type`, `receives` (`records`; `files` is
+reserved for the File pipeline, ADR-0005), `inputs` (ROS topic names), `time_key`
+(default `date`) and `time_format` (`double` | `iso8601`, default `double`) controlling
+the normalized timestamp field written into each Record before routing.
+
+Type-specific parameters:
+
+| Type       | Required                                    | Optional                                                                                                          |
+| ---------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `postgres` | `user`, `password`, `database`, `table`     | `host` (default `127.0.0.1`), `port` (default `5432`)                                                             |
+| `s3`       | `bucket`                                    | `region`, `endpoint`, `key_prefix`, `access_key_id` + `secret_access_key` (together), `force_path_style`, `batch_timeout_secs` |
+| `file`     | `path` (Vector template syntax allowed)     |                                                                                                                    |
+| `console`  |                                             |                                                                                                                    |
+
+Invalid parameters (unknown `type`, missing required field, half a credential pair, an
+out-of-range port…) are rejected with a clear error at Bridge startup — before Vector
+is ever started.
+
+### The `dc.<tag>` routing contract (public API)
+
+The Bridge exposes one Shipper route per **Tag**. The Tag for a topic is its name with
+the leading `/` dropped and the remaining `/` turned into `.`
+(`/dc/measurement/uptime` → `dc.measurement.uptime`), and its route is named
+**`dc.<tag>`** — the leading `dc.` names the Bridge's route transform, the rest is the
+Tag verbatim (so `/dc/measurement/uptime`'s Records are consumable as
+`dc.dc.measurement.uptime`). These names are **stable public API**: blessed sinks are
+wired to them internally, and custom snippets consume them the same way. A route
+exists for every topic listed in any configured Destination's `inputs`.
+
+### Passthrough: `custom_config_files`
+
+Any Vector sink type ships Records with zero DC code by consuming `dc.<tag>` routes
+from a raw Vector config snippet (TOML):
+
+```toml
+# ~/.dc/custom_sinks.toml — an un-blessed sink type (http), pure Vector config
+[sinks.my_http]
+type = "http"
+inputs = ["dc.dc.measurement.uptime"]   # the public dc.<tag> route
+uri = "http://127.0.0.1:8080/ingest"
+encoding.codec = "json"
+```
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    custom_config_files: ["$HOME/.dc/custom_sinks.toml"]
+```
+
+Snippets must not re-define component ids owned by the generated config (the
+`dc_bridge_in` source, the `dc_bridge_normalize` and `dc` transforms, or any configured
+Destination's name) or by another snippet. An invalid or colliding snippet is a loud
+Bridge startup error naming the offending file; as a backstop, the merged config set is
+also checked with `vector validate` before the Shipper is started.
+
+---
+
+## Legacy (Humble): embedded Fluent Bit destination plugins
+
+Everything below documents the Humble-era architecture, which the DC 2.0 line
+replaces (ADR-0001).
+
 ## Description
 A destination is where the data will be sent: AWS S3, stdout, AWS Kinesis. It has the possibility to use [outputs from fluentbit](https://docs.fluentbit.io/manual/pipeline/outputs).
 

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -21,7 +21,7 @@ dc_bridge:
     shipper:
       data_dir: "$HOME/.dc/buffer"   # Vector's disk-buffer directory
       # buffer_max_bytes: 268435488  # optional; Vector's disk-buffer minimum
-    destinations: ["pgsql", "minio"]
+    destinations: ["pgsql", "rustfs"]
     pgsql:
       type: postgres
       receives: records
@@ -32,19 +32,26 @@ dc_bridge:
       password: "$DC_PG_PASSWORD"          # $VAR / ${VAR} env references are expanded
       database: "dc"
       table: "dc"
-    minio:
+    rustfs:
       type: s3
       receives: records
       inputs: ["/dc/measurement/uptime"]
       bucket: "dc-records"
       endpoint: "http://127.0.0.1:9000"    # omit for AWS S3
       region: "us-east-1"
-      access_key_id: "minioadmin"          # omit both to use ambient AWS credentials
+      access_key_id: "rustfsadmin"         # omit both to use ambient AWS credentials
       secret_access_key: "$DC_S3_SECRET"
-      force_path_style: true               # MinIO-style path addressing
+      force_path_style: true               # path-style addressing for self-hosted stores
       key_prefix: "robot1/"
       batch_timeout_secs: 60               # object write interval; Vector default 300
 ```
+
+The `s3` type works with any S3-compatible store. For self-hosting,
+[RustFS](https://rustfs.com/) (Apache 2.0, S3-compatible, a drop-in MinIO
+replacement) is the recommended choice — MinIO's community edition was archived
+upstream in 2026 and no longer receives maintenance — but existing MinIO or Ceph RGW
+deployments work identically: set `endpoint`, explicit credentials, and (typically)
+`force_path_style: true`.
 
 Common parameters for every blessed type: `type`, `receives` (`records`; `files` is
 reserved for the File pipeline, ADR-0005), `inputs` (ROS topic names), `time_key`

--- a/progress.txt
+++ b/progress.txt
@@ -464,3 +464,23 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
   issues #247/#248); a reusable committed dev container for the Jazzy+ros2_rust
   toolchain (still rebuilt ad hoc per session — the #245 image was reused here, which
   helped, but nothing is checked in).
+
+### #246 follow-up — RustFS replaces MinIO as the recommended self-hosted S3 store
+
+- Prompted by MinIO's community edition being discontinued (maintenance mode Dec 2025,
+  "no longer maintained" Feb 2026, repo archived Apr 2026 — verified via current
+  sources, not assumed): docs, params examples, code comments, and the e2e test now
+  recommend RustFS (Apache-2.0, S3-compatible, drop-in MinIO replacement,
+  `rustfs/rustfs` image, S3 API on :9000, defaults `rustfsadmin`/`rustfsadmin`)
+  instead. The `s3` blessed type itself is store-agnostic — nothing in the rendered
+  config changes; existing MinIO/Ceph deployments keep working and the docs say so.
+- Renames: fixture `s3_minio.toml` → `s3_custom_endpoint.toml` (re-`vector validate`d),
+  render test → `renders_an_s3_destination_with_a_self_hosted_custom_endpoint`, e2e
+  test → `published_record_reaches_s3_bucket_when_reachable` (destination name
+  `rustfs`, RustFS default credentials, store-agnostic skip message).
+- **Verified against a real RustFS container** (replacing the MinIO one in the dev
+  netns): `mc` works against it (alias/mb/anonymous-set-public all S3-standard), and
+  the full `colcon test` matrix passed 6/6 in 3 consecutive runs with RustFS up (zero
+  skips — the bucket assertion ran for real, object content confirmed with normalized
+  `date` and Tag) plus 1 run with stores down (skip path). Vector's `aws_s3` sink
+  needed no changes to deliver to RustFS.

--- a/progress.txt
+++ b/progress.txt
@@ -370,3 +370,97 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
   toolchain (every DC 2.0 Rust-package slice so far — #242, #243, #244, and this one —
   has rebuilt the same ad hoc Docker environment from scratch in-session, with nothing
   checked into the repo to reuse it; worth its own follow-up issue).
+
+### #246 - DC 2.0 S5: S3/file/console blessed destinations + passthrough contract
+
+- Completed the blessed Destination set in `dc_bridge_core::render` (ADR-0003):
+  `DestinationKind` now has `Postgres`, `S3`, `File`, and `Console` variants.
+  - `s3` → Vector `aws_s3` sink: required `bucket`; optional `region`, `endpoint`
+    (MinIO/Ceph-style custom endpoints), `key_prefix`, `access_key_id` +
+    `secret_access_key` (validated as both-or-neither — half a pair is a clear
+    `IncompleteS3Auth` startup error; omit both for ambient AWS credentials),
+    `force_path_style`, and `batch_timeout_secs` (>0 validated; omitted, Vector's own
+    300 s default applies). `secret_access_key` gets the same `$VAR` env expansion as
+    the Postgres `password`. `encoding.codec = "json"` (Vector 0.57 removed the `ndjson`
+    codec name; newline/array framing is the sink's default) + the shared disk buffer.
+  - `file` → Vector `file` sink: required `path` (Vector template syntax passes
+    through), JSON encoding, disk buffer.
+  - `console` → Vector `console` sink on stdout, JSON encoding, deliberately *no* disk
+    buffer (debugging sink; a disk buffer would replay old output across restarts).
+  - `time_key`/`time_format` moved from `PostgresParams` up to `Destination` — they
+    were always destination-generic (the Humble flb destinations all had them), and the
+    normalize transform now renders one `if includes([tags], .tag)` block per
+    destination of any type. `RawPostgresParams` became the flat, all-types
+    `RawDestinationParams` (mirroring how ROS declares `<name>.*` params).
+- **Aligned the passthrough routing contract with ADR-0003: routes are now per-Tag, not
+  per-Destination.** #245 rendered one route branch per Destination (`dc.<name>`); the
+  ADR and #246 fix the public name as `dc.<tag>` — one branch per distinct Tag across
+  every Destination's `inputs`, branch id = the Tag verbatim, so Records for Tag
+  `dc.measurement.uptime` are consumable at `dc.dc.measurement.uptime` (leading `dc.` =
+  the route transform id, rest = Tag). Blessed sinks now consume their inputs' per-Tag
+  routes (`sink_inputs`), and custom snippets consume exactly the same names. Verified
+  against the real Vector 0.57.0 binary *before* writing the Rust (downloaded, checksum
+  -verified against vector_vendor's pin): route ids containing dots validate and
+  resolve, multi-`--config` merging works, and duplicate component ids across files are
+  rejected by `vector validate` with a clear error.
+- Passthrough (`custom_config_files` parameter): a list of raw Vector TOML snippet
+  paths ($VAR-expanded), read at startup and validated by the new pure
+  `validate_custom_config_files`: must parse as TOML, define ≥1 component, and not
+  claim component ids owned by the rendered config (`dc_bridge_in`,
+  `dc_bridge_normalize`, `dc` — destination names colliding with those are now also
+  rejected via `ReservedDestinationName`, a latent #245 gap since a destination named
+  `dc` would have collided with the route transform) or by another snippet — each its
+  own `RenderError` variant with a test. Snippets are handed to Vector as extra
+  `--config` args (`SupervisorConfig::vector` now takes a path list). As a backstop,
+  `main.rs` runs `vector validate --no-environment` over the merged config set before
+  the Supervisor starts (catches what pure checks can't: dangling `dc.<tag>` inputs,
+  bad sink options), so every bad-snippet path is a loud startup error naming the file,
+  never a supervised-Vector crash loop.
+- Gold-file tests: 3 new fixtures (`s3_minio.toml` — custom endpoint + auth +
+  force_path_style + batch timeout; `s3_aws.toml` — region + ambient credentials;
+  `file_and_console.toml`) generated from the renderer's real output like #245's, and
+  all 6 fixtures (3 regenerated for per-Tag routes) `vector validate`d against the real
+  pinned binary. `dc_bridge_core` is now at 55 tests (`cargo test`, no ROS needed);
+  `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean.
+- Docs: `doc/src/dc/destinations.md` got a "DC 2.0 (Jazzy)" section — config contract
+  with param tables for all four blessed types, **the `dc.<tag>` routing contract
+  documented as stable public API**, and a `custom_config_files` walkthrough with an
+  un-blessed `http` sink example; the Fluent Bit content below it is explicitly marked
+  Legacy (Humble). `dc_bringup/params/dc_params.yaml` gained commented-out s3 (MinIO)/
+  file/console/custom_config_files examples next to the live `pgsql` block.
+- **Verified in the real ROS 2 Jazzy + ros2_rust Docker environment** (fresh container
+  from the image the #244/#245 sessions built, this worktree bind-mounted;
+  `colcon build --packages-up-to dc_bridge` succeeded first try — zero changes needed
+  to main.rs). `tests/end_to_end.rs` grew from 3 to 6 `colcon test`-integrated tests:
+  - `published_record_reaches_minio_bucket_when_reachable` — the MinIO demo acceptance
+    criterion, automated: a real MinIO container (bucket `dc-records`, anonymous public
+    read so the test asserts via plain `curl` + `zcat` instead of a SigV4 client),
+    dc_bridge configured purely via ROS params, marker Record published, object
+    content-asserted (skips with a clear message when nothing listens on :9000).
+  - `custom_snippet_ships_records_to_an_http_sink` — the passthrough demo acceptance
+    criterion, automated and fully self-contained: the test binds its own TCP listener,
+    plays the HTTP server (200-everything, Content-Length-aware request capture), and
+    asserts a snippet's un-blessed `http` sink consuming `dc.dc.measurement.uptime`
+    delivers the published Record.
+  - `colliding_custom_snippet_fails_startup_loudly` — snippet claiming the `pgsql` sink
+    id must make dc_bridge exit non-zero naming the component, not start anyway.
+  - The 3 existing tests (readiness, SIGTERM, Postgres row) unchanged in behavior.
+- **Found and fixed one real bug the expanded test matrix caught**: with the containers
+  down (skip-path run), `stops_the_supervised_vector_process_on_sigterm` intermittently
+  failed — the ctrlc handler was installed only *after* `Supervisor::start()`, so a
+  SIGTERM landing in that window (widened in practice by the new `vector validate`
+  startup step shifting test timing) killed dc_bridge via the OS default and orphaned
+  the freshly-spawned Vector (the leftover PID from the failing run was later found as
+  a zombie, confirming the diagnosis). Fixed by installing the handler *before* the
+  first `start()` and making `Supervisor::start` a no-op after `stop()` (new
+  `start_never_spawns_after_stop` regression test alongside #245's
+  `poll_restart_never_respawns_after_stop`).
+- Final matrix: `colcon test --packages-select dc_bridge` green 6/6 tests in 11
+  consecutive runs — 5 with MinIO+Postgres up (real store assertions), 5 with both down
+  (skip paths) post-fix, plus the initial run — with zero leftover Vector processes.
+  `pre-commit` clean on every changed file (same `build-doc`/`poetry-requirements`/
+  `pycln`/`flake8` skips as #242-#245, all broken/heavy independent of this diff).
+- **Not done / left for follow-up**: `receives: files` (the File pipeline, ADR-0005,
+  issues #247/#248); a reusable committed dev container for the Jazzy+ros2_rust
+  toolchain (still rebuilt ad hoc per session — the #245 image was reused here, which
+  helped, but nothing is checked in).

--- a/progress.txt
+++ b/progress.txt
@@ -484,3 +484,24 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
   skips — the bucket assertion ran for real, object content confirmed with normalized
   `date` and Tag) plus 1 run with stores down (skip path). Vector's `aws_s3` sink
   needed no changes to deliver to RustFS.
+
+### #246 follow-up — store-backed e2e tests hard-fail instead of skipping
+
+- Decision (from review discussion): the Postgres- and S3-backed end-to-end tests must
+  never skip. Investigation of the old skip path showed it was worse than intended:
+  libtest swallows passing tests' output, so the "skipping…" eprintln never appeared
+  anywhere in a default `colcon test` run (confirmed empirically — zero "skipping"
+  occurrences in colcon's captured stdout.log during stores-down runs) and a run whose
+  store assertions never executed reported the same "6 passed" as a real one — a change
+  could look verified when the pipeline was never exercised.
+- `published_record_lands_in_postgres` and `published_record_reaches_s3_bucket`
+  (renamed from `*_when_reachable`) now keep the fast TCP pre-probe but `assert!` on
+  it: missing store = immediate test failure (~3 s, not a slow pipeline timeout) with
+  setup instructions in the panic message (the compose file / the exact RustFS + `mc`
+  one-liners). Running the dc_bridge suite now *requires* both containers; module doc
+  and README updated to say so and why.
+- Verified both directions in the real environment: stores up → 6/6 green, 3
+  consecutive runs; stores down → exactly the two store tests fail immediately with
+  the instructive messages visible in the failure output, and `colcon test-result`
+  exits 1 (CI-gating works; `colcon test` itself always exits 0 by colcon convention)
+  — then green again after restarting the containers.


### PR DESCRIPTION
Closes #246

## What this does

Completes the blessed Destination set (ADR-0003) in `dc_bridge`'s config renderer and lands the passthrough contract:

- **`s3` blessed type** → Vector `aws_s3` sink: required `bucket`; optional `region`, `endpoint` (RustFS/MinIO/Ceph-style custom endpoints), `key_prefix`, `access_key_id`+`secret_access_key` (both-or-neither, validated; omit for ambient AWS credentials; `$VAR` env expansion on the secret), `force_path_style`, `batch_timeout_secs`.
- **`file` blessed type** → Vector `file` sink (`path` with Vector template syntax, JSON encoding, disk buffer).
- **`console` blessed type** → stdout JSON sink (no disk buffer — debugging sink).
- **Per-Tag routes (`dc.<tag>`), documented as public API**: #245 rendered per-Destination routes (`dc.<name>`); ADR-0003 fixes the contract as one route per Tag. The route transform `dc` now has one branch per distinct Tag across all `inputs`, branch id = Tag verbatim, so e.g. Tag `dc.measurement.uptime` is consumable at `dc.dc.measurement.uptime` by blessed sinks and custom snippets alike. Contract documented in `doc/src/dc/destinations.md`.
- **Passthrough (`custom_config_files`)**: raw Vector TOML snippets merged natively via extra `--config` args, exposing Vector's whole sink catalog with zero DC code. Invalid/colliding snippets fail loudly at startup: pure validation (TOML parse, ≥1 component, no collisions with rendered ids or other snippets — each a `RenderError` naming the file) plus a `vector validate --no-environment` backstop before the Supervisor starts. Destination names claiming rendered component ids (`dc`, `dc_bridge_in`, `dc_bridge_normalize`) are now rejected too (latent #245 gap).

## Acceptance criteria

- ✅ Gold-file tests cover s3 (self-hosted custom endpoint + AWS ambient-credentials variants), file, and console — fixtures generated from the renderer's real output and `vector validate`d against the real pinned Vector 0.57.0
- ✅ Demo: Records reach an S3-compatible store's bucket configured purely via ROS params — automated as `published_record_reaches_s3_bucket` (verified against a real RustFS container; object content asserted)
- ✅ Demo: a passthrough snippet ships Records to an un-blessed `http` sink by consuming `dc.dc.measurement.uptime` — automated as `custom_snippet_ships_records_to_an_http_sink`, fully self-contained (the test plays the HTTP server)
- ✅ Invalid/colliding snippets fail loudly at startup — unit tests per `RenderError` variant + `colliding_custom_snippet_fails_startup_loudly` end-to-end
- ✅ `dc.<tag>` routing contract documented as public API in the destinations docs page

## Verification

- Vector semantics (dotted route ids, multi-`--config` merge, duplicate-id rejection, sink schemas) verified against the real checksum-pinned Vector 0.57.0 binary **before** writing the Rust; all 6 gold fixtures re-validated with it.
- `dc_bridge_core`: 55 tests, `clippy --all-targets -- -D warnings` and `fmt --check` clean (plain cargo, no ROS).
- Real ROS 2 Jazzy + ros2_rust Docker environment: `colcon build --packages-up-to dc_bridge` clean first try; `colcon test --packages-select dc_bridge` green 6/6 in 11 consecutive runs — with RustFS/MinIO+Postgres containers up (real store assertions: object landed in the bucket with normalized `date`, row landed in Postgres), 5 with both down (skip paths) — zero leftover Vector processes.
- **One real bug found and fixed by the expanded matrix**: a SIGTERM landing between `Supervisor::start()` and ctrlc-handler installation orphaned the freshly-spawned Vector (reproduced; the orphan was later found as a zombie). Handler now installs before the first `start()`, and `start()` is a no-op after `stop()` (`start_never_spawns_after_stop` regression test).
- `pre-commit` clean on all changed files (usual `build-doc`/`poetry-requirements`/`pycln`/`flake8` skips, broken/heavy independent of this diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ML2GZ914n2tN1ptiqdPb2x


---

**Update**: since MinIO's community edition was discontinued upstream (repo archived April 2026), the docs, examples, and the s3 end-to-end test now recommend **RustFS** (Apache-2.0, S3-compatible drop-in replacement) as the self-hosted store. The `s3` blessed type is store-agnostic — the rendered config is unchanged and existing MinIO/Ceph deployments keep working. Full test matrix re-verified against a real RustFS container (6/6 green, 3 consecutive runs, real bucket assertions, plus the stores-down skip path).



**Update 2**: per review, the Postgres- and S3-backed tests now **hard-fail with setup instructions instead of skipping** when their store is missing. The old skip note was swallowed by libtest output capture, so a run whose store assertions never executed was indistinguishable from a verified one. Running the dc_bridge suite now requires both containers; verified both directions (stores up: 6/6 green ×3; stores down: exactly the two store tests fail in ~3s and `colcon test-result` exits 1).
