### PR TITLE
DC 2.0 S6: Launch integration — deterministic startup ordering

### DIFF
--- a/dc_bridge/dc_bridge_core/Cargo.lock
+++ b/dc_bridge/dc_bridge_core/Cargo.lock
@@ -12,6 +12,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 name = "dc_bridge_core"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "rmpv",
  "serde_json",
  "socket2",

--- a/dc_bridge/dc_bridge_core/Cargo.toml
+++ b/dc_bridge/dc_bridge_core/Cargo.toml
@@ -17,5 +17,8 @@ toml = "0.8"
 serde_json = "1"
 thiserror = "1"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 socket2 = "0.5"

--- a/dc_bridge/dc_bridge_core/src/supervisor.rs
+++ b/dc_bridge/dc_bridge_core/src/supervisor.rs
@@ -60,13 +60,32 @@ impl Supervisor {
     /// Spawns the supervised process. A no-op once [`Supervisor::stop`] has been
     /// called, so a signal handler installed *before* the first `start()` (as `main.rs`
     /// does) can never race it into spawning a process nobody will ever stop.
+    ///
+    /// On Linux the child gets `PR_SET_PDEATHSIG(SIGKILL)`, so it cannot outlive the
+    /// Bridge even when the Bridge dies by SIGKILL/crash (paths no signal handler can
+    /// cover). Without it, a SIGKILLed Bridge orphans Vector, which keeps the Fluent
+    /// Forward port bound — the launch-respawned Bridge then spawns a second Vector
+    /// that crash-loops on the bind, and the pipeline never recovers. Note the kernel
+    /// delivers the signal when the spawning *thread* exits, not just the process; both
+    /// `main.rs` call sites (main thread, and a background thread that lives until
+    /// process exit) satisfy this.
     pub fn start(&mut self) -> io::Result<()> {
         if self.stopped {
             return Ok(());
         }
-        let child = Command::new(&self.config.program)
-            .args(&self.config.args)
-            .spawn()?;
+        let mut command = Command::new(&self.config.program);
+        command.args(&self.config.args);
+        #[cfg(target_os = "linux")]
+        unsafe {
+            use std::os::unix::process::CommandExt;
+            command.pre_exec(|| {
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) != 0 {
+                    return Err(io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = command.spawn()?;
         self.child = Some(child);
         Ok(())
     }
@@ -76,6 +95,11 @@ impl Supervisor {
             Some(child) => matches!(child.try_wait(), Ok(None)),
             None => false,
         }
+    }
+
+    /// Pid of the currently supervised process, if one has been spawned.
+    pub fn child_id(&self) -> Option<u32> {
+        self.child.as_ref().map(|child| child.id())
     }
 
     /// Checks whether the supervised process has exited and, if so, restarts it

--- a/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
+++ b/dc_bridge/dc_bridge_core/tests/supervisor_tests.rs
@@ -104,3 +104,49 @@ fn start_never_spawns_after_stop() {
         "start() must not spawn anything once the supervisor has been stopped"
     );
 }
+
+/// The supervised process must not outlive whoever spawned it, even when the Bridge
+/// dies by a path no signal handler covers (SIGKILL, crash). `start()` sets
+/// `PR_SET_PDEATHSIG(SIGKILL)` on Linux, which the kernel delivers when the spawning
+/// *thread* exits — so spawning from a short-lived thread and joining it stands in
+/// for "the Bridge process was SIGKILLed" without having to kill the test runner.
+#[cfg(target_os = "linux")]
+#[test]
+fn supervised_process_dies_with_its_spawner() {
+    let child_pid = std::thread::spawn(|| {
+        let mut supervisor = Supervisor::new(SupervisorConfig {
+            program: "sh".into(),
+            args: vec!["-c".to_string(), "sleep 30".to_string()],
+            restart_backoff: Duration::from_millis(0),
+        });
+        supervisor.start().unwrap();
+        assert!(supervisor.is_running());
+        supervisor.child_id().unwrap()
+    })
+    .join()
+    .unwrap();
+
+    // Once PDEATHSIG fires the child is a zombie (state Z) until reaped — and nothing
+    // will reap it here, since its `Child` handle was dropped with the thread. /proc
+    // state is the visible difference (kill(pid, 0) still succeeds on zombies). Poll
+    // briefly: signal delivery on thread exit is fast but asynchronous. The state
+    // field is the first character after the ")" closing the comm field.
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let state = std::fs::read_to_string(format!("/proc/{child_pid}/stat"))
+            .ok()
+            .and_then(|stat| {
+                let after_comm = &stat[stat.rfind(')')? + 1..];
+                after_comm.split_whitespace().next().map(str::to_string)
+            });
+        match state.as_deref() {
+            None | Some("Z") => break, // gone entirely, or killed-but-unreaped
+            _ if std::time::Instant::now() > deadline => {
+                panic!(
+                    "supervised process (pid {child_pid}) survived its spawner (state {state:?})"
+                );
+            }
+            _ => std::thread::sleep(Duration::from_millis(50)),
+        }
+    }
+}

--- a/dc_bringup/CMakeLists.txt
+++ b/dc_bringup/CMakeLists.txt
@@ -17,4 +17,9 @@ install(
   DIRECTORY launch params
   DESTINATION share/${PROJECT_NAME})
 
+install(
+  PROGRAMS scripts/bridge_ready_gate.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME bridge_ready_gate)
+
 ament_package()

--- a/dc_bringup/launch/dc_bringup.launch.py
+++ b/dc_bringup/launch/dc_bringup.launch.py
@@ -6,14 +6,44 @@ from launch.actions import (
     DeclareLaunchArgument,
     GroupAction,
     IncludeLaunchDescription,
+    LogInfo,
+    RegisterEventHandler,
     SetEnvironmentVariable,
+    Shutdown,
 )
 from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import LoadComposableNodes, Node, SetParameter
 from launch_ros.descriptions import ComposableNode
 from nav2_common.launch import RewrittenYaml
+
+
+def start_collection_after_gate(collection_actions):
+    """Handler for the bridge_ready_gate's exit (ADR-0006 startup ordering).
+
+    Gate exited 0 (Bridge reported ready): start the lifecycle manager, which
+    configures and activates the collection nodes. Gate exited non-zero (the
+    Bridge never became ready before the gate's deadline): shut the whole
+    launch down loudly rather than leave a half-started pipeline running.
+    """
+
+    def on_gate_exit(event, context):
+        if event.returncode == 0:
+            return [
+                LogInfo(msg="dc_bridge reports ready; activating collection nodes."),
+                *collection_actions,
+            ]
+        return [
+            LogInfo(
+                msg="dc_bridge never became ready "
+                f"(bridge_ready_gate exited {event.returncode}); shutting down."
+            ),
+            Shutdown(reason="dc_bridge never became ready"),
+        ]
+
+    return on_gate_exit
 
 
 def generate_launch_description():
@@ -104,6 +134,71 @@ def generate_launch_description():
         "group_node", default_value="False", description="Start group_node"
     )
 
+    # ADR-0006 deterministic startup: the Bridge (which spawns and supervises
+    # Vector) comes up as a plain node first; a readiness gate process blocks on
+    # its ~/ready service; only when the gate exits successfully does the
+    # lifecycle manager start and activate the collection nodes. No Record can
+    # be emitted before the pipeline can accept it. The gate and the deferred
+    # lifecycle manager exist once per composition branch because a launch
+    # action instance cannot be shared between groups.
+    lifecycle_manager_params = [
+        {
+            "use_sim_time": use_sim_time,
+            "autostart": autostart,
+            "node_names": [
+                "measurement_server",
+            ],
+            "transitions": ["configure", "activate"],
+            "bond_timeout": 10.0,
+        },
+    ]
+
+    bridge_ready_gate = Node(
+        package="dc_bringup",
+        executable="bridge_ready_gate",
+        name="bridge_ready_gate",
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+        parameters=[configured_params],
+    )
+
+    lifecycle_manager_node = Node(
+        package="dc_lifecycle_manager",
+        executable="lifecycle_manager",
+        name="lifecycle_manager_dc",
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+        arguments=["--ros-args", "--log-level", log_level],
+        parameters=lifecycle_manager_params,
+    )
+
+    bridge_ready_gate_composed = Node(
+        package="dc_bringup",
+        executable="bridge_ready_gate",
+        name="bridge_ready_gate",
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+        parameters=[configured_params],
+    )
+
+    load_lifecycle_manager_composed = LoadComposableNodes(
+        target_container=container_name,
+        composable_node_descriptions=[
+            ComposableNode(
+                package="dc_lifecycle_manager",
+                plugin="dc_lifecycle_manager::LifecycleManager",
+                name="lifecycle_manager_dc",
+                parameters=lifecycle_manager_params,
+            ),
+        ],
+    )
+
     load_nodes = GroupAction(
         condition=IfCondition(PythonExpression(["not ", use_composition])),
         actions=[
@@ -166,7 +261,8 @@ def generate_launch_description():
             # the DC 2.0 embedded-Fluent-Bit demolition slice (#241/#242); dc_bridge (Rust)
             # stands in its place, forwarding Records to the Vector shipper it supervises
             # internally (ADRs 0001/0004/0006). It is a plain node outside the lifecycle
-            # manager, so it isn't in lifecycle_manager_dc's node_names below.
+            # manager, so it isn't in lifecycle_manager_dc's node_names; launch respawn
+            # supervises it unconditionally (ADR-0006), independent of use_respawn.
             Node(
                 package="dc_bridge",
                 executable="dc_bridge",
@@ -175,29 +271,16 @@ def generate_launch_description():
                     "stdout": "screen",
                     "stderr": "screen",
                 },
-                respawn=use_respawn,
+                respawn=True,
                 respawn_delay=2.0,
                 parameters=[configured_params],
             ),
-            Node(
-                package="dc_lifecycle_manager",
-                executable="lifecycle_manager",
-                name="lifecycle_manager_dc",
-                output={
-                    "stdout": "screen",
-                    "stderr": "screen",
-                },
-                arguments=["--ros-args", "--log-level", log_level],
-                parameters=[
-                    {
-                        "autostart": autostart,
-                        "node_names": [
-                            "measurement_server",
-                        ],
-                        "transitions": ["configure", "activate"],
-                        "bond_timeout": 10.0,
-                    },
-                ],
+            bridge_ready_gate,
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=bridge_ready_gate,
+                    on_exit=start_collection_after_gate([lifecycle_manager_node]),
+                )
             ),
         ],
     )
