### PR TITLE
DC 2.0 S7: Uploader — verified File uploads with metadata Records (ADR-0005)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,10 @@ The DC component that receives Records from ROS topics and hands them to the Shi
 The external process (Vector by default) that buffers, transforms, and reliably delivers Records to Destinations.
 _Avoid_: forwarder, agent, data plane, backend
 
+**Shipper ingest protocol**:
+The wire format on the local socket between the Bridge and the Shipper (default port 24224). It is Fluentd's open "Forward" specification — chosen as the cheapest Shipper-native listener with built-in receipt acknowledgement (ADR-0002) — but **no Fluentd or Fluent Bit software runs anywhere in DC 2.0**: the Bridge implements the sender side itself (~170 lines of msgpack). Say "shipper ingest protocol"; the word "fluent" should only appear in the generated Shipper config (`type = "fluent"`) and interop docs.
+_Avoid_: "Fluent Forward" as a component name — it is a message format, not software in the pipeline
+
 **File**:
 A binary artifact produced by a Measurement (image, video, map) that is uploaded to object storage as-is; only its metadata travels as a Record.
 

--- a/dc_bridge/Cargo.lock
+++ b/dc_bridge/Cargo.lock
@@ -8,8 +8,17 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b901da946b7b1620d44563e10c7634681af855a7f5fb59bd09b6eb801dcf6e49"
 dependencies = [
- "itertools",
+ "itertools 0.8.2",
  "walkdir",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -79,7 +88,7 @@ dependencies = [
  "polling",
  "rustix",
  "slab",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -184,6 +193,15 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -239,6 +257,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,7 +286,19 @@ checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
 ]
 
 [[package]]
@@ -283,6 +323,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +352,16 @@ name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-common"
@@ -314,7 +380,7 @@ checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
  "nix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -345,9 +411,13 @@ dependencies = [
 name = "dc_bridge_core"
 version = "0.1.0"
 dependencies = [
+ "libc",
+ "object_store",
  "rmpv",
+ "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
+ "tokio",
  "toml",
 ]
 
@@ -365,13 +435,23 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -385,6 +465,17 @@ dependencies = [
  "block2",
  "libc",
  "objc2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -406,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -447,6 +538,27 @@ name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures"
@@ -550,6 +662,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "geometry_msgs"
 version = "5.3.8"
 dependencies = [
@@ -560,14 +682,41 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -580,6 +729,25 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -600,8 +768,53 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
@@ -610,6 +823,193 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -623,10 +1023,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -689,6 +1104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,13 +1128,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -730,7 +1167,7 @@ checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -788,10 +1225,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools 0.14.0",
+ "md-5 0.10.6",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.5",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "parking"
@@ -881,7 +1360,7 @@ dependencies = [
  "hermit-abi",
  "pin-project-lite",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -909,9 +1388,9 @@ dependencies = [
  "bytes",
  "fallible-iterator",
  "hmac",
- "md-5",
+ "md-5 0.11.0",
  "memchr",
- "rand",
+ "rand 0.10.2",
  "sha2",
  "stringprep",
 ]
@@ -928,12 +1407,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -947,9 +1510,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -958,8 +1537,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom",
- "rand_core",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -967,6 +1565,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rclrs"
@@ -998,6 +1605,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1024,6 +1687,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustflags"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,7 +1708,54 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1047,6 +1763,12 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1058,10 +1780,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "sensor_msgs"
@@ -1081,6 +1835,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1126,6 +1881,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "service_msgs"
 version = "2.0.4"
 dependencies = [
@@ -1141,8 +1908,14 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.11.3",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "siphasher"
@@ -1169,8 +1942,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "std_msgs"
@@ -1201,6 +1980,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1223,12 +2008,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -1240,6 +2054,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -1268,7 +2103,19 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
- "windows-sys",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1290,11 +2137,21 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
+ "rand 0.10.2",
  "socket2",
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1364,6 +2221,88 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,12 +2336,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "uuid"
 version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1414,6 +2377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef73bfbaf3216cb59c205d7176bee1194e0d84348979da31f4a71fefe3c2054e"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,6 +2390,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -1512,10 +2490,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1540,7 +2541,42 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1550,6 +2586,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +2620,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -1572,6 +2699,115 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "zmij"
@@ -1590,10 +2826,6 @@ version = "5.3.8"
 [[patch.unused]]
 name = "composition_interfaces"
 version = "2.0.4"
-
-[[patch.unused]]
-name = "dc_bridge"
-version = "0.1.0"
 
 [[patch.unused]]
 name = "diagnostic_msgs"

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -1,18 +1,27 @@
 # dc_bridge
 
-The Bridge (ADRs 0001/0004/0006): a Rust (`rclrs`) node that subscribes to `dc_interfaces/msg/StringStamped`
+The Bridge (ADRs 0001/0004/0005/0006): a Rust (`rclrs`) node that subscribes to `dc_interfaces/msg/StringStamped`
 Record topics and forwards every Record to the Vector shipper over the Fluent Forward
 protocol. It renders Vector's configuration from ROS parameters for the blessed
 Destination set (`postgres`, `s3`, `file`, `console` — ADR-0003) and passes raw Vector
 snippets (`custom_config_files`) through for everything else in Vector's sink catalog,
 via the public per-Tag `dc.<tag>` routes documented in `doc/src/dc/destinations.md`.
+It also hosts the **Uploader** (ADR-0005): `receives: files` Destinations are served by
+the Bridge itself — Records referencing Files (`local_paths`/`remote_paths`) get their
+Files uploaded via `object_store` (multipart + resumable), verified, and reported as
+status/metadata Records under the `dc.files` Tag (see `doc/src/dc/destinations.md`).
 
 ## Layout
 
 - **`dc_bridge_core/`** — the ROS-independent core: `Forwarder` (msgpack framing, socket
   lifecycle, reconnection, backpressure), `Supervisor` (generic process respawn),
   `Readiness` (TCP-accept probe), `config` (topic → Fluent Forward tag), `vector_config`
-  (locates the vendored binary), and `render` (ADR-0003's config renderer — see below).
+  (locates the vendored binary), `render` (ADR-0003's config renderer — see below), and
+  `uploader` (ADR-0005's Uploader: `group` parses the Files a Record references,
+  `store` wraps each `receives: files` Destination's `object_store` client,
+  `multipart` implements resumable multipart uploads with a per-part checkpoint
+  sidecar, `content_type` sniffs metadata; `tests/uploader_tests.rs` covers the #248
+  acceptance criteria against `object_store`'s in-memory backend with temp files).
   It's a standalone crate with its own `Cargo.toml` (declaring `[workspace]` so it never
   gets swept into the outer package's workspace) and zero ROS dependencies, so it builds
   and tests with plain Cargo:
@@ -45,8 +54,12 @@ via the public per-Tag `dc.<tag>` routes documented in `doc/src/dc/destinations.
   params (verified against RustFS, the recommended self-hosted store now that MinIO's
   community edition is archived upstream); a `custom_config_files` snippet shipping
   Records to an un-blessed `http` sink by consuming the public `dc.<tag>` route
-  (self-contained — the test plays the HTTP server); and a colliding snippet failing
-  dc_bridge startup loudly. The store-backed tests **require** a Postgres at
+  (self-contained — the test plays the HTTP server); a colliding snippet failing
+  dc_bridge startup loudly; and the Uploader demo (issue #248): a camera-shaped Record
+  whose File lands verified in the S3 store, with `file_status`/`group_complete`/
+  deletion rows landing in Postgres through the Shipper's parameterized sink, and
+  republished (retried) Records producing no duplicate rows. The store-backed tests
+  **require** a Postgres at
   127.0.0.1:5432 and an S3-compatible store at 127.0.0.1:9000 and hard-fail
   immediately with setup instructions when they're missing — they deliberately never
   skip, since libtest swallows passing tests' output and a skipped run is

--- a/dc_bridge/dc_bridge_core/Cargo.lock
+++ b/dc_bridge/dc_bridge_core/Cargo.lock
@@ -3,22 +3,194 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "dc_bridge_core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "futures",
  "libc",
+ "object_store",
  "rmpv",
+ "serde",
  "serde_json",
- "socket2",
- "thiserror",
+ "socket2 0.5.10",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
  "toml",
 ]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "either"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "equivalent"
@@ -27,10 +199,435 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -43,10 +640,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -55,10 +678,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mio"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-traits"
@@ -67,6 +744,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "object_store"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http",
+ "http-body-util",
+ "humantime",
+ "hyper",
+ "itertools",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.5",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -79,12 +857,210 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.5.10",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.3",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.19",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.5.10",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -106,12 +1082,138 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -157,14 +1259,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "socket2"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -189,12 +1343,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+dependencies = [
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -206,6 +1402,92 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2 0.6.5",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "libc",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -250,10 +1532,318 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -262,6 +1852,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -335,6 +1934,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/dc_bridge/dc_bridge_core/Cargo.toml
+++ b/dc_bridge/dc_bridge_core/Cargo.toml
@@ -14,11 +14,17 @@ description = "ROS-independent Bridge logic (Forwarder, Supervisor, Readiness) f
 [dependencies]
 rmpv = "1"
 toml = "0.8"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
+object_store = { version = "0.12", features = ["aws"] }
+tokio = { version = "1", features = ["rt", "time", "net"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 socket2 = "0.5"
+tempfile = "3"
+async-trait = "0.1"
+futures = "0.3"

--- a/dc_bridge/dc_bridge_core/src/lib.rs
+++ b/dc_bridge/dc_bridge_core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod forwarder;
 pub mod readiness;
 pub mod render;
 pub mod supervisor;
+pub mod uploader;
 pub mod vector_config;
 
 pub use config::{BridgeConfig, TopicConfig};
@@ -19,3 +20,7 @@ pub use render::{
     TimeFormat, MIN_DISK_BUFFER_BYTES, ROUTE_TRANSFORM_ID,
 };
 pub use supervisor::{Supervisor, SupervisorConfig};
+pub use uploader::store::{Storage, UploadStore};
+pub use uploader::{
+    ffprobe_duration_prober, ProcessSummary, UploadError, Uploader, UploaderConfig, FILE_STATUS_TAG,
+};

--- a/dc_bridge/dc_bridge_core/src/render.rs
+++ b/dc_bridge/dc_bridge_core/src/render.rs
@@ -69,6 +69,11 @@ pub struct Destination {
     /// ROS topic names feeding this Destination; the Fluent Forward tag each one is
     /// routed under is derived the same way `TopicConfig` derives it for subscriptions.
     pub inputs: Vec<String>,
+    /// Extra Fluent Forward Tags routed to this Destination that don't come from a
+    /// topic subscription — Bridge-internal producers. Today that's the Uploader's
+    /// status Tag (`dc.files`), appended to the `files.metadata_destination`
+    /// Destination by `main.rs`; never set from user parameters directly.
+    pub extra_tags: Vec<String>,
     /// Event field the normalized timestamp is written to before routing.
     pub time_key: String,
     pub time_format: TimeFormat,
@@ -162,8 +167,14 @@ pub enum RenderError {
     UnsupportedType(String, String),
     #[error("destination '{0}': receives '{1}' is invalid (expected 'records' or 'files')")]
     InvalidReceives(String, String),
-    #[error("destination '{0}': `receives: files` is not yet supported (only `records`)")]
-    FilesNotSupported(String),
+    #[error(
+        "destination '{0}': `receives: files` requires `type: s3` (object storage); got type '{1}'"
+    )]
+    FilesRequireObjectStorage(String, String),
+    #[error(
+        "internal error: `receives: files` destination '{0}' reached the shipper config renderer; File uploads are handled by the Bridge's Uploader (ADR-0005), not by a Vector sink"
+    )]
+    FilesDestinationInShipperConfig(String),
     #[error("destination '{0}': time_format '{1}' is invalid (expected 'double' or 'iso8601')")]
     InvalidTimeFormat(String, String),
     #[error("destination '{0}': missing required field `{1}`")]
@@ -323,8 +334,13 @@ pub fn destination_from_raw(
             ))
         }
     };
-    if receives != Receives::Records {
-        return Err(RenderError::FilesNotSupported(name.to_string()));
+    // A `receives: files` Destination is consumed by the Bridge's Uploader (ADR-0005),
+    // which speaks object storage — only the `s3` blessed type qualifies.
+    if receives == Receives::Files && type_str != "s3" {
+        return Err(RenderError::FilesRequireObjectStorage(
+            name.to_string(),
+            type_str.to_string(),
+        ));
     }
 
     let time_key = optional(raw.time_key).unwrap_or_else(|| "date".to_string());
@@ -360,6 +376,7 @@ pub fn destination_from_raw(
         name: name.to_string(),
         receives,
         inputs,
+        extra_tags: Vec::new(),
         time_key,
         time_format,
         kind,
@@ -442,11 +459,15 @@ fn validate(config: &RenderConfig) -> Result<(), RenderError> {
         if !seen.insert(dest.name.as_str()) {
             return Err(RenderError::DuplicateDestination(dest.name.clone()));
         }
-        if dest.inputs.is_empty() {
+        // A Destination fed only by Bridge-internal Tags (the metadata destination
+        // pattern) legitimately has no topic inputs.
+        if dest.inputs.is_empty() && dest.extra_tags.is_empty() {
             return Err(RenderError::EmptyInputs(dest.name.clone()));
         }
         if dest.receives != Receives::Records {
-            return Err(RenderError::FilesNotSupported(dest.name.clone()));
+            return Err(RenderError::FilesDestinationInShipperConfig(
+                dest.name.clone(),
+            ));
         }
     }
     Ok(())
@@ -533,6 +554,14 @@ fn derived_tags(inputs: &[String]) -> BTreeSet<String> {
         .collect()
 }
 
+/// Every Tag routed to a Destination: its `inputs` topics' derived Tags plus any
+/// Bridge-internal `extra_tags` (e.g. the Uploader's status Tag).
+fn destination_tags(dest: &Destination) -> BTreeSet<String> {
+    let mut tags = derived_tags(&dest.inputs);
+    tags.extend(dest.extra_tags.iter().cloned());
+    tags
+}
+
 /// A VRL `includes([...], .tag)` condition matching any of `tags`.
 fn tag_condition(tags: &BTreeSet<String>) -> String {
     let quoted: Vec<String> = tags.iter().map(|t| format!("{:?}", t)).collect();
@@ -542,7 +571,7 @@ fn tag_condition(tags: &BTreeSet<String>) -> String {
 fn render_normalize_source(config: &RenderConfig) -> String {
     let mut out = String::new();
     for dest in &config.destinations {
-        let cond = tag_condition(&derived_tags(&dest.inputs));
+        let cond = tag_condition(&destination_tags(dest));
         writeln!(out, "if {cond} {{").unwrap();
         match dest.time_format {
             TimeFormat::Double => writeln!(
@@ -583,7 +612,7 @@ fn percent_encode_userinfo(value: &str) -> String {
 /// its `inputs` topics.
 fn sink_inputs(dest: &Destination) -> Value {
     Value::Array(
-        derived_tags(&dest.inputs)
+        destination_tags(dest)
             .iter()
             .map(|tag| Value::String(route_output_for_tag(tag)))
             .collect(),
@@ -714,7 +743,7 @@ pub fn render(config: &RenderConfig) -> Result<String, RenderError> {
     let all_tags: BTreeSet<String> = config
         .destinations
         .iter()
-        .flat_map(|dest| derived_tags(&dest.inputs))
+        .flat_map(destination_tags)
         .collect();
     let mut route_branches = Table::new();
     for tag in &all_tags {
@@ -764,6 +793,7 @@ mod tests {
             name: name.to_string(),
             receives: Receives::Records,
             inputs: inputs.iter().map(|s| s.to_string()).collect(),
+            extra_tags: Vec::new(),
             time_key: "date".to_string(),
             time_format,
             kind,
@@ -1119,16 +1149,95 @@ mod tests {
     }
 
     #[test]
-    fn destination_from_raw_rejects_receives_files_clearly_for_now() {
-        let err = destination_from_raw(
-            "archive",
-            "postgres",
+    fn destination_from_raw_rejects_receives_files_on_non_object_storage_types() {
+        for bad_type in ["postgres", "file", "console"] {
+            let err = destination_from_raw(
+                "archive",
+                bad_type,
+                "files",
+                vec!["/dc/measurement/map".to_string()],
+                RawDestinationParams::default(),
+            )
+            .unwrap_err();
+            assert_eq!(
+                err,
+                RenderError::FilesRequireObjectStorage("archive".to_string(), bad_type.to_string()),
+                "type '{bad_type}' must be rejected for receives: files"
+            );
+        }
+    }
+
+    #[test]
+    fn destination_from_raw_accepts_a_receives_files_s3_destination() {
+        let dest = destination_from_raw(
+            "minio",
+            "s3",
             "files",
-            vec!["/dc/measurement/map".to_string()],
-            RawDestinationParams::default(),
+            vec!["/dc/measurement/camera".to_string()],
+            RawDestinationParams {
+                bucket: Some("dc-files"),
+                endpoint: Some("http://127.0.0.1:9000"),
+                access_key_id: Some("rustfsadmin"),
+                secret_access_key: Some("rustfsadmin"),
+                ..Default::default()
+            },
         )
-        .unwrap_err();
-        assert_eq!(err, RenderError::FilesNotSupported("archive".to_string()));
+        .unwrap();
+        assert_eq!(dest.receives, Receives::Files);
+        assert!(matches!(dest.kind, DestinationKind::S3(_)));
+    }
+
+    #[test]
+    fn render_rejects_a_files_destination_reaching_the_shipper_config() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.destinations[0].receives = Receives::Files;
+        assert_eq!(
+            render(&config),
+            Err(RenderError::FilesDestinationInShipperConfig(
+                "pgsql".to_string()
+            ))
+        );
+    }
+
+    /// The metadata-destination pattern: the Uploader's status Tag is appended as an
+    /// `extra_tags` entry, so the normalize condition, the public route, and the sink's
+    /// inputs all carry it alongside topic-derived Tags.
+    #[test]
+    fn extra_tags_are_routed_normalized_and_consumed_like_topic_tags() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.destinations[0]
+            .extra_tags
+            .push("dc.files".to_string());
+        let rendered = render(&config).unwrap();
+        let parsed = parsed(&rendered);
+
+        let route = parsed["transforms"]["dc"]["route"].as_table().unwrap();
+        assert_eq!(
+            route.keys().collect::<Vec<_>>(),
+            vec!["dc.files", "dc.group.robot"]
+        );
+        let inputs = parsed["sinks"]["pgsql"]["inputs"].as_array().unwrap();
+        assert_eq!(
+            inputs,
+            &[
+                Value::String("dc.dc.files".to_string()),
+                Value::String("dc.dc.group.robot".to_string()),
+            ]
+        );
+        let normalize = parsed["transforms"]["dc_bridge_normalize"]["source"]
+            .as_str()
+            .unwrap();
+        assert!(normalize.contains(r#"includes(["dc.files", "dc.group.robot"], .tag)"#));
+    }
+
+    #[test]
+    fn a_destination_with_only_extra_tags_needs_no_topic_inputs() {
+        let mut config = basic_config(TimeFormat::Double);
+        config.destinations[0].inputs = vec![];
+        config.destinations[0]
+            .extra_tags
+            .push("dc.files".to_string());
+        assert!(render(&config).is_ok());
     }
 
     #[test]

--- a/dc_bridge/dc_bridge_core/src/uploader/content_type.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/content_type.rs
@@ -1,0 +1,86 @@
+//! Content-type sniffing for uploaded Files, replacing the Humble Go plugin's
+//! `http.DetectContentType` call. Magic-byte based for the formats DC Measurements
+//! actually produce (camera JPEGs, map PGM/PNG/YAML, videos), with a UTF-8 text
+//! fallback — pure, no I/O, so it's trivially unit-testable.
+
+/// Sniffs a content type from the first bytes of a File (512 bytes is plenty, matching
+/// what `http.DetectContentType` consumed on Humble).
+pub fn sniff(buf: &[u8]) -> &'static str {
+    if buf.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return "image/png";
+    }
+    if buf.starts_with(b"\xff\xd8\xff") {
+        return "image/jpeg";
+    }
+    if buf.starts_with(b"GIF87a") || buf.starts_with(b"GIF89a") {
+        return "image/gif";
+    }
+    // ISO base media file format (mp4/mov): a `ftyp` box at offset 4.
+    if buf.len() >= 12 && &buf[4..8] == b"ftyp" {
+        return "video/mp4";
+    }
+    if buf.len() >= 12 && buf.starts_with(b"RIFF") && &buf[8..12] == b"AVI " {
+        return "video/x-msvideo";
+    }
+    // Matroska/WebM EBML header.
+    if buf.starts_with(b"\x1a\x45\xdf\xa3") {
+        return "video/x-matroska";
+    }
+    // Netpbm map formats (nav map PGM being the DC-relevant one).
+    if pnm_magic(buf, b'2') || pnm_magic(buf, b'5') {
+        return "image/x-portable-graymap";
+    }
+    if pnm_magic(buf, b'3') || pnm_magic(buf, b'6') {
+        return "image/x-portable-pixmap";
+    }
+    if pnm_magic(buf, b'1') || pnm_magic(buf, b'4') {
+        return "image/x-portable-bitmap";
+    }
+    if buf.starts_with(b"%PDF-") {
+        return "application/pdf";
+    }
+    // Printable UTF-8 (YAML metadata files, JSON, logs…).
+    if !buf.is_empty() && std::str::from_utf8(buf).is_ok_and(|s| !s.contains('\0')) {
+        return "text/plain; charset=utf-8";
+    }
+    "application/octet-stream"
+}
+
+/// `P<digit>` followed by whitespace, the Netpbm magic shape.
+fn pnm_magic(buf: &[u8], digit: u8) -> bool {
+    buf.len() >= 3 && buf[0] == b'P' && buf[1] == digit && buf[2].is_ascii_whitespace()
+}
+
+/// Whether a sniffed content type is a video — the gate for duration probing. Unlike the
+/// Humble plugin (which also probed `application/octet-stream`), only `video/*` types
+/// are probed, so ffprobe never runs on arbitrary binary Files.
+pub fn is_video(content_type: &str) -> bool {
+    content_type.starts_with("video/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sniffs_the_formats_measurements_produce() {
+        assert_eq!(sniff(b"\x89PNG\r\n\x1a\nrest"), "image/png");
+        assert_eq!(sniff(b"\xff\xd8\xff\xe0jfif"), "image/jpeg");
+        assert_eq!(sniff(b"P5\n640 480\n255\n"), "image/x-portable-graymap");
+        assert_eq!(sniff(b"\x00\x00\x00\x20ftypisom....."), "video/mp4");
+        assert_eq!(
+            sniff(b"image: map.pgm\nresolution: 0.05\n"),
+            "text/plain; charset=utf-8"
+        );
+        assert_eq!(sniff(b"\x00\x01\x02\x03"), "application/octet-stream");
+        assert_eq!(sniff(b""), "application/octet-stream");
+    }
+
+    #[test]
+    fn only_video_types_are_videos() {
+        assert!(is_video("video/mp4"));
+        assert!(is_video("video/x-msvideo"));
+        assert!(!is_video("image/png"));
+        assert!(!is_video("application/octet-stream"));
+    }
+}

--- a/dc_bridge/dc_bridge_core/src/uploader/group.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/group.rs
@@ -1,0 +1,216 @@
+//! Parsing the Files a Record references out of its JSON payload — the
+//! `local_paths`/`remote_paths` structure Measurements embed (see
+//! `dc_measurements/plugins/measurements/{camera,map}.cpp`), replacing the Humble-era
+//! parallel `src_fields`/`upload_fields` config arrays.
+//!
+//! The shape, per File-bearing (sub-)object:
+//!
+//! ```json
+//! {
+//!   "name": "map",
+//!   "local_paths":  { "yaml": "/tmp/map.yaml", "pgm": "/tmp/map.pgm" },
+//!   "remote_paths": { "minio": { "yaml": "robot/map.yaml", "pgm": "robot/map.pgm" } }
+//! }
+//! ```
+//!
+//! `remote_paths` is keyed by Destination name: a File is uploaded to every configured
+//! `receives: files` Destination whose name appears in its `remote_paths`. The whole
+//! payload is walked recursively, so both a bare Measurement Record and a Group-merged
+//! Record (Files nested under per-Measurement keys) parse the same way; all Files found
+//! in one Record form one group (ADR-0005's group completion marker covers exactly this
+//! set).
+
+use serde_json::Value;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// One File referenced by a Record: its `local_paths` key, the on-robot path, and the
+/// object key it should land under per Destination.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileRef {
+    /// The `local_paths` key naming this File within its Measurement ("pgm", "raw", …).
+    pub key: String,
+    pub local_path: String,
+    /// Destination name → object key, from `remote_paths.<destination>.<key>`. Only
+    /// configured Destinations are retained; never empty (a File no configured
+    /// Destination references is not part of the upload group).
+    pub remote_paths: BTreeMap<String, String>,
+}
+
+/// Every File one Record references — the unit ADR-0005's group completion marker is
+/// emitted for.
+#[derive(Debug, Clone, PartialEq)]
+pub struct FileGroup {
+    pub group_name: String,
+    pub robot_name: Option<String>,
+    pub robot_id: Option<Value>,
+    pub files: Vec<FileRef>,
+}
+
+/// Extracts the [`FileGroup`] a Record payload references. `fallback_group` names the
+/// group when the payload carries no `name` field (the Record's Tag is the natural
+/// caller choice); `storages` is the set of configured `receives: files` Destination
+/// names. Returns files in deterministic (local-path-sorted) order; the group is empty
+/// if the Record references no Files any configured Destination receives.
+pub fn parse_file_group(
+    payload: &Value,
+    fallback_group: &str,
+    storages: &BTreeSet<String>,
+) -> FileGroup {
+    let mut files: BTreeMap<String, FileRef> = BTreeMap::new();
+    collect_files(payload, storages, &mut files);
+
+    let group_name = payload
+        .get("name")
+        .and_then(Value::as_str)
+        .unwrap_or(fallback_group)
+        .to_string();
+    let robot_name = payload
+        .get("robot_name")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let robot_id = payload.get("id").cloned().filter(|v| !v.is_null());
+
+    FileGroup {
+        group_name,
+        robot_name,
+        robot_id,
+        files: files.into_values().collect(),
+    }
+}
+
+fn collect_files(
+    value: &Value,
+    storages: &BTreeSet<String>,
+    files: &mut BTreeMap<String, FileRef>,
+) {
+    let Value::Object(obj) = value else {
+        return;
+    };
+
+    if let Some(Value::Object(local_paths)) = obj.get("local_paths") {
+        let remote_paths = obj.get("remote_paths");
+        for (key, local) in local_paths {
+            let Some(local_path) = local.as_str().filter(|p| !p.is_empty()) else {
+                continue;
+            };
+            let mut remotes = BTreeMap::new();
+            for storage in storages {
+                if let Some(remote) = remote_paths
+                    .and_then(|r| r.get(storage))
+                    .and_then(|s| s.get(key))
+                    .and_then(Value::as_str)
+                    .filter(|p| !p.is_empty())
+                {
+                    remotes.insert(storage.clone(), remote.to_string());
+                }
+            }
+            if remotes.is_empty() {
+                continue;
+            }
+            // The same local path can appear in several sub-objects; merge their
+            // Destination sets rather than uploading twice.
+            files
+                .entry(local_path.to_string())
+                .and_modify(|f| f.remote_paths.extend(remotes.clone()))
+                .or_insert_with(|| FileRef {
+                    key: key.clone(),
+                    local_path: local_path.to_string(),
+                    remote_paths: remotes,
+                });
+        }
+    }
+
+    for (key, child) in obj {
+        // `base64` holds inline file content (potentially huge) and never Files.
+        if key == "local_paths" || key == "remote_paths" || key == "base64" {
+            continue;
+        }
+        collect_files(child, storages, files);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn storages(names: &[&str]) -> BTreeSet<String> {
+        names.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_a_flat_measurement_record_like_the_map_measurement_produces() {
+        let payload = json!({
+            "name": "map",
+            "robot_name": "robot1",
+            "id": "r1",
+            "resolution": 0.05,
+            "local_paths":  { "yaml": "/tmp/map.yaml", "pgm": "/tmp/map.pgm" },
+            "remote_paths": { "minio": { "yaml": "maps/map.yaml", "pgm": "maps/map.pgm" } }
+        });
+        let group = parse_file_group(&payload, "dc.measurement.map", &storages(&["minio"]));
+        assert_eq!(group.group_name, "map");
+        assert_eq!(group.robot_name.as_deref(), Some("robot1"));
+        assert_eq!(group.robot_id, Some(json!("r1")));
+        assert_eq!(group.files.len(), 2);
+        assert_eq!(group.files[0].local_path, "/tmp/map.pgm");
+        assert_eq!(group.files[0].remote_paths["minio"], "maps/map.pgm");
+    }
+
+    #[test]
+    fn walks_group_merged_records_with_files_nested_under_measurement_keys() {
+        let payload = json!({
+            "camera": {
+                "local_paths":  { "raw": "/tmp/cam.jpg" },
+                "remote_paths": { "minio": { "raw": "cam/cam.jpg" } }
+            },
+            "map": {
+                "local_paths":  { "pgm": "/tmp/map.pgm" },
+                "remote_paths": { "minio": { "pgm": "maps/map.pgm" } }
+            }
+        });
+        let group = parse_file_group(&payload, "dc.group.robot", &storages(&["minio"]));
+        assert_eq!(group.group_name, "dc.group.robot");
+        assert_eq!(group.files.len(), 2);
+    }
+
+    #[test]
+    fn keeps_only_configured_destinations_and_drops_unreferenced_files() {
+        let payload = json!({
+            "local_paths":  { "raw": "/tmp/cam.jpg", "png": "/tmp/preview.png" },
+            "remote_paths": {
+                "minio":     { "raw": "cam/cam.jpg" },
+                "elsewhere": { "raw": "other/cam.jpg", "png": "other/preview.png" }
+            }
+        });
+        let group = parse_file_group(&payload, "dc.measurement.camera", &storages(&["minio"]));
+        // `png` has no remote path on any configured Destination → not in the group;
+        // `elsewhere` is not a configured Destination → dropped from `raw`'s set.
+        assert_eq!(group.files.len(), 1);
+        assert_eq!(group.files[0].local_path, "/tmp/cam.jpg");
+        assert_eq!(
+            group.files[0].remote_paths.keys().collect::<Vec<_>>(),
+            vec!["minio"]
+        );
+    }
+
+    #[test]
+    fn a_record_without_files_yields_an_empty_group() {
+        let payload = json!({ "uptime_s": 42 });
+        let group = parse_file_group(&payload, "dc.measurement.uptime", &storages(&["minio"]));
+        assert!(group.files.is_empty());
+        assert_eq!(group.group_name, "dc.measurement.uptime");
+    }
+
+    #[test]
+    fn base64_subtrees_are_not_walked() {
+        let payload = json!({
+            "base64": {
+                "local_paths":  { "yaml": "/tmp/decoy.yaml" },
+                "remote_paths": { "minio": { "yaml": "decoy.yaml" } }
+            }
+        });
+        let group = parse_file_group(&payload, "dc.measurement.map", &storages(&["minio"]));
+        assert!(group.files.is_empty());
+    }
+}

--- a/dc_bridge/dc_bridge_core/src/uploader/mod.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/mod.rs
@@ -30,16 +30,18 @@
 pub mod content_type;
 pub mod group;
 pub mod multipart;
+mod status;
 pub mod store;
 
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::collections::{BTreeSet, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use group::{FileGroup, FileRef};
 use object_store::path::Path as ObjectPath;
+use status::StatusContext;
 use store::Storage;
 
 /// The Tag the Uploader's status/metadata Records are emitted under. The Destination
@@ -148,6 +150,13 @@ enum EnsureOutcome {
     MissingLocal,
 }
 
+/// What [`Uploader::upload_and_verify_file`] found for one File across all its
+/// Destinations.
+struct FileOutcome {
+    verified_everywhere: bool,
+    missing: bool,
+}
+
 pub struct Uploader {
     config: UploaderConfig,
     storages: Vec<Storage>,
@@ -203,43 +212,11 @@ impl Uploader {
         let mut verified_files: Vec<&FileRef> = Vec::new();
 
         for file in &group.files {
-            let meta = self.file_meta(&file.local_path);
-            let mut verified_everywhere = true;
-
-            for (storage_name, remote_path) in &file.remote_paths {
-                let storage = self
-                    .storages
-                    .iter()
-                    .find(|s| &s.name == storage_name)
-                    .expect("parse_file_group only keeps configured storages");
-
-                match self.ensure_uploaded(storage, file, meta.as_ref(), remote_path) {
-                    Ok(EnsureOutcome::Verified) => {
-                        let meta = meta.as_ref().expect("Verified implies a local file");
-                        self.emit_once(
-                            emit,
-                            &format!("uploaded|{}|{}", file.local_path, storage.name),
-                            uploaded_row(&group, file, storage, remote_path, meta),
-                        )?;
-                    }
-                    Ok(EnsureOutcome::VerifiedRemoteOnly) => {}
-                    Ok(EnsureOutcome::MissingLocal) => {
-                        verified_everywhere = false;
-                        summary.missing += 1;
-                        self.emit_once(
-                            emit,
-                            &format!("missing|{}|{}", file.local_path, storage.name),
-                            missing_row(&group, file, storage, remote_path),
-                        )?;
-                    }
-                    Err(e) => {
-                        verified_everywhere = false;
-                        failures.push(format!("'{}' -> {}: {e}", file.local_path, storage.name));
-                    }
-                }
+            let outcome = self.upload_and_verify_file(&group, file, emit, &mut failures)?;
+            if outcome.missing {
+                summary.missing += 1;
             }
-
-            if verified_everywhere {
+            if outcome.verified_everywhere {
                 summary.verified += 1;
                 verified_files.push(file);
             }
@@ -250,38 +227,15 @@ impl Uploader {
         // incomplete forever — loud in the status table, never guessed complete.
         if summary.verified == summary.files {
             summary.group_complete = true;
-            let files_key: Vec<&str> = group.files.iter().map(|f| f.local_path.as_str()).collect();
-            self.emit_once(
-                emit,
-                &format!("group|{}|{}", group.group_name, files_key.join("|")),
-                group_complete_row(&group),
-            )?;
+            self.emit_group_complete(&group, emit)?;
         }
 
         // Deletion strictly after verified upload on all storages — per File, so one
         // permanently failing File doesn't strand its group-mates on a full disk.
         if self.config.delete_when_sent {
             for file in &verified_files {
-                let local = Path::new(&file.local_path);
-                if !local.exists() {
-                    continue;
-                }
-                if let Err(e) = std::fs::remove_file(local) {
-                    failures.push(format!("failed to delete '{}': {e}", file.local_path));
-                    continue;
-                }
-                summary.deleted += 1;
-                for (storage_name, remote_path) in &file.remote_paths {
-                    let storage = self
-                        .storages
-                        .iter()
-                        .find(|s| &s.name == storage_name)
-                        .expect("parse_file_group only keeps configured storages");
-                    self.emit_once(
-                        emit,
-                        &format!("deleted|{}|{}", file.local_path, storage.name),
-                        deleted_row(&group, file, storage, remote_path),
-                    )?;
+                if self.delete_verified_file(&group, file, emit, &mut failures)? {
+                    summary.deleted += 1;
                 }
             }
         }
@@ -290,6 +244,106 @@ impl Uploader {
             return Err(UploadError::Incomplete(failures.join("; ")));
         }
         Ok(summary)
+    }
+
+    /// Uploads and verifies one File on every Destination that receives it, emitting
+    /// an `uploaded`/`missing` status row per Destination as each result lands.
+    fn upload_and_verify_file(
+        &self,
+        group: &FileGroup,
+        file: &FileRef,
+        emit: &mut dyn FnMut(Value) -> Result<(), String>,
+        failures: &mut Vec<String>,
+    ) -> Result<FileOutcome, UploadError> {
+        let meta = self.file_meta(&file.local_path);
+        let mut outcome = FileOutcome {
+            verified_everywhere: true,
+            missing: false,
+        };
+
+        for (storage_name, remote_path) in &file.remote_paths {
+            let storage = self.storage(storage_name);
+            let ctx = StatusContext::new(group, file, storage, remote_path);
+
+            match self.ensure_uploaded(storage, file, meta.as_ref(), remote_path) {
+                Ok(EnsureOutcome::Verified) => {
+                    let meta = meta.as_ref().expect("Verified implies a local file");
+                    self.emit_once(
+                        emit,
+                        &format!("uploaded|{}|{}", file.local_path, storage.name),
+                        ctx.uploaded(meta),
+                    )?;
+                }
+                Ok(EnsureOutcome::VerifiedRemoteOnly) => {}
+                Ok(EnsureOutcome::MissingLocal) => {
+                    outcome.verified_everywhere = false;
+                    outcome.missing = true;
+                    self.emit_once(
+                        emit,
+                        &format!("missing|{}|{}", file.local_path, storage.name),
+                        ctx.missing(),
+                    )?;
+                }
+                Err(e) => {
+                    outcome.verified_everywhere = false;
+                    failures.push(format!("'{}' -> {}: {e}", file.local_path, storage.name));
+                }
+            }
+        }
+
+        Ok(outcome)
+    }
+
+    fn emit_group_complete(
+        &self,
+        group: &FileGroup,
+        emit: &mut dyn FnMut(Value) -> Result<(), String>,
+    ) -> Result<(), UploadError> {
+        let files_key: Vec<&str> = group.files.iter().map(|f| f.local_path.as_str()).collect();
+        self.emit_once(
+            emit,
+            &format!("group|{}|{}", group.group_name, files_key.join("|")),
+            status::group_complete_row(group),
+        )
+    }
+
+    /// Deletes one already-verified File and emits a `deleted` row per Destination.
+    /// A no-op (returns `false`) if the File is already gone or fails to delete.
+    fn delete_verified_file(
+        &self,
+        group: &FileGroup,
+        file: &FileRef,
+        emit: &mut dyn FnMut(Value) -> Result<(), String>,
+        failures: &mut Vec<String>,
+    ) -> Result<bool, UploadError> {
+        let local = Path::new(&file.local_path);
+        if !local.exists() {
+            return Ok(false);
+        }
+        if let Err(e) = std::fs::remove_file(local) {
+            failures.push(format!("failed to delete '{}': {e}", file.local_path));
+            return Ok(false);
+        }
+        for (storage_name, remote_path) in &file.remote_paths {
+            let storage = self.storage(storage_name);
+            let ctx = StatusContext::new(group, file, storage, remote_path);
+            self.emit_once(
+                emit,
+                &format!("deleted|{}|{}", file.local_path, storage.name),
+                ctx.deleted(),
+            )?;
+        }
+        Ok(true)
+    }
+
+    /// Looks up a configured Destination by name. Every name that reaches here comes
+    /// from `group::parse_file_group`, which only keeps names present in
+    /// `storage_names` — so this can never miss.
+    fn storage(&self, name: &str) -> &Storage {
+        self.storages
+            .iter()
+            .find(|s| s.name == name)
+            .expect("parse_file_group only keeps configured storages")
     }
 
     fn file_meta(&self, local_path: &str) -> Option<FileMeta> {
@@ -403,103 +457,4 @@ impl Uploader {
         self.emitted.lock().unwrap().insert(dedup_key.to_string());
         Ok(())
     }
-}
-
-fn unix_now() -> f64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64()
-}
-
-/// The shared status-row fields, preserving the Humble `out_files_metrics` column set.
-fn base_row(
-    group: &FileGroup,
-    file: &FileRef,
-    storage: &Storage,
-    remote_path: &str,
-) -> serde_json::Map<String, Value> {
-    let mut row = serde_json::Map::new();
-    row.insert("kind".into(), json!("file_status"));
-    row.insert("group_name".into(), json!(group.group_name));
-    if let Some(robot_name) = &group.robot_name {
-        row.insert("robot_name".into(), json!(robot_name));
-    }
-    if let Some(robot_id) = &group.robot_id {
-        row.insert("robot_id".into(), robot_id.clone());
-    }
-    row.insert("local_path".into(), json!(file.local_path));
-    row.insert(
-        "remote_path".into(),
-        json!(format!(
-            "{}{}",
-            storage.url_prefix,
-            storage.object_key(remote_path)
-        )),
-    );
-    row.insert("storage_type".into(), json!(storage.name));
-    row.insert("updated_at".into(), json!(unix_now()));
-    row
-}
-
-fn uploaded_row(
-    group: &FileGroup,
-    file: &FileRef,
-    storage: &Storage,
-    remote_path: &str,
-    meta: &FileMeta,
-) -> Value {
-    let mut row = base_row(group, file, storage, remote_path);
-    row.insert("uploaded".into(), json!(true));
-    row.insert("on_filesystem".into(), json!(true));
-    row.insert("deleted".into(), json!(false));
-    row.insert("content_type".into(), json!(meta.content_type));
-    row.insert("size".into(), json!(meta.size));
-    if let Some(duration) = meta.duration {
-        row.insert("duration".into(), json!(duration));
-    }
-    Value::Object(row)
-}
-
-fn missing_row(group: &FileGroup, file: &FileRef, storage: &Storage, remote_path: &str) -> Value {
-    let mut row = base_row(group, file, storage, remote_path);
-    row.insert("uploaded".into(), json!(false));
-    row.insert("on_filesystem".into(), json!(false));
-    row.insert("deleted".into(), json!(false));
-    Value::Object(row)
-}
-
-fn deleted_row(group: &FileGroup, file: &FileRef, storage: &Storage, remote_path: &str) -> Value {
-    let mut row = base_row(group, file, storage, remote_path);
-    row.insert("uploaded".into(), json!(true));
-    row.insert("on_filesystem".into(), json!(false));
-    row.insert("deleted".into(), json!(true));
-    Value::Object(row)
-}
-
-/// ADR-0005's group completion marker — the "manifest as completion checkpoint".
-fn group_complete_row(group: &FileGroup) -> Value {
-    let mut row = serde_json::Map::new();
-    row.insert("kind".into(), json!("group_complete"));
-    row.insert("group_name".into(), json!(group.group_name));
-    if let Some(robot_name) = &group.robot_name {
-        row.insert("robot_name".into(), json!(robot_name));
-    }
-    if let Some(robot_id) = &group.robot_id {
-        row.insert("robot_id".into(), robot_id.clone());
-    }
-    row.insert("complete".into(), json!(true));
-    row.insert("file_count".into(), json!(group.files.len()));
-    row.insert(
-        "files".into(),
-        Value::Array(
-            group
-                .files
-                .iter()
-                .map(|f| json!({ "key": f.key, "local_path": f.local_path }))
-                .collect(),
-        ),
-    );
-    row.insert("updated_at".into(), json!(unix_now()));
-    Value::Object(row)
 }

--- a/dc_bridge/dc_bridge_core/src/uploader/mod.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/mod.rs
@@ -1,0 +1,505 @@
+//! The Uploader (ADR-0005): verified File uploads with metadata Records, replacing the
+//! Humble-era Go plugins (`out_minio`, `out_files_metrics`).
+//!
+//! For each Record referencing Files (see [`group`]), per File: upload to every
+//! `receives: files` Destination via the `object_store` abstraction ([`store`], with
+//! multipart + resume for large Files — [`multipart`]), **verify** the object landed
+//! (`head` + size comparison — an upload only counts once the store says the bytes are
+//! there), extract metadata (content type, size, video duration), and emit a status
+//! Record per File × Destination through an injected emit function (`main.rs` wires it
+//! to the Forwarder under [`FILE_STATUS_TAG`], so status rows reach PostgreSQL through
+//! the Shipper's parameterized sink — no SQL strings anywhere in DC). The upload-status
+//! semantics (uploaded / on-filesystem / deleted per File and storage) are preserved
+//! from Humble, but append-only: deletion emits a new status Record rather than
+//! updating a row, since the pipeline is insert-only by design.
+//!
+//! Group completion (ADR-0005): once — and only once — every File the Record references
+//! is verified on every Destination that receives it, a `group_complete` marker Record
+//! is emitted, so consumers never guess whether a multi-File group (map = pgm+yaml,
+//! camera batches) has fully arrived. A consumer querying mid-upload sees per-File
+//! status rows but no marker.
+//!
+//! Local deletion (`files.delete_when_sent`) happens per File, strictly after that
+//! File is verified on **all** its Destinations. Retries are idempotent: an
+//! already-verified object short-circuits (no re-upload) and every status Record is
+//! emitted at most once per Uploader instance (keyed dedup), so a retried Record
+//! produces no duplicate rows. A Record redelivered after its Files were deleted
+//! locally is recognized (object verified remotely, nothing on disk) and produces no
+//! spurious "missing" rows.
+
+pub mod content_type;
+pub mod group;
+pub mod multipart;
+pub mod store;
+
+use serde_json::{json, Value};
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use group::{FileGroup, FileRef};
+use object_store::path::Path as ObjectPath;
+use store::Storage;
+
+/// The Tag the Uploader's status/metadata Records are emitted under. The Destination
+/// named by `files.metadata_destination` gets this Tag appended to its inputs, so the
+/// rendered Shipper config routes these Records to it like any others (public route
+/// `dc.dc.files` under ADR-0003's addressing).
+pub const FILE_STATUS_TAG: &str = "dc.files";
+
+#[derive(Debug, Clone)]
+pub struct UploaderConfig {
+    /// Delete a local File once it is verified uploaded on all its Destinations.
+    pub delete_when_sent: bool,
+    /// Directory for multipart resume sidecars (survives Bridge restarts).
+    pub state_dir: PathBuf,
+    /// Files at least this large upload multipart (and therefore resumable).
+    pub multipart_threshold_bytes: u64,
+    /// Part size for multipart uploads. S3 requires ≥ 5 MiB for all but the last part.
+    pub multipart_part_size_bytes: u64,
+    /// Upload/verify attempts per (File, Destination) within one `process_record` call
+    /// before the Record is reported as incomplete (the caller re-queues it).
+    pub max_attempts: u32,
+    /// Sleep between those attempts.
+    pub retry_backoff: Duration,
+}
+
+impl UploaderConfig {
+    pub fn new(state_dir: PathBuf, delete_when_sent: bool) -> Self {
+        Self {
+            delete_when_sent,
+            state_dir,
+            multipart_threshold_bytes: 16 * 1024 * 1024,
+            multipart_part_size_bytes: 8 * 1024 * 1024,
+            max_attempts: 3,
+            retry_backoff: Duration::from_millis(500),
+        }
+    }
+}
+
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum UploadError {
+    /// At least one (File, Destination) upload could not be verified within
+    /// `max_attempts`; the Record should be re-processed later (idempotently).
+    #[error("upload incomplete, will retry: {0}")]
+    Incomplete(String),
+    /// The injected emit function failed permanently (status Records must not be
+    /// silently dropped, so this too re-queues the Record).
+    #[error("failed to emit a status Record: {0}")]
+    Emit(String),
+}
+
+/// What one `process_record` call did — the assertion surface for tests and logging.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProcessSummary {
+    /// Files referenced by the Record (with at least one configured Destination).
+    pub files: usize,
+    /// Files verified on every Destination that receives them (this call or earlier).
+    pub verified: usize,
+    /// Files not on disk and not verified remotely.
+    pub missing: usize,
+    /// Local Files deleted by this call.
+    pub deleted: usize,
+    /// Whether the group completion marker has been emitted (this call or earlier).
+    pub group_complete: bool,
+}
+
+/// Probes a video's duration in seconds; `None` if it can't be determined.
+pub type DurationProber = Box<dyn Fn(&Path) -> Option<f64> + Send + Sync>;
+
+/// A [`DurationProber`] shelling out to ffprobe (the Humble behavior, minus the shell:
+/// the path is passed as an argument vector, never interpolated into a shell string).
+pub fn ffprobe_duration_prober(ffprobe_binary: PathBuf) -> DurationProber {
+    Box::new(move |path: &Path| {
+        let output = std::process::Command::new(&ffprobe_binary)
+            .arg("-i")
+            .arg(path)
+            .args([
+                "-show_entries",
+                "format=duration",
+                "-v",
+                "quiet",
+                "-of",
+                "csv=p=0",
+            ])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+    })
+}
+
+struct FileMeta {
+    size: u64,
+    content_type: &'static str,
+    duration: Option<f64>,
+}
+
+enum EnsureOutcome {
+    /// Object verified on the store (uploaded now or already there).
+    Verified,
+    /// Nothing on disk, but the object is already verified remotely — the
+    /// redelivered-after-delete case; counts as verified, emits nothing.
+    VerifiedRemoteOnly,
+    /// Nothing on disk and nothing (matching) in the store: can never succeed.
+    MissingLocal,
+}
+
+pub struct Uploader {
+    config: UploaderConfig,
+    storages: Vec<Storage>,
+    storage_names: BTreeSet<String>,
+    duration_prober: DurationProber,
+    runtime: tokio::runtime::Runtime,
+    /// Dedup keys of every status Record already emitted, making retried Records
+    /// idempotent (no duplicate rows).
+    emitted: Mutex<HashSet<String>>,
+}
+
+impl Uploader {
+    pub fn new(
+        config: UploaderConfig,
+        storages: Vec<Storage>,
+        duration_prober: DurationProber,
+    ) -> std::io::Result<Self> {
+        std::fs::create_dir_all(&config.state_dir)?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let storage_names = storages.iter().map(|s| s.name.clone()).collect();
+        Ok(Self {
+            config,
+            storages,
+            storage_names,
+            duration_prober,
+            runtime,
+            emitted: Mutex::new(HashSet::new()),
+        })
+    }
+
+    /// Processes one Record's Files end to end: upload + verify everywhere, status
+    /// Records, group completion marker, delete-when-sent. `emit` receives each status
+    /// Record's JSON payload (already deduplicated); returning `Err` re-queues the
+    /// Record without risking duplicate rows.
+    pub fn process_record(
+        &self,
+        payload: &Value,
+        fallback_group: &str,
+        emit: &mut dyn FnMut(Value) -> Result<(), String>,
+    ) -> Result<ProcessSummary, UploadError> {
+        let group = group::parse_file_group(payload, fallback_group, &self.storage_names);
+        let mut summary = ProcessSummary {
+            files: group.files.len(),
+            ..ProcessSummary::default()
+        };
+        if group.files.is_empty() {
+            return Ok(summary);
+        }
+
+        let mut failures: Vec<String> = Vec::new();
+        let mut verified_files: Vec<&FileRef> = Vec::new();
+
+        for file in &group.files {
+            let meta = self.file_meta(&file.local_path);
+            let mut verified_everywhere = true;
+
+            for (storage_name, remote_path) in &file.remote_paths {
+                let storage = self
+                    .storages
+                    .iter()
+                    .find(|s| &s.name == storage_name)
+                    .expect("parse_file_group only keeps configured storages");
+
+                match self.ensure_uploaded(storage, file, meta.as_ref(), remote_path) {
+                    Ok(EnsureOutcome::Verified) => {
+                        let meta = meta.as_ref().expect("Verified implies a local file");
+                        self.emit_once(
+                            emit,
+                            &format!("uploaded|{}|{}", file.local_path, storage.name),
+                            uploaded_row(&group, file, storage, remote_path, meta),
+                        )?;
+                    }
+                    Ok(EnsureOutcome::VerifiedRemoteOnly) => {}
+                    Ok(EnsureOutcome::MissingLocal) => {
+                        verified_everywhere = false;
+                        summary.missing += 1;
+                        self.emit_once(
+                            emit,
+                            &format!("missing|{}|{}", file.local_path, storage.name),
+                            missing_row(&group, file, storage, remote_path),
+                        )?;
+                    }
+                    Err(e) => {
+                        verified_everywhere = false;
+                        failures.push(format!("'{}' -> {}: {e}", file.local_path, storage.name));
+                    }
+                }
+            }
+
+            if verified_everywhere {
+                summary.verified += 1;
+                verified_files.push(file);
+            }
+        }
+
+        // Group completion marker: only when every File in the group is verified on
+        // every Destination that receives it (ADR-0005). Missing Files keep the group
+        // incomplete forever — loud in the status table, never guessed complete.
+        if summary.verified == summary.files {
+            summary.group_complete = true;
+            let files_key: Vec<&str> = group.files.iter().map(|f| f.local_path.as_str()).collect();
+            self.emit_once(
+                emit,
+                &format!("group|{}|{}", group.group_name, files_key.join("|")),
+                group_complete_row(&group),
+            )?;
+        }
+
+        // Deletion strictly after verified upload on all storages — per File, so one
+        // permanently failing File doesn't strand its group-mates on a full disk.
+        if self.config.delete_when_sent {
+            for file in &verified_files {
+                let local = Path::new(&file.local_path);
+                if !local.exists() {
+                    continue;
+                }
+                if let Err(e) = std::fs::remove_file(local) {
+                    failures.push(format!("failed to delete '{}': {e}", file.local_path));
+                    continue;
+                }
+                summary.deleted += 1;
+                for (storage_name, remote_path) in &file.remote_paths {
+                    let storage = self
+                        .storages
+                        .iter()
+                        .find(|s| &s.name == storage_name)
+                        .expect("parse_file_group only keeps configured storages");
+                    self.emit_once(
+                        emit,
+                        &format!("deleted|{}|{}", file.local_path, storage.name),
+                        deleted_row(&group, file, storage, remote_path),
+                    )?;
+                }
+            }
+        }
+
+        if !failures.is_empty() {
+            return Err(UploadError::Incomplete(failures.join("; ")));
+        }
+        Ok(summary)
+    }
+
+    fn file_meta(&self, local_path: &str) -> Option<FileMeta> {
+        let path = Path::new(local_path);
+        let size = std::fs::metadata(path).ok()?.len();
+        let mut head = [0u8; 512];
+        let n = std::fs::File::open(path)
+            .and_then(|mut f| std::io::Read::read(&mut f, &mut head))
+            .unwrap_or(0);
+        let content_type = content_type::sniff(&head[..n]);
+        let duration = content_type::is_video(content_type)
+            .then(|| (self.duration_prober)(path))
+            .flatten();
+        Some(FileMeta {
+            size,
+            content_type,
+            duration,
+        })
+    }
+
+    /// Upload-and-verify one (File, Destination) with bounded retries. Verification is
+    /// a `head` on the object plus a size comparison; an already-matching object
+    /// short-circuits the upload entirely (idempotent retries).
+    fn ensure_uploaded(
+        &self,
+        storage: &Storage,
+        file: &FileRef,
+        meta: Option<&FileMeta>,
+        remote_path: &str,
+    ) -> Result<EnsureOutcome, String> {
+        let key = storage.object_key(remote_path);
+        let location = ObjectPath::from(key.as_str());
+        let mut last_err = String::new();
+
+        for attempt in 0..self.config.max_attempts {
+            if attempt > 0 {
+                std::thread::sleep(self.config.retry_backoff);
+            }
+
+            let head = self.runtime.block_on(storage.store.head(&location));
+            match (&head, meta) {
+                (Ok(obj), Some(meta)) if obj.size == meta.size => {
+                    return Ok(EnsureOutcome::Verified)
+                }
+                // No local file: any existing object is taken as the verified upload
+                // of a Record redelivered after delete-when-sent (size unknowable).
+                (Ok(_), None) => return Ok(EnsureOutcome::VerifiedRemoteOnly),
+                _ => {}
+            }
+            let Some(meta) = meta else {
+                return Ok(EnsureOutcome::MissingLocal);
+            };
+
+            let uploaded = if meta.size >= self.config.multipart_threshold_bytes {
+                let state_path =
+                    multipart::resume_state_path(&self.config.state_dir, &storage.name, &key);
+                self.runtime.block_on(multipart::upload_resumable(
+                    storage.store.as_ref(),
+                    &location,
+                    Path::new(&file.local_path),
+                    meta.size,
+                    self.config.multipart_part_size_bytes,
+                    &state_path,
+                ))
+            } else {
+                match std::fs::read(&file.local_path) {
+                    Ok(bytes) => self
+                        .runtime
+                        .block_on(
+                            storage
+                                .store
+                                .put(&location, object_store::PutPayload::from(bytes)),
+                        )
+                        .map(|_| ()),
+                    Err(e) => {
+                        last_err = format!("failed to read local file: {e}");
+                        continue;
+                    }
+                }
+            };
+            if let Err(e) = uploaded {
+                last_err = e.to_string();
+                continue;
+            }
+
+            // The upload call returning is not proof the object landed — verify.
+            match self.runtime.block_on(storage.store.head(&location)) {
+                Ok(obj) if obj.size == meta.size => return Ok(EnsureOutcome::Verified),
+                Ok(obj) => {
+                    last_err = format!(
+                        "verification failed: object has {} bytes, local file has {}",
+                        obj.size, meta.size
+                    );
+                }
+                Err(e) => last_err = format!("verification failed: {e}"),
+            }
+        }
+        Err(last_err)
+    }
+
+    fn emit_once(
+        &self,
+        emit: &mut dyn FnMut(Value) -> Result<(), String>,
+        dedup_key: &str,
+        row: Value,
+    ) -> Result<(), UploadError> {
+        if self.emitted.lock().unwrap().contains(dedup_key) {
+            return Ok(());
+        }
+        emit(row).map_err(UploadError::Emit)?;
+        self.emitted.lock().unwrap().insert(dedup_key.to_string());
+        Ok(())
+    }
+}
+
+fn unix_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+/// The shared status-row fields, preserving the Humble `out_files_metrics` column set.
+fn base_row(
+    group: &FileGroup,
+    file: &FileRef,
+    storage: &Storage,
+    remote_path: &str,
+) -> serde_json::Map<String, Value> {
+    let mut row = serde_json::Map::new();
+    row.insert("kind".into(), json!("file_status"));
+    row.insert("group_name".into(), json!(group.group_name));
+    if let Some(robot_name) = &group.robot_name {
+        row.insert("robot_name".into(), json!(robot_name));
+    }
+    if let Some(robot_id) = &group.robot_id {
+        row.insert("robot_id".into(), robot_id.clone());
+    }
+    row.insert("local_path".into(), json!(file.local_path));
+    row.insert(
+        "remote_path".into(),
+        json!(format!(
+            "{}{}",
+            storage.url_prefix,
+            storage.object_key(remote_path)
+        )),
+    );
+    row.insert("storage_type".into(), json!(storage.name));
+    row.insert("updated_at".into(), json!(unix_now()));
+    row
+}
+
+fn uploaded_row(
+    group: &FileGroup,
+    file: &FileRef,
+    storage: &Storage,
+    remote_path: &str,
+    meta: &FileMeta,
+) -> Value {
+    let mut row = base_row(group, file, storage, remote_path);
+    row.insert("uploaded".into(), json!(true));
+    row.insert("on_filesystem".into(), json!(true));
+    row.insert("deleted".into(), json!(false));
+    row.insert("content_type".into(), json!(meta.content_type));
+    row.insert("size".into(), json!(meta.size));
+    if let Some(duration) = meta.duration {
+        row.insert("duration".into(), json!(duration));
+    }
+    Value::Object(row)
+}
+
+fn missing_row(group: &FileGroup, file: &FileRef, storage: &Storage, remote_path: &str) -> Value {
+    let mut row = base_row(group, file, storage, remote_path);
+    row.insert("uploaded".into(), json!(false));
+    row.insert("on_filesystem".into(), json!(false));
+    row.insert("deleted".into(), json!(false));
+    Value::Object(row)
+}
+
+fn deleted_row(group: &FileGroup, file: &FileRef, storage: &Storage, remote_path: &str) -> Value {
+    let mut row = base_row(group, file, storage, remote_path);
+    row.insert("uploaded".into(), json!(true));
+    row.insert("on_filesystem".into(), json!(false));
+    row.insert("deleted".into(), json!(true));
+    Value::Object(row)
+}
+
+/// ADR-0005's group completion marker — the "manifest as completion checkpoint".
+fn group_complete_row(group: &FileGroup) -> Value {
+    let mut row = serde_json::Map::new();
+    row.insert("kind".into(), json!("group_complete"));
+    row.insert("group_name".into(), json!(group.group_name));
+    if let Some(robot_name) = &group.robot_name {
+        row.insert("robot_name".into(), json!(robot_name));
+    }
+    if let Some(robot_id) = &group.robot_id {
+        row.insert("robot_id".into(), robot_id.clone());
+    }
+    row.insert("complete".into(), json!(true));
+    row.insert("file_count".into(), json!(group.files.len()));
+    row.insert(
+        "files".into(),
+        Value::Array(
+            group
+                .files
+                .iter()
+                .map(|f| json!({ "key": f.key, "local_path": f.local_path }))
+                .collect(),
+        ),
+    );
+    row.insert("updated_at".into(), json!(unix_now()));
+    Value::Object(row)
+}

--- a/dc_bridge/dc_bridge_core/src/uploader/multipart.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/multipart.rs
@@ -1,0 +1,156 @@
+//! Multipart, resumable uploads for large Files (ADR-0005): robot networks are flaky
+//! and videos/maps are large, so an interrupted transfer must resume, not restart.
+//!
+//! Built on `object_store`'s low-level [`MultipartStore`] API rather than the
+//! high-level `put_multipart` writer, because only the low-level API exposes the
+//! persistent [`MultipartId`] and per-part [`PartId`]s that make resumption possible:
+//! both are checkpointed to a JSON sidecar file after every part, so a new process (or
+//! a retry after a dropped connection) re-reads the sidecar, skips every part that
+//! already landed, and finishes the same multipart upload instead of starting over.
+//! The sidecar is removed once the upload completes.
+
+use object_store::multipart::PartId;
+use object_store::path::Path as ObjectPath;
+use object_store::{MultipartId, PutPayload};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use super::store::UploadStore;
+
+/// Progress of one interrupted multipart upload, checkpointed after every part.
+#[derive(Debug, Serialize, Deserialize)]
+struct ResumeState {
+    multipart_id: MultipartId,
+    part_size: u64,
+    file_size: u64,
+    /// `content_id` of each completed part, by part index; `None` = not yet uploaded.
+    parts: Vec<Option<String>>,
+}
+
+/// Where the resume sidecar for one (storage, object key) upload lives. Stable across
+/// runs — FNV-1a rather than `DefaultHasher`, whose keys are randomized per process.
+pub fn resume_state_path(state_dir: &Path, storage_name: &str, object_key: &str) -> PathBuf {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in storage_name.bytes().chain([0u8]).chain(object_key.bytes()) {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    state_dir.join(format!("multipart-{hash:016x}.json"))
+}
+
+fn generic_err(
+    source: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+) -> object_store::Error {
+    object_store::Error::Generic {
+        store: "dc_bridge uploader resume state",
+        source: source.into(),
+    }
+}
+
+fn load_state(state_path: &Path, part_size: u64, file_size: u64) -> Option<ResumeState> {
+    let content = fs::read_to_string(state_path).ok()?;
+    let state: ResumeState = serde_json::from_str(&content).ok()?;
+    // A sidecar from a different policy or a changed file can't be resumed safely.
+    (state.part_size == part_size
+        && state.file_size == file_size
+        && state.parts.len() == part_count(file_size, part_size))
+    .then_some(state)
+}
+
+fn save_state(state_path: &Path, state: &ResumeState) -> Result<(), object_store::Error> {
+    let tmp = state_path.with_extension("json.tmp");
+    let content = serde_json::to_string(state).map_err(generic_err)?;
+    fs::write(&tmp, content).map_err(generic_err)?;
+    fs::rename(&tmp, state_path).map_err(generic_err)?;
+    Ok(())
+}
+
+fn part_count(file_size: u64, part_size: u64) -> usize {
+    (file_size.div_ceil(part_size)).max(1) as usize
+}
+
+/// Uploads `local` to `location` on `store` in `part_size`-byte parts, checkpointing
+/// progress to `state_path` so an interrupted upload resumes from the last completed
+/// part. `file_size` must be `local`'s current size (the caller already stat'ed it).
+pub async fn upload_resumable(
+    store: &dyn UploadStore,
+    location: &ObjectPath,
+    local: &Path,
+    file_size: u64,
+    part_size: u64,
+    state_path: &Path,
+) -> Result<(), object_store::Error> {
+    let n_parts = part_count(file_size, part_size);
+
+    let mut state = match load_state(state_path, part_size, file_size) {
+        Some(state) => state,
+        None => {
+            let multipart_id = store.create_multipart(location).await?;
+            let state = ResumeState {
+                multipart_id,
+                part_size,
+                file_size,
+                parts: vec![None; n_parts],
+            };
+            save_state(state_path, &state)?;
+            state
+        }
+    };
+
+    let mut file = fs::File::open(local).map_err(generic_err)?;
+    for idx in 0..n_parts {
+        if state.parts[idx].is_some() {
+            continue;
+        }
+        let offset = idx as u64 * part_size;
+        let len = part_size.min(file_size - offset) as usize;
+        let mut buf = vec![0u8; len];
+        file.seek(SeekFrom::Start(offset)).map_err(generic_err)?;
+        file.read_exact(&mut buf).map_err(generic_err)?;
+
+        let part = store
+            .put_part(location, &state.multipart_id, idx, PutPayload::from(buf))
+            .await?;
+        state.parts[idx] = Some(part.content_id);
+        save_state(state_path, &state)?;
+    }
+
+    let parts: Vec<PartId> = state
+        .parts
+        .iter()
+        .map(|content_id| PartId {
+            content_id: content_id
+                .clone()
+                .expect("every part index was just filled in"),
+        })
+        .collect();
+    store
+        .complete_multipart(location, &state.multipart_id, parts)
+        .await?;
+    let _ = fs::remove_file(state_path);
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resume_state_paths_are_stable_and_distinct() {
+        let dir = Path::new("/state");
+        let a = resume_state_path(dir, "minio", "maps/map.pgm");
+        assert_eq!(a, resume_state_path(dir, "minio", "maps/map.pgm"));
+        assert_ne!(a, resume_state_path(dir, "s3", "maps/map.pgm"));
+        assert_ne!(a, resume_state_path(dir, "minio", "maps/other.pgm"));
+    }
+
+    #[test]
+    fn part_count_covers_edge_sizes() {
+        assert_eq!(part_count(0, 1024), 1);
+        assert_eq!(part_count(1, 1024), 1);
+        assert_eq!(part_count(1024, 1024), 1);
+        assert_eq!(part_count(1025, 1024), 2);
+    }
+}

--- a/dc_bridge/dc_bridge_core/src/uploader/status.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/status.rs
@@ -1,0 +1,123 @@
+//! Status-Record row shapes the Uploader emits (ADR-0005), preserving the Humble
+//! `out_files_metrics` column set. [`StatusContext`] bundles the (group, File,
+//! Destination) a row is about — the one tuple every row shares — so each row
+//! constructor only states what makes that row distinct.
+
+use serde_json::{json, Value};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::group::{FileGroup, FileRef};
+use super::store::Storage;
+use super::FileMeta;
+
+fn unix_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}
+
+/// The (group, File, Destination) a status row is about.
+pub(super) struct StatusContext<'a> {
+    group: &'a FileGroup,
+    file: &'a FileRef,
+    storage: &'a Storage,
+    remote_path: &'a str,
+}
+
+impl<'a> StatusContext<'a> {
+    pub(super) fn new(
+        group: &'a FileGroup,
+        file: &'a FileRef,
+        storage: &'a Storage,
+        remote_path: &'a str,
+    ) -> Self {
+        Self {
+            group,
+            file,
+            storage,
+            remote_path,
+        }
+    }
+
+    /// The shared status-row fields, preserving the Humble `out_files_metrics` column set.
+    fn base_row(&self) -> serde_json::Map<String, Value> {
+        let mut row = serde_json::Map::new();
+        row.insert("kind".into(), json!("file_status"));
+        row.insert("group_name".into(), json!(self.group.group_name));
+        if let Some(robot_name) = &self.group.robot_name {
+            row.insert("robot_name".into(), json!(robot_name));
+        }
+        if let Some(robot_id) = &self.group.robot_id {
+            row.insert("robot_id".into(), robot_id.clone());
+        }
+        row.insert("local_path".into(), json!(self.file.local_path));
+        row.insert(
+            "remote_path".into(),
+            json!(format!(
+                "{}{}",
+                self.storage.url_prefix,
+                self.storage.object_key(self.remote_path)
+            )),
+        );
+        row.insert("storage_type".into(), json!(self.storage.name));
+        row.insert("updated_at".into(), json!(unix_now()));
+        row
+    }
+
+    pub(super) fn uploaded(&self, meta: &FileMeta) -> Value {
+        let mut row = self.base_row();
+        row.insert("uploaded".into(), json!(true));
+        row.insert("on_filesystem".into(), json!(true));
+        row.insert("deleted".into(), json!(false));
+        row.insert("content_type".into(), json!(meta.content_type));
+        row.insert("size".into(), json!(meta.size));
+        if let Some(duration) = meta.duration {
+            row.insert("duration".into(), json!(duration));
+        }
+        Value::Object(row)
+    }
+
+    pub(super) fn missing(&self) -> Value {
+        let mut row = self.base_row();
+        row.insert("uploaded".into(), json!(false));
+        row.insert("on_filesystem".into(), json!(false));
+        row.insert("deleted".into(), json!(false));
+        Value::Object(row)
+    }
+
+    pub(super) fn deleted(&self) -> Value {
+        let mut row = self.base_row();
+        row.insert("uploaded".into(), json!(true));
+        row.insert("on_filesystem".into(), json!(false));
+        row.insert("deleted".into(), json!(true));
+        Value::Object(row)
+    }
+}
+
+/// ADR-0005's group completion marker — the "manifest as completion checkpoint".
+pub(super) fn group_complete_row(group: &FileGroup) -> Value {
+    let mut row = serde_json::Map::new();
+    row.insert("kind".into(), json!("group_complete"));
+    row.insert("group_name".into(), json!(group.group_name));
+    if let Some(robot_name) = &group.robot_name {
+        row.insert("robot_name".into(), json!(robot_name));
+    }
+    if let Some(robot_id) = &group.robot_id {
+        row.insert("robot_id".into(), robot_id.clone());
+    }
+    row.insert("complete".into(), json!(true));
+    row.insert("file_count".into(), json!(group.files.len()));
+    row.insert(
+        "files".into(),
+        Value::Array(
+            group
+                .files
+                .iter()
+                .map(|f| json!({ "key": f.key, "local_path": f.local_path }))
+                .collect(),
+        ),
+    );
+    row.insert("updated_at".into(), json!(unix_now()));
+    Value::Object(row)
+}

--- a/dc_bridge/dc_bridge_core/src/uploader/store.rs
+++ b/dc_bridge/dc_bridge_core/src/uploader/store.rs
@@ -1,0 +1,128 @@
+//! The object-storage side of the Uploader (ADR-0005): a [`Storage`] wraps one
+//! `receives: files` Destination's `object_store` client. The `object_store` crate is
+//! the abstraction the ADR names — S3-compatible today (AWS, RustFS, MinIO, Ceph…),
+//! GCS/Azure become new constructors here without touching the upload logic.
+
+use crate::render::S3Params;
+use object_store::aws::AmazonS3Builder;
+use object_store::multipart::MultipartStore;
+use object_store::ObjectStore;
+use std::sync::Arc;
+
+/// What the Uploader needs from a store: plain puts plus the low-level multipart API
+/// ([`MultipartStore`]) whose persistent upload ids make interrupted transfers
+/// resumable (ADR-0005's "multipart, resumable uploads" consequence). Implemented by
+/// `object_store`'s cloud backends and its `InMemory` test double alike.
+pub trait UploadStore: ObjectStore + MultipartStore {}
+impl<T: ObjectStore + MultipartStore> UploadStore for T {}
+
+/// One `receives: files` Destination, ready to upload to.
+#[derive(Clone)]
+pub struct Storage {
+    /// The Destination's configured name — the key Files' `remote_paths` maps use, and
+    /// the `storage_type` value in emitted status Records.
+    pub name: String,
+    /// Prefix rendering an object key into the `remote_path` status field
+    /// (`s3://<bucket>/`), preserving the Humble status-row shape.
+    pub url_prefix: String,
+    /// Prepended to every object key (the Destination's `key_prefix`, if any).
+    pub key_prefix: String,
+    pub store: Arc<dyn UploadStore>,
+}
+
+impl std::fmt::Debug for Storage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Storage")
+            .field("name", &self.name)
+            .field("url_prefix", &self.url_prefix)
+            .field("key_prefix", &self.key_prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Storage {
+    /// Builds the S3 client for a `type: s3, receives: files` Destination. Credentials
+    /// and endpoint semantics match the Records-side `aws_s3` Vector sink: explicit
+    /// key pair when configured, ambient AWS environment/instance credentials
+    /// otherwise; custom `endpoint` for self-hosted stores (http endpoints allowed —
+    /// robot-LAN RustFS/MinIO deployments are rarely TLS-terminated).
+    pub fn s3(name: &str, params: &S3Params) -> Result<Self, object_store::Error> {
+        // `from_env` picks up ambient AWS credentials/region; explicit config overrides.
+        let mut builder = AmazonS3Builder::from_env().with_bucket_name(&params.bucket);
+        if let Some(region) = &params.region {
+            builder = builder.with_region(region);
+        }
+        if let Some(endpoint) = &params.endpoint {
+            builder = builder
+                .with_endpoint(endpoint)
+                .with_allow_http(endpoint.starts_with("http://"));
+        }
+        if let Some(auth) = &params.auth {
+            builder = builder
+                .with_access_key_id(&auth.access_key_id)
+                .with_secret_access_key(&auth.secret_access_key);
+        }
+        if let Some(force_path_style) = params.force_path_style {
+            builder = builder.with_virtual_hosted_style_request(!force_path_style);
+        }
+        Ok(Self {
+            name: name.to_string(),
+            url_prefix: format!("s3://{}/", params.bucket),
+            key_prefix: params.key_prefix.clone().unwrap_or_default(),
+            store: Arc::new(builder.build()?),
+        })
+    }
+
+    /// A [`Storage`] over any [`UploadStore`] — how tests inject `InMemory` (or an
+    /// instrumented wrapper around it).
+    pub fn custom(name: &str, url_prefix: &str, store: Arc<dyn UploadStore>) -> Self {
+        Self {
+            name: name.to_string(),
+            url_prefix: url_prefix.to_string(),
+            key_prefix: String::new(),
+            store,
+        }
+    }
+
+    /// The full object key for a File's remote path on this Storage.
+    pub fn object_key(&self, remote_path: &str) -> String {
+        format!("{}{}", self.key_prefix, remote_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::render::S3Auth;
+
+    fn params() -> S3Params {
+        S3Params {
+            bucket: "dc-records".to_string(),
+            region: Some("us-east-1".to_string()),
+            endpoint: Some("http://127.0.0.1:9000".to_string()),
+            key_prefix: Some("robot1/".to_string()),
+            auth: Some(S3Auth {
+                access_key_id: "rustfsadmin".to_string(),
+                secret_access_key: "rustfsadmin".to_string(),
+            }),
+            force_path_style: Some(true),
+            batch_timeout_secs: None,
+        }
+    }
+
+    #[test]
+    fn builds_an_s3_storage_with_the_humble_style_url_prefix() {
+        let storage = Storage::s3("minio", &params()).unwrap();
+        assert_eq!(storage.name, "minio");
+        assert_eq!(storage.url_prefix, "s3://dc-records/");
+        assert_eq!(storage.object_key("maps/map.pgm"), "robot1/maps/map.pgm");
+    }
+
+    #[test]
+    fn key_prefix_defaults_to_empty() {
+        let mut p = params();
+        p.key_prefix = None;
+        let storage = Storage::s3("minio", &p).unwrap();
+        assert_eq!(storage.object_key("maps/map.pgm"), "maps/map.pgm");
+    }
+}

--- a/dc_bridge/dc_bridge_core/tests/uploader_tests.rs
+++ b/dc_bridge/dc_bridge_core/tests/uploader_tests.rs
@@ -1,0 +1,671 @@
+//! Uploader acceptance-criteria tests (issue #248, ADR-0005) against `object_store`'s
+//! in-memory backend and real temp files: happy path, verify-fails-then-retry, delete
+//! only after verified upload on all configured storages, metadata Record shape,
+//! file-missing-on-disk, group completion markers, idempotent retries (no duplicate
+//! status rows), video duration extraction, and multipart resume after interruption.
+
+use async_trait::async_trait;
+use dc_bridge_core::uploader::store::UploadStore;
+use dc_bridge_core::{ProcessSummary, Storage, UploadError, Uploader, UploaderConfig};
+use futures::stream::BoxStream;
+use object_store::memory::InMemory;
+use object_store::multipart::{MultipartStore, PartId};
+use object_store::path::Path as ObjectPath;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartId, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result as StoreResult,
+};
+use serde_json::{json, Value};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicI64, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tempfile::TempDir;
+
+/// An `InMemory` store instrumented with call counters and failure injection — the
+/// "in-memory `object_store` backend" the acceptance criteria name, plus the knobs the
+/// retry/interruption tests need.
+#[derive(Debug, Default)]
+struct Instrumented {
+    inner: InMemory,
+    puts: AtomicUsize,
+    /// Successful `put_part` indices, in call order.
+    part_puts: Mutex<Vec<usize>>,
+    multipart_creates: AtomicUsize,
+    /// Fail the next N `head` calls.
+    fail_next_heads: AtomicI64,
+    /// Fail every `put` for these object keys.
+    fail_put_keys: Mutex<HashSet<String>>,
+    /// Remaining `put_part` calls allowed before they start failing (i64::MAX = all).
+    allow_parts: AtomicI64,
+}
+
+impl Instrumented {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            allow_parts: AtomicI64::new(i64::MAX),
+            ..Self::default()
+        })
+    }
+
+    fn injected(what: &str) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "instrumented-test-store",
+            source: format!("injected {what} failure").into(),
+        }
+    }
+
+    fn object_bytes(&self, key: &str) -> Vec<u8> {
+        futures::executor::block_on(async {
+            self.inner
+                .get(&ObjectPath::from(key))
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap()
+                .to_vec()
+        })
+    }
+
+    fn has_object(&self, key: &str) -> bool {
+        futures::executor::block_on(self.inner.head(&ObjectPath::from(key))).is_ok()
+    }
+}
+
+impl std::fmt::Display for Instrumented {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Instrumented({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for Instrumented {
+    async fn put_opts(
+        &self,
+        location: &ObjectPath,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> StoreResult<PutResult> {
+        if self
+            .fail_put_keys
+            .lock()
+            .unwrap()
+            .contains(location.as_ref())
+        {
+            return Err(Self::injected("put"));
+        }
+        self.puts.fetch_add(1, Ordering::SeqCst);
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &ObjectPath,
+        opts: PutMultipartOptions,
+    ) -> StoreResult<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(&self, location: &ObjectPath, options: GetOptions) -> StoreResult<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn head(&self, location: &ObjectPath) -> StoreResult<ObjectMeta> {
+        if self.fail_next_heads.fetch_sub(1, Ordering::SeqCst) > 0 {
+            return Err(Self::injected("head"));
+        }
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &ObjectPath) -> StoreResult<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(&self, prefix: Option<&ObjectPath>) -> BoxStream<'static, StoreResult<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&ObjectPath>) -> StoreResult<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &ObjectPath, to: &ObjectPath) -> StoreResult<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &ObjectPath, to: &ObjectPath) -> StoreResult<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+#[async_trait]
+impl MultipartStore for Instrumented {
+    async fn create_multipart(&self, path: &ObjectPath) -> StoreResult<MultipartId> {
+        self.multipart_creates.fetch_add(1, Ordering::SeqCst);
+        self.inner.create_multipart(path).await
+    }
+
+    async fn put_part(
+        &self,
+        path: &ObjectPath,
+        id: &MultipartId,
+        part_idx: usize,
+        data: PutPayload,
+    ) -> StoreResult<PartId> {
+        if self.allow_parts.fetch_sub(1, Ordering::SeqCst) <= 0 {
+            return Err(Self::injected("put_part"));
+        }
+        let part = self.inner.put_part(path, id, part_idx, data).await?;
+        self.part_puts.lock().unwrap().push(part_idx);
+        Ok(part)
+    }
+
+    async fn complete_multipart(
+        &self,
+        path: &ObjectPath,
+        id: &MultipartId,
+        parts: Vec<PartId>,
+    ) -> StoreResult<PutResult> {
+        self.inner.complete_multipart(path, id, parts).await
+    }
+
+    async fn abort_multipart(&self, path: &ObjectPath, id: &MultipartId) -> StoreResult<()> {
+        self.inner.abort_multipart(path, id).await
+    }
+}
+
+struct Fixture {
+    tmp: TempDir,
+    stores: Vec<Arc<Instrumented>>,
+    storages: Vec<Storage>,
+}
+
+impl Fixture {
+    fn new(storage_names: &[&str]) -> Self {
+        let tmp = TempDir::new().unwrap();
+        let stores: Vec<Arc<Instrumented>> =
+            storage_names.iter().map(|_| Instrumented::new()).collect();
+        let storages = storage_names
+            .iter()
+            .zip(&stores)
+            .map(|(name, store)| {
+                Storage::custom(
+                    name,
+                    &format!("s3://{name}-bucket/"),
+                    store.clone() as Arc<dyn UploadStore>,
+                )
+            })
+            .collect();
+        Self {
+            tmp,
+            stores,
+            storages,
+        }
+    }
+
+    fn config(&self, delete_when_sent: bool) -> UploaderConfig {
+        let mut config = UploaderConfig::new(self.tmp.path().join("state"), delete_when_sent);
+        config.retry_backoff = Duration::from_millis(0);
+        config
+    }
+
+    fn uploader(&self, delete_when_sent: bool) -> Uploader {
+        self.uploader_with(self.config(delete_when_sent), |_| None)
+    }
+
+    fn uploader_with(
+        &self,
+        config: UploaderConfig,
+        prober: impl Fn(&std::path::Path) -> Option<f64> + Send + Sync + 'static,
+    ) -> Uploader {
+        Uploader::new(config, self.storages.clone(), Box::new(prober)).unwrap()
+    }
+
+    fn write_file(&self, name: &str, content: &[u8]) -> String {
+        let path = self.tmp.path().join(name);
+        std::fs::write(&path, content).unwrap();
+        path.to_string_lossy().into_owned()
+    }
+}
+
+/// A camera-style Record payload referencing one File per configured storage.
+fn camera_payload(local_path: &str, storages: &[&str]) -> Value {
+    let mut remote = serde_json::Map::new();
+    for storage in storages {
+        remote.insert(storage.to_string(), json!({ "raw": "cam/2026/img.jpg" }));
+    }
+    json!({
+        "name": "camera",
+        "robot_name": "robot1",
+        "id": "r1",
+        "local_paths": { "raw": local_path },
+        "remote_paths": remote,
+    })
+}
+
+fn collect_rows(rows: &Arc<Mutex<Vec<Value>>>) -> impl FnMut(Value) -> Result<(), String> {
+    let rows = rows.clone();
+    move |row| {
+        rows.lock().unwrap().push(row);
+        Ok(())
+    }
+}
+
+fn rows_of_kind<'a>(rows: &'a [Value], kind: &str) -> Vec<&'a Value> {
+    rows.iter().filter(|r| r["kind"] == json!(kind)).collect()
+}
+
+const JPEG_BYTES: &[u8] = b"\xff\xd8\xff\xe0fake-jpeg-body";
+
+#[test]
+fn happy_path_uploads_to_every_storage_verifies_and_emits_status_rows() {
+    let fx = Fixture::new(&["minio", "s3_archive"]);
+    let local = fx.write_file("img.jpg", JPEG_BYTES);
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+
+    let summary = uploader
+        .process_record(
+            &camera_payload(&local, &["minio", "s3_archive"]),
+            "dc.measurement.camera",
+            &mut collect_rows(&rows),
+        )
+        .unwrap();
+
+    assert_eq!(
+        summary,
+        ProcessSummary {
+            files: 1,
+            verified: 1,
+            missing: 0,
+            deleted: 0,
+            group_complete: true,
+        }
+    );
+    for store in &fx.stores {
+        assert_eq!(store.object_bytes("cam/2026/img.jpg"), JPEG_BYTES);
+    }
+    let rows = rows.lock().unwrap();
+    let uploaded = rows_of_kind(&rows, "file_status");
+    assert_eq!(uploaded.len(), 2, "one status row per File x storage");
+    assert_eq!(rows_of_kind(&rows, "group_complete").len(), 1);
+    // The local File must still be on disk: delete_when_sent is off.
+    assert!(std::path::Path::new(&local).exists());
+}
+
+/// The metadata Record shape: the Humble `out_files_metrics` column set, preserved.
+#[test]
+fn metadata_record_has_the_humble_status_row_shape() {
+    let fx = Fixture::new(&["minio"]);
+    let local = fx.write_file("img.jpg", JPEG_BYTES);
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+
+    uploader
+        .process_record(
+            &camera_payload(&local, &["minio"]),
+            "dc.measurement.camera",
+            &mut collect_rows(&rows),
+        )
+        .unwrap();
+
+    let rows = rows.lock().unwrap();
+    let row = rows_of_kind(&rows, "file_status")[0];
+    assert_eq!(row["group_name"], json!("camera"));
+    assert_eq!(row["robot_name"], json!("robot1"));
+    assert_eq!(row["robot_id"], json!("r1"));
+    assert_eq!(row["local_path"], json!(local));
+    assert_eq!(
+        row["remote_path"],
+        json!("s3://minio-bucket/cam/2026/img.jpg")
+    );
+    assert_eq!(row["storage_type"], json!("minio"));
+    assert_eq!(row["uploaded"], json!(true));
+    assert_eq!(row["on_filesystem"], json!(true));
+    assert_eq!(row["deleted"], json!(false));
+    assert_eq!(row["content_type"], json!("image/jpeg"));
+    assert_eq!(row["size"], json!(JPEG_BYTES.len()));
+    assert!(row["updated_at"].as_f64().unwrap() > 0.0);
+    assert!(
+        row.get("duration").is_none(),
+        "no duration for non-video content"
+    );
+
+    let marker = rows_of_kind(&rows, "group_complete")[0];
+    assert_eq!(marker["complete"], json!(true));
+    assert_eq!(marker["file_count"], json!(1));
+    assert_eq!(marker["files"][0]["local_path"], json!(local));
+}
+
+#[test]
+fn verify_failure_is_retried_without_a_second_upload() {
+    let fx = Fixture::new(&["minio"]);
+    let local = fx.write_file("img.jpg", JPEG_BYTES);
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+
+    // Attempt 1: pre-check head fails (injected), put succeeds, verification head
+    // fails (injected). Attempt 2: pre-check head sees the object → verified, no
+    // second put.
+    fx.stores[0].fail_next_heads.store(2, Ordering::SeqCst);
+
+    let summary = uploader
+        .process_record(
+            &camera_payload(&local, &["minio"]),
+            "dc.measurement.camera",
+            &mut collect_rows(&rows),
+        )
+        .unwrap();
+
+    assert_eq!(summary.verified, 1);
+    assert_eq!(fx.stores[0].puts.load(Ordering::SeqCst), 1);
+    let rows = rows.lock().unwrap();
+    assert_eq!(rows_of_kind(&rows, "file_status").len(), 1);
+}
+
+#[test]
+fn local_file_is_deleted_only_after_verified_upload_on_all_storages() {
+    let fx = Fixture::new(&["minio", "s3_archive"]);
+    let local = fx.write_file("img.jpg", JPEG_BYTES);
+    let uploader = fx.uploader(true);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+    let payload = camera_payload(&local, &["minio", "s3_archive"]);
+
+    // The second storage rejects every put: the Record must come back as incomplete,
+    // and the local File must survive.
+    fx.stores[1]
+        .fail_put_keys
+        .lock()
+        .unwrap()
+        .insert("cam/2026/img.jpg".to_string());
+
+    let err = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap_err();
+    assert!(matches!(err, UploadError::Incomplete(_)));
+    assert!(
+        std::path::Path::new(&local).exists(),
+        "File must not be deleted before verified upload everywhere"
+    );
+    {
+        let rows = rows.lock().unwrap();
+        assert!(rows_of_kind(&rows, "group_complete").is_empty());
+        assert!(rows.iter().all(|r| r["deleted"] == json!(false)));
+    }
+
+    // Storage heals; the retried Record completes: upload verified everywhere, group
+    // marker emitted, File deleted, deletion rows appended — and the first storage's
+    // already-verified upload is not re-uploaded and not re-reported.
+    fx.stores[1].fail_put_keys.lock().unwrap().clear();
+    let summary = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+    assert_eq!(summary.verified, 1);
+    assert_eq!(summary.deleted, 1);
+    assert!(summary.group_complete);
+    assert!(!std::path::Path::new(&local).exists());
+    assert_eq!(fx.stores[0].puts.load(Ordering::SeqCst), 1);
+    {
+        let rows = rows.lock().unwrap();
+        let uploaded: Vec<_> = rows_of_kind(&rows, "file_status")
+            .into_iter()
+            .filter(|r| r["uploaded"] == json!(true) && r["deleted"] == json!(false))
+            .collect();
+        assert_eq!(uploaded.len(), 2, "exactly one uploaded row per storage");
+        let deleted: Vec<_> = rows_of_kind(&rows, "file_status")
+            .into_iter()
+            .filter(|r| r["deleted"] == json!(true))
+            .collect();
+        assert_eq!(deleted.len(), 2, "one deletion row per storage");
+        for row in deleted {
+            assert_eq!(row["on_filesystem"], json!(false));
+            assert_eq!(row["uploaded"], json!(true));
+        }
+    }
+
+    // A Record redelivered after delete-when-sent (e.g. the Bridge restarted) is
+    // recognized by the verified remote objects: no spurious rows, no failure.
+    let before = rows.lock().unwrap().len();
+    let summary = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+    assert_eq!(summary.verified, 1);
+    assert!(summary.group_complete);
+    assert_eq!(summary.missing, 0);
+    assert_eq!(rows.lock().unwrap().len(), before, "no duplicate rows");
+}
+
+#[test]
+fn retried_records_do_not_duplicate_status_rows() {
+    let fx = Fixture::new(&["minio"]);
+    let local = fx.write_file("img.jpg", JPEG_BYTES);
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+    let payload = camera_payload(&local, &["minio"]);
+
+    uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+    let after_first = rows.lock().unwrap().len();
+    let summary = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+
+    assert!(summary.group_complete);
+    assert_eq!(fx.stores[0].puts.load(Ordering::SeqCst), 1, "no re-upload");
+    assert_eq!(rows.lock().unwrap().len(), after_first, "no duplicate rows");
+}
+
+#[test]
+fn a_file_missing_on_disk_is_reported_and_never_completes_its_group() {
+    let fx = Fixture::new(&["minio"]);
+    let local = fx.tmp.path().join("never-written.jpg");
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+
+    let summary = uploader
+        .process_record(
+            &camera_payload(&local.to_string_lossy(), &["minio"]),
+            "dc.measurement.camera",
+            &mut collect_rows(&rows),
+        )
+        .unwrap();
+
+    assert_eq!(summary.missing, 1);
+    assert_eq!(summary.verified, 0);
+    assert!(!summary.group_complete);
+    let rows = rows.lock().unwrap();
+    let row = rows_of_kind(&rows, "file_status")[0];
+    assert_eq!(row["uploaded"], json!(false));
+    assert_eq!(row["on_filesystem"], json!(false));
+    assert!(rows_of_kind(&rows, "group_complete").is_empty());
+    assert!(!fx.stores[0].has_object("cam/2026/img.jpg"));
+}
+
+/// A map-style multi-File group: the completion marker appears only once every File is
+/// verified, and a consumer querying mid-upload can tell partial from complete.
+#[test]
+fn group_completion_marker_is_emitted_only_after_every_file_is_verified() {
+    let fx = Fixture::new(&["minio"]);
+    let yaml = fx.write_file("map.yaml", b"image: map.pgm\nresolution: 0.05\n");
+    let pgm = fx.write_file("map.pgm", b"P5\n2 2\n255\n\x00\x01\x02\x03");
+    let payload = json!({
+        "name": "map",
+        "local_paths":  { "yaml": yaml, "pgm": pgm },
+        "remote_paths": { "minio": { "yaml": "maps/map.yaml", "pgm": "maps/map.pgm" } },
+    });
+    let uploader = fx.uploader(false);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+
+    // First pass: the pgm upload fails → partial group. Mid-upload state: one File's
+    // status row present, NO group_complete marker.
+    fx.stores[0]
+        .fail_put_keys
+        .lock()
+        .unwrap()
+        .insert("maps/map.pgm".to_string());
+    let err = uploader
+        .process_record(&payload, "dc.measurement.map", &mut collect_rows(&rows))
+        .unwrap_err();
+    assert!(matches!(err, UploadError::Incomplete(_)));
+    {
+        let rows = rows.lock().unwrap();
+        assert_eq!(rows_of_kind(&rows, "file_status").len(), 1);
+        assert!(
+            rows_of_kind(&rows, "group_complete").is_empty(),
+            "a partial group must not carry a completion marker"
+        );
+    }
+
+    // Second pass: the pgm lands → the marker is emitted, exactly once, listing both.
+    fx.stores[0].fail_put_keys.lock().unwrap().clear();
+    let summary = uploader
+        .process_record(&payload, "dc.measurement.map", &mut collect_rows(&rows))
+        .unwrap();
+    assert!(summary.group_complete);
+    let rows = rows.lock().unwrap();
+    assert_eq!(rows_of_kind(&rows, "file_status").len(), 2);
+    let markers = rows_of_kind(&rows, "group_complete");
+    assert_eq!(markers.len(), 1);
+    assert_eq!(markers[0]["file_count"], json!(2));
+}
+
+#[test]
+fn video_duration_is_extracted_for_video_content_types_only() {
+    let fx = Fixture::new(&["minio"]);
+    let mut mp4 = b"\x00\x00\x00\x20ftypisom".to_vec();
+    mp4.extend_from_slice(&[0u8; 64]);
+    let video = fx.write_file("clip.mp4", &mp4);
+    let image = fx.write_file("img.jpg", JPEG_BYTES);
+
+    let probed = Arc::new(Mutex::new(Vec::<PathBuf>::new()));
+    let probed_clone = probed.clone();
+    let uploader = fx.uploader_with(fx.config(false), move |path| {
+        probed_clone.lock().unwrap().push(path.to_path_buf());
+        Some(12.34)
+    });
+    let payload = json!({
+        "name": "inspection",
+        "local_paths":  { "video": video, "still": image },
+        "remote_paths": { "minio": { "video": "insp/clip.mp4", "still": "insp/img.jpg" } },
+    });
+    let rows = Arc::new(Mutex::new(Vec::new()));
+    uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+
+    let rows = rows.lock().unwrap();
+    let by_path = |suffix: &str| {
+        rows_of_kind(&rows, "file_status")
+            .into_iter()
+            .find(|r| r["local_path"].as_str().unwrap().ends_with(suffix))
+            .unwrap()
+            .clone()
+    };
+    assert_eq!(by_path("clip.mp4")["duration"], json!(12.34));
+    assert_eq!(by_path("clip.mp4")["content_type"], json!("video/mp4"));
+    assert!(by_path("img.jpg").get("duration").is_none());
+    let probed = probed.lock().unwrap();
+    assert_eq!(probed.len(), 1, "the prober runs only for video files");
+    assert!(probed[0].to_string_lossy().ends_with("clip.mp4"));
+}
+
+/// The real ffprobe code path, exercised against a stub binary: the duration must come
+/// from running the configured executable, not from parsing magic.
+#[test]
+fn ffprobe_prober_parses_the_binary_output() {
+    let tmp = TempDir::new().unwrap();
+    let stub = tmp.path().join("ffprobe");
+    std::fs::write(&stub, "#!/bin/sh\necho 3.25\n").unwrap();
+    let mut perms = std::fs::metadata(&stub).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&stub, perms).unwrap();
+
+    let prober = dc_bridge_core::ffprobe_duration_prober(stub);
+    assert_eq!(prober(tmp.path()), Some(3.25));
+
+    let missing = dc_bridge_core::ffprobe_duration_prober(tmp.path().join("nonexistent"));
+    assert_eq!(missing(tmp.path()), None);
+}
+
+/// ADR-0005's multipart resume: an interrupted large-File transfer picks up from the
+/// last checkpointed part — never re-uploading completed parts, never restarting.
+#[test]
+fn interrupted_multipart_upload_resumes_instead_of_restarting() {
+    let fx = Fixture::new(&["minio"]);
+    // 4 parts of 1 KiB (config below): distinct content per part to catch misordering.
+    let content: Vec<u8> = (0..4096u32).map(|i| (i % 251) as u8).collect();
+    let local = fx.write_file("big.bin", &content);
+    let payload = json!({
+        "name": "video_batch",
+        "local_paths":  { "bin": local },
+        "remote_paths": { "minio": { "bin": "big/big.bin" } },
+    });
+
+    let mut config = fx.config(false);
+    config.multipart_threshold_bytes = 1024;
+    config.multipart_part_size_bytes = 1024;
+    config.max_attempts = 1;
+
+    // First run: the transfer dies after 2 parts.
+    fx.stores[0].allow_parts.store(2, Ordering::SeqCst);
+    let uploader = fx.uploader_with(config.clone(), |_| None);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+    let err = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap_err();
+    assert!(matches!(err, UploadError::Incomplete(_)));
+    assert_eq!(*fx.stores[0].part_puts.lock().unwrap(), vec![0, 1]);
+    assert!(!fx.stores[0].has_object("big/big.bin"));
+
+    // Second run — a fresh Uploader over the same state dir, as after a Bridge
+    // restart: only the two missing parts are uploaded, the same multipart upload is
+    // completed, and the object verifies byte-for-byte.
+    fx.stores[0].allow_parts.store(i64::MAX, Ordering::SeqCst);
+    let uploader = fx.uploader_with(config, |_| None);
+    let summary = uploader
+        .process_record(&payload, "dc.measurement.camera", &mut collect_rows(&rows))
+        .unwrap();
+    assert_eq!(summary.verified, 1);
+    assert!(summary.group_complete);
+    assert_eq!(
+        *fx.stores[0].part_puts.lock().unwrap(),
+        vec![0, 1, 2, 3],
+        "resume must upload only the parts that had not landed"
+    );
+    assert_eq!(
+        fx.stores[0].multipart_creates.load(Ordering::SeqCst),
+        1,
+        "resume must reuse the interrupted multipart upload, not create a new one"
+    );
+    assert_eq!(fx.stores[0].object_bytes("big/big.bin"), content);
+    // The resume sidecar is cleaned up after completion.
+    let state_dir = fx.tmp.path().join("state");
+    let leftovers: Vec<_> = std::fs::read_dir(&state_dir)
+        .map(|entries| entries.filter_map(|e| e.ok()).collect())
+        .unwrap_or_default();
+    assert!(
+        leftovers.is_empty(),
+        "resume state must be removed once the upload completes: {leftovers:?}"
+    );
+}
+
+/// Records that reference no Files pass through as no-ops (the Uploader shares topics
+/// with Records-destinations; not every Record carries Files).
+#[test]
+fn records_without_files_are_noops() {
+    let fx = Fixture::new(&["minio"]);
+    let uploader = fx.uploader(true);
+    let rows = Arc::new(Mutex::new(Vec::new()));
+    let summary = uploader
+        .process_record(
+            &json!({ "uptime_s": 42 }),
+            "dc.measurement.uptime",
+            &mut collect_rows(&rows),
+        )
+        .unwrap();
+    assert_eq!(summary, ProcessSummary::default());
+    assert!(rows.lock().unwrap().is_empty());
+}

--- a/dc_bridge/src/main.rs
+++ b/dc_bridge/src/main.rs
@@ -15,6 +15,14 @@
 //! config so a bad snippet fails loudly at startup, and passed to Vector as additional
 //! `--config` files.
 //!
+//! `receives: files` Destinations (ADR-0005) are not rendered into the Vector config at
+//! all: Records on their `inputs` topics go to the Bridge's own Uploader
+//! (`dc_bridge_core::uploader`, worker thread spawned by [`spawn_uploader_worker`]),
+//! which uploads each referenced File to every such Destination via `object_store`,
+//! verifies it landed, and emits per-File status plus group-completion metadata Records
+//! back through the Forwarder under the `dc.files` Tag — routed by the rendered config
+//! to the `files.metadata_destination` Destination like any other Records.
+//!
 //! Built, run, and `colcon test`-covered (see tests/end_to_end.rs) in a real ROS 2
 //! Jazzy + ros2_rust Docker environment: the node locates and supervises the vendored
 //! Vector binary, the `~/ready` service answers correctly, a `StringStamped` Record
@@ -24,18 +32,20 @@
 
 use dc_bridge_core::render::{
     destination_from_raw, expand_env, render as render_vector_config, validate_custom_config_files,
-    CustomConfigFile, RawDestinationParams, RenderConfig, MIN_DISK_BUFFER_BYTES,
+    CustomConfigFile, Destination, DestinationKind, RawDestinationParams, Receives, RenderConfig,
+    MIN_DISK_BUFFER_BYTES,
 };
-use dc_bridge_core::{readiness, vector_config};
+use dc_bridge_core::{ffprobe_duration_prober, readiness, vector_config};
 use dc_bridge_core::{
-    Forwarder, ForwarderConfig, Readiness, Record, Supervisor, SupervisorConfig, TopicConfig,
+    Forwarder, ForwarderConfig, Readiness, Record, Storage, Supervisor, SupervisorConfig,
+    TopicConfig, Uploader, UploaderConfig, FILE_STATUS_TAG,
 };
 use dc_interfaces::msg::StringStamped;
 use rclrs::{CreateBasicExecutor, RclrsErrorFilter};
 use std::collections::BTreeSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{mpsc, Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std_srvs::srv::{Trigger_Request, Trigger_Response};
 
@@ -63,8 +73,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .get();
     let forward_addr: SocketAddr = format!("{}:{}", vector_host, vector_port).parse()?;
 
-    let render_config = build_render_config(&node, forward_addr)?;
-    let rendered_vector_config = render_vector_config(&render_config)?;
+    let bridge_config = build_bridge_config(&node, forward_addr)?;
+    let render_config = &bridge_config.render_config;
+    let rendered_vector_config = render_vector_config(render_config)?;
 
     // ADR-0003 passthrough: raw Vector config snippets merged natively by Vector via
     // additional `--config` arguments. Collision-checked against the rendered config
@@ -82,7 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("failed to read custom config file '{path}': {e}"))?;
         custom_config_files.push(CustomConfigFile { path, content });
     }
-    validate_custom_config_files(&render_config, &custom_config_files)?;
+    validate_custom_config_files(render_config, &custom_config_files)?;
 
     let vector_binary = if !vector_binary_override.is_empty() {
         PathBuf::from(vector_binary_override.to_string())
@@ -145,10 +156,44 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         forward_addr,
     ))));
 
+    // The Uploader (ADR-0005): `receives: files` Destinations are not Vector sinks —
+    // the Bridge itself uploads the Files those Records reference, verifies them, and
+    // emits status/metadata Records through the Forwarder under FILE_STATUS_TAG. A
+    // dedicated worker thread keeps slow uploads off the subscription callbacks.
+    // Mutex-wrapped because `mpsc::Sender` is Send but not Sync, while subscription
+    // callbacks (like the Forwarder's) may be shared across executor threads.
+    let uploader_tx = if bridge_config.files_destinations.is_empty() {
+        None
+    } else {
+        Some(Arc::new(Mutex::new(spawn_uploader_worker(
+            &bridge_config,
+            forward_addr,
+        )?)))
+    };
+
+    // Tags forwarded to Vector (Records-destination inputs) vs. tags scanned for File
+    // references (files-destination inputs). A topic can be in both sets.
+    let records_tags: BTreeSet<String> = render_config
+        .destinations
+        .iter()
+        .flat_map(|d| d.inputs.iter())
+        .map(|topic| TopicConfig::new(topic.clone(), None).tag)
+        .collect();
+    let files_tags: BTreeSet<String> = bridge_config
+        .files_destinations
+        .iter()
+        .flat_map(|d| d.inputs.iter())
+        .map(|topic| TopicConfig::new(topic.clone(), None).tag)
+        .collect();
+
     // Every Destination's `inputs` topic is subscribed to exactly once, even if more
     // than one Destination consumes it.
     let mut subscribed_topics = BTreeSet::new();
-    for destination in &render_config.destinations {
+    for destination in render_config
+        .destinations
+        .iter()
+        .chain(&bridge_config.files_destinations)
+    {
         for topic in &destination.inputs {
             subscribed_topics.insert(topic.clone());
         }
@@ -160,17 +205,27 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let topic_config = TopicConfig::new(topic, None);
         let forwarder = forwarder.clone();
         let tag = topic_config.tag.clone();
+        let forward_to_vector = records_tags.contains(&tag);
+        let uploader_tx = files_tags
+            .contains(&tag)
+            .then(|| uploader_tx.clone())
+            .flatten();
         let subscription =
             node.create_subscription(topic_config.topic.as_str(), move |msg: StringStamped| {
                 let timestamp = header_stamp_to_system_time(&msg.header);
                 let payload = serde_json::from_str(&msg.data)
                     .unwrap_or_else(|_| serde_json::Value::String(msg.data.clone()));
-                let record = Record::new(tag.clone(), timestamp, payload);
-                if let Err(e) = forwarder.lock().unwrap().send(&record) {
-                    eprintln!(
-                        "dc_bridge: failed to forward record on tag '{}': {}",
-                        tag, e
-                    );
+                if let Some(tx) = &uploader_tx {
+                    let _ = tx.lock().unwrap().send((tag.clone(), payload.clone()));
+                }
+                if forward_to_vector {
+                    let record = Record::new(tag.clone(), timestamp, payload);
+                    if let Err(e) = forwarder.lock().unwrap().send(&record) {
+                        eprintln!(
+                            "dc_bridge: failed to forward record on tag '{}': {}",
+                            tag, e
+                        );
+                    }
                 }
             })?;
         _subscriptions.push(subscription);
@@ -217,15 +272,33 @@ fn validate_with_vector(
     Ok(())
 }
 
-/// Declares the `shipper`/`destinations` parameters (ADR-0003's config contract) and
-/// builds the [`RenderConfig`] the config renderer needs. `$NAME`/`${NAME}` references in
-/// `shipper.data_dir` and each Postgres destination's `password` are expanded against the
-/// real process environment (`std::env::var`) here — `dc_bridge_core::render` itself
-/// never touches the environment, so it stays pure and testable without ROS or Vector.
-fn build_render_config(
+/// Everything the parameter contract configures: the Shipper-side [`RenderConfig`]
+/// (Records destinations only), the `receives: files` Destinations the Uploader
+/// handles (ADR-0005), and the `files.*` Uploader options.
+struct BridgeConfig {
+    render_config: RenderConfig,
+    files_destinations: Vec<Destination>,
+    files: FilesParams,
+}
+
+/// The `files.*` parameter block from the issue-#248 config contract.
+struct FilesParams {
+    delete_when_sent: bool,
+    ffprobe_binary: String,
+    multipart_threshold_bytes: Option<i64>,
+    multipart_part_size_bytes: Option<i64>,
+}
+
+/// Declares the `shipper`/`destinations`/`files` parameters (ADR-0003's config
+/// contract plus ADR-0005's Uploader) and builds the [`BridgeConfig`]. `$NAME`/
+/// `${NAME}` references in `shipper.data_dir` and destination credentials are expanded
+/// against the real process environment (`std::env::var`) here — `dc_bridge_core`
+/// itself never touches the environment, so it stays pure and testable without ROS or
+/// Vector.
+fn build_bridge_config(
     node: &rclrs::Node,
     forward_addr: SocketAddr,
-) -> Result<RenderConfig, Box<dyn std::error::Error>> {
+) -> Result<BridgeConfig, Box<dyn std::error::Error>> {
     let data_dir_raw: Arc<str> = node
         .declare_parameter("shipper.data_dir")
         .default(Arc::from("$HOME/.dc/buffer"))
@@ -250,12 +323,162 @@ fn build_render_config(
         destinations.push(declare_destination(node, name)?);
     }
 
-    Ok(RenderConfig {
-        forward_addr,
-        data_dir,
-        buffer_max_bytes: buffer_max_bytes.max(0) as u64,
-        destinations,
+    // `receives: files` Destinations are the Uploader's (ADR-0005), never Vector sinks.
+    let (files_destinations, mut records_destinations): (Vec<_>, Vec<_>) = destinations
+        .into_iter()
+        .partition(|d| d.receives == Receives::Files);
+
+    let delete_when_sent: bool = node
+        .declare_parameter("files.delete_when_sent")
+        .default(false)
+        .mandatory()?
+        .get();
+    let ffprobe_binary: Arc<str> = node
+        .declare_parameter("files.ffprobe_binary")
+        .default(Arc::from("ffprobe"))
+        .mandatory()?
+        .get();
+    let multipart_threshold_bytes: Option<i64> = node
+        .declare_parameter("files.multipart_threshold_bytes")
+        .optional()?
+        .get();
+    let multipart_part_size_bytes: Option<i64> = node
+        .declare_parameter("files.multipart_part_size_bytes")
+        .optional()?
+        .get();
+    let files = FilesParams {
+        delete_when_sent,
+        ffprobe_binary: ffprobe_binary.to_string(),
+        multipart_threshold_bytes,
+        multipart_part_size_bytes,
+    };
+    let metadata_destination: Arc<str> = node
+        .declare_parameter("files.metadata_destination")
+        .default(Arc::from(""))
+        .mandatory()?
+        .get();
+
+    if !files_destinations.is_empty() {
+        // The Uploader's status Records must land somewhere: the configured
+        // metadata destination gets the Uploader's Tag appended to its routed set.
+        if metadata_destination.is_empty() {
+            return Err(
+                "`files.metadata_destination` is required when a `receives: files` \
+                 destination is configured"
+                    .into(),
+            );
+        }
+        let target = records_destinations
+            .iter_mut()
+            .find(|d| d.name.as_str() == metadata_destination.as_ref())
+            .ok_or_else(|| {
+                format!(
+                    "files.metadata_destination '{metadata_destination}' does not name a \
+                     configured `receives: records` destination"
+                )
+            })?;
+        target.extra_tags.push(FILE_STATUS_TAG.to_string());
+    }
+
+    Ok(BridgeConfig {
+        render_config: RenderConfig {
+            forward_addr,
+            data_dir,
+            buffer_max_bytes: buffer_max_bytes.max(0) as u64,
+            destinations: records_destinations,
+        },
+        files_destinations,
+        files,
     })
+}
+
+/// Builds the Uploader from the `receives: files` Destinations and starts its worker
+/// thread. The returned channel receives `(tag, payload)` pairs from the topic
+/// subscriptions; the worker retries each Record (idempotently — verified objects are
+/// never re-uploaded, status rows never duplicated) with capped backoff until its
+/// Files are all verified, and emits status Records through its own Forwarder
+/// connection under [`FILE_STATUS_TAG`].
+fn spawn_uploader_worker(
+    bridge_config: &BridgeConfig,
+    forward_addr: SocketAddr,
+) -> Result<mpsc::Sender<(String, serde_json::Value)>, Box<dyn std::error::Error>> {
+    let mut storages = Vec::with_capacity(bridge_config.files_destinations.len());
+    for dest in &bridge_config.files_destinations {
+        let DestinationKind::S3(params) = &dest.kind else {
+            // destination_from_raw enforces `type: s3` for `receives: files`.
+            return Err(format!(
+                "internal error: files destination '{}' is not object storage",
+                dest.name
+            )
+            .into());
+        };
+        storages.push(Storage::s3(&dest.name, params)?);
+    }
+
+    let mut config = UploaderConfig::new(
+        PathBuf::from(&bridge_config.render_config.data_dir).join("uploader"),
+        bridge_config.files.delete_when_sent,
+    );
+    if let Some(threshold) = bridge_config.files.multipart_threshold_bytes {
+        config.multipart_threshold_bytes = threshold.max(1) as u64;
+    }
+    if let Some(part_size) = bridge_config.files.multipart_part_size_bytes {
+        config.multipart_part_size_bytes = part_size.max(1) as u64;
+    }
+    let prober = ffprobe_duration_prober(PathBuf::from(&bridge_config.files.ffprobe_binary));
+    let uploader = Uploader::new(config, storages, prober)?;
+
+    let (tx, rx) = mpsc::channel::<(String, serde_json::Value)>();
+    std::thread::spawn(move || {
+        // The Uploader's own Forwarder connection, so long uploads never hold the
+        // subscription callbacks' Forwarder lock.
+        let mut forwarder = Forwarder::new(ForwarderConfig::new(forward_addr));
+        let mut emit = move |row: serde_json::Value| -> Result<(), String> {
+            let record = Record::new(FILE_STATUS_TAG, SystemTime::now(), row);
+            let mut last_err = String::new();
+            // Vector may be briefly down (restart, backpressure); keep trying for a
+            // while before handing the whole Record back for an idempotent retry.
+            for _ in 0..120 {
+                match forwarder.send(&record) {
+                    Ok(()) => return Ok(()),
+                    Err(e) => {
+                        last_err = e.to_string();
+                        std::thread::sleep(Duration::from_millis(500));
+                    }
+                }
+            }
+            Err(last_err)
+        };
+
+        while let Ok((tag, payload)) = rx.recv() {
+            let mut backoff = Duration::from_secs(1);
+            loop {
+                match uploader.process_record(&payload, &tag, &mut emit) {
+                    Ok(summary) => {
+                        if summary.files > 0 {
+                            eprintln!(
+                                "dc_bridge uploader: group '{}': {} file(s), {} verified, \
+                                 {} missing, {} deleted, complete={}",
+                                tag,
+                                summary.files,
+                                summary.verified,
+                                summary.missing,
+                                summary.deleted,
+                                summary.group_complete
+                            );
+                        }
+                        break;
+                    }
+                    Err(e) => {
+                        eprintln!("dc_bridge uploader: {e}; retrying in {backoff:?}");
+                        std::thread::sleep(backoff);
+                        backoff = (backoff * 2).min(Duration::from_secs(60));
+                    }
+                }
+            }
+        }
+    });
+    Ok(tx)
 }
 
 /// Declares every `<name>.*` parameter one Destination might need — the flat union

--- a/dc_bridge/tests/end_to_end.rs
+++ b/dc_bridge/tests/end_to_end.rs
@@ -724,6 +724,265 @@ fn bucket_prefix_contains_marker(prefix: &str, marker: &str) -> bool {
     false
 }
 
+/// The Uploader (ADR-0005, issue #248) end to end — the demo acceptance criterion "a
+/// camera Measurement's File lands in MinIO and its status row appears in PostgreSQL",
+/// automated (with `ros2 topic pub`-style publishing standing in for the camera
+/// Measurement, which the Bridge is agnostic to, and RustFS standing in for MinIO —
+/// same S3 API):
+///
+/// dc_bridge is configured with a `receives: files` s3 Destination named `rustfs` plus
+/// a Records `pgsql` Destination serving as `files.metadata_destination` (no topic
+/// inputs of its own — it only receives the Uploader's `dc.files` Tag). A camera-shaped
+/// Record referencing a real local JPEG via `local_paths`/`remote_paths` is published;
+/// the test asserts the File's bytes land in the bucket, the `file_status` row
+/// (uploaded, verified metadata) and the `group_complete` marker row land in Postgres
+/// through the Shipper's parameterized sink, and — `files.delete_when_sent: true` — the
+/// local File is deleted afterwards with a `deleted: true` status row appended.
+///
+/// REQUIRES both stores (Postgres at 127.0.0.1:5432, S3 store at 127.0.0.1:9000 with
+/// the public-read `dc-records` bucket) — fails immediately with setup instructions
+/// otherwise, same policy as the other store-backed tests here.
+#[test]
+fn camera_file_upload_reaches_s3_and_status_rows_reach_postgres() {
+    assert!(
+        postgres_reachable(),
+        "no Postgres reachable at {PG_HOST}:{PG_PORT} — this end-to-end test requires \
+         one and deliberately fails (not skips) without it. Start \
+         tools/infrastructure/docker/docker-compose.postgresql.yaml (or an equivalent \
+         postgres:13 container with user/password 'dc'/'password' and database 'dc')"
+    );
+    assert!(
+        s3_store_reachable(),
+        "nothing listening at 127.0.0.1:9000 — this end-to-end test requires an \
+         S3-compatible store and deliberately fails (not skips) without one. Start \
+         e.g. a RustFS container (credentials rustfsadmin/rustfsadmin) and create a \
+         public-read bucket: mc alias set local http://127.0.0.1:9000 rustfsadmin \
+         rustfsadmin && mc mb -p local/dc-records && mc anonymous set public \
+         local/dc-records"
+    );
+
+    let _guard = PROCESS_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+    const STATUS_TABLE: &str = "dc_files_e2e";
+    let mut db = Client::connect(
+        &format!(
+            "host={PG_HOST} port={PG_PORT} user={PG_USER} password={PG_PASSWORD} \
+             dbname={PG_DATABASE}"
+        ),
+        NoTls,
+    )
+    .expect("failed to connect to the test Postgres instance");
+    db.batch_execute(&format!(
+        "CREATE TABLE IF NOT EXISTS {STATUS_TABLE} (
+            date double precision, kind text, group_name text, robot_name text,
+            local_path text, remote_path text, storage_type text, uploaded boolean,
+            on_filesystem boolean, deleted boolean, content_type text, size bigint,
+            file_count integer, complete boolean, updated_at double precision);
+         DELETE FROM {STATUS_TABLE};"
+    ))
+    .expect("failed to prepare the status table");
+
+    // The "camera Measurement output": a real JPEG-magic File on disk, referenced via
+    // the local_paths/remote_paths structure camera.cpp embeds.
+    let marker = format!(
+        "e2e_upload_{}_{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let local_dir = std::env::temp_dir().join(format!("dc_bridge_files_{marker}"));
+    std::fs::create_dir_all(&local_dir).expect("failed to create the camera output dir");
+    let local_path = local_dir.join("image.jpg");
+    let mut jpeg = b"\xff\xd8\xff\xe0".to_vec();
+    jpeg.extend_from_slice(marker.as_bytes());
+    std::fs::write(&local_path, &jpeg).expect("failed to write the camera File");
+    let remote_key = format!("e2e-files/{marker}/image.jpg");
+
+    let args: Vec<String> = [
+        "--ros-args",
+        "-p",
+        &format!("shipper.data_dir:={}", unique_data_dir()),
+        "-p",
+        "destinations:=[\"pgsql\", \"rustfs\"]",
+        // The metadata destination: a Records postgres Destination with no topic
+        // inputs — it exists to receive the Uploader's dc.files status Records.
+        "-p",
+        "pgsql.type:=postgres",
+        "-p",
+        &format!("pgsql.host:={PG_HOST}"),
+        "-p",
+        &format!("pgsql.port:={PG_PORT}"),
+        "-p",
+        &format!("pgsql.user:={PG_USER}"),
+        "-p",
+        &format!("pgsql.password:={PG_PASSWORD}"),
+        "-p",
+        &format!("pgsql.database:={PG_DATABASE}"),
+        "-p",
+        &format!("pgsql.table:={STATUS_TABLE}"),
+        // The files Destination (ADR-0005). Its name is the key the Record's
+        // remote_paths uses.
+        "-p",
+        "rustfs.type:=s3",
+        "-p",
+        "rustfs.receives:=files",
+        "-p",
+        "rustfs.inputs:=[\"/dc/measurement/camera\"]",
+        "-p",
+        "rustfs.bucket:=dc-records",
+        "-p",
+        "rustfs.endpoint:=http://127.0.0.1:9000",
+        "-p",
+        "rustfs.region:=us-east-1",
+        "-p",
+        "rustfs.access_key_id:=rustfsadmin",
+        "-p",
+        "rustfs.secret_access_key:=rustfsadmin",
+        "-p",
+        "rustfs.force_path_style:=true",
+        "-p",
+        "files.metadata_destination:=pgsql",
+        "-p",
+        "files.delete_when_sent:=true",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect();
+    let mut child = spawn_dc_bridge_with_args(&args, Stdio::null(), Stdio::null());
+    assert!(
+        wait_for_ready(Instant::now() + Duration::from_secs(30)),
+        "dc_bridge's readiness service never reported ready within 30s with a \
+         receives: files destination configured"
+    );
+
+    let context = rclrs::Context::default_from_env().expect("failed to create an rclrs context");
+    let executor = context.create_basic_executor();
+    let node = executor
+        .create_node("dc_bridge_end_to_end_files_test")
+        .expect("failed to create the test node");
+    let publisher = node
+        .create_publisher::<StringStamped>("/dc/measurement/camera")
+        .expect("failed to create a publisher on /dc/measurement/camera");
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap();
+    let mut message = StringStamped::default();
+    message.header.stamp.sec = now.as_secs() as i32;
+    message.header.stamp.nanosec = now.subsec_nanos();
+    message.data = format!(
+        r#"{{"name": "camera", "robot_name": "robot1",
+            "local_paths": {{"raw": "{}"}},
+            "remote_paths": {{"rustfs": {{"raw": "{remote_key}"}}}}}}"#,
+        local_path.display()
+    );
+
+    // Publish until the whole chain is observable: object in the bucket, uploaded +
+    // group_complete + deleted rows in Postgres, local File gone. (Republishing is
+    // deliberate: retried Records must stay idempotent.)
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut object_ok = false;
+    let mut rows_ok = false;
+    let mut deleted_row_ok = false;
+    while Instant::now() < deadline && !(object_ok && rows_ok && deleted_row_ok) {
+        publisher
+            .publish(&message)
+            .expect("failed to publish the camera Record");
+        std::thread::sleep(Duration::from_millis(500));
+
+        if !object_ok {
+            let object = Command::new("curl")
+                .args([
+                    "-s",
+                    &format!("http://127.0.0.1:9000/dc-records/{remote_key}"),
+                ])
+                .output()
+                .expect("failed to fetch the uploaded object");
+            object_ok = String::from_utf8_lossy(&object.stdout).contains(&marker);
+        }
+        let rows = db
+            .query(
+                &format!(
+                    "SELECT kind, uploaded, on_filesystem, deleted, content_type, size, \
+                     storage_type, remote_path, complete, file_count, date \
+                     FROM {STATUS_TABLE} WHERE group_name = 'camera'"
+                ),
+                &[],
+            )
+            .expect("failed to query the status table");
+        let uploaded_row = rows.iter().any(|r| {
+            r.get::<_, String>(0) == "file_status"
+                && r.get::<_, bool>(1)
+                && r.get::<_, bool>(2)
+                && !r.get::<_, bool>(3)
+                && r.get::<_, String>(4) == "image/jpeg"
+                && r.get::<_, i64>(5) == jpeg.len() as i64
+                && r.get::<_, String>(6) == "rustfs"
+                && r.get::<_, String>(7) == format!("s3://dc-records/{remote_key}")
+                && r.get::<_, f64>(10) > 0.0
+        });
+        let complete_row = rows.iter().any(|r| {
+            r.get::<_, String>(0) == "group_complete"
+                && r.get::<_, bool>(8)
+                && r.get::<_, i32>(9) == 1
+        });
+        rows_ok = uploaded_row && complete_row;
+        deleted_row_ok = rows
+            .iter()
+            .any(|r| r.get::<_, String>(0) == "file_status" && r.get::<_, bool>(3));
+    }
+
+    // Idempotency across the repeated publishes above: exactly one row per status
+    // transition, no duplicates.
+    let counts: Vec<(String, i64)> = db
+        .query(
+            &format!(
+                "SELECT kind || '/' || COALESCE(deleted::text, ''), count(*) \
+                 FROM {STATUS_TABLE} WHERE group_name = 'camera' GROUP BY 1 ORDER BY 1"
+            ),
+            &[],
+        )
+        .expect("failed to count status rows")
+        .into_iter()
+        .map(|r| (r.get(0), r.get(1)))
+        .collect();
+
+    terminate(&mut child);
+    let local_file_gone = !local_path.exists();
+    std::fs::remove_dir_all(&local_dir).ok();
+
+    assert!(
+        object_ok,
+        "expected the camera File's bytes (marker '{marker}') at \
+         dc-records/{remote_key} within 60s"
+    );
+    assert!(
+        rows_ok,
+        "expected a verified file_status row and a group_complete row in \
+         {STATUS_TABLE} within 60s; got counts: {counts:?}"
+    );
+    assert!(
+        deleted_row_ok,
+        "expected a deleted=true status row after delete_when_sent; got counts: {counts:?}"
+    );
+    assert!(
+        local_file_gone,
+        "expected the local File to be deleted after verified upload (delete_when_sent)"
+    );
+    // `group_complete` rows carry no `deleted` field → NULL → the empty COALESCE arm.
+    assert_eq!(
+        counts,
+        vec![
+            ("file_status/false".to_string(), 1),
+            ("file_status/true".to_string(), 1),
+            ("group_complete/".to_string(), 1),
+        ],
+        "status rows must not be duplicated by republished (retried) Records"
+    );
+}
+
 /// Sends SIGTERM (dc_bridge's install-hooked signal, not SIGKILL) and waits for exit.
 /// `kill`'s own stderr is suppressed: if dc_bridge has already exited by the time this
 /// runs (e.g. it reacted fast enough that the signal is redundant), that's not this

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -52,6 +52,28 @@ dc_bridge:
     #   receives: records
     #   inputs: ["/dc/measurement/uptime"]
     #
+    # File uploads (ADR-0005): a `receives: files` destination is served by the
+    # Bridge's Uploader, not by a Vector sink — Records on its `inputs` topics are
+    # scanned for the `local_paths`/`remote_paths` File references Measurements embed
+    # (camera, map, …), each File is uploaded (multipart + resumable for large ones)
+    # and verified, and per-File status plus group-completion metadata Records are
+    # routed to `files.metadata_destination`. The destination name ("minio" here) must
+    # match the key the Measurement writes under `remote_paths`.
+    #
+    # minio:
+    #   type: s3
+    #   receives: files
+    #   inputs: ["/dc/measurement/camera"]
+    #   bucket: "dc-files"
+    #   endpoint: "http://127.0.0.1:9000"
+    #   access_key_id: "rustfsadmin"
+    #   secret_access_key: "$DC_S3_SECRET"
+    #   force_path_style: true
+    # files:
+    #   delete_when_sent: true         # delete local Files after verified upload everywhere
+    #   metadata_destination: "pgsql"  # receives the dc.files status/metadata Records
+    #   ffprobe_binary: "ffprobe"      # video duration probe (optional)
+    #
     # Any other Vector sink type via the ADR-0003 passthrough: raw Vector config
     # snippets consuming the public per-Tag `dc.<tag>` routes (see
     # doc/src/dc/destinations.md for the routing contract).

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -53,10 +53,10 @@ upstream in 2026 and no longer receives maintenance — but existing MinIO or Ce
 deployments work identically: set `endpoint`, explicit credentials, and (typically)
 `force_path_style: true`.
 
-Common parameters for every blessed type: `type`, `receives` (`records`; `files` is
-reserved for the File pipeline, ADR-0005), `inputs` (ROS topic names), `time_key`
-(default `date`) and `time_format` (`double` | `iso8601`, default `double`) controlling
-the normalized timestamp field written into each Record before routing.
+Common parameters for every blessed type: `type`, `receives` (`records` | `files`, see
+the File uploads section below), `inputs` (ROS topic names), `time_key` (default
+`date`) and `time_format` (`double` | `iso8601`, default `double`) controlling the
+normalized timestamp field written into each Record before routing.
 
 Type-specific parameters:
 
@@ -107,6 +107,64 @@ Snippets must not re-define component ids owned by the generated config (the
 Destination's name) or by another snippet. An invalid or colliding snippet is a loud
 Bridge startup error naming the offending file; as a backstop, the merged config set is
 also checked with `vector validate` before the Shipper is started.
+
+### File uploads: `receives: files` (the Uploader, ADR-0005)
+
+A Destination with `receives: files` (only `type: s3` qualifies) is served by the
+Bridge's **Uploader**, not by a Vector sink: Records arriving on its `inputs` topics
+are scanned for the `local_paths`/`remote_paths` File references Measurements embed
+(camera, map, …), and each referenced File is uploaded via the `object_store`
+abstraction to every `receives: files` Destination whose **name appears as a key in
+the Record's `remote_paths`** — so the Destination name in the params file must match
+the remote key the Measurement is configured with:
+
+```json
+{
+  "name": "map",
+  "local_paths":  { "yaml": "/tmp/map.yaml", "pgm": "/tmp/map.pgm" },
+  "remote_paths": { "minio": { "yaml": "robot/map.yaml", "pgm": "robot/map.pgm" } }
+}
+```
+
+Per File the Uploader: uploads (**multipart and resumable** for large Files — an
+interrupted transfer picks up from the last completed part after a reconnect or Bridge
+restart, using progress checkpointed under `<shipper.data_dir>/uploader/`), **verifies**
+the object landed (`head` + size comparison), extracts metadata (content type, size,
+and duration via ffprobe for `video/*` Files), and emits a **status Record** under the
+`dc.files` Tag, routed like any Record to the Destination named by
+`files.metadata_destination`. Status rows preserve the Humble `files_metrics` shape —
+`group_name`, `robot_name`/`robot_id` (when present in the Record), `local_path`,
+`remote_path` (`s3://bucket/key`), `storage_type`, `uploaded`, `on_filesystem`,
+`deleted`, `content_type`, `size`, `duration`, `updated_at` — but the log is
+**append-only**: deletion appends a `deleted: true` row instead of updating one, and
+PostgreSQL is only ever written through the Shipper's parameterized sink (no SQL
+strings anywhere in DC).
+
+Two guarantees consumers can rely on:
+
+- **Group completion markers**: when one Record references several Files (map =
+  pgm+yaml, camera batches), a `kind: group_complete` Record listing every File is
+  emitted only after **all** of them are verified on **all** their Destinations — a
+  consumer querying mid-upload sees per-File rows but no marker, and never has to guess
+  whether a group fully arrived.
+- **Deletion only after verified upload**: with `files.delete_when_sent: true`, a local
+  File is removed only once it is verified on every Destination that receives it.
+  Retries are idempotent — already-verified objects are not re-uploaded and status rows
+  are never duplicated.
+
+The `files` block:
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    files:
+      delete_when_sent: true         # default false
+      metadata_destination: "pgsql"  # required with any receives: files destination;
+                                     # must name a receives: records destination
+      ffprobe_binary: "ffprobe"      # optional; video duration probe
+      # multipart_threshold_bytes: 16777216  # optional; multipart above this size
+      # multipart_part_size_bytes: 8388608   # optional; >= 5 MiB for real S3 stores
+```
 
 ---
 

--- a/docs/adr/0002-vector-as-default-shipper.md
+++ b/docs/adr/0002-vector-as-default-shipper.md
@@ -6,3 +6,32 @@ Both upstream Fluent Bit and Vector can sit behind the Bridge's Forward-protocol
 
 - CI publishes a "vector-slim" prebuilt binary (feature-flagged build, ~30–40MB) for constrained deployments; users never compile Vector themselves.
 - A `vector_vendor` ament package downloads the official static binary at build time, pinned to an exact version by checksum (arch-detected); a `vector_path` parameter allows using a system-installed Vector instead. Apt-repo install and Docker remain documented alternatives.
+
+## Why the forward protocol is the Bridge→Shipper wire format
+
+The Bridge must hand Records to the Shipper across a process boundary such that **the
+sender knows what arrived** — durable ingest is impossible without receipt
+acknowledgement. Requirements: a listener the Shipper already ships, sender-visible
+acks, and a minimal Rust client. Vector's source menu, filtered:
+
+- `socket`, `stdin` — one-way byte streams; no response direction exists, so the
+  Shipper cannot confirm receipt. A Shipper restart silently loses in-flight Records.
+- `file` — durable, but Vector neither deletes consumed files nor exposes its
+  checkpoint, so the Bridge would rotate blind (delete too early = loss, too late =
+  unbounded disk); fixing that means building an acknowledged queue anyway.
+- websocket — Vector has a websocket sink, not a source.
+- `http` — ack-capable (response deferred until the event is buffered) but costs an
+  HTTP client plus batching logic; equal capability at a higher price.
+- `vector` (native gRPC) — ack-capable; drags tonic/prost/protobuf codegen into the
+  Bridge for no functional gain.
+- `fluent` (Fluentd's open "Forward" spec) — ack-capable (`chunk`/`ack` options are in
+  the spec), and the client side is ~170 lines of msgpack over TCP. **Chosen: the
+  cheapest ack-capable listener.**
+
+**The forward format is not Fluent Bit.** It is an open wire specification from the
+CNCF Fluentd project; no Fluentd/Fluent Bit software runs, links, or vendors into
+DC 2.0 (the embedded Fluent Bit is demolished separately, ADR-0001). DC docs call
+this boundary the **shipper ingest protocol**; the name "fluent" appears only in the
+generated Vector config (`type = "fluent"`) and interop documentation. A side effect,
+not a goal: any forward-speaking receiver (including stock upstream Fluent Bit, ~5MB
+RSS vs Vector's ~100MB) can be swapped in behind the boundary without Bridge changes.

--- a/progress.txt
+++ b/progress.txt
@@ -578,3 +578,84 @@ only ever been checked by hand, interactively, in the (now torn-down) Docker ses
   into `colcon test` needs the full C++ stack in CI first — #249); the reusable dev
   container for the Jazzy+ros2_rust toolchain (still ad hoc, now also with the C++ stack
   deps installed on top of the #246 image).
+
+### #248 - DC 2.0 S7: Uploader — verified File uploads with metadata Records
+
+- Added `dc_bridge_core::uploader` (ADR-0005), replacing the Humble Go plugins
+  (`out_minio`, `out_files_metrics`) with a Rust module inside the Bridge:
+  - `uploader/group.rs` — parses the Files a Record references from the
+    `local_paths`/`remote_paths` structure Measurements already embed (verified against
+    `camera.cpp`/`map.cpp`; no more parallel `src_fields`/`upload_fields` arrays).
+    `remote_paths` is keyed by Destination name; the payload is walked recursively so
+    bare Measurement Records and Group-merged Records parse identically; `base64`
+    subtrees are skipped. All Files in one Record form one group.
+  - `uploader/store.rs` — the `object_store` abstraction the ADR names: an
+    `UploadStore` trait (`ObjectStore + MultipartStore`) + `Storage` per
+    `receives: files` Destination. S3 today (`AmazonS3Builder`, `from_env` for ambient
+    AWS credentials, custom endpoint + path-style for RustFS/MinIO/Ceph); GCS/Azure are
+    new constructors, not new upload logic.
+  - `uploader/multipart.rs` — multipart, *resumable* uploads on `MultipartStore`'s
+    low-level API (the high-level writer hides the `MultipartId`/`PartId`s that make
+    resumption possible): progress is checkpointed to a JSON sidecar after every part
+    (FNV-named, atomic tmp+rename), so an interrupted transfer — dropped connection or
+    Bridge restart — resumes from the last completed part instead of restarting.
+  - `uploader/content_type.rs` — magic-byte sniffing (PNG/JPEG/PGM/mp4/…, UTF-8 text
+    fallback) replacing Go's `http.DetectContentType`; duration probing only for
+    `video/*` (dropping Humble's probe-octet-stream quirk), via an injectable prober
+    (production: ffprobe, argument-vector not `sh -c`).
+  - `uploader/mod.rs` — the flow: per File × storage, head+size **verify-or-upload**
+    (an already-verified object short-circuits — idempotent retries), verified-only
+    status Records, group-completion marker only when *every* File in the group is
+    verified on *all* its storages, then `delete_when_sent` deletion strictly after
+    per-File verification everywhere, with `deleted: true` rows appended (append-only
+    status log — the insert-only parameterized sink replaces Humble's SQL UPDATE; no
+    SQL strings anywhere). Status rows preserve the Humble `files_metrics` column set.
+    Every emission is deduped by key, so retried/redelivered Records never duplicate
+    rows; a Record redelivered after deletion is recognized by its verified remote
+    objects (no spurious "missing" rows). Missing-on-disk Files get an
+    `on_filesystem: false` row and permanently block their group's completion marker.
+- Status Records are emitted through the Forwarder under the new `dc.files` Tag. The
+  renderer (`render.rs`) grew `extra_tags` on `Destination` (Bridge-internal Tags
+  routed/normalized/consumed exactly like topic-derived ones), `main.rs` appends
+  `dc.files` to the `files.metadata_destination` Destination, and a Destination with
+  only extra tags needs no topic inputs (the "metadata-only pgsql" pattern).
+  `receives: files` now validates as `type: s3`-only (`FilesRequireObjectStorage`) and
+  files-Destinations are partitioned out of the shipper config before rendering.
+- `main.rs`: declares `files.delete_when_sent` / `files.metadata_destination` /
+  `files.ffprobe_binary` / `files.multipart_{threshold,part_size}_bytes`; subscribes
+  files-Destination `inputs` topics and hands their Records to an Uploader worker
+  thread (own Forwarder connection; infinite capped-backoff retry per Record, safe
+  because processing is idempotent). Topics feeding only files-Destinations are not
+  forwarded to Vector.
+- Tests: `dc_bridge_core` 55 → 82 (`cargo test`, no ROS needed; clippy -D warnings +
+  fmt clean), including `tests/uploader_tests.rs` covering every #248 unit criterion
+  against `object_store`'s in-memory backend + temp files with an instrumented
+  failure-injecting wrapper: happy path, metadata-Record shape (Humble column set),
+  verify-fails-then-retry (exactly one put), delete-only-after-verified-everywhere
+  (failing second storage blocks deletion; healing completes it; redelivery after
+  delete adds nothing), no-duplicate-rows on retry, file-missing-on-disk,
+  partial-vs-complete group marker, video duration (injected prober + real ffprobe
+  code path against a stub binary), and interrupted-multipart resume (parts [0,1] then
+  exactly [2,3] on a fresh Uploader over the same state dir, one `create_multipart`
+  total, byte-identical object, sidecar cleaned up).
+- **Verified in the real ROS 2 Jazzy + ros2_rust environment** (fresh container from
+  the #244-era `dc_bridge_build_env` image with this worktree bound in, plus
+  postgres:13 and RustFS sharing its netns): `colcon build --packages-up-to dc_bridge`
+  succeeded first try — `main.rs` needed zero post-build fixes. New e2e test
+  `camera_file_upload_reaches_s3_and_status_rows_reach_postgres` automates the demo
+  criterion (publisher standing in for the camera Measurement, RustFS for MinIO): a
+  camera-shaped Record referencing a real JPEG → object bytes verified in the bucket,
+  `file_status` row (uploaded/verified metadata, `s3://` remote path) and
+  `group_complete` marker land in Postgres via the Shipper's parameterized sink, local
+  File deleted with a `deleted: true` row appended, and the repeated republishing the
+  test does proves end-to-end idempotency (exactly one row per status transition).
+  `colcon test --packages-select dc_bridge`: 7/7 green, 4 consecutive runs, zero
+  leftover Vector processes. Docs updated (`doc/src/dc/destinations.md` "File uploads"
+  section, `dc_params.yaml` files example, dc_bridge README).
+- `pre-commit` clean on the diff (same `build-doc`/`poetry-requirements`/`pycln`/
+  `flake8` environment-gap skips as #242-#247; `go-fmt` additionally fails locally for
+  lack of a `gofmt` binary, on untouched legacy Humble Go files only).
+- **Not done / left for follow-up**: GCS/Azure `Storage` constructors (config surface
+  undefined until a blessed type exists for them); thumbnail/preview generation is
+  #256; the reusable committed dev container (still ad hoc — this session again built
+  containers from the uncommitted `dc_bridge_build_env` image).


### PR DESCRIPTION
## Summary

Implements the Uploader module inside the Bridge (ADR-0005), replacing the Humble-era Go plugins (`out_minio`, `out_files_metrics`). Closes #248.

- **`dc_bridge_core::uploader`** — consumes Records referencing Files via the `local_paths`/`remote_paths` structure Measurements already embed (no more parallel `src_fields`/`upload_fields` arrays). Per File: upload via the `object_store` abstraction to every `receives: files` Destination, **verify** the object landed (head + size), extract metadata (content type via magic bytes, size, ffprobe video duration for `video/*`), and emit status/metadata Records through the Forwarder under the `dc.files` Tag — routed to the configured `files.metadata_destination` through the Shipper's parameterized PostgreSQL sink. **No SQL strings anywhere in the pipeline** (Humble's `UPDATE deleted=true` becomes an append-only `deleted: true` row).
- **Group completion markers** (ADR-0005): a `group_complete` Record is emitted only after *every* File a Record references is verified on *all* its Destinations — a consumer querying mid-upload sees per-File rows but no marker, and never guesses.
- **Multipart, resumable uploads**: large Files use `MultipartStore`'s low-level API with per-part progress checkpointed to a sidecar file, so an interrupted transfer (dropped connection, Bridge restart) resumes from the last completed part instead of restarting.
- **`delete_when_sent`**: local Files are removed strictly after verified upload on all configured storages, per File. Retries are idempotent — verified objects short-circuit re-upload and status rows are never duplicated (keyed dedup), including Records redelivered after deletion.
- **Config contract** (from the issue): `receives: files` (s3-type only) Destinations + the `files.{delete_when_sent, metadata_destination, ffprobe_binary}` block; the renderer grew `extra_tags` so the metadata Destination consumes `dc.files` like any topic-derived Tag (and may have no topic inputs of its own). Upload-status semantics (uploaded / on-filesystem / deleted per File and storage) preserve the Humble `files_metrics` column set.

## Acceptance criteria

- ✅ Unit tests against the in-memory `object_store` backend with temp files: happy path, verify-fails-then-retry (exactly one put), delete only after verified upload on all storages, metadata Record shape, file-missing-on-disk — `dc_bridge_core/tests/uploader_tests.rs`, 82 total `cargo test` (clippy `-D warnings` + fmt clean)
- ✅ Demo: camera Measurement's File lands in the S3 store and its status row appears in PostgreSQL — automated as `camera_file_upload_reaches_s3_and_status_rows_reach_postgres` in `tests/end_to_end.rs`, verified in the real Jazzy + ros2_rust Docker env against live RustFS + Postgres (7/7 e2e green, 4 consecutive runs, zero leftover processes)
- ✅ Local deletion never before verified upload everywhere; idempotent retries (no duplicate status rows) — unit + e2e (the e2e test republishes the Record repeatedly and asserts exactly one row per status transition)
- ✅ Video duration extracted for video content types (injected prober + the real ffprobe code path against a stub binary)
- ✅ No string-formatted SQL in the pipeline (status rows go through Vector's parameterized `postgres` sink)
- ✅ Group-complete status only after every File verified; partial vs complete distinguishable mid-upload
- ✅ Multipart resume after interruption (unit test: parts `[0,1]` land, transfer dies, a fresh Uploader over the same state dir uploads exactly `[2,3]`, one `create_multipart` total, byte-identical object)

Docs: new "File uploads" section in `doc/src/dc/destinations.md`, `dc_params.yaml` example block, dc_bridge README.

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FZ3fpst6RSBPdN7R1nHTM3