@@ -259,7 +342,8 @@ def generate_launch_description():
             # destination_server (dc_destinations) is COLCON_IGNOREd on the jazzy line pending
             # the DC 2.0 embedded-Fluent-Bit demolition slice (#241/#242); dc_bridge (Rust)
             # stands in its place. rclrs has no rclcpp_components equivalent, so it always
-            # runs as a plain node (ADR-0006), even when the rest of the stack is composed.
+            # runs as a plain node (ADR-0006), even when the rest of the stack is composed;
+            # launch respawn supervises it unconditionally, independent of use_respawn.
             Node(
                 package="dc_bridge",
                 executable="dc_bridge",
@@ -268,6 +352,8 @@ def generate_launch_description():
                     "stdout": "screen",
                     "stderr": "screen",
                 },
+                respawn=True,
+                respawn_delay=2.0,
                 parameters=[configured_params],
             ),
             LoadComposableNodes(
@@ -279,22 +365,14 @@ def generate_launch_description():
                         name="measurement_server",
                         parameters=[configured_params],
                     ),
-                    ComposableNode(
-                        package="dc_lifecycle_manager",
-                        plugin="dc_lifecycle_manager::LifecycleManager",
-                        name="lifecycle_manager_dc",
-                        parameters=[
-                            {
-                                "autostart": autostart,
-                                "node_names": [
-                                    "measurement_server",
-                                ],
-                                "transitions": ["configure", "activate"],
-                                "bond_timeout": 10.0,
-                            },
-                        ],
-                    ),
                 ],
+            ),
+            bridge_ready_gate_composed,
+            RegisterEventHandler(
+                OnProcessExit(
+                    target_action=bridge_ready_gate_composed,
+                    on_exit=start_collection_after_gate([load_lifecycle_manager_composed]),
+                )
             ),
         ],
     )

--- a/dc_bringup/package.xml
+++ b/dc_bringup/package.xml
@@ -15,7 +15,10 @@
     <exec_depend>dc_group</exec_depend>
     <exec_depend>dc_measurements</exec_depend>
     <exec_depend>dc_services</exec_depend>
+    <exec_depend>nav2_common</exec_depend>
     <exec_depend>nav2_lifecycle_manager</exec_depend>
+    <exec_depend>rclpy</exec_depend>
+    <exec_depend>std_srvs</exec_depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/dc_bringup/scripts/bridge_ready_gate.py
+++ b/dc_bringup/scripts/bridge_ready_gate.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Readiness gate for the DC bringup startup sequence (ADR-0006).
+
+Polls the Bridge's readiness service (``std_srvs/Trigger``, default
+``dc_bridge/ready``) until it answers ``success=True``, then exits 0.
+``dc_bringup.launch.py`` starts the lifecycle manager — and therefore the
+activation of the collection nodes — only on this process's successful
+exit, so no Record can be emitted before the Bridge and the Vector
+shipper it supervises are able to accept it. Exits 1 if the deadline
+passes first, which the launch file turns into a full shutdown.
+"""
+
+import sys
+import time
+
+import rclpy
+from rclpy.node import Node
+from std_srvs.srv import Trigger
+
+
+def main():
+    rclpy.init()
+    node = Node("bridge_ready_gate")
+    service = node.declare_parameter("service", "dc_bridge/ready").value
+    timeout_s = node.declare_parameter("timeout_s", 120.0).value
+    poll_interval_s = node.declare_parameter("poll_interval_s", 0.5).value
+
+    client = node.create_client(Trigger, service)
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if not client.wait_for_service(timeout_sec=min(poll_interval_s, remaining)):
+            continue
+        future = client.call_async(Trigger.Request())
+        rclpy.spin_until_future_complete(
+            node, future, timeout_sec=min(poll_interval_s * 2, remaining)
+        )
+        if future.done():
+            response = future.result()
+            if response is not None and response.success:
+                node.get_logger().info(f"Bridge is ready: {response.message}")
+                node.destroy_node()
+                rclpy.shutdown()
+                return 0
+        else:
+            client.remove_pending_request(future)
+        time.sleep(poll_interval_s)
+
+    node.get_logger().error(f"Bridge did not report ready on '{service}' within {timeout_s}s")
+    node.destroy_node()
+    rclpy.shutdown()
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        # Launch shutdown (SIGINT) while still polling: exit quietly.
+        sys.exit(130)

--- a/dc_lifecycle_manager/src/lifecycle_manager.cpp
+++ b/dc_lifecycle_manager/src/lifecycle_manager.cpp
@@ -50,12 +50,12 @@ LifecycleManager::LifecycleManager(const rclcpp::NodeOptions& options)
   callback_group_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   manager_srv_ = create_service<ManageLifecycleNodes>(get_name() + std::string("/manage_nodes"),
                                                       std::bind(&LifecycleManager::managerCallback, this, _1, _2, _3),
-                                                      rclcpp::ServicesQoS().get_rmw_qos_profile(), callback_group_);
+                                                      rclcpp::ServicesQoS(), callback_group_);
 
   is_active_srv_ =
       create_service<std_srvs::srv::Trigger>(get_name() + std::string("/is_active"),
                                              std::bind(&LifecycleManager::isActiveCallback, this, _1, _2, _3),
-                                             rclcpp::ServicesQoS().get_rmw_qos_profile(), callback_group_);
+                                             rclcpp::ServicesQoS(), callback_group_);
 
   transition_state_map_[Transition::TRANSITION_CONFIGURE] = State::PRIMARY_STATE_INACTIVE;
   transition_state_map_[Transition::TRANSITION_CLEANUP] = State::PRIMARY_STATE_UNCONFIGURED;
@@ -273,19 +273,14 @@ bool LifecycleManager::startup()
 {
   message("Starting managed nodes bringup...");
 
-  for (size_t i = 0; i < node_names_.size(); i++)
+  // Each transition in `transitions` is applied to every managed node before the
+  // next transition runs (all nodes configured, then all activated) — not paired
+  // index-wise with `node_names`, which silently dropped every transition beyond
+  // the node count (e.g. a single managed node was configured but never activated).
+  for (const auto& transition : transitions_)
   {
-    try
+    if (!changeStateForAllNodes(getTransition(transition)))
     {
-      if (!changeStateForNode(node_names_[i], getTransition(transitions_[i])))
-      {
-        return false;
-      }
-    }
-    catch (const std::runtime_error& e)
-    {
-      RCLCPP_ERROR(get_logger(), "Failed to change state for node: %s. Exception: %s.", node_names_[i].c_str(),
-                   e.what());
       return false;
     }
   }

--- a/dc_measurements/plugins/measurements/camera.cpp
+++ b/dc_measurements/plugins/measurements/camera.cpp
@@ -75,8 +75,8 @@ void Camera::onConfigure()
 
   if (std::find(detection_modules_.begin(), detection_modules_.end(), "barcode") != detection_modules_.end())
   {
-    cli_barcodes_ = node->create_client<dc_interfaces::srv::DetectBarcode>(
-        "/dc/service/detect_barcodes", rmw_qos_profile_services_default, client_cb_group_);
+    cli_barcodes_ = node->create_client<dc_interfaces::srv::DetectBarcode>("/dc/service/detect_barcodes",
+                                                                           rclcpp::ServicesQoS(), client_cb_group_);
     while (!cli_barcodes_->wait_for_service(std::chrono::seconds(1)))
     {
       if (!rclcpp::ok())
@@ -90,8 +90,8 @@ void Camera::onConfigure()
 
   if (draw_det_barcodes_)
   {
-    cli_draw_image_ = node->create_client<dc_interfaces::srv::DrawImage>(
-        "/dc/service/draw_image", rmw_qos_profile_services_default, client_cb_group_);
+    cli_draw_image_ = node->create_client<dc_interfaces::srv::DrawImage>("/dc/service/draw_image",
+                                                                         rclcpp::ServicesQoS(), client_cb_group_);
     while (!cli_draw_image_->wait_for_service(std::chrono::seconds(1)))
     {
       if (!rclcpp::ok())

--- a/dc_util/include/dc_util/node_utils.hpp
+++ b/dc_util/include/dc_util/node_utils.hpp
@@ -128,7 +128,7 @@ template <typename NodeT>
 bool get_bool_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_BOOL);
-  bool bool_param;
+  bool bool_param = false;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, bool_param))
@@ -152,7 +152,7 @@ bool get_bool_type_param(NodeT node, const std::string& plugin_name, const std::
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
                                                rclcpp::ParameterValue(default_value));
-  bool bool_param;
+  bool bool_param = false;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, bool_param))
@@ -174,7 +174,7 @@ template <typename NodeT>
 int get_int_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_INTEGER);
-  int int_param;
+  int int_param = 0;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, int_param))
@@ -198,7 +198,7 @@ int get_int_type_param(NodeT node, const std::string& plugin_name, const std::st
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
                                                rclcpp::ParameterValue(default_value));
-  int int_param;
+  int int_param = 0;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, int_param))
@@ -220,7 +220,7 @@ template <typename NodeT>
 int get_float_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_DOUBLE);
-  float float_param;
+  float float_param = 0.0F;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, float_param))
@@ -244,7 +244,7 @@ int get_float_type_param(NodeT node, const std::string& plugin_name, const std::
 {
   nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
                                                rclcpp::ParameterValue(default_value));
-  float float_param;
+  float float_param = 0.0F;
   try
   {
     if (!node->get_parameter(plugin_name + "." + param_name, float_param))

--- a/doc/src/dc/data_pipeline.md
+++ b/doc/src/dc/data_pipeline.md
@@ -1,5 +1,33 @@
 # Data Pipeline
 
+## DC 2.0 (Jazzy): deterministic startup ordering
+
+On the Jazzy line, `dc_bringup.launch.py` brings the pipeline up in a fixed order
+(ADR-0006), so no Record can be emitted before the pipeline is able to accept it:
+
+1. **Bridge first.** `dc_bridge` starts as a plain node (outside the lifecycle
+   manager) and spawns the Vector shipper as a supervised child process. The
+   measurement server also starts here, but stays unconfigured and inactive — its
+   publishers cannot emit anything yet.
+2. **Readiness gate.** A `bridge_ready_gate` process blocks polling the Bridge's
+   `~/ready` service (`std_srvs/Trigger`), which answers `success=True` only once
+   Vector is accepting Fluent Forward connections. The gate's `service`,
+   `timeout_s` (default 120 s), and `poll_interval_s` parameters are configurable
+   from the params file under `bridge_ready_gate:`.
+3. **Activation.** Only when the gate exits successfully does the launch start
+   `lifecycle_manager_dc`, which configures and then activates the collection
+   nodes. If the Bridge never becomes ready before the gate's deadline, the whole
+   launch shuts down loudly instead of leaving a half-started pipeline running.
+
+Supervision after startup: the launch file respawns `dc_bridge` unconditionally
+(independent of `use_respawn`), and the Bridge supervises its Vector child —
+including a Linux parent-death signal, so Vector can never outlive the Bridge
+even across a SIGKILL/crash. Records published while the Bridge is down are
+dropped (topics are fire-and-forget); delivery resumes as soon as the respawned
+Bridge is ready.
+
+## Legacy (Humble): embedded Fluent Bit pipeline
+
 ```mermaid
 flowchart LR
     dc_bringup_launch["DC Bringup Launch"]

--- a/progress.txt
+++ b/progress.txt
@@ -505,3 +505,76 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
   the instructive messages visible in the failure output, and `colcon test-result`
   exits 1 (CI-gating works; `colcon test` itself always exits 0 by colcon convention)
   — then green again after restarting the containers.
+
+### #247 - DC 2.0 S6: Launch integration — deterministic startup ordering
+
+- Rewired `dc_bringup/launch/dc_bringup.launch.py` (both composition branches) into the
+  ADR-0006 deterministic startup chain: dc_bridge (which spawns/supervises Vector) starts
+  first as a plain node; a new `bridge_ready_gate` process blocks on the Bridge's
+  `~/ready` service; only when the gate exits 0 does a `RegisterEventHandler(OnProcessExit)`
+  start the lifecycle manager (plain `Node` in the non-composed branch, deferred
+  `LoadComposableNodes` in the composed one), which configures+activates
+  `measurement_server` exactly as before. If the gate times out (Bridge never ready), the
+  handler logs it and issues a full launch `Shutdown` instead of leaving a half-started
+  pipeline. The Bridge's launch `respawn` is now unconditional (`respawn=True`,
+  independent of `use_respawn`) per ADR-0006 — in the composed branch it previously had
+  no respawn at all.
+- New `dc_bringup/scripts/bridge_ready_gate.py` (installed as `bridge_ready_gate`): rclpy
+  node polling a `std_srvs/Trigger` service until `success=True`; parameters `service`
+  (default `dc_bridge/ready`), `timeout_s` (120), `poll_interval_s` (0.5), configurable
+  from the params file (`bridge_ready_gate:` section); exit 0 = ready, 1 = deadline
+  passed. The gate nodes take `configured_params` like every other node. Added
+  `rclpy`/`std_srvs` exec_depends (plus the previously-undeclared `nav2_common` the launch
+  file already imported).
+- **Supervisor hardening in `dc_bridge_core` (found while verifying the "kill the Bridge"
+  criterion)**: `Supervisor::start` now sets `PR_SET_PDEATHSIG(SIGKILL)` on the spawned
+  Vector (Linux `pre_exec`), so Vector can never outlive the Bridge even when the Bridge
+  dies by SIGKILL/crash — paths the #244 ctrlc handler can't cover. Without it (verified
+  empirically as a negative control with the old binary): SIGKILL orphans Vector, which
+  keeps port 24224 bound; the launch-respawned Bridge then spawns a second Vector that
+  crash-loops on the bind, and data flows through the *unsupervised orphan* — looks
+  recovered until shutdown leaves the orphan behind. New `libc` dependency (Linux-only
+  target), new `child_id()` accessor, new `supervised_process_dies_with_its_spawner`
+  regression test (PDEATHSIG fires on spawner-thread exit, so a joined thread stands in
+  for the killed process). 56 `cargo test` pass, clippy/fmt clean.
+- **Three latent bugs fixed that this slice's first-ever real Jazzy build/run of the C++
+  stack exposed** (the #242 port was verified read-only; CI for Jazzy doesn't exist yet):
+  1. `dc_lifecycle_manager::startup()` paired node i with transition i, so with the
+     DC 2.0 single managed node (`measurement_server`) + `transitions: [configure,
+     activate]`, **activate never ran** — "Managed nodes are active" printed while the
+     LifecyclePublisher stayed inactive and zero Records flowed. Now each transition in
+     `transitions` is applied to all nodes in order (configure all, then activate all).
+  2. `dc_lifecycle_manager`/`dc_measurements` used Jazzy-removed `rmw_qos_profile_t`
+     create_service/create_client overloads (deprecation = error under `-Werror`); now
+     `rclcpp::ServicesQoS()`.
+  3. `dc_util/node_utils.hpp` primitive param locals were uninitialized →
+     `-Wmaybe-uninitialized` errors with GCC 13 at -O2; now initialized.
+- Docs: `doc/src/dc/data_pipeline.md` got a "DC 2.0 (Jazzy): deterministic startup
+  ordering" section (startup chain, gate params, supervision + drop semantics while the
+  Bridge is down); the Fluent Bit flowchart below is now explicitly "Legacy (Humble)".
+- **Verified in the real ROS 2 Jazzy + ros2_rust Docker environment** (extended the #246
+  container with the full C++ stack: rosdep-installed nav2/OpenCV/etc. deps, built all 8
+  remaining dc_* packages with colcon). Acceptance criteria, all machine-checked by a
+  harness asserting on launch logs + a live Postgres (uptime Record per second,
+  `init_collect` at activation):
+  - **Startup order deterministic across 20 consecutive launches — in BOTH composition
+    modes (40 launches total)**: every run had gate-ready < lifecycle-bringup <
+    measurement-activation line order, zero pre-activation publish attempts (the
+    LifecyclePublisher "not activated" warn never appears in a gated launch), and zero
+    leftover processes between runs.
+  - **First emitted Record delivered in every run**: min(date) in Postgres within the
+    1-second Fluent-Forward-truncation window of the "Activating" log timestamp, and row
+    count == contiguous seconds span (no drops, no replays) in all 40 runs.
+  - **Kill the Bridge → respawn + recovery without operator action**: verified for both
+    SIGTERM and SIGKILL — launch respawns dc_bridge, `~/ready` recovers, rows resume
+    (e.g. 5 at kill → 18 after), exactly one live Vector during recovery, no orphans
+    after shutdown.
+  - **Gate failure = loud full shutdown**: with a broken destination (`port: 99999`) and
+    `timeout_s: 15`, the Bridge crash-loops with a clear `InvalidPort` error, the gate
+    exits 1 at 15 s, and launch prints "dc_bridge never became ready … shutting down"
+    and takes the whole system down cleanly (no survivors).
+- **Not done / left for follow-up**: a committed launch_testing-based automated test for
+  the ordering (the verification harness above lived in the session scratchpad; wiring it
+  into `colcon test` needs the full C++ stack in CI first — #249); the reusable dev
+  container for the Jazzy+ros2_rust toolchain (still ad hoc, now also with the C++ stack
+  deps installed on top of the #246 image).


### PR DESCRIPTION
Closes #247

## What

ADR-0006 deterministic startup in `dc_bringup.launch.py`, both composition branches:

1. **Bridge first** — `dc_bridge` starts as a plain node and spawns/supervises Vector. The measurement server starts too but stays unconfigured and inactive.
2. **Ready gate** — new `bridge_ready_gate` executable (rclpy) blocks polling the Bridge's `~/ready` service; `service`/`timeout_s`/`poll_interval_s` configurable from the params file.
3. **Activation** — an `OnProcessExit` handler starts the lifecycle manager (plain node non-composed; deferred `LoadComposableNodes` composed) only on gate exit 0, which configures + activates `measurement_server` exactly as before. Gate deadline exceeded ⇒ loud full-launch `Shutdown`, never a half-started pipeline.

Supervision: the Bridge's launch `respawn` is now unconditional (independent of `use_respawn`), and `dc_bridge_core::Supervisor` sets `PR_SET_PDEATHSIG(SIGKILL)` on Vector so it cannot outlive a SIGKILLed/crashed Bridge — without this the orphan keeps port 24224 bound and the respawned Bridge's Vector crash-loops on the bind (verified as a negative control with the pre-fix binary; regression test added).

## Latent bugs fixed (first real Jazzy build/run of the C++ stack)

- `dc_lifecycle_manager::startup()` paired node *i* with transition *i* — the single DC 2.0 managed node was **configured but never activated** (zero Records flowed while "Managed nodes are active" printed). Transitions now apply to all nodes, in order.
- Jazzy-removed `rmw_qos_profile_t` service overloads → `rclcpp::ServicesQoS()` (`dc_lifecycle_manager`, camera plugin).
- Uninitialized primitive param locals in `dc_util/node_utils.hpp` broke `-Werror` under GCC 13 `-Wmaybe-uninitialized`.

## Acceptance criteria — all verified in a real Jazzy + ros2_rust Docker env against live Postgres

- ✅ Single launch file, no manual steps: Vector → Bridge → ready gate → lifecycle manager → active collection
- ✅ Collection nodes not activated before Bridge ready: machine-checked log ordering + zero `LifecyclePublisher` pre-activation warnings in every run
- ✅ Killing the Bridge (SIGTERM **and** SIGKILL) triggers respawn; readiness and row delivery recover without operator action; exactly one live Vector throughout; no orphans after shutdown
- ✅ Startup order deterministic across 20 consecutive launches — in **both** composition modes (40 launches, all green)
- ✅ First emitted Record delivered in all 40 runs: `min(date)` within the 1 s Fluent-Forward truncation window of the "Activating" timestamp, and row count == contiguous seconds span (no drops/replays)
- Bonus: broken-destination config (`InvalidPort`) fails loudly at the gate deadline and takes the whole launch down cleanly

`pre-commit` clean on all changed files (usual `build-doc`/`poetry-requirements`/`pycln`/`flake8` skips, broken/heavy independent of this diff); `cargo test` 56/56, clippy/fmt clean. See `progress.txt` for the full verification log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VewordeuDqbM4R2cuWMaqY