### PR TITLE
docs: DC 2.0 migration guide + docs overhaul (S11)

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,21 +1,39 @@
-# Humble-line only (branches: humble below) and disabled_manually; the jazzy-line docs
-# build is tracked at #252 (DC 2.0 S11: migration guide + docs overhaul), not wired up
-# here yet. `container: image:` pulls a tag `.github/workflows/docker.yaml`'s `doc` job
-# used to build from containers/doc/Containerfile — that job is gone (see
-# containers/doc/Containerfile's header), so this workflow can't currently produce a
-# fresh image even if re-enabled.
+# DC 2.0 (Jazzy) documentation build and deploy (#252). Builds the mdbook site and the
+# strictdoc requirements export, and publishes to GitHub Pages on pushes to `jazzy`.
+#
+# Like ci.yaml, this runs the same script a developer runs locally
+# (tools/ci/pre-commit/build_doc.sh, also the `build-doc` pre-commit hook) inside a Podman
+# image built from containers/doc/Containerfile — no CI-only docs script, and the pinned
+# mdbook toolchain is identical in both places. The image is tagged with the commit SHA
+# for traceability but is not pushed: nothing else consumes it (CLAUDE.md, "Containers:
+# Podman, not Docker").
+#
+# The docs build is a real gate: mdbook's linkcheck backend fails the job on a broken
+# internal link, and book.toml sets `create-missing = false` so a SUMMARY.md entry
+# pointing at a missing page fails too. External links are not followed — see the comment
+# on `follow-web-links` in doc/book.toml.
+
 name: Documentation
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - humble
+      - jazzy
     paths:
       - doc/**
+      - requirements/**
+      - containers/doc/Containerfile
+      - tools/ci/pre-commit/build_doc.sh
       - .github/workflows/doc.yaml
   pull_request:
+    branches:
+      - jazzy
     paths:
       - doc/**
+      - requirements/**
+      - containers/doc/Containerfile
+      - tools/ci/pre-commit/build_doc.sh
       - .github/workflows/doc.yaml
 
 permissions:
@@ -26,32 +44,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
-    runs-on: ubuntu-22.04
-    container:
-      image: minipada/ros2_data_collection:humble-doc
+  build:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Build the documentation
+        env:
+          IMAGE_TAG: dc-doc:${{ github.sha }}
+        run: ./tools/ci/pre-commit/build_doc.sh
+
+      - name: Upload the built site
+        uses: actions/upload-artifact@v4
         with:
-          path: .
-      - name: Install Python dependencies
-        uses: py-actions/py-dependency-install@v4
-        with:
-          path: "requirements.txt"
-      - name: Install Python dependencies (dev)
-        uses: py-actions/py-dependency-install@v4
-        with:
-          path: "requirements-dev.txt"
-      - name: Generate strictdoc pages
-        run: |
-          strictdoc export requirements --experimental-enable-file-traceability --enable-mathjax --format=html --output-dir doc/src/dc/requirements --project-title "ROS 2 Data Collection"
-      - name: Build documentation
-        working-directory: ./doc
-        run: mdbook build
-      - name: Deploy
-        if: github.event_name != 'pull_request'
-        uses: peaceiris/actions-gh-pages@v3
+          name: doc-site
+          path: doc/book/html
+
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push'
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/book/html

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: build-doc
         name: Build documentation
-        entry: ./tools/ci/pre-commit/build_doc.sh --ros-version=humble
+        entry: ./tools/ci/pre-commit/build_doc.sh
         language: script
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/containers/doc/Containerfile
+++ b/containers/doc/Containerfile
@@ -1,24 +1,37 @@
-# ghcr.io/minipada/ros2_data_collection:${ROS_DISTRO}-doc
-# Image to build the documentation. Currently orphaned on this branch: the humble-line
-# `.github/workflows/docker.yaml` `doc` job that built and pushed this image was removed
-# (dead weight — disabled, humble-branch-scoped, same as the ci/ci-testing/source/
-# source-sim Dockerfiles it shipped alongside); `.github/workflows/doc.yaml` and
-# `tools/ci/pre-commit/build_doc.sh` still pull the tag it used to produce. Kept
-# (renamed docker/doc/Dockerfile -> containers/doc/Containerfile per the Podman
-# convention) rather than deleted because #252 (DC 2.0 S11: migration guide + docs
-# overhaul) is the tracked place to re-wire a live jazzy docs build — do that there,
-# not by reviving this file in isolation.
-FROM rust:1.68.2-bullseye AS ros2_dc_doc_builder
+# Documentation builder image: mdbook (plus the preprocessors doc/book.toml declares) and
+# strictdoc. Built and used by `tools/ci/pre-commit/build_doc.sh`, which both
+# `.github/workflows/doc.yaml` and the `build-doc` pre-commit hook call — so a local docs
+# build and the CI docs build run the exact same toolchain. The image stays local to
+# whoever builds it; nothing publishes it (see CLAUDE.md, "Containers: Podman, not
+# Docker" — this repo has no registry for runnable images yet).
+#
+# Versions are pinned because mdbook's plugin ABI is not stable across minor versions: a
+# preprocessor built against mdbook 0.4.x fails outright under 0.5.x, and mdbook-admonish
+# refuses to run unless doc/book.toml's `assets_version` matches the assets it ships.
+# Bumping any one of these means re-running `mdbook-admonish install doc` and rebuilding.
+FROM docker.io/library/rust:1.96-bookworm
 
-WORKDIR /
+# The mdbook crates move together; bump and re-test as a set.
+ARG MDBOOK_VERSION=0.4.52
+ARG MDBOOK_ADMONISH_VERSION=1.20.0
+ARG MDBOOK_MERMAID_VERSION=0.14.1
+ARG MDBOOK_OPEN_ON_GH_VERSION=2.4.3
+ARG MDBOOK_LINKCHECK_VERSION=0.7.7
+ARG STRICTDOC_VERSION=0.0.40
 
-COPY requirements.txt .
-COPY requirements-dev.txt .
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get -q update && \
-    # Python3
-    apt-get -q install --no-install-recommends -y python-is-python3 python3-pip && \
-    pip3 install --no-cache-dir -r requirements.txt -r requirements-dev.txt && \
-    cargo install mdbook mdbook-admonish mdbook-linkcheck mdbook-mermaid mdbook-open-on-gh && \
-    # Clear apt-cache to reduce image size
+    apt-get -q install --no-install-recommends -y python3-pip && \
     rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages --no-cache-dir "strictdoc==${STRICTDOC_VERSION}"
+
+RUN cargo install --locked mdbook --version "${MDBOOK_VERSION}" && \
+    cargo install --locked mdbook-admonish --version "${MDBOOK_ADMONISH_VERSION}" && \
+    cargo install --locked mdbook-mermaid --version "${MDBOOK_MERMAID_VERSION}" && \
+    cargo install --locked mdbook-open-on-gh --version "${MDBOOK_OPEN_ON_GH_VERSION}" && \
+    cargo install --locked mdbook-linkcheck --version "${MDBOOK_LINKCHECK_VERSION}" && \
+    rm -rf "${CARGO_HOME}/registry"
+
+WORKDIR /ws

--- a/dc_cli/dc_cli/list_plugins.py
+++ b/dc_cli/dc_cli/list_plugins.py
@@ -59,12 +59,9 @@ def conditions():
     )
 
 
-@app.command()
-def destinations():
-    """List destination plugins with their descriptions."""
-    print_plugins(
-        path=pathlib.Path(get_package_share_directory("dc_destinations"), "destination_plugin.xml")
-    )
+# There is no `destinations` command: DC 2.0 has no destination pluginlib layer to list
+# (ADR-0003). Destinations are the four blessed types plus the passthrough, all
+# configuration — see doc/src/dc/destinations.md.
 
 
 if __name__ == "__main__":

--- a/doc/book.toml
+++ b/doc/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["The Contributors"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Data Collection for ROS 2"
 
@@ -17,13 +16,13 @@ command = "mdbook-mermaid"
 
 [preprocessor.admonish]
 command = "mdbook-admonish"
-assets_version = "2.0.0" # do not edit: managed by `mdbook-admonish install`
+assets_version = "3.1.0" # do not edit: managed by `mdbook-admonish install`
 
 [output.html]
 mathjax-support = true
 default-theme = "navy"
 git-repository-url = "https://github.com/minipada/ros2_data_collection"
-edit-url-template = "https://github.com/minipada/ros2_data_collection/edit/humble/doc/{path}"
+edit-url-template = "https://github.com/minipada/ros2_data_collection/edit/jazzy/doc/{path}"
 additional-css = ["open-in.css", "./css/mdbook-admonish.css", "css/logo.css", "css/lineicon.css", "css/theme.css"]
 additional-js = ["js/mermaid.js", "js/mermaid-init.js", "js/theme.js"]
 
@@ -44,9 +43,11 @@ expand = true
 heading-split-level = 2
 
 [output.linkcheck]
-# Should we check links on the internet? Enabling this option adds a
-# non-negligible performance impact
-follow-web-links = true
+# Should we check links on the internet? Off: the docs build runs in CI on every doc
+# change, and third-party hosts (github.com in particular, which 403s the checker's
+# user-agent) make external checking flaky in a way that says nothing about the docs.
+# Internal links — the ones a docs change can actually break — are still checked.
+follow-web-links = false
 
 # Are we allowed to link to files outside of the book's root directory? This
 # may help prevent linking to sensitive files (e.g. "../../../../etc/shadow")

--- a/doc/css/mdbook-admonish.css
+++ b/doc/css/mdbook-admonish.css
@@ -1,33 +1,4 @@
 @charset "UTF-8";
-:root {
-  --md-admonition-icon--note:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
-  --md-admonition-icon--abstract:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
-  --md-admonition-icon--info:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
-  --md-admonition-icon--tip:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
-  --md-admonition-icon--success:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
-  --md-admonition-icon--question:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
-  --md-admonition-icon--warning:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
-  --md-admonition-icon--failure:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
-  --md-admonition-icon--danger:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
-  --md-admonition-icon--bug:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
-  --md-admonition-icon--example:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
-  --md-admonition-icon--quote:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
-  --md-details-icon:
-    url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
-}
-
 :is(.admonition) {
   display: flow-root;
   margin: 1.5625em 0;
@@ -75,29 +46,34 @@ a.admonition-anchor-link::before {
   content: "§";
 }
 
-:is(.admonition-title, summary) {
+:is(.admonition-title, summary.admonition-title) {
   position: relative;
+  min-height: 4rem;
   margin-block: 0;
   margin-inline: -1.6rem -1.2rem;
   padding-block: 0.8rem;
   padding-inline: 4.4rem 1.2rem;
   font-weight: 700;
   background-color: rgba(68, 138, 255, 0.1);
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
   display: flex;
 }
-:is(.admonition-title, summary) p {
+:is(.admonition-title, summary.admonition-title) p {
   margin: 0;
 }
-html :is(.admonition-title, summary):last-child {
+html :is(.admonition-title, summary.admonition-title):last-child {
   margin-bottom: 0;
 }
-:is(.admonition-title, summary)::before {
+:is(.admonition-title, summary.admonition-title)::before {
   position: absolute;
   top: 0.625em;
   inset-inline-start: 1.6rem;
   width: 2rem;
   height: 2rem;
   background-color: #448aff;
+  print-color-adjust: exact;
+  -webkit-print-color-adjust: exact;
   mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
   -webkit-mask-image: url('data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"></svg>');
   mask-repeat: no-repeat;
@@ -106,10 +82,15 @@ html :is(.admonition-title, summary):last-child {
   -webkit-mask-size: contain;
   content: "";
 }
-:is(.admonition-title, summary):hover a.admonition-anchor-link {
+:is(.admonition-title, summary.admonition-title):hover a.admonition-anchor-link {
   display: initial;
 }
 
+@media print {
+  details.admonition::details-content {
+    display: contents;
+  }
+}
 details.admonition > summary.admonition-title::after {
   position: absolute;
   top: 0.625em;
@@ -130,205 +111,227 @@ details.admonition > summary.admonition-title::after {
 details[open].admonition > summary.admonition-title::after {
   transform: rotate(90deg);
 }
+summary.admonition-title::-webkit-details-marker {
+  display: none;
+}
 
-:is(.admonition):is(.note) {
+:root {
+  --md-details-icon: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M8.59 16.58 13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.42Z'/></svg>");
+}
+
+:root {
+  --md-admonition-icon--admonish-note: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20.71 7.04c.39-.39.39-1.04 0-1.41l-2.34-2.34c-.37-.39-1.02-.39-1.41 0l-1.84 1.83 3.75 3.75M3 17.25V21h3.75L17.81 9.93l-3.75-3.75L3 17.25z'/></svg>");
+  --md-admonition-icon--admonish-abstract: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17 9H7V7h10m0 6H7v-2h10m-3 6H7v-2h7M12 3a1 1 0 0 1 1 1 1 1 0 0 1-1 1 1 1 0 0 1-1-1 1 1 0 0 1 1-1m7 0h-4.18C14.4 1.84 13.3 1 12 1c-1.3 0-2.4.84-2.82 2H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V5a2 2 0 0 0-2-2z'/></svg>");
+  --md-admonition-icon--admonish-info: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 9h-2V7h2m0 10h-2v-6h2m-1-9A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z'/></svg>");
+  --md-admonition-icon--admonish-tip: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M17.66 11.2c-.23-.3-.51-.56-.77-.82-.67-.6-1.43-1.03-2.07-1.66C13.33 7.26 13 4.85 13.95 3c-.95.23-1.78.75-2.49 1.32-2.59 2.08-3.61 5.75-2.39 8.9.04.1.08.2.08.33 0 .22-.15.42-.35.5-.23.1-.47.04-.66-.12a.58.58 0 0 1-.14-.17c-1.13-1.43-1.31-3.48-.55-5.12C5.78 10 4.87 12.3 5 14.47c.06.5.12 1 .29 1.5.14.6.41 1.2.71 1.73 1.08 1.73 2.95 2.97 4.96 3.22 2.14.27 4.43-.12 6.07-1.6 1.83-1.66 2.47-4.32 1.53-6.6l-.13-.26c-.21-.46-.77-1.26-.77-1.26m-3.16 6.3c-.28.24-.74.5-1.1.6-1.12.4-2.24-.16-2.9-.82 1.19-.28 1.9-1.16 2.11-2.05.17-.8-.15-1.46-.28-2.23-.12-.74-.1-1.37.17-2.06.19.38.39.76.63 1.06.77 1 1.98 1.44 2.24 2.8.04.14.06.28.06.43.03.82-.33 1.72-.93 2.27z'/></svg>");
+  --md-admonition-icon--admonish-success: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m9 20.42-6.21-6.21 2.83-2.83L9 14.77l9.88-9.89 2.83 2.83L9 20.42z'/></svg>");
+  --md-admonition-icon--admonish-question: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='m15.07 11.25-.9.92C13.45 12.89 13 13.5 13 15h-2v-.5c0-1.11.45-2.11 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41a2 2 0 0 0-2-2 2 2 0 0 0-2 2H8a4 4 0 0 1 4-4 4 4 0 0 1 4 4 3.2 3.2 0 0 1-.93 2.25M13 19h-2v-2h2M12 2A10 10 0 0 0 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10c0-5.53-4.5-10-10-10z'/></svg>");
+  --md-admonition-icon--admonish-warning: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M13 14h-2V9h2m0 9h-2v-2h2M1 21h22L12 2 1 21z'/></svg>");
+  --md-admonition-icon--admonish-failure: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M20 6.91 17.09 4 12 9.09 6.91 4 4 6.91 9.09 12 4 17.09 6.91 20 12 14.91 17.09 20 20 17.09 14.91 12 20 6.91z'/></svg>");
+  --md-admonition-icon--admonish-danger: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M11 15H6l7-14v8h5l-7 14v-8z'/></svg>");
+  --md-admonition-icon--admonish-bug: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 12h-4v-2h4m0 6h-4v-2h4m6-6h-2.81a5.985 5.985 0 0 0-1.82-1.96L17 4.41 15.59 3l-2.17 2.17a6.002 6.002 0 0 0-2.83 0L8.41 3 7 4.41l1.62 1.63C7.88 6.55 7.26 7.22 6.81 8H4v2h2.09c-.05.33-.09.66-.09 1v1H4v2h2v1c0 .34.04.67.09 1H4v2h2.81c1.04 1.79 2.97 3 5.19 3s4.15-1.21 5.19-3H20v-2h-2.09c.05-.33.09-.66.09-1v-1h2v-2h-2v-1c0-.34-.04-.67-.09-1H20V8z'/></svg>");
+  --md-admonition-icon--admonish-example: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M7 13v-2h14v2H7m0 6v-2h14v2H7M7 7V5h14v2H7M3 8V5H2V4h2v4H3m-1 9v-1h3v4H2v-1h2v-.5H3v-1h1V17H2m2.25-7a.75.75 0 0 1 .75.75c0 .2-.08.39-.21.52L3.12 13H5v1H2v-.92L4 11H2v-1h2.25z'/></svg>");
+  --md-admonition-icon--admonish-quote: url("data:image/svg+xml;charset=utf-8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 17h3l2-4V7h-6v6h3M6 17h3l2-4V7H5v6h3l-2 4z'/></svg>");
+}
+
+:is(.admonition):is(.admonish-note) {
   border-color: #448aff;
 }
 
-:is(.note) > :is(.admonition-title, summary) {
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(68, 138, 255, 0.1);
 }
-:is(.note) > :is(.admonition-title, summary)::before {
+:is(.admonish-note) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #448aff;
-  mask-image: var(--md-admonition-icon--note);
-  -webkit-mask-image: var(--md-admonition-icon--note);
+  mask-image: var(--md-admonition-icon--admonish-note);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-note);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.abstract, .summary, .tldr) {
+:is(.admonition):is(.admonish-abstract, .admonish-summary, .admonish-tldr) {
   border-color: #00b0ff;
 }
 
-:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary) {
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 176, 255, 0.1);
 }
-:is(.abstract, .summary, .tldr) > :is(.admonition-title, summary)::before {
+:is(.admonish-abstract, .admonish-summary, .admonish-tldr) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00b0ff;
-  mask-image: var(--md-admonition-icon--abstract);
-  -webkit-mask-image: var(--md-admonition-icon--abstract);
+  mask-image: var(--md-admonition-icon--admonish-abstract);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-abstract);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.info, .todo) {
+:is(.admonition):is(.admonish-info, .admonish-todo) {
   border-color: #00b8d4;
 }
 
-:is(.info, .todo) > :is(.admonition-title, summary) {
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 184, 212, 0.1);
 }
-:is(.info, .todo) > :is(.admonition-title, summary)::before {
+:is(.admonish-info, .admonish-todo) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00b8d4;
-  mask-image: var(--md-admonition-icon--info);
-  -webkit-mask-image: var(--md-admonition-icon--info);
+  mask-image: var(--md-admonition-icon--admonish-info);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-info);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.tip, .hint, .important) {
+:is(.admonition):is(.admonish-tip, .admonish-hint, .admonish-important) {
   border-color: #00bfa5;
 }
 
-:is(.tip, .hint, .important) > :is(.admonition-title, summary) {
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 191, 165, 0.1);
 }
-:is(.tip, .hint, .important) > :is(.admonition-title, summary)::before {
+:is(.admonish-tip, .admonish-hint, .admonish-important) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00bfa5;
-  mask-image: var(--md-admonition-icon--tip);
-  -webkit-mask-image: var(--md-admonition-icon--tip);
+  mask-image: var(--md-admonition-icon--admonish-tip);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-tip);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.success, .check, .done) {
+:is(.admonition):is(.admonish-success, .admonish-check, .admonish-done) {
   border-color: #00c853;
 }
 
-:is(.success, .check, .done) > :is(.admonition-title, summary) {
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(0, 200, 83, 0.1);
 }
-:is(.success, .check, .done) > :is(.admonition-title, summary)::before {
+:is(.admonish-success, .admonish-check, .admonish-done) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #00c853;
-  mask-image: var(--md-admonition-icon--success);
-  -webkit-mask-image: var(--md-admonition-icon--success);
+  mask-image: var(--md-admonition-icon--admonish-success);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-success);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.question, .help, .faq) {
+:is(.admonition):is(.admonish-question, .admonish-help, .admonish-faq) {
   border-color: #64dd17;
 }
 
-:is(.question, .help, .faq) > :is(.admonition-title, summary) {
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(100, 221, 23, 0.1);
 }
-:is(.question, .help, .faq) > :is(.admonition-title, summary)::before {
+:is(.admonish-question, .admonish-help, .admonish-faq) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #64dd17;
-  mask-image: var(--md-admonition-icon--question);
-  -webkit-mask-image: var(--md-admonition-icon--question);
+  mask-image: var(--md-admonition-icon--admonish-question);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-question);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.warning, .caution, .attention) {
+:is(.admonition):is(.admonish-warning, .admonish-caution, .admonish-attention) {
   border-color: #ff9100;
 }
 
-:is(.warning, .caution, .attention) > :is(.admonition-title, summary) {
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 145, 0, 0.1);
 }
-:is(.warning, .caution, .attention) > :is(.admonition-title, summary)::before {
+:is(.admonish-warning, .admonish-caution, .admonish-attention) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff9100;
-  mask-image: var(--md-admonition-icon--warning);
-  -webkit-mask-image: var(--md-admonition-icon--warning);
+  mask-image: var(--md-admonition-icon--admonish-warning);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-warning);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.failure, .fail, .missing) {
+:is(.admonition):is(.admonish-failure, .admonish-fail, .admonish-missing) {
   border-color: #ff5252;
 }
 
-:is(.failure, .fail, .missing) > :is(.admonition-title, summary) {
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 82, 82, 0.1);
 }
-:is(.failure, .fail, .missing) > :is(.admonition-title, summary)::before {
+:is(.admonish-failure, .admonish-fail, .admonish-missing) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff5252;
-  mask-image: var(--md-admonition-icon--failure);
-  -webkit-mask-image: var(--md-admonition-icon--failure);
+  mask-image: var(--md-admonition-icon--admonish-failure);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-failure);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.danger, .error) {
+:is(.admonition):is(.admonish-danger, .admonish-error) {
   border-color: #ff1744;
 }
 
-:is(.danger, .error) > :is(.admonition-title, summary) {
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(255, 23, 68, 0.1);
 }
-:is(.danger, .error) > :is(.admonition-title, summary)::before {
+:is(.admonish-danger, .admonish-error) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #ff1744;
-  mask-image: var(--md-admonition-icon--danger);
-  -webkit-mask-image: var(--md-admonition-icon--danger);
+  mask-image: var(--md-admonition-icon--admonish-danger);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-danger);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.bug) {
+:is(.admonition):is(.admonish-bug) {
   border-color: #f50057;
 }
 
-:is(.bug) > :is(.admonition-title, summary) {
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(245, 0, 87, 0.1);
 }
-:is(.bug) > :is(.admonition-title, summary)::before {
+:is(.admonish-bug) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #f50057;
-  mask-image: var(--md-admonition-icon--bug);
-  -webkit-mask-image: var(--md-admonition-icon--bug);
+  mask-image: var(--md-admonition-icon--admonish-bug);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-bug);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.example) {
+:is(.admonition):is(.admonish-example) {
   border-color: #7c4dff;
 }
 
-:is(.example) > :is(.admonition-title, summary) {
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(124, 77, 255, 0.1);
 }
-:is(.example) > :is(.admonition-title, summary)::before {
+:is(.admonish-example) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #7c4dff;
-  mask-image: var(--md-admonition-icon--example);
-  -webkit-mask-image: var(--md-admonition-icon--example);
+  mask-image: var(--md-admonition-icon--admonish-example);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-example);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
   -webkit-mask-repeat: no-repeat;
 }
 
-:is(.admonition):is(.quote, .cite) {
+:is(.admonition):is(.admonish-quote, .admonish-cite) {
   border-color: #9e9e9e;
 }
 
-:is(.quote, .cite) > :is(.admonition-title, summary) {
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title) {
   background-color: rgba(158, 158, 158, 0.1);
 }
-:is(.quote, .cite) > :is(.admonition-title, summary)::before {
+:is(.admonish-quote, .admonish-cite) > :is(.admonition-title, summary.admonition-title)::before {
   background-color: #9e9e9e;
-  mask-image: var(--md-admonition-icon--quote);
-  -webkit-mask-image: var(--md-admonition-icon--quote);
+  mask-image: var(--md-admonition-icon--admonish-quote);
+  -webkit-mask-image: var(--md-admonition-icon--admonish-quote);
   mask-repeat: no-repeat;
   -webkit-mask-repeat: no-repeat;
   mask-size: contain;
@@ -339,7 +342,8 @@ details[open].admonition > summary.admonition-title::after {
   background-color: var(--sidebar-bg);
 }
 
-.ayu :is(.admonition), .coal :is(.admonition) {
+.ayu :is(.admonition),
+.coal :is(.admonition) {
   background-color: var(--theme-hover);
 }
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [Introduction](./dc/introduction.md)
 - [Setup](./dc/setup.md)
+- [Migrating from DC 1.x to DC 2.0](./dc/migration.md)
 - [Demos](./dc/demos.md)
   - [Uptime](./dc/demos/uptime_stdout.md)
   - [Group memory and uptime](./dc/demos/memory_uptime_stdout.md)

--- a/doc/src/dc/cli.md
+++ b/doc/src/dc/cli.md
@@ -17,7 +17,12 @@ ros2 run dc_cli list_plugins --help
 │ by-package       List plugins of a pluginlib file with their descriptions, by package name and filename.                  │
 │ by-path          List plugins of a pluginlib file with their descriptions, by their path.                                 │
 │ conditions       List condition plugins with their descriptions.                                                          │
-│ destinations     List destination plugins with their descriptions.                                                        │
 │ measurements     List measurement plugins with their descriptions.                                                        │
 ╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+```admonish info
+There is no `destinations` command. Destinations are not pluginlib plugins in DC 2.0
+(ADR-0003): the four blessed types are listed in [Destinations](./destinations.md), and
+everything else is reached through the passthrough.
 ```

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -1,28 +1,168 @@
 # Concepts
 
-There are a few key concepts that are really important to understand how DC operates.
+DC has a small, fixed vocabulary. Using it precisely makes the rest of the documentation
+— and the configuration files — unambiguous.
+
+## Glossary
+
+| Term                      | Definition                                                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| **Measurement**           | A source of sampled data (CPU, position, camera inspection…) that emits Records.                              |
+| **Record**                | One timestamped JSON document flowing through the pipeline.                                                   |
+| **Condition**             | A boolean predicate on robot state that gates whether a Measurement's Records are collected.                  |
+| **Group**                 | A merge of Records from several Measurements into one Record, based on time proximity.                        |
+| **File**                  | A binary artifact produced by a Measurement (image, video, map), uploaded to object storage as-is; only its metadata travels as a Record. |
+| **Destination**           | An external system that receives Records or Files (PostgreSQL, S3-compatible storage, console…).              |
+| **Blessed Destination**   | A Destination DC configures natively from ROS parameters: `postgres`, `s3`, `file`, `console`.                |
+| **Passthrough Destination** | A Destination configured by handing raw Shipper configuration through DC, unlocking the Shipper's full catalog without DC code. |
+| **Bridge**                | The DC component (`dc_bridge`) that receives Records from ROS topics and hands them to the Shipper.           |
+| **Shipper**               | The external process (Vector by default) that buffers, transforms, and reliably delivers Records to Destinations. |
+| **Tag**                   | A label carried by a Record naming the route it is delivered on.                                              |
+
+Relationships between them:
+
+- A **Measurement** emits **Records**, optionally gated by one or more **Conditions**
+- A **Group** merges Records from several **Measurements** into one **Record**
+- The **Bridge** forwards every **Record** to the **Shipper**
+- The **Shipper** delivers Records to one or more **Destinations**
+- A **File** is uploaded to an object-storage **Destination**; its metadata becomes a **Record**
+- A **Record** carries a **Tag**; each Tag names a route Destinations subscribe to
+
+```admonish example title="Words that mean something specific here"
+"Sink" is the Shipper's internal configuration unit, not the DC concept — the DC concept
+is **Destination**. "Route" is the Shipper-side path a **Tag** selects. A camera image is
+a **File**, not a Record; the Record is the JSON document describing where that File went.
+```
 
 ## ROS 2
 
-ROS 2 is the core middleware used for DC. If you are unfamilar with this, please visit [the ROS 2 documentation](https://docs.ros.org/en/rolling/) before continuing.
+ROS 2 is the core middleware used for DC. If you are unfamiliar with it, visit
+[the ROS 2 documentation](https://docs.ros.org/en/rolling/) before continuing.
 
-## Shipper (Vector)
+## Records
 
-DC's data plane is an external **Shipper** process, [Vector](https://vector.dev/),
-fed over the Fluent Forward protocol by the **Bridge** (`dc_bridge`). The Bridge
-renders Vector's configuration from plain ROS parameters — see
-[Destinations](./destinations.md) — spawns and supervises the Vector process, and
-forwards every Record it receives on its configured input topics. DC gets Vector's
-disk buffering, retries, and native sinks (PostgreSQL, S3-compatible storage, and
-many more) without embedding or forking the Shipper itself (ADR-0001,
-`docs/adr/`).
+A Record is a single data unit in JSON, published on a ROS topic as a
+`dc_interfaces/msg/StringStamped` message. For example, a Record from the Memory
+Measurement:
+
+```json
+{
+    "date": "2022-12-04T14:16:06.810999008",
+    "memory": {
+        "used": 76.007431
+    }
+}
+```
+
+The `StringStamped` message carries:
+
+1. **header**: ROS timestamp as `std_msgs/Header`
+2. **data**: the Record, as a JSON string
+3. **group_key**: the key this Record is nested under when merged into a Group
+
+The `data` string **must** be valid JSON:
+
+```bash
+"Robot_X:1.5, Robot_Y:1.8" # Not a valid Record
+"{'x': 1.5, 'y': 1.8}"     # Valid Record
+```
+
+### Timestamps
+
+The timestamp is the time the Record was created. Measurements convert ROS time to a
+UTC timestamp. Each Destination normalizes it into one field before delivery, controlled
+by `time_key` (default `date`) and `time_format` (`double` for Unix epoch seconds, or
+`iso8601`).
+
+### JSON validation
+
+Each Record is validated against a JSON schema by default, following the
+[JSON Schema Validation](https://json-schema.org/draft/2020-12/json-schema-validation.html)
+specification. Each Measurement ships its own schema, which can be overridden from a
+custom package or disabled per Measurement with `enable_validator: false`. See
+[Data validation](./data_validation.md).
+
+## Bridge and Shipper
+
+DC's data plane is an external **Shipper** process, [Vector](https://vector.dev/), fed
+by the **Bridge** (`dc_bridge`) over a local socket. The Bridge renders the Shipper's
+entire configuration from plain ROS parameters — see [Destinations](./destinations.md) —
+spawns and supervises the Shipper process, and forwards every Record it receives on its
+configured input topics.
+
+DC gets the Shipper's disk buffering, backpressure handling, retries, and native
+Destination support (PostgreSQL, S3-compatible storage, and many more) without embedding
+or forking it (ADR-0001, ADR-0002 in
+[`docs/adr/`](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr)).
+
+```admonish info title="Shipper ingest protocol"
+The wire format on the local Bridge↔Shipper socket (default port 24224) is Fluentd's
+open "Forward" specification — chosen as the cheapest Shipper-native listener with
+built-in receipt acknowledgement (ADR-0002). **No Fluentd or Fluent Bit software runs
+anywhere in DC 2.0**: the Bridge implements the sender side itself in a few hundred
+lines of msgpack. The word "fluent" only appears in the generated Shipper config
+(`type = "fluent"`).
+```
+
+## Tags
+
+Every Record carries a **Tag**, derived mechanically from the topic it was published on:
+the leading `/` is dropped and the remaining `/` become `.`.
+
+| Topic                     | Tag                    | Public Shipper route      |
+| ------------------------- | ---------------------- | ------------------------- |
+| `/dc/measurement/uptime`  | `dc.measurement.uptime`| `dc.dc.measurement.uptime`|
+| `/dc/group/robot`         | `dc.group.robot`       | `dc.dc.group.robot`       |
+| *(Uploader-internal)*     | `dc.files`             | `dc.dc.files`             |
+
+Tags are what the Shipper routes on, and the `dc.<tag>` route names are
+[stable public API](./destinations.md#the-dctag-routing-contract-public-api) that
+passthrough Destinations consume.
+
+```admonish warning title="Tags are not how you select a Destination"
+In DC 1.x, a Measurement's `tags` parameter named the destination plugins that should
+receive its Records. In DC 2.0 that is inverted: a Destination declares the **topics** it
+receives in its own `inputs` list, and Tags are derived, not configured. Delete `tags:`
+from Measurement and Group configurations — see the [migration guide](./migration.md#tags-what-changed).
+```
+
+## Destinations
+
+A Destination is where data ends up: PostgreSQL, S3-compatible storage, a file, or the
+console are **blessed** (rendered from plain ROS parameters); any other Vector sink is
+reachable through the **passthrough**. See [Destinations](./destinations.md) for the full
+contract.
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    destinations: ["console"]                 # Destination names to enable
+    console:                                  # a name you choose
+      type: console                           # a blessed type
+      receives: records
+      inputs: ["/dc/measurement/uptime"]      # the topics this Destination receives
+
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime"]
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      topic_output: "/dc/measurement/uptime"  # matched by the Destination's `inputs`
+```
+
+## Conditions
+
+A Condition enables or disables one or more Measurements. For example, collect camera
+images only when the robot is stopped. A Measurement can require that all, any, or none
+of a set of Conditions are active. See [Conditions](./conditions.md).
 
 ## Lifecycle Nodes and Bond
+
 *(Source: [Nav2 documentation](https://navigation.ros.org/concepts/index.html))*
 
 Lifecycle (or Managed, more correctly) nodes are unique to ROS 2. More information can be [found here](https://design.ros2.org/articles/node_lifecycle.html). They are nodes that contain state machine transitions for bringup and teardown of ROS 2 servers. This helps in deterministic behavior of ROS systems in startup and shutdown. It also helps users structure their programs in reasonable ways for commercial uses and debugging.
 
-When a node is started, it is in the unconfigured state, only processing the node’s constructor which should not contain any ROS networking setup or parameter reading. By the launch system, or the supplied lifecycle manager, the nodes need to be transitioned to inactive by configuring. After, it is possible to activate the node by transitioning through the activating stage.
+When a node is started, it is in the unconfigured state, only processing the node's constructor which should not contain any ROS networking setup or parameter reading. By the launch system, or the supplied lifecycle manager, the nodes need to be transitioned to inactive by configuring. After, it is possible to activate the node by transitioning through the activating stage.
 
 This state will allow the node to process information and be fully setup to run. The configuration stage, triggering the on_configure() method, will setup all parameters, ROS networking interfaces, and for safety systems, all dynamically allocated memory. The activation stage, triggering the on_activate() method, will active the ROS networking interfaces and set any states in the program to start processing information.
 
@@ -32,95 +172,24 @@ The lifecycle node framework is used extensively through out this project and al
 
 Within DC, we use a wrapper of LifecycleNodes, nav2_util LifecycleNode from Nav2. This wrapper wraps much of the complexities of LifecycleNodes for typical applications. It also includes a bond connection for the lifecycle manager to ensure that after a server transitions up, it also remains active. If a server crashes, it lets the lifecycle manager know and transition down the system to prevent a critical failure. See [Eloquent to Foxy](https://navigation.ros.org/migration/Eloquent.html#eloquent-migration) for details.
 
-## Measurements
-
-Measurements are a single data unit presented in JSON format, that can contain different fields. For example, Memory measurement:
-
-```json
-{
-    "date": "2022-12-04T14:16:06.810999008",
-    "memory": {
-        "used": 76.007431
-    },
-}
+```admonish info
+The Bridge is deliberately **not** a lifecycle node and **not** under the lifecycle
+manager (ADR-0006): it must be up and its Shipper ready *before* the collection nodes
+are allowed to activate. See [Data Pipeline](./data_pipeline.md).
 ```
-
-Every incoming piece of data that belongs to a log or a metric that is retrieved by DC is considered an Event or Record.
-
-Internally, it will always be a JSON string sent in a ROS message of StringStamped type. This ROS message contains:
-
-1. **header**: ROS timestamp as std_msgs/Header
-2. **data**: JSON message as string
-3. **group_key**: a string used as a key for the new message when grouping multiple messages together
-
-## Tag(s)
-Every measurement requires to have at least a tag configured (via the `tags` parameter) so it is sent to its destination(s). This tag corresponds to the name of a Destination declared on the Bridge (`dc_bridge`) in the same configuration.
-
-Example:
-
-```yaml
-dc_bridge:
-  ros__parameters:
-    destinations: ["console"]
-    console: # Custom name for the Destination
-      type: console
-      receives: records
-      inputs: ["/dc/measurement/string_stamped"]
-measurement_server:
-  ros__parameters:
-    measurement_plugins: ["uptime"]
-    uptime:
-      plugin: "dc_measurements/Uptime"
-      topic_output: "/dc/measurement/uptime"
-      tags: ["console"] # Match the Destination name set on the Bridge
-```
-
-See [Destinations](./destinations.md) for the full config renderer contract, including
-`inputs`/`tags` matching and the `dc.<tag>` routing convention.
-
-## Destinations
-A destination is where the data will be sent: PostgreSQL, S3-compatible storage, a
-file, or the console are blessed (rendered from plain ROS parameters); any other
-Vector sink is reachable through the passthrough. See [Destinations](./destinations.md)
-for the full contract.
-
-## Conditions
-A condition enables or disables one or multiple measurements to be published and thus collected. We could for example enable collecting camera images only when a robot is stopped.
-
-Data collection for a measurement can be enabled if one of many conditions are activated, multiple conditions are activated or none.
-
-## Timestamp
-
-The Timestamp represents the time when an Event was created. All events are converting the ROS now time to timestamps (UTC)
-
-## JSON Messages
-
-In DC, all messages sent by measurements are a ROS message and the data string **must** be a JSON message.
-
-```bash
-"Robot_X:1.5, Robot_Y:1.8" # Not valid data string
-"{'x': 1.5, 'y': 1.8}"     # Valid data string
-```
-
-## JSON validation
-
-Each record follows a JSON schema by default, it follows this specification document [JSON Schema Validation](https://json-schema.org/draft/2020-12/json-schema-validation.html).
-
-Each measurement has its own JSON schema, which can be overwritten in a custom package or disabled.
 
 ## Buffering and data persistence
 
-Vector, the Shipper, manages its own disk buffer (`shipper.data_dir` on the Bridge's
-parameters) with a documented minimum size (`shipper.buffer_max_bytes`). This buffer
-persists across reboots: Records accepted by the Bridge but not yet delivered to a
-Destination survive an outage of that Destination, a robot reboot, or a Bridge
-restart, and are delivered — with end-to-end acknowledgements — once the Destination
-is reachable again.
+The Shipper manages its own disk buffer (`shipper.data_dir` on the Bridge's parameters)
+with a documented minimum size (`shipper.buffer_max_bytes`). This buffer persists across
+reboots: Records accepted by the Bridge but not yet delivered to a Destination survive an
+outage of that Destination, a robot reboot, or a Bridge restart, and are delivered — with
+end-to-end acknowledgements — once the Destination is reachable again.
 
-## Scheduling and Retries
+## Scheduling and retries
 
-Vector retries delivery to a Destination on failure with its own backoff, independent
-of DC code; see [its documentation](https://vector.dev/docs/) for details. The Bridge
-itself is supervised by DC (launch respawn) and, in turn, supervises its own Vector
-child process — including a Linux parent-death signal so Vector can never outlive the
-Bridge across a crash or SIGKILL.
+The Shipper retries delivery to a Destination on failure with its own backoff,
+independent of DC code; see [Vector's documentation](https://vector.dev/docs/) for
+details. The Bridge itself is supervised by DC (launch respawn) and, in turn, supervises
+its own Shipper child process — including a Linux parent-death signal so the Shipper can
+never outlive the Bridge across a crash or SIGKILL.

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -11,7 +11,21 @@ By here, you must have built the workspace following the [setup guide](./setup.m
 Copy the configuration and save it as a yaml file, and then run:
 
 ```bash
-ros2 launch dc_bringup params_file:="my_file.yaml"
+ros2 launch dc_bringup dc_bringup.launch.py params_file:="my_file.yaml"
+```
+
+Examples that use a Group also need the Group node:
+
+```bash
+ros2 launch dc_bringup dc_bringup.launch.py params_file:="my_file.yaml" group_node:=True
+```
+
+```admonish tip
+Every example follows the same shape: a `dc_bridge` block declaring **Destinations** and
+the topics each one `inputs`, and a `measurement_server` block declaring **Measurements**
+and the topic each one publishes on. Routing is the overlap between the two lists —
+nothing on the Measurement side names a Destination. If you are migrating a DC 1.x
+configuration, start with the [migration guide](./migration.md).
 ```
 
 ## Running the examples
@@ -32,7 +46,6 @@ measurement_server:                           # Measurement node configuration
     uptime:                                   # Plugin name, you choose
       plugin: "dc_measurements/Uptime"        # Plugin class name, fixed
       topic_output: "/dc/measurement/uptime"  # Topic where data will be published
-      tags: ["console"]                       # The Bridge will match this against a Destination name
 ```
 
 ### Example 2: Uptime to the console with ISO 8601 timestamps
@@ -54,7 +67,6 @@ measurement_server:
     uptime:
       plugin: "dc_measurements/Uptime"
       topic_output: "/dc/measurement/uptime"
-      tags: ["console"]
 ```
 
 ### Example 3: Uptime to the console only at start and 3 times
@@ -74,7 +86,6 @@ measurement_server:
     uptime:
       plugin: "dc_measurements/Uptime"
       topic_output: "/dc/measurement/uptime"
-      tags: ["console"]
       init_max_measurements: 3               # Maximum records to collect
 ```
 
@@ -96,12 +107,10 @@ measurement_server:
       plugin: "dc_measurements/Memory"
       topic_output: "/dc/measurement/memory"
       polling_interval: 5000                  # Interval to which data is collected in milliseconds
-      tags: ["console"]
     cpu:
       plugin: "dc_measurements/Cpu"
       topic_output: "/dc/measurement/cpu"
       polling_interval: 5000                  # Interval to which data is collected in milliseconds
-      tags: ["console"]
 ```
 
 ### Example 5: CPU and Memory as a group to the console every 5 seconds forever
@@ -123,7 +132,6 @@ group_server:                                 # Group server configuration
       output: "/dc/group/cpu_memory"          # Topic where result will be published
       sync_delay: 5.0                         # How long to queue up messages before passing them through.
       group_key: "cpu_memory"
-      tags: ["console"]
 
 measurement_server:
   ros__parameters:
@@ -132,12 +140,10 @@ measurement_server:
       plugin: "dc_measurements/Memory"
       topic_output: "/dc/measurement/memory"
       polling_interval: 5000
-      tags: ["console"]
     cpu:
       plugin: "dc_measurements/Cpu"
       topic_output: "/dc/measurement/cpu"
       polling_interval: 5000
-      tags: ["console"]
 ```
 
 ### Example 6: Custom ROS message to the console every 2 seconds forever
@@ -149,16 +155,15 @@ dc_bridge:
     console:
       type: console
       receives: records
-      inputs: ["/dc/measurement/string_stamped"]
+      inputs: ["/dc/measurement/my_string_stamped"]
 
 measurement_server:
   ros__parameters:
     measurement_plugins: ["my_string_stamped"]
     my_string_stamped:
       plugin: "dc_measurements/StringStamped"           # Plugin that allow to publish from your nodes
-      topic_output: "/dc/measurement/my_string_stamped" # Topic where data is republished with tags
+      topic_output: "/dc/measurement/my_string_stamped" # Topic where the Record is republished
       topic: "/hello-world"                             # Input topic where you are publishing
-      tags: ["console"]
       polling_interval: 2000
       enable_validator: false                           # By default, StringStamped message does not have a JSON schema since it uses custom input data
 ```
@@ -178,7 +183,7 @@ dc_bridge:
     console:
       type: console
       receives: records
-      inputs: ["/dc/measurement/string_stamped"]
+      inputs: ["/dc/measurement/my_string_stamped"]
 
 measurement_server:
   ros__parameters:
@@ -187,9 +192,135 @@ measurement_server:
       plugin: "dc_measurements/StringStamped"
       topic_output: "/dc/measurement/my_string_stamped"
       topic: "/hello-world"
-      tags: ["console"]
       enable_validator: false
       timer_based: false                                 # Get all data published on the input topic. Ignores polling_interval
 ```
 
-Now that you know how it works, you can set your own measurements and destinations.
+### Example 8: Uptime to PostgreSQL, and to the console at the same time
+
+A Record is delivered to every Destination that lists its topic — listing the same topic
+twice is how you fan out.
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"            # Where the Shipper keeps its disk buffer
+    destinations: ["pgsql", "console"]
+    pgsql:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "$DC_PG_PASSWORD"             # $VAR / ${VAR} are read from the environment
+      database: "dc"
+      table: "dc"
+    console:
+      type: console
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime"]
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      topic_output: "/dc/measurement/uptime"
+```
+
+```admonish warning
+The Shipper's `postgres` Destination maps a Record's top-level JSON keys onto **existing**
+columns; it does not create tables or columns. Create the table before starting DC.
+```
+
+### Example 9: Camera images to object storage, with their metadata in PostgreSQL
+
+Files (images, maps, videos) never travel through the Shipper. A `receives: files`
+Destination is served by the Bridge's Uploader, and the per-File status Records it
+produces go to whichever Destination `files.metadata_destination` names.
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["pgsql", "rustfs"]
+    pgsql:                                    # the Records, and the File status log
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/camera"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "$DC_PG_PASSWORD"
+      database: "dc"
+      table: "dc"
+    rustfs:                                   # the File bytes
+      type: s3
+      receives: files
+      inputs: ["/dc/measurement/camera"]
+      bucket: "dc-files"
+      endpoint: "http://127.0.0.1:9000"       # omit for AWS S3
+      region: "us-east-1"
+      access_key_id: "rustfsadmin"
+      secret_access_key: "$DC_S3_SECRET"
+      force_path_style: true                  # path-style addressing for self-hosted stores
+    files:
+      delete_when_sent: true                  # delete locally once verified remotely
+      metadata_destination: "pgsql"
+
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["camera"]
+    camera:
+      plugin: "dc_measurements/Camera"
+      topic_output: "/dc/measurement/camera"
+      cam_topic: "/camera/image_raw"
+      cam_name: "camera"
+      save_detections_img: true
+      save_inspected_path: "camera/inspected/%Y-%m-%dT%H-%M-%S"
+      detection_modules: ["barcode"]
+      remote_keys: ["rustfs"]                 # must equal the receives: files Destination name
+      remote_prefixes: [""]
+```
+
+### Example 10: A Destination DC does not bless, via the passthrough
+
+Any sink in [Vector's catalog](https://vector.dev/docs/reference/configuration/sinks/) is
+reachable by handing raw Shipper configuration through, consuming the public `dc.<tag>`
+route for the topic you want.
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["console"]
+    console:
+      type: console
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+    custom_config_files: ["$HOME/.dc/http_sink.toml"]
+
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime"]
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      topic_output: "/dc/measurement/uptime"
+```
+
+```toml
+# $HOME/.dc/http_sink.toml — raw Vector configuration, merged as-is
+[sinks.my_api]
+type = "http"
+inputs = ["dc.dc.measurement.uptime"]   # /dc/measurement/uptime's public route
+uri = "http://127.0.0.1:8080/ingest"
+encoding.codec = "json"
+```
+
+Now that you know how it works, you can set up your own Measurements and Destinations —
+see [Measurements](./measurements.md) and [Destinations](./destinations.md) for every
+parameter.

--- a/doc/src/dc/data_pipeline.md
+++ b/doc/src/dc/data_pipeline.md
@@ -1,27 +1,113 @@
 # Data Pipeline
 
-## DC 2.0 (Jazzy): deterministic startup ordering
+This page follows one piece of data from the sensor that produced it to the external
+system that stores it. The vocabulary — Measurement, Record, Group, File, Bridge,
+Shipper, Destination, Tag — is defined in [Concepts](./concepts.md) and used
+consistently throughout.
 
-On the Jazzy line, `dc_bringup.launch.py` brings the pipeline up in a fixed order
-(ADR-0006), so no Record can be emitted before the pipeline is able to accept it:
+## The path of a Record
 
-1. **Bridge first.** `dc_bridge` starts as a plain node (outside the lifecycle
-   manager) and spawns the Vector shipper as a supervised child process. The
-   measurement server also starts here, but stays unconfigured and inactive — its
-   publishers cannot emit anything yet.
-2. **Readiness gate.** A `bridge_ready_gate` process blocks polling the Bridge's
-   `~/ready` service (`std_srvs/Trigger`), which answers `success=True` only once
-   Vector is accepting Fluent Forward connections. The gate's `service`,
-   `timeout_s` (default 120 s), and `poll_interval_s` parameters are configurable
-   from the params file under `bridge_ready_gate:`.
+```mermaid
+flowchart LR
+    subgraph ros["ROS 2 graph"]
+        meas["Measurement plugins<br/>(measurement_server)"]
+        cond["Conditions"]
+        group["Group node<br/>(group_server)"]
+    end
+    subgraph bridge["Bridge (dc_bridge)"]
+        fwd["Forwarder"]
+        upl["Uploader"]
+    end
+    subgraph shipper["Shipper (Vector)"]
+        route["dc.&lt;tag&gt; routes"]
+        buf[("Disk buffer")]
+    end
+    subgraph dest["Destinations"]
+        pg["PostgreSQL"]
+        s3["S3-compatible storage"]
+        other["Any Vector sink<br/>(passthrough)"]
+    end
+
+    cond -- gate --> meas
+    meas -- "Records (StringStamped)" --> fwd
+    meas -- "Records" --> group
+    group -- "merged Records" --> fwd
+    meas -. "Files on disk" .-> upl
+    fwd -- "shipper ingest protocol" --> route
+    route --> buf
+    buf --> pg
+    buf --> other
+    upl -- "File bytes" --> s3
+    upl -- "status Records (dc.files)" --> fwd
+```
+
+1. **A Measurement produces a Record.** Each Measurement plugin samples its source on a
+   timer (or on an input topic) and publishes one timestamped JSON document as a
+   `dc_interfaces/msg/StringStamped` on its `topic_output`. **Conditions** can gate
+   whether the Measurement collects at all.
+2. **Optionally, a Group merges Records.** The Group node subscribes to several
+   Measurement topics and publishes one merged Record on `/dc/group/<name>` once their
+   timestamps line up (`sync_delay`).
+3. **The Bridge forwards every Record.** `dc_bridge` subscribes to every topic listed in
+   any Destination's `inputs`, derives that topic's **Tag**, and hands the Record to the
+   Shipper over the local shipper ingest socket (default `127.0.0.1:24224`), with
+   receipt acknowledgement.
+4. **The Shipper routes, buffers and delivers.** Vector normalizes the Record's
+   timestamp field, exposes it on the public `dc.<tag>` route, writes it to a persistent
+   disk buffer, and delivers it to each Destination wired to that route — retrying with
+   its own backoff until it succeeds.
+5. **Files take a different path.** A **File** (camera image, map, video) is never sent
+   through the Shipper. The Bridge's **Uploader** reads the `local_paths` /
+   `remote_paths` references embedded in the Record, uploads the bytes directly to
+   object storage, verifies them, and emits a *status Record* under the `dc.files` Tag —
+   which then travels the ordinary Record path. See
+   [File uploads](./destinations.md#file-uploads-receives-files-the-uploader-adr-0005).
+
+## Where each piece is configured
+
+| Stage                          | Node               | Parameters                                     |
+| ------------------------------ | ------------------ | ---------------------------------------------- |
+| Producing Records              | `measurement_server` | [Measurements](./measurements.md)             |
+| Gating collection              | `measurement_server` | [Conditions](./conditions.md)                 |
+| Merging Records                | `group_server`     | [Groups](./groups.md)                          |
+| Routing, buffering, delivering | `dc_bridge`        | [Destinations](./destinations.md)              |
+
+Routing is decided in exactly one place: a Destination's `inputs` list names the topics
+it receives. Nothing on the producing side selects a Destination.
+
+## Deterministic startup ordering
+
+`dc_bringup.launch.py` brings the pipeline up in a fixed order (ADR-0006), so no Record
+can be emitted before the pipeline is able to accept it:
+
+1. **Bridge first.** `dc_bridge` starts as a plain node (outside the lifecycle manager)
+   and spawns the Vector Shipper as a supervised child process. The measurement server
+   also starts here, but stays unconfigured and inactive — its publishers cannot emit
+   anything yet.
+2. **Readiness gate.** A `bridge_ready_gate` process blocks, polling the Bridge's
+   `~/ready` service (`std_srvs/Trigger`), which answers `success=True` only once the
+   Shipper is accepting connections on its ingest socket. The gate's `service`,
+   `timeout_s` (default 120 s), and `poll_interval_s` parameters are configurable from
+   the params file under `bridge_ready_gate:`.
 3. **Activation.** Only when the gate exits successfully does the launch start
-   `lifecycle_manager_dc`, which configures and then activates the collection
-   nodes. If the Bridge never becomes ready before the gate's deadline, the whole
-   launch shuts down loudly instead of leaving a half-started pipeline running.
+   `lifecycle_manager_dc`, which configures and then activates the collection nodes. If
+   the Bridge never becomes ready before the gate's deadline, the whole launch shuts
+   down loudly instead of leaving a half-started pipeline running.
 
-Supervision after startup: the launch file respawns `dc_bridge` unconditionally
-(independent of `use_respawn`), and the Bridge supervises its Vector child —
-including a Linux parent-death signal, so Vector can never outlive the Bridge
-even across a SIGKILL/crash. Records published while the Bridge is down are
-dropped (topics are fire-and-forget); delivery resumes as soon as the respawned
-Bridge is ready.
+## Durability and supervision
+
+- **Disk buffering.** The Shipper owns a persistent disk buffer at `shipper.data_dir`.
+  A Record the Bridge has handed over survives a Destination outage, a Bridge restart,
+  and a robot reboot; delivery resumes — with end-to-end acknowledgements — once the
+  Destination is reachable again.
+- **Backpressure.** When a Destination is slow, the Shipper stops acknowledging, and the
+  Bridge propagates that backwards rather than dropping data silently.
+- **Supervision.** The launch file respawns `dc_bridge` unconditionally (independent of
+  `use_respawn`), and the Bridge supervises its Shipper child — including a Linux
+  parent-death signal, so the Shipper can never outlive the Bridge even across a
+  SIGKILL or crash.
+- **The one lossy window.** Records published while the Bridge is down are dropped: ROS
+  topics are fire-and-forget and nothing buffers upstream of the Bridge. Delivery
+  resumes as soon as the respawned Bridge is ready.
+- **Delivery semantics.** At-least-once. After a crash or an induced outage, a boundary
+  Record may be re-sent; deduplicate on read if that matters to you.

--- a/doc/src/dc/data_validation.md
+++ b/doc/src/dc/data_validation.md
@@ -2,7 +2,7 @@
 
 ## Model
 
-Each measurement cam validate its data with a model.
+Each Measurement can validate the Records it emits against a model.
 
 We use use [JSON schema validator for JSON for Modern C++](https://github.com/pboettch/json-schema-validator).
 

--- a/doc/src/dc/demos/tb3_stdout.md
+++ b/doc/src/dc/demos/tb3_stdout.md
@@ -263,6 +263,6 @@ So...what happened?
 3. In parallel, each time the map plugin sends a ROS message, it also saves the files on the filesystem. Open a file browser to the path you set in the configuration to a path mentioned in the map JSON
 4. The "robot" group node subscribes to /dc/measurement/cmd_vel, /dc/measurement/position and /dc/measurement/speed and publish on /dc/group/robot when it collects data from all 3 topics
 5. Run ID and robot_name is appended in the JSON of each
-6. `dc_bridge`, which subscribes to `/dc/group/robot` and `/dc/measurement/map` directly, receives the data and forwards it to the external Vector process over the Fluent Forward protocol
+6. `dc_bridge`, which subscribes to `/dc/group/robot` and `/dc/measurement/map` directly, receives the data and forwards it to the external Vector process over the shipper ingest protocol
 7. Vector's generated config applies a `remap` transform that writes the configured `time_key` in the requested `time_format`
 8. Vector's `console` sink, the only one matching the `console` Destination we configured, prints the JSON to stdout

--- a/doc/src/dc/demos/uptime_stdout.md
+++ b/doc/src/dc/demos/uptime_stdout.md
@@ -114,7 +114,7 @@ dc_bridge:
 
 #### Destinations
 
-Let's analyze piece by piece. `dc_bridge` is the single C++ node that owns every Destination; each entry in the `destinations` list names a section, defined below it, that describes where data goes. We need the topic list on each Destination because the Bridge subscribes to those topics itself and forwards what it receives to an external [Vector](https://vector.dev) process over the Fluent Forward protocol.
+Let's analyze piece by piece. `dc_bridge` is the single C++ node that owns every Destination; each entry in the `destinations` list names a section, defined below it, that describes where data goes. We need the topic list on each Destination because the Bridge subscribes to those topics itself and forwards what it receives to an external [Vector](https://vector.dev) process over the shipper ingest protocol.
 
 **destinations (Mandatory)**: List all the Destinations to enable. Each name must have a matching section at the same level.
 
@@ -163,6 +163,6 @@ So...what happened?
 
 1. The measurement plugin starts publishing data to /dc/measurement/uptime, which contains the JSON and timestamp of the message
 2. Run ID and robot_name is appended in the JSON
-3. `dc_bridge`, which subscribes to this topic directly, receives the data and forwards it to Vector over the Fluent Forward protocol
+3. `dc_bridge`, which subscribes to this topic directly, receives the data and forwards it to Vector over the shipper ingest protocol
 4. Vector's generated config applies a `remap` transform that writes the configured `time_key` in the requested `time_format`
 5. Vector's `console` sink, the only one matching the `console` Destination we configured, prints the JSON to stdout

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -1,15 +1,44 @@
-# Overview
+# Destinations
 
-## DC 2.0 (Jazzy): blessed Destinations + passthrough
+A **Destination** is an external system that receives Records or Files. In the DC 2.0
+architecture (ADR-0003,
+[`docs/adr/`](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr)), the
+pluginlib destination-plugin layer is retired. The Bridge (`dc_bridge`) renders the
+external Vector **Shipper's** configuration from plain ROS parameters for a **blessed
+set** of Destination types — `postgres`, `s3`, `file`, `console` — and every other
+destination in Vector's sink catalog is available through the **passthrough**: raw Vector
+config snippets listed in the `custom_config_files` parameter, merged natively by Vector.
 
-In the DC 2.0 architecture (ADR-0003, `docs/adr/`), the pluginlib destination-plugin
-layer is retired. The Bridge (`dc_bridge`) renders the external Vector Shipper's
-configuration from plain ROS parameters for a **blessed set** of Destination types —
-`postgres`, `s3`, `file`, `console` — and every other destination in Vector's sink
-catalog is available through the **passthrough**: raw Vector config snippets listed in
-the `custom_config_files` parameter, merged natively by Vector.
+Coming from DC 1.x and its `flb_*` destination plugins? See the
+[migration guide](./migration.md).
 
-### Configuration contract
+```admonish abstract title="What is public API here"
+Three things on this page are a stable contract you can build against, not
+implementation detail:
+
+1. **The configuration shape** — `destinations: [...]` plus one block per Destination
+   with `type`, `receives`, `inputs`, and that type's own fields.
+2. **The `dc.<tag>` routes** — one Shipper route per Tag, named deterministically from
+   the topic. Passthrough snippets consume these.
+3. **The File status Record** — the fields the Uploader writes under the `dc.files` Tag.
+
+Everything else the renderer emits (component ids other than the reserved ones, the
+exact TOML layout, Vector's own defaults) may change.
+```
+
+## Bridge node parameters
+
+| Parameter                   | Description                                                                        | Type        | Default              |
+| --------------------------- | ---------------------------------------------------------------------------------- | ----------- | -------------------- |
+| `destinations`              | Names of the Destinations to enable                                                | list\[str\] | N/A (mandatory)      |
+| `shipper.data_dir`          | Directory for the Shipper's persistent disk buffer                                 | str         | `"$HOME/.dc/buffer"` |
+| `shipper.buffer_max_bytes`  | Disk-buffer size; Vector rejects anything below ~256 MiB                           | int         | Vector's minimum     |
+| `custom_config_files`       | Raw Vector config snippets (TOML) to merge — the passthrough                       | list\[str\] | `[]`                 |
+| `vector_forward_host`       | Host the Shipper's ingest socket listens on                                        | str         | `"127.0.0.1"`        |
+| `vector_forward_port`       | Port the Shipper's ingest socket listens on                                        | int         | `24224`              |
+| `files.*`                   | Uploader settings; see [File uploads](#file-uploads-receives-files-the-uploader-adr-0005) | —     | —                    |
+
+## Configuration contract
 
 Every Destination is declared in the `destinations` list of the `dc_bridge` node's
 parameters, with a parameter block named after it (see
@@ -71,7 +100,7 @@ Invalid parameters (unknown `type`, missing required field, half a credential pa
 out-of-range port…) are rejected with a clear error at Bridge startup — before Vector
 is ever started.
 
-### The `dc.<tag>` routing contract (public API)
+## The `dc.<tag>` routing contract (public API)
 
 The Bridge exposes one Shipper route per **Tag**. The Tag for a topic is its name with
 the leading `/` dropped and the remaining `/` turned into `.`
@@ -82,7 +111,7 @@ Tag verbatim (so `/dc/measurement/uptime`'s Records are consumable as
 wired to them internally, and custom snippets consume them the same way. A route
 exists for every topic listed in any configured Destination's `inputs`.
 
-### Passthrough: `custom_config_files`
+## Passthrough: `custom_config_files`
 
 Any Vector sink type ships Records with zero DC code by consuming `dc.<tag>` routes
 from a raw Vector config snippet (TOML):
@@ -108,7 +137,7 @@ Destination's name) or by another snippet. An invalid or colliding snippet is a 
 Bridge startup error naming the offending file; as a backstop, the merged config set is
 also checked with `vector validate` before the Shipper is started.
 
-### File uploads: `receives: files` (the Uploader, ADR-0005)
+## File uploads: `receives: files` (the Uploader, ADR-0005)
 
 A Destination with `receives: files` (only `type: s3` qualifies) is served by the
 Bridge's **Uploader**, not by a Vector sink: Records arriving on its `inputs` topics
@@ -166,3 +195,10 @@ dc_bridge:
       # multipart_part_size_bytes: 8388608   # optional; >= 5 MiB for real S3 stores
 ```
 
+A Destination named by `metadata_destination` may declare **no `inputs` at all** — being
+named there is itself what routes the `dc.files` Tag to it. That is the usual shape when
+the status log lives in its own table: one `postgres` Destination with `inputs` for the
+Records, and a second one with no `inputs` for the File status log.
+
+`inputs` is otherwise mandatory: a Destination that neither lists a topic nor receives
+`dc.files` would have nothing to deliver, and is rejected at Bridge startup.

--- a/doc/src/dc/faq.md
+++ b/doc/src/dc/faq.md
@@ -1,10 +1,23 @@
 # FAQ
 
-## I can't find a measurement and/or destination I need
+## I can't find a Measurement I need
 
-Even though measurements and destinations will constantly be added in the future, the current focus is on getting feedback, fixing bugs, documentation and reach a minimum test coverage.
+Measurements will keep being added, but the current focus is on getting feedback, fixing
+bugs, documentation and reaching a minimum test coverage.
 
-Create a feature request in [Github Discussions](https://github.com/Minipada/ros2_data_collection/discussions/categories/ideas-and-feature-requests)...or better, write your plugin and do a Pull Request.
+Create a feature request in [Github Discussions](https://github.com/Minipada/ros2_data_collection/discussions/categories/ideas-and-feature-requests)...or better, write your plugin and open a Pull Request.
+
+## I can't find the Destination I need
+
+You do not need one to exist. The four **blessed** Destination types are the ones DC
+configures natively from ROS parameters; everything else in Vector's catalog works today
+through the [passthrough](./destinations.md#passthrough-custom_config_files) — see the
+question below.
+
+## I'm coming from DC 1.x and my `flb_*` destinations are gone
+
+They were replaced, not dropped. The [migration guide](./migration.md) maps every
+DC 1.x Destination to its DC 2.0 equivalent with before/after configuration.
 
 ## How can I send data to a Destination that isn't blessed?
 

--- a/doc/src/dc/future_work.md
+++ b/doc/src/dc/future_work.md
@@ -3,9 +3,8 @@
 DC still being in early development, it requires:
 1. High test coverage
 2. Automation: docker image build, PR and commit builds
-3. More measurement plugins
-4. More destination plugins
+3. More Measurement plugins
+4. More blessed Destination types, promoted from the passthrough as usage justifies it
 5. Guide for the Backend developer: I would like DC to be simple enough so a web developer can run it, get the data and work on its backend application
 6. Guide for the ROS developer: I would like DC to be simple enough so a ROS developer can collect data without the expertise of knowing how to manage databases
-7. Handle python destination plugins
-8. More use cases showcased in demos
+7. More use cases showcased in demos

--- a/doc/src/dc/groups.md
+++ b/doc/src/dc/groups.md
@@ -1,7 +1,10 @@
 # Groups
 
 ## Description
-Each measurement is part of a group. This allows measurements to be grouped together later on. For example, having the measurements cpu and position belonging to the same group, data will be published together on `/dc/group/my_group`
+
+A **Group** merges the Records of several Measurements into one Record, based on time
+proximity. For example, grouping the `cpu` and `position` Measurements publishes a single
+merged Record on `/dc/group/my_group`:
 
 ```json
 {
@@ -10,7 +13,19 @@ Each measurement is part of a group. This allows measurements to be grouped toge
 }
 ```
 
-Currently, this node is written in python. The main reason for it is that we don't know how to allocate and pass different amount of variables to the TimeSynchronizer. In python it is quite simple, but not so in C++.
+A merged Record is an ordinary Record from there on: it carries the Tag derived from its
+output topic, and a Destination receives it by listing that topic in `inputs`.
+
+```admonish info
+The Group node is written in Python: allocating and passing a variable number of inputs to
+the `ApproximateTimeSynchronizer` is straightforward there and awkward in C++.
+```
+
+```admonish warning title="tags no longer selects a Destination"
+As with Measurements, a Group's DC 1.x `tags` parameter no longer routes anything —
+remove it and list the Group's `output` topic in the receiving Destination's `inputs`.
+See the [migration guide](./migration.md#tags-what-changed).
+```
 
 ## Node parameters
 
@@ -27,7 +42,6 @@ Currently, this node is written in python. The main reason for it is that we don
 | sync_delay         | Delay to wait during all subscriber data need to reach before being published again | float       | 5.0                 |
 | group_key          | Dictionary key under which data is grouped                                          | str         | {group_name}        |
 | exclude_keys       | List of keys to exclude from the published data. Data depth is separated by a dot   | list\[str\] | N/A                 |
-| tags               | Destination names, used to know where data will be forwarded to                     | list\[str\] | N/A                 |
 | nested_data        | Whether measurements are nested dictionaries or flat                                | bool        | false               |
 | include_group_name | Include group name in the JSON as key="name" and value=<group_key>                  | bool        | true                |
 
@@ -36,29 +50,25 @@ Currently, this node is written in python. The main reason for it is that we don
 ```yaml
 group_server:
   ros__parameters:
-    groups: ["map", "memory_uptime"]
+    groups: ["memory_cpu", "memory_uptime", "cameras", "map"]
     memory_cpu:
       inputs: ["/dc/measurement/memory", "/dc/measurement/cpu"]
       output: "/dc/group/memory_cpu"
       sync_delay: 5.0
       group_key: "memory_cpu"
-      tags: ["pgsql"]
     memory_uptime:
       inputs: ["/dc/measurement/memory", "/dc/measurement/uptime"]
       output: "/dc/group/memory_uptime"
       sync_delay: 5.0
       group_key: "memory_uptime"
-      tags: ["console"]
     cameras:
       inputs: ["/dc/measurement/camera"]
       output: "/dc/group/cameras"
       sync_delay: 5.0
       group_key: "cameras"
-      tags: ["rustfs", "console"]
     map:
       inputs: ["/dc/measurement/map"]
       output: "/dc/group/map"
       sync_delay: 5.0
       group_key: "map"
-      tags: ["rustfs", "console"]
 ```

--- a/doc/src/dc/infrastructure_setup.md
+++ b/doc/src/dc/infrastructure_setup.md
@@ -1,1 +1,14 @@
 # Infrastructure setup
+
+DC delivers Records and Files to systems you run yourself. These pages cover bringing up
+the ones the demos and examples assume:
+
+| Page                                    | Used as                                                        |
+| --------------------------------------- | -------------------------------------------------------------- |
+| [PostgreSQL](./infrastructure_setup/postgresql.md) | A `postgres` Destination, and the File status log   |
+| [RustFS](./infrastructure_setup/rustfs.md)         | An `s3` Destination, for Records and for File uploads |
+| [InfluxDB](./infrastructure_setup/influxdb.md)     | A passthrough Destination (`influxdb_logs`)         |
+| [IP camera](./infrastructure_setup/ip_camera.md)   | An RTSP source for the IP camera Measurement        |
+
+The compose files live in `tools/infrastructure/docker/`. None of this is required to run
+DC — the `console` and `file` Destinations need nothing external.

--- a/doc/src/dc/introduction.md
+++ b/doc/src/dc/introduction.md
@@ -8,13 +8,12 @@
 
 **Source code**: [https://github.com/minipada/ros2_data_collection](https://github.com/minipada/ros2_data_collection)
 
-[![ROS 2](https://img.shields.io/badge/ROS%202-humble-informational?style=for-the-badge)](https://docs.ros.org/en/humble/index.html) ![python](https://img.shields.io/badge/python-3.10.4-informational?style=for-the-badge) ![C++](https://img.shields.io/badge/C++-17-informational?style=for-the-badge)
+[![ROS 2](https://img.shields.io/badge/ROS%202-jazzy-informational?style=for-the-badge)](https://docs.ros.org/en/jazzy/index.html) ![python](https://img.shields.io/badge/python-3.12-informational?style=for-the-badge) ![C++](https://img.shields.io/badge/C++-17-informational?style=for-the-badge)
 
 [![codecov](https://codecov.io/gh/Minipada/ros2_data_collection/branch/humble/graph/badge.svg?token=Y2UA5OE0KR)](https://codecov.io/gh/Minipada/ros2_data_collection) [![tests](https://minipada.testspace.com/spaces/219054/badge?token=8214fc76eff8c09b47136742d644d2a1ac0e38e3)](https://minipada.testspace.com/spaces/219054?utm_campaign=badge&utm_medium=referral&utm_source=test)
 
-| Humble                                                                                                                                                                                                                        |
+| Jazzy                                                                                                                                                                                                                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [![Docker](https://github.com/minipada/ros2_data_collection/actions/workflows/docker.yaml/badge.svg)](https://github.com/minipada/ros2_data_collection/actions/workflows/docker.yaml)                                         |
 | [![Format](https://github.com/minipada/ros2_data_collection/actions/workflows/format.yaml/badge.svg)](https://github.com/minipada/ros2_data_collection/actions/workflows/format.yaml)                                         |
 | [![Documentation](https://github.com/minipada/ros2_data_collection/actions/workflows/doc.yaml/badge.svg)](https://github.com/minipada/ros2_data_collection/actions/workflows/doc.yaml)                                        |
 | [![Github Pages](https://github.com/Minipada/ros2_data_collection/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/Minipada/ros2_data_collection/actions/workflows/pages/pages-build-deployment) |
@@ -24,6 +23,7 @@
 For detailed instructions:
 
 - [Setup](https://minipada.github.io/ros2_data_collection/dc/setup.html)
+- [Migrating from DC 1.x to DC 2.0](https://minipada.github.io/ros2_data_collection/dc/migration.html)
 - [Demos](https://minipada.github.io/ros2_data_collection/dc/demos.html)
 - [Concepts](https://minipada.github.io/ros2_data_collection/dc/concepts.html)
 - [Data Pipeline](https://minipada.github.io/ros2_data_collection/dc/data_pipeline.html)
@@ -45,7 +45,7 @@ For detailed instructions:
 
 The DC (Data Collection) project aims at integrating data collection pipelines into ROS 2. The goal is to integrate data collection pipelines with existing APIs to enable data analytics, rather than live monitoring, which already has excellent tools available. As companies increasingly turn to autonomous robots, the ability to understand and improve operations for any type of machine in any environment has become crucial. This involves mostly pick and drop and inspection operations. This framework aims at helping collecting, validating (through JSON schemas) and sending reliably the data to create such APIs and dashboards.
 
-DC uses a modular approach, based on [pluginlib](https://index.ros.org/p/pluginlib/) and greatly inspired by [Nav2](https://navigation.ros.org/) for its architecture. Pluginlib is used to configure which measurements are collected. Measurements are pluginlib plugins. Data leaves the robot through the Bridge (`dc_bridge`), a thin ROS 2 node that renders and supervises an external Shipper, [Vector](https://vector.dev/): *Vector is a fast, lightweight observability data pipeline, distributed as a single static binary, with native sinks for PostgreSQL, S3-compatible storage, and many more. DC gets its performance, reliability, and data integrity (backpressure handling and disk buffering) without embedding or forking it*.
+DC uses a modular approach, based on [pluginlib](https://index.ros.org/p/pluginlib/) and greatly inspired by [Nav2](https://navigation.ros.org/) for its architecture. Pluginlib is used to configure which **Measurements** are collected. Data leaves the robot through the **Bridge** (`dc_bridge`), a thin ROS 2 node that renders and supervises an external **Shipper**, [Vector](https://vector.dev/): *Vector is a fast, lightweight observability data pipeline, distributed as a single static binary, with native sinks for PostgreSQL, S3-compatible storage, and many more. DC gets its performance, reliability, and data integrity (backpressure handling and disk buffering) without embedding or forking it*. Four **Destination** types are configured natively from ROS parameters; every other Vector sink is reachable by passing raw Shipper configuration through, with no DC code.
 
 ## Why collect data from robots?
 
@@ -62,17 +62,17 @@ DC uses a modular approach, based on [pluginlib](https://index.ros.org/p/pluginl
 
 * **Open source**: Currently all tools on the market are not open source. This project is in [MPL-2.0 license](https://www.mozilla.org/en-US/MPL/2.0/), in summary you can use without asking permission and without paying
 * **Modular approach**: based on pluginlib and greatly inspired by Nav2 for its architecture
-* **Reliable data collection**: validate and send data to create APIs and dashboards
-* **Flexible data collection**: set polling interval for each measurement or collect every measurement with StringStamped messages
-* **Customizable validation**: validate data using existing or customized JSON schemas
-* **Easy to extend**: add new measurements or destinations by simply adding a plugin
+* **Reliable data collection**: validate and send Records to create APIs and dashboards
+* **Flexible data collection**: set polling interval for each Measurement or collect every Measurement with StringStamped messages
+* **Customizable validation**: validate Records using existing or customized JSON schemas
+* **Easy to extend**: add new Measurements by writing a plugin; add new Destinations with configuration alone
 * **Flexible data collection conditions**: collect data based on conditions such as whether the robot is moving or if a field is equal to a value
 * **Trigger-based data collection**: collect data when a defined set of combination of all, any, or no condition are met
 * **Customizable record collection**: configure the number of records to collect at the start and when a condition is activated.
 * **Data inspection**: inspect data from camera input including barcode and QR codes
-* **Fast and efficient**: high performance, using an external Vector shipper for backend processing, and designed to minimize code duplication and reduce human errors
-* **Grouped measurements**: measurements can be grouped using the group node based on the ApproximateTimeSynchronizer
-* **File saving**: files can be saved, including map_server maps, camera images, and any file produced by a measurement
+* **Fast and efficient**: high performance, using an external Shipper for delivery, and designed to minimize code duplication and reduce human errors
+* **Grouped Measurements**: Records can be merged into Groups using the group node, based on the ApproximateTimeSynchronizer
+* **File uploads**: Files — `map_server` maps, camera images, videos, anything a Measurement produces — are uploaded to object storage with verified, resumable transfers, and their metadata is recorded as a Record
 * **Easy to use**: designed to be easy to learn and use
 * **No C++ 3rd party library required**: all 3rd party libraries have a vendor package in the repository
 
@@ -121,14 +121,14 @@ flowchart LR
         end
     end
 
-    subgraph g_n["Group node"]
+    subgraph g_n["Group node (merged Records)"]
         gr_boot_system["System (boot)"]
         gr_system["System"]
         gr_robot["Robot"]
         gr_inspection["Inspection"]
     end
 
-    subgraph d_n["Destination node"]
+    subgraph d_n["Bridge + Shipper → Destinations"]
         pl_pgsql["PostgreSQL"]
         pl_rustfs["RustFS"]
         pl_s3["S3"]
@@ -151,9 +151,9 @@ flowchart LR
     gr_boot_system -- os, network interfaces\n, permissions and uptime --> pl_pgsql
     gr_robot -- Robot cmd_vel, position. speed --> pl_pgsql
     gr_system -- Available space,\n memory used and cpu usage --> pl_pgsql
-    gr_inspection -- Image paths on s3 and rustfs --> pl_pgsql
-    gr_inspection -- Raw, rotated and/or inspected images --> pl_rustfs
-    gr_inspection -- Raw, rotated and/or inspected images --> pl_s3
+    gr_inspection -- File metadata Records --> pl_pgsql
+    gr_inspection -- "Raw, rotated and/or inspected images (Files)" --> pl_rustfs
+    gr_inspection -- "Raw, rotated and/or inspected images (Files)" --> pl_s3
 ```
 
 # License

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -1,6 +1,9 @@
 # Measurements
+
 ## Description
-Measurements are a single data unit presented in JSON format, that can contain different fields. For example, Memory measurement:
+
+A **Measurement** is a source of sampled data that emits **Records** — timestamped JSON
+documents — on its own ROS topic. For example, a Record from the Memory Measurement:
 
 ```json
 {
@@ -16,8 +19,20 @@ Measurements are a single data unit presented in JSON format, that can contain d
 
 ## Node parameters
 
-This node enables data collection from ROS 2 topics. Each topic is configured in a measurement, which is loaded in this node with pluginlib; the Bridge (`dc_bridge`) subscribes to the same topics and forwards Records to the destinations enabled there (see [Destinations](./destinations.md)).
-In addition, conditions are pluginlibs plugin also loaded dynamically. They are optional plugins that allow to collect on some conditions, e.g robot is moving.
+This node collects data and publishes it as Records. Each Measurement is a pluginlib
+plugin loaded into this node and publishes on its own `topic_output`; the Bridge
+(`dc_bridge`) subscribes to those topics and forwards the Records to the Destinations
+that list them in `inputs` (see [Destinations](./destinations.md)). **Conditions** are
+pluginlib plugins loaded here too — optional predicates that gate whether a Measurement
+collects, e.g. only when the robot is not moving.
+
+```admonish warning title="tags no longer selects a Destination"
+In DC 1.x, a Measurement's `tags` parameter named the destination plugins that should
+receive its Records. In DC 2.0, a Destination declares the topics it receives in its own
+`inputs` list. The parameter is still read, and a non-empty value is still written into
+the Record as a `tags` field, but it has no routing effect — remove it. See the
+[migration guide](./migration.md#tags-what-changed).
+```
 
 | Parameter name                                 | Description                                                                                                                                                 | Type(s)     | Default                       |
 | ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------- |
@@ -53,9 +68,8 @@ Each measurement is collected through a node and has these configuration paramet
 | **condition_max_measurements** | Collect a maximum of n measurements when conditions are activated (-1 = never, 0 = infinite) | int         | 0                                    |
 | **enable_validator**           | Will validate the data against a JSON schema                                                 | bool        | true                                 |
 | **json_schema_path**           | Path to the JSON schema, ignored if empty string                                             | str         | N/A (optional)                       |
-| **tags**                       | Destination names, used by the Bridge to match Records to destinations                       | list\[str\] | N/A (mandatory)                      |
-| **remote_prefixes**            | Prefixes to apply to the paths when sending files to a destination                           | str         | N/A (optional)                       |
-| **remote_keys**                | Used by some plugins to generate remote paths                                                | list\[str\] | N/A (optional)                       |
+| **remote_prefixes**            | Prefixes to apply to the remote paths of the Files this Measurement produces                 | str         | N/A (optional)                       |
+| **remote_keys**                | Destination names the Files this Measurement produces are uploaded to; each becomes a key under the Record's `remote_paths` | list\[str\] | N/A (optional) |
 | **if_all_conditions**          | Collect only if all conditions are activated                                                 | list\[str\] | N/A (optional)                       |
 | **if_any_conditions**          | Collect if any conditions is activated                                                       | list\[str\] | N/A (optional)                       |
 | **if_none_conditions**         | Collect only if all conditions are not activated                                             | list\[str\] | N/A (optional)                       |

--- a/doc/src/dc/migration.md
+++ b/doc/src/dc/migration.md
@@ -1,0 +1,605 @@
+# Migrating from DC 1.x to DC 2.0
+
+DC 1.x (the `humble` line) embedded Fluent Bit inside the ROS 2 process and exposed one
+pluginlib **destination plugin** per output (`flb_pgsql`, `flb_minio`, `flb_s3`, …).
+DC 2.0 (the `jazzy` line) retires that layer: an external **Shipper** process
+([Vector](https://vector.dev/)) does the buffering and delivery, and the **Bridge**
+(`dc_bridge`) renders the Shipper's whole configuration from plain ROS parameters.
+
+The reasoning is recorded in [`docs/adr/`](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr):
+ADR-0001 (external shipper replaces embedded Fluent Bit), ADR-0002 (Vector as the
+default shipper), ADR-0003 (blessed Destinations + passthrough), ADR-0005 (file uploads
+are a Bridge responsibility), ADR-0006 (the Bridge lives outside the lifecycle manager)
+and ADR-0007 (the Bridge is C++).
+
+```admonish info
+Nothing in the **collection** half of DC changed. Measurement plugins, Conditions,
+Groups, JSON schema validation, and the `dc_interfaces/StringStamped` message are the
+same. Everything below is about the **delivery** half.
+```
+
+## At a glance
+
+| DC 1.x (Humble)                                       | DC 2.0 (Jazzy)                                                                 |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `destination_server` node                             | `dc_bridge` node                                                               |
+| `destination_plugins: [...]`                          | `destinations: [...]`                                                          |
+| `plugin: "dc_destinations/FlbPgSQL"`                  | `type: postgres`                                                               |
+| 13 pluginlib destination plugins                      | 4 **blessed** types (`postgres`, `s3`, `file`, `console`) + **passthrough**    |
+| Embedded Fluent Bit (forked, built from source)       | External Vector binary, vendored by `vector_vendor`, supervised by the Bridge  |
+| `flb.*` service parameters                            | `shipper.data_dir` / `shipper.buffer_max_bytes` (Vector's own defaults for the rest) |
+| `tags: [...]` on Measurements/Groups selects outputs  | A Destination's `inputs: [...]` topic list selects what it receives            |
+| `flb_minio` + `flb_files_metrics` to upload Files     | One `receives: files` Destination + one `files:` block (the Bridge's Uploader) |
+| `src_fields` / `upload_fields` field lists            | Gone — the Uploader reads `local_paths` / `remote_paths` from the Record       |
+| A destination not in the list needs a new C++ plugin  | Any Vector sink via `custom_config_files` — no DC code                         |
+| Fluent Bit Go plugins (`out_minio.so`, `plugin_path`) | Gone — no Go toolchain, no `plugin_path`                                       |
+
+## The five edits that cover most configurations
+
+1. Rename the node: `destination_server:` → `dc_bridge:`.
+2. Rename the list: `destination_plugins:` → `destinations:`.
+3. Replace each plugin's `plugin: "dc_destinations/Flb…"` with `type: <blessed type>`
+   and add `receives: records` (or `receives: files`, see [Files](#files-flb_minio--flb_files_metrics)).
+4. Delete every `tags:` entry from `measurement_server` and `group_server`, and delete
+   the whole `flb:` block. Routing is now the Destination's `inputs:` list.
+5. Add a `shipper:` block with a `data_dir` for Vector's disk buffer.
+
+A minimal before/after:
+
+```yaml
+# DC 1.x
+destination_server:
+  ros__parameters:
+    flb:
+      flush: "1"
+      storage_path: "/var/log/flb-storage/"
+      storage_sync: "full"
+      scheduler_cap: "2000"
+    destination_plugins: ["flb_stdout"]
+    flb_stdout:
+      plugin: "dc_destinations/FlbStdout"
+      inputs: ["/dc/measurement/uptime"]
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime"]
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      topic_output: "/dc/measurement/uptime"
+      tags: ["flb_stdout"]
+```
+
+```yaml
+# DC 2.0
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["console"]
+    console:
+      type: console
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime"]
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      topic_output: "/dc/measurement/uptime"
+```
+
+## Tags: what changed
+
+In DC 1.x, a Measurement's `tags` parameter named the destination plugins that should
+receive its Records, and the embedded engine matched the two.
+
+In DC 2.0 a **Tag** is derived mechanically from the topic a Record was published on —
+the leading `/` is dropped and the remaining `/` become `.`, so
+`/dc/measurement/uptime` carries the Tag `dc.measurement.uptime`. Every Tag is exposed
+on the Shipper as the public route `dc.<tag>` (see
+[the routing contract](./destinations.md#the-dctag-routing-contract-public-api)), and a
+Destination subscribes by listing the **topics** it wants in `inputs`.
+
+Consequences for a migrated configuration:
+
+- **Delete `tags:`** from every Measurement and Group. It no longer selects a
+  Destination. (The parameter is still read and, if non-empty, still written into the
+  Record's JSON as a `tags` field — harmless, but it is data, not routing.)
+- **A Destination's `inputs` is the routing decision.** To send a Measurement's Records
+  to two Destinations, list its `topic_output` in both Destinations' `inputs`.
+- **`remote_keys` on file-producing Measurements must be renamed to the Destination
+  name.** See below.
+
+## Destination-by-destination reference
+
+The `...` in the "before" snippets stands for the surrounding `destination_server:` /
+`ros__parameters:` block; the "after" snippets sit under `dc_bridge:` /
+`ros__parameters:`. Destination names (`console`, `pgsql`, `rustfs`, …) are yours to
+choose — only `type` is fixed.
+
+### `flb_stdout` → blessed `console`
+
+```yaml
+# Before
+flb_stdout:
+  plugin: "dc_destinations/FlbStdout"
+  inputs: ["/dc/group/data"]
+  format: "json"
+  json_date_key: "date"
+  json_date_format: "iso8601"
+```
+
+```yaml
+# After
+destinations: ["console"]
+console:
+  type: console
+  receives: records
+  inputs: ["/dc/group/data"]
+  time_key: "date"          # was json_date_key
+  time_format: "iso8601"    # was json_date_format; "double" | "iso8601"
+```
+
+`format` is gone: the `console` Destination always writes JSON.
+
+### `rcl` → blessed `console`
+
+The `rcl` plugin re-published Records through ROS 2 logging. There is no equivalent —
+Records leave the ROS graph at the Bridge. Use the `console` Destination above; it
+writes to the Bridge's stdout, which your ROS 2 launch and journald capture already.
+
+### `flb_pgsql` → blessed `postgres`
+
+```yaml
+# Before
+flb_pgsql:
+  plugin: "dc_destinations/FlbPgSQL"
+  inputs: ["/dc/group/data"]
+  host: "127.0.0.1"
+  port: 5432
+  user: fluentbit
+  password: password
+  database: "fluentbit"
+  table: "dc"
+  timestamp_key: "date"
+  async: false
+  time_format: "double"
+  time_key: "date"
+```
+
+```yaml
+# After
+destinations: ["pgsql"]
+pgsql:
+  type: postgres
+  receives: records
+  inputs: ["/dc/group/data"]
+  host: "127.0.0.1"
+  port: 5432
+  user: "dc"
+  password: "$DC_PG_PASSWORD"   # $VAR / ${VAR} are expanded from the environment
+  database: "dc"
+  table: "dc"
+  time_key: "date"              # was timestamp_key *and* time_key; now one field
+  time_format: "double"
+```
+
+`async`, `min_pool_size`/`max_pool_size` and the other connection-pool knobs are gone —
+Vector manages its own connections. Note that the Shipper's `postgres` sink maps each
+Record's **top-level JSON keys onto existing columns**; it does not create tables or
+columns. Create the table up front (see
+[`tools/infrastructure/docker/config/postgresql/init.sql`](https://github.com/minipada/ros2_data_collection/blob/jazzy/tools/infrastructure/docker/config/postgresql/init.sql)
+for the demo schema).
+
+### `flb_s3` → blessed `s3`
+
+```yaml
+# Before
+flb_s3:
+  plugin: "dc_destinations/FlbS3"
+  inputs: ["/dc/group/data"]
+  bucket: my-bucket
+  region: us-west-2
+  total_file_size: "50M"
+  use_put_object: false
+  compression: "gzip"
+  s3_key_format: "/$TAG/%Y/%m/%d/%H_%M_%S.gz"
+```
+
+```yaml
+# After
+destinations: ["s3"]
+s3:
+  type: s3
+  receives: records
+  inputs: ["/dc/group/data"]
+  bucket: "my-bucket"
+  region: "us-west-2"
+  key_prefix: "records/"       # replaces s3_key_format's directory part
+  batch_timeout_secs: 60       # object write interval; Vector's default is 300
+  # access_key_id / secret_access_key omitted: ambient AWS credentials are used
+```
+
+`total_file_size`, `use_put_object`, `compression` and `s3_key_format` have no DC
+parameter — Vector's `aws_s3` sink owns batching, compression and key naming. If you
+need to override its defaults, express the sink through the
+[passthrough](#anything-else-passthrough) instead.
+
+### `flb_file` → blessed `file`
+
+```yaml
+# Before
+flb_file:
+  plugin: "dc_destinations/FlbFile"
+  inputs: ["/dc/group/memory_uptime"]
+  path: "$HOME/data"
+  file: "uptime"
+  format: "out_file"
+  mkdir: true
+```
+
+```yaml
+# After
+destinations: ["local_log"]
+local_log:
+  type: file
+  receives: records
+  inputs: ["/dc/group/memory_uptime"]
+  path: "$HOME/data/uptime-%Y-%m-%d.log"   # one field; Vector template syntax allowed
+```
+
+`path` and `file` merge into a single `path`, which accepts Vector's template syntax
+(strftime specifiers, `{{ field }}` interpolation) so one Destination can fan out across
+files. Parent directories are always created (`mkdir` is gone), and the output is always
+newline-delimited JSON (`format`, `delimiter`, `label_delimiter` are gone).
+
+### Files: `flb_minio` + `flb_files_metrics`
+
+This is the one migration that collapses two plugins, two copies of the same
+credentials, and four hand-maintained field lists into a single Destination.
+
+In DC 1.x, uploading a camera image or a map meant:
+
+- `flb_minio` (a Go plugin loaded from `plugin_path`) to push the bytes, configured with
+  `src_fields` (where local paths live in the Record) and `upload_fields` (where remote
+  paths live);
+- `flb_files_metrics` (a second Go plugin) to record upload status in PostgreSQL,
+  configured with the **same** object-store credentials, the **same** field lists, plus
+  its own `pgsql.*` block;
+- and `flb_pgsql` for the Records themselves.
+
+```yaml
+# Before
+destination_plugins: ["flb_minio", "flb_files_metrics", "flb_pgsql"]
+flb_minio:
+  plugin: "dc_destinations/FlbMinIO"
+  inputs: ["/dc/measurement/camera", "/dc/measurement/map"]
+  plugin_path: "/root/ws/src/ros2_data_collection/dc_destinations/flb_plugins/lib/out_minio.so"
+  endpoint: 127.0.0.1:9000
+  access_key_id: XEYqG4ZcPY5jiq5i
+  secret_access_key: ji011KCtI82ZeQS6UwsQAg8x9VR4lSaQ
+  use_ssl: false
+  create_bucket: true
+  bucket: "mybucket"
+  src_fields: ["local_paths.inspected", "local_paths.pgm", "local_paths.yaml"]
+  upload_fields:
+    ["remote_paths.minio.inspected", "remote_paths.minio.pgm", "remote_paths.minio.yaml"]
+flb_files_metrics:
+  plugin: "dc_destinations/FlbFilesMetrics"
+  inputs: ["/dc/measurement/camera", "/dc/measurement/map"]
+  file_storage: ["minio"]
+  db_type: "pgsql"
+  delete_when_sent: true
+  minio:
+    endpoint: 127.0.0.1:9000
+    access_key_id: XEYqG4ZcPY5jiq5i
+    secret_access_key: ji011KCtI82ZeQS6UwsQAg8x9VR4lSaQ
+    use_ssl: false
+    bucket: "mybucket"
+    src_fields: ["local_paths.inspected", "local_paths.pgm", "local_paths.yaml"]
+    upload_fields:
+      ["remote_paths.minio.inspected", "remote_paths.minio.pgm", "remote_paths.minio.yaml"]
+  pgsql:
+    host: "127.0.0.1"
+    port: "5432"
+    user: fluentbit
+    password: password
+    database: "fluentbit"
+    table: "files_metrics"
+    ssl: false
+```
+
+```yaml
+# After
+destinations: ["pgsql", "pgsql_files", "rustfs"]
+pgsql:                                 # the Records themselves
+  type: postgres
+  receives: records
+  inputs: ["/dc/measurement/camera", "/dc/measurement/map"]
+  host: "127.0.0.1"
+  port: 5432
+  user: "dc"
+  password: "$DC_PG_PASSWORD"
+  database: "dc"
+  table: "dc"
+pgsql_files:                           # the per-File status log (was files_metrics)
+  type: postgres
+  receives: records
+  # no `inputs`: fed only by files.metadata_destination below
+  host: "127.0.0.1"
+  port: 5432
+  user: "dc"
+  password: "$DC_PG_PASSWORD"
+  database: "dc"
+  table: "dc_files"
+rustfs:                                # the File bytes (was flb_minio)
+  type: s3
+  receives: files
+  inputs: ["/dc/measurement/camera", "/dc/measurement/map"]
+  bucket: "dc-files"
+  endpoint: "http://127.0.0.1:9000"
+  region: "us-east-1"
+  access_key_id: "rustfsadmin"
+  secret_access_key: "$DC_S3_SECRET"
+  force_path_style: true
+files:
+  delete_when_sent: true
+  metadata_destination: "pgsql_files"
+```
+
+What disappeared and why:
+
+| DC 1.x                                          | DC 2.0                                                                                     |
+| ----------------------------------------------- | -------------------------------------------------------------------------------------------|
+| `plugin_path` + a Go build                      | Nothing — the Uploader is C++ inside `dc_bridge`                                           |
+| `src_fields` / `upload_fields`                  | Nothing — the Uploader reads `local_paths` / `remote_paths` straight from the Record       |
+| `file_storage: ["minio", "s3"]`                 | Every `receives: files` Destination is used; the Record's `remote_paths` keys pick which   |
+| A second copy of the object-store credentials   | One Destination block, used for both the upload and the status log                         |
+| `db_type` + a `pgsql:` sub-block                | `files.metadata_destination`, naming an ordinary `receives: records` Destination           |
+| `use_ssl: false`                                | The scheme in `endpoint` (`http://` vs `https://`)                                         |
+| `create_bucket: true`                           | Nothing — create the bucket out-of-band (the demo compose file does this with a one-shot container) |
+| `ignored` column in `files_metrics`             | Dropped; the status log is append-only (a deletion appends `deleted: true` instead of updating) |
+
+````admonish warning title="Rename remote_keys to the Destination name"
+The Uploader sends a File to the `receives: files` Destination whose **name is a key in
+the Record's `remote_paths`**. File-producing Measurements build those keys from their
+`remote_keys` parameter, which in DC 1.x conventionally said `minio`:
+
+```yaml
+# Before
+map:
+  plugin: "dc_measurements/Map"
+  remote_keys: ["minio"]     # produced remote_paths.minio.{yaml,pgm}
+
+# After
+map:
+  plugin: "dc_measurements/Map"
+  remote_keys: ["rustfs"]    # must equal the Destination name declared on dc_bridge
+```
+
+If the two disagree, the Files are collected but never uploaded, and no status Record is
+emitted.
+````
+
+Two guarantees the Uploader adds over `flb_files_metrics`: uploads are **multipart and
+resumable** (an interrupted transfer resumes from the last completed part), and a
+`kind: group_complete` marker Record is emitted only once **every** File referenced by a
+Record has been verified on **every** Destination that receives it. See
+[File uploads](./destinations.md#file-uploads-receives-files-the-uploader-adr-0005) for
+the full contract.
+
+```admonish info title="MinIO to RustFS"
+MinIO's community edition was archived upstream in 2026. DC 2.0's demos and
+infrastructure files use [RustFS](https://rustfs.com/) (Apache 2.0, S3-compatible)
+instead. This is a *recommendation*, not a requirement — the blessed `s3` type talks to
+MinIO, Ceph RGW, or AWS S3 with the same parameters.
+```
+
+### `flb_http` → passthrough `http`
+
+```yaml
+# Before
+flb_http:
+  plugin: "dc_destinations/FlbHTTP"
+  inputs: ["/dc/measurement/data"]
+  host: "127.0.0.1"
+  port: 80
+  uri: "/"
+  format: "json"
+```
+
+```yaml
+# After — dc_bridge parameters
+destinations: ["console"]              # keep at least one blessed Destination, or none
+custom_config_files: ["$HOME/.dc/http_sink.toml"]
+```
+
+```toml
+# After — $HOME/.dc/http_sink.toml
+[sinks.my_http]
+type = "http"
+inputs = ["dc.dc.measurement.data"]    # the public dc.<tag> route for that topic
+uri = "http://127.0.0.1:80/"
+encoding.codec = "json"
+```
+
+`http_user`/`http_passwd` become Vector's `auth.strategy = "basic"` block; `header`
+entries become a `[sinks.my_http.request.headers]` table.
+
+### `flb_influxdb` → passthrough `influxdb_logs`
+
+```yaml
+# Before
+flb_influxdb:
+  plugin: "dc_destinations/FlbInfluxDB"
+  inputs: ["/dc/measurement/uptime"]
+  host: "127.0.0.1"
+  port: 8086
+  database: "ros"
+```
+
+```toml
+# After — a passthrough snippet listed in custom_config_files
+[sinks.influxdb]
+type = "influxdb_logs"
+inputs = ["dc.dc.measurement.uptime"]
+endpoint = "http://127.0.0.1:8086"
+measurement = "dc"
+
+[sinks.influxdb.influxdb1_settings]
+database = "ros"
+```
+
+A complete, runnable version of this ships with the demos —
+[`dc_demos/config/tb3_simulation_influxdb_sink.toml`](https://github.com/minipada/ros2_data_collection/blob/jazzy/dc_demos/config/tb3_simulation_influxdb_sink.toml),
+used by the [InfluxDB demo](./demos/tb3_aws_influxdb.md). For InfluxDB 2.x use
+`influxdb2_settings` with `org`, `bucket` and `token` instead.
+
+### `flb_kinesis_streams` → passthrough `aws_kinesis_streams`
+
+```yaml
+# Before
+flb_kinesis_streams:
+  plugin: "dc_destinations/FlbKinesisStreams"
+  inputs: ["/dc/measurement/data"]
+  region: "us-east-1"
+  stream: my_stream
+```
+
+```toml
+# After
+[sinks.kinesis]
+type = "aws_kinesis_streams"
+inputs = ["dc.dc.measurement.data"]
+region = "us-east-1"
+stream_name = "my_stream"
+partition_key_field = "name"
+encoding.codec = "json"
+```
+
+`role_arn` becomes Vector's `auth.assume_role`.
+
+### `flb_slack` → passthrough `http`
+
+Vector has no dedicated Slack sink; post to the same incoming webhook with the `http`
+sink.
+
+```yaml
+# Before
+flb_slack:
+  plugin: "dc_destinations/FlbSlack"
+  inputs: ["/dc/group/data"]
+  webhook: https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX
+```
+
+```toml
+# After
+[transforms.slack_payload]
+type = "remap"
+inputs = ["dc.dc.group.data"]
+source = '. = { "text": encode_json(.) }'   # Slack wants {"text": "..."}
+
+[sinks.slack]
+type = "http"
+inputs = ["slack_payload"]
+uri = "$SLACK_WEBHOOK_URL"
+encoding.codec = "json"
+```
+
+### `flb_tcp` → passthrough `socket`
+
+```yaml
+# Before
+flb_tcp:
+  plugin: "dc_destinations/FlbTCP"
+  inputs: ["/dc/measurement/uptime"]
+  host: "127.0.0.1"
+  port: 5170
+```
+
+```toml
+# After
+[sinks.tcp]
+type = "socket"
+inputs = ["dc.dc.measurement.uptime"]
+mode = "tcp"
+address = "127.0.0.1:5170"
+encoding.codec = "json"
+```
+
+### `flb_null` → delete it, or passthrough `blackhole`
+
+`flb_null` discarded Records. In DC 2.0 a topic that is not listed in any Destination's
+`inputs` is simply never routed anywhere, so the usual migration is to **delete the
+destination entirely**. If you were using it to exercise the pipeline under load, the
+equivalent is Vector's `blackhole` sink:
+
+```toml
+[sinks.devnull]
+type = "blackhole"
+inputs = ["dc.dc.measurement.data"]
+```
+
+### Anything else: passthrough
+
+Any sink in [Vector's catalog](https://vector.dev/docs/reference/configuration/sinks/)
+— Kafka, Elasticsearch, Loki, Datadog, ClickHouse, GCP, Azure … — is reachable the same
+way, with no DC code and no new language toolchain. See
+[Destinations](./destinations.md#passthrough-custom_config_files) for the rules
+(snippets must not redefine component ids the generated config owns, and the merged set
+is checked with `vector validate` before the Shipper starts).
+
+## Service-level parameters
+
+The `flb:` block configured the embedded Fluent Bit engine. Vector's equivalents are
+either its own defaults or a `shipper:` parameter on the Bridge.
+
+| DC 1.x `flb.*`                                                       | DC 2.0                                                                     |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------|
+| `storage_path`                                                       | `shipper.data_dir` (default `$HOME/.dc/buffer`)                            |
+| `storage_backlog_mem_limit`                                          | `shipper.buffer_max_bytes` (Vector's minimum is ~256 MiB)                  |
+| `flush`, `grace`                                                     | Vector's own flush/shutdown behaviour; no DC parameter                     |
+| `log_level`                                                          | Vector's `VECTOR_LOG` environment variable                                 |
+| `storage_sync`, `storage_checksum`, `in_storage_type`                | Vector's disk buffers are always durable and checksummed; no DC parameter  |
+| `scheduler_cap`, `scheduler_base`                                    | Vector's per-sink retry backoff; no DC parameter                           |
+| `http_server`, `metrics`                                             | Vector's `internal_metrics` source via the passthrough                     |
+| `in_storage_pause_on_chunks_overlimit`                               | Vector applies backpressure to the Bridge instead; no DC parameter         |
+
+Two Bridge parameters replace the implicit in-process connection between the measurement
+node and the embedded engine:
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    vector_forward_host: "127.0.0.1"   # where the Shipper listens
+    vector_forward_port: 24224
+```
+
+## Build and runtime changes
+
+- **No Fluent Bit fork.** DC 1.x built a patched Fluent Bit (and, before #235, needed
+  root to run it). `fluent_bit_plugins` and `dc_destinations` no longer exist.
+- **No Go toolchain.** The `out_minio.so` / `out_files_metrics.so` Go plugins are gone
+  along with `plugin_path`.
+- **Vector is vendored.** `vector_vendor` downloads a pinned, checksummed Vector binary
+  at build time. Point `-Dvector_path=/usr/bin/vector` (or `VECTOR_PATH`) at a
+  system-installed binary for air-gapped builds.
+- **Startup is ordered.** The Bridge starts before the collection nodes and a readiness
+  gate blocks activation until the Shipper is accepting connections, so no Record is
+  produced before the pipeline can accept it. See
+  [Data Pipeline](./data_pipeline.md).
+
+See [Setup](./setup.md) for the resulting install, which is now `rosdep install` +
+`colcon build`.
+
+## Migration checklist
+
+- [ ] `destination_server:` renamed to `dc_bridge:`, `destination_plugins:` to `destinations:`
+- [ ] Every destination has a `type:` and a `receives:` instead of a `plugin:`
+- [ ] The `flb:` block is deleted; `shipper.data_dir` is set
+- [ ] Every `tags:` entry under `measurement_server` / `group_server` is deleted
+- [ ] Every Destination lists the topics it should receive in `inputs:`
+- [ ] File-producing Measurements' `remote_keys` match a `receives: files` Destination name
+- [ ] `files.metadata_destination` names a `receives: records` Destination
+- [ ] Un-blessed destinations are expressed as `custom_config_files` snippets consuming `dc.<tag>` routes
+- [ ] Destination tables exist in PostgreSQL, and object-storage buckets are created
+- [ ] Secrets moved out of the params file into `$VAR` environment references

--- a/doc/src/dc/setup.md
+++ b/doc/src/dc/setup.md
@@ -1,114 +1,125 @@
 # Setup
 
-## Use docker
+DC 2.0 is an ordinary ROS 2 workspace: `rosdep install`, `colcon build`, done. There is
+no forked shipper to compile, no Go toolchain, and nothing needs root.
 
-### Available images
+```admonish info
+This is the DC 2.0 (`jazzy`) install. The `humble` line still embeds a patched Fluent Bit
+and has a considerably longer setup; if you are coming from it, read the
+[migration guide](./migration.md).
+```
 
-Docker images with latest code are available on the [Docker public registry](https://hub.docker.com/repository/docker/minipada/ros2_data_collection):
+## Requirements
 
-| Image                                           | Description                                                     |
-| ----------------------------------------------- | --------------------------------------------------------------- |
-| minipada/ros2_data_collection:humble-ci         | ROS base image augmented with all DC dependencies to use for CI |
-| minipada/ros2_data_collection:humble-ci-testing | CI image using the ROS testing repository                       |
-| minipada/ros2_data_collection:humble-source     | DC source compiled                                              |
-| minipada/ros2_data_collection:humble-source-sim | DC source compiled with all simulation packages                 |
-| minipada/ros2_data_collection:humble-doc        | Documentation                                                   |
+- ROS 2 Jazzy (`ros-jazzy-ros-base` or larger), on Ubuntu 24.04 or a Debian equivalent
+- `colcon`, `rosdep`, `git`, a C++17 compiler
+- x86-64 or aarch64 — the architectures `vector_vendor` has a pinned Vector binary for
 
-Get any by running:
+## Build
 
 ```bash
-docker pull minipada/ros2_data_collection:<TAG>
-```
+# 1. Clone into a workspace
+mkdir -p ~/ws/src && cd ~/ws/src
+git clone https://github.com/minipada/ros2_data_collection.git
 
-### Docker workflow
-
-When developing, use the *source-sim* image with a docker compose file. The latest one is available on the repository:
-
-```yaml
-version: "3.9"
-
-services:
-  ros2-data-collection:
-    image: minipada/ros2_data_collection:humble-source-sim
-    privileged: true
-    container_name: ros2-data-collection
-    environment:
-      - QT_X11_NO_MITSHM=1
-      - NVIDIA_VISIBLE_DEVICES=all
-      - NVIDIA_DRIVER_CAPABILITIES=compute,utility,display
-      - DISPLAY=unix$DISPLAY
-      - XAUTHORITY=$XAUTHORITY
-    volumes:
-      - ${HOME}/.Xauthority:/root/.Xauthority
-      - /tmp/.X11-unix:/tmp/.X11-unix
-      - /var/run/docker.sock:/var/run/docker.sock
-      - ${PWD}:/root/ws/src/ros2_data_collection
-    network_mode: "host"
-    restart: "unless-stopped"
-    stop_grace_period: "3s"
-    runtime: nvidia
-    command: tail -F anything
-    working_dir: /root/ws
-```
-
-Then, to allow GUI (RViz, Gazebo) to work in the container, execute:
-
-```bash
-xhost +
-```
-
-Then start the container:
-
-```bash
-docker compose up -d
-```
-
-And get in the container with:
-```bash
-docker exec -it ros2-data-collection /ros_entrypoint.sh bash
-```
-
-## Build from source
-
-### Download the repository
-Given that there is no apt packages available, you will need to build from source.
-
-Download the repository in your workspace
-
-```bash
-git clone github.com/minipada/ros2_data_collection.git
-```
-
-### Install dependencies
-#### Install system and C/C++ dependencies
-```
+# 2. Register DC's local rosdep rules (two header-only C++ libraries upstream
+#    rosdistro has no key for), then resolve dependencies
+cd ~/ws
+echo "yaml file://$PWD/src/ros2_data_collection/rosdep/dc.yaml" \
+  | sudo tee /etc/ros/rosdep/sources.list.d/10-dc.list
+rosdep update
 rosdep install --from-paths src --ignore-src -r -y
-```
 
-Some packages are external C++ packages but a vendor package has been included in the repository so colcon will handle it.
-In addition, since this set of packages has no python external dependencies, you won't need anything else.
-
-#### Install python dependencies
-This project uses [poetry](https://python-poetry.org/) to manage python dependencies. It is easy to use and it is possible to set each package version like in a requirements.txt and manage multiple python environments.
-If you have poetry on your machine, you can execute:
-
-`poetry install`
-
-If not, you can install python dependencies from the provided requirements.txt:
-
-`pip3 install -r requirements.txt`
-
-### Build
-
-```bash
+# 3. Build
+source /opt/ros/jazzy/setup.bash
 colcon build
 ```
 
-### Run
-```bash
-source install/setup.bash
-ros2 launch dc_bringup bringup.launch.py
+That is the whole install. `colcon build` also runs `vector_vendor`, which downloads a
+pinned, checksummed [Vector](https://vector.dev/) binary — the external **Shipper** the
+Bridge supervises at runtime (ADR-0002).
+
+```admonish tip title="Air-gapped or distro-packaged Vector"
+Point the build at a Vector binary you already have instead of downloading one:
+
+    colcon build --cmake-args -Dvector_path=/usr/bin/vector
+
+The `VECTOR_PATH` environment variable does the same thing.
 ```
 
+```admonish warning title="Simulation demo packages"
+`dc_demos` and `dc_simulation` still target Gazebo Classic, which Jazzy dropped. Until
+they are ported (tracked in [#268](https://github.com/minipada/ros2_data_collection/issues/268)),
+exclude them if their dependencies are not resolvable on your machine:
+
+    touch src/ros2_data_collection/dc_demos/COLCON_IGNORE
+    touch src/ros2_data_collection/dc_simulation/COLCON_IGNORE
+```
+
+### Python dependencies
+
+Only some Measurement plugins (camera inspection, QR code detection) need Python
+packages beyond what ROS 2 installs. `rosdep` covers the ones with rosdistro keys; for
+the rest:
+
+```bash
+pip3 install -r requirements.txt   # or `poetry install`
+```
+
+## Run
+
+```bash
+source install/setup.bash
+ros2 launch dc_bringup dc_bringup.launch.py
+```
+
+The default parameters file (`dc_bringup/params/dc_params.yaml`) collects uptime and
+writes it to a local PostgreSQL Destination. To run your own:
+
+```bash
+ros2 launch dc_bringup dc_bringup.launch.py params_file:=/path/to/my_params.yaml
+```
+
+See [Configuration examples](./configuration_examples.md) for configurations you can
+copy, and [Destinations](./destinations.md) for the full Bridge configuration contract.
+
+### Useful launch arguments
+
+| Argument      | Default          | Description                                                |
+| ------------- | ---------------- | ---------------------------------------------------------- |
+| `params_file` | `dc_params.yaml` | Parameters file for every DC node                          |
+| `group_node`  | `False`          | Start the Group node (needed by any `group_server` config) |
+| `namespace`   | `""`             | Top-level namespace                                        |
+| `log_level`   | `info`           | Log level for the DC nodes                                 |
+| `autostart`   | `True`           | Let the lifecycle manager configure and activate the nodes |
+
+### What starts, in what order
+
+`dc_bringup.launch.py` brings the pipeline up deterministically (ADR-0006): the Bridge
+and its Shipper first, then a readiness gate, and only then the collection nodes. If the
+Shipper never becomes ready, the launch shuts down loudly instead of collecting data
+nowhere. [Data Pipeline](./data_pipeline.md) describes this in full.
+
+## Containers
+
+The repository builds a full workspace image with Podman — the same one CI uses:
+
+```bash
+IMAGE_TAG=dc-workspace:local ./tools/e2e/scripts/build.sh
+```
+
+`tools/e2e/scripts/test.sh` runs `colcon test` against that image, and
+`tools/e2e/scripts/run.sh` drives the zero-loss end-to-end harness. See
+[`tools/e2e/README.md`](https://github.com/minipada/ros2_data_collection/blob/jazzy/tools/e2e/README.md).
+
+## Infrastructure
+
+DC delivers to systems you run yourself. `tools/infrastructure/docker/` has compose
+files that bring up PostgreSQL and RustFS (S3-compatible object storage) preconfigured
+for the demos; see [Infrastructure setup](./infrastructure_setup.md).
+
 ## Issues
-If you run into any issues when building ROS 2 Data Collection, you can use the search tool in the issues tab on [GitHub](https://github.com/minipada/ros2_data_collection) and always feel free to [open a ticket](https://github.com/minipada/ros2_data_collection).
+
+If you run into problems building DC, search the issue tracker on
+[GitHub](https://github.com/minipada/ros2_data_collection/issues) and feel free to
+[open a ticket](https://github.com/minipada/ros2_data_collection/issues/new).

--- a/progress.txt
+++ b/progress.txt
@@ -1149,3 +1149,126 @@ the cause, not a real regression.
   `pycln`, `flake8`); `mdbook` isn't installed either, so the doc site itself wasn't
   built, though a manual code-fence-balance check across every edited `.md` file found
   no unbalanced fences.
+
+### #252 - DC 2.0 S11: Migration guide + docs overhaul
+
+- **New `doc/src/dc/migration.md`** — the DC 1.x → DC 2.0 migration guide, added to
+  `SUMMARY.md` right after Setup. Covers **all 13** Humble destination plugins with
+  before/after YAML (the issue says "eleven"; the authoritative list is
+  `origin/humble:dc_destinations/destination_plugin.xml`, which registers 12 `flb_*`
+  classes plus `rcl` — every one is covered, so the superset satisfies the criterion):
+  `flb_stdout`/`flb_pgsql`/`flb_s3`/`flb_file` → the blessed `console`/`postgres`/`s3`/
+  `file` types; `rcl` → `console` (no ROS-logging equivalent exists — Records leave the
+  ROS graph at the Bridge); `flb_http`/`flb_influxdb`/`flb_kinesis_streams`/`flb_slack`/
+  `flb_tcp`/`flb_null` → passthrough Vector snippets (`http`, `influxdb_logs`,
+  `aws_kinesis_streams`, `http` + a `remap` for Slack's `{"text": …}` envelope, `socket`
+  with `mode = "tcp"`, `blackhole` — or, for `flb_null`, just deleting the destination,
+  since an unlisted topic is now routed nowhere by construction). The
+  `flb_minio` + `flb_files_metrics` case gets its own section: two Go plugins, two copies
+  of the object-store credentials and four hand-maintained `src_fields`/`upload_fields`
+  lists collapse into one `receives: files` Destination + one `files:` block, with a
+  table of what disappeared and why (`plugin_path`, `file_storage`, `db_type`,
+  `use_ssl`, `create_bucket`, the `ignored` column). Tag renaming is called out in its
+  own admonition: `remote_keys: ["minio"]` → `remote_keys: ["<destination name>"]`,
+  since the Uploader matches the Destination name against the Record's `remote_paths`
+  keys and a mismatch silently uploads nothing. Also a `flb.*` → `shipper.*` service
+  parameter table, the "five edits that cover most configurations" opener, and a
+  migration checklist.
+- **`setup.md` rewritten** to the actual DC 2.0 install: clone → register
+  `rosdep/dc.yaml` as a local rosdep source → `rosdep install` → `colcon build`. No
+  Fluent Bit fork, no Go, no root, and the whole `minipada/ros2_data_collection:humble-*`
+  Docker-image section (those images are humble-line and nothing publishes them on this
+  branch) replaced with the Podman `tools/e2e/scripts/build.sh` path. Documents
+  `-Dvector_path=` / `VECTOR_PATH` for air-gapped builds, the `dc_demos`/`dc_simulation`
+  `COLCON_IGNORE` caveat (#268), the real launch file name
+  (`dc_bringup.launch.py` — the old page said `bringup.launch.py`, which does not
+  exist) and its useful arguments.
+- **Vocabulary overhaul** across `concepts.md` (now opens with the CONTEXT.md glossary
+  table + relationships, and an explicit "shipper ingest protocol" admonition replacing
+  "Fluent Forward" as a component name), `data_pipeline.md` (rewritten from a
+  startup-ordering-only page into the full path of a Record — mermaid diagram, the
+  five stages, a where-each-piece-is-configured table, the separate File path, plus the
+  existing ADR-0006 ordering and a durability/supervision section that states the one
+  lossy window and at-least-once delivery honestly) and `destinations.md` (retitled from
+  "Overview", added a Bridge node-parameter table and an explicit "what is public API
+  here" admonition). Also `measurements.md`, `groups.md`, `configuration_examples.md`,
+  `introduction.md`/`README.md` (jazzy badges, the dead `docker.yaml` badge removed,
+  "Destination node" → "Bridge + Shipper → Destinations" in the pipeline diagram),
+  `faq.md`, `future_work.md`, `data_validation.md`, `infrastructure_setup.md` (was a
+  bare heading; now indexes the four infra pages) and the `Fluent Forward` phrasing in
+  three demo pages.
+- **`tags` documented as dead, not silently kept**: verified in source before writing —
+  `dc_measurements/.../measurement.hpp::addTags` still declares the parameter and still
+  injects a `tags` field into the Record's JSON, but `dc_bridge/src/render.cpp` routes
+  purely on `.tag` (the Forward tag derived from the topic in `topic_config.cpp`), never
+  on that JSON field. So the docs now say exactly that: the parameter is read and
+  written as *data*, has no routing effect, and should be removed. Dropped the `tags`
+  rows from the measurements/groups parameter tables and every `tags:` line from the
+  configuration examples.
+- **Public-API framing (acceptance criterion 4)**: `destinations.md` now states the three
+  stable contracts (the `destinations`/`type`/`receives`/`inputs` config shape, the
+  `dc.<tag>` route names, the File status Record fields) and what is explicitly *not*
+  stable. Documented the previously-undocumented case that a Destination named by
+  `files.metadata_destination` may legally declare no `inputs` at all (`render.cpp`'s
+  `EmptyInputs` check passes because `extra_tags` carries `dc.files`) — the shape both
+  demos actually use.
+- **Small code fix pulled in because the docs claimed it worked**: removed
+  `dc_cli`'s `list_plugins destinations` command. It called
+  `get_package_share_directory("dc_destinations")`, a package deleted in #250, so the
+  command could only ever raise; `cli.md` documented it as working.
+- **Docs build wired into CI for real (acceptance criterion 5)** — this is the "#252 is
+  the tracked place to re-wire a live jazzy docs build" note in
+  `containers/doc/Containerfile` and `tools/ci/pre-commit/build_doc.sh` coming due:
+  - `containers/doc/Containerfile` rewritten: fully-qualified base
+    (`docker.io/library/rust:1.96-bookworm`) and **pinned** mdbook toolchain
+    (mdbook 0.4.52, mdbook-admonish 1.20.0, mdbook-mermaid 0.14.1, mdbook-open-on-gh
+    2.4.3, mdbook-linkcheck 0.7.7, strictdoc 0.0.40). Pinning is not cosmetic: mdbook's
+    preprocessor ABI is not stable, and the current-latest mdbook 0.5.4 fails outright
+    against every one of those preprocessors.
+  - `tools/ci/pre-commit/build_doc.sh` rewritten from `docker run` against a
+    never-published `minipada/ros2_data_collection:<distro>-doc` tag to `podman
+    build` + `podman run` against a locally built `dc-doc:<tag>` image, doing both the
+    strictdoc export (into `doc/src/dc/requirements`, already gitignored) and
+    `mdbook build`. `.pre-commit-config.yaml`'s `build-doc` entry lost its now-meaningless
+    `--ros-version=humble` argument.
+  - `.github/workflows/doc.yaml` rewritten from the humble-branch, `container: image:`
+    workflow into a jazzy-branch Podman job that calls that same script (no CI-only docs
+    script, matching `ci.yaml`'s philosophy), uploads the site as an artifact, and
+    deploys to Pages on push. Image tagged `dc-doc:<github.sha>` for traceability, not
+    pushed (nothing consumes it).
+  - `doc/book.toml` fixes needed to make the build actually pass: dropped the
+    `multilingual` key (removed from mdbook's schema), re-ran `mdbook-admonish install`
+    to move the checked-in assets from 2.0.0 → 3.1.0 (mdbook-admonish hard-fails on a
+    mismatch) with the regenerated CSS consolidated back into `doc/css/`, pointed
+    `edit-url-template` at `jazzy` instead of `humble`, and set `follow-web-links =
+    false` — external link checking is flaky in a way that says nothing about the docs
+    (github.com 403s the checker's user-agent outright), while internal links, which are
+    what a docs change can actually break, are still checked and still fail the build.
+- **Verification — the docs build was actually run, not just wired**: `mdbook build`
+  passes with the html + linkcheck backends (zero broken internal links; `create-missing
+  = false` means a bad SUMMARY entry would also fail), and the full containerized
+  `IMAGE_TAG=dc-doc:local ./tools/ci/pre-commit/build_doc.sh` — the exact command CI
+  runs — completes strictdoc export + mdbook build + linkcheck cleanly. `pre-commit run`
+  over all 25 changed files passes everything including `build-doc`, `hadolint`,
+  `shellcheck`, `codespell`, `black`, `isort` and `check-yaml`; only the three
+  long-standing environment-gap hooks still fail here (`pycln` and `flake8` are broken
+  installs — missing `pkg_resources`/`pyproject.toml` in their pre-commit venvs — and
+  `poetry-requirements` needs a `poetry` that isn't installed), same as every prior
+  DC 2.0 slice.
+  - Caught and fixed two rendering bugs that a "does it build?" check alone would have
+    missed, by grepping the generated HTML for unprocessed `admonish` blocks:
+    mdbook-admonish silently leaves a block as literal text (no error, exit 0) if its
+    `title="…"` contains backticks or a `→`, which had broken four admonitions across
+    `migration.md`, `groups.md` and `measurements.md`; and a fenced code block nested
+    inside an admonition needs a 4-backtick outer fence — the `~~~`-inside-``` form
+    parses as CommonMark but mdbook-admonish does not handle it. Also verified the
+    cross-page anchors (`#the-dctag-routing-contract-public-api`,
+    `#passthrough-custom_config_files`,
+    `#file-uploads-receives-files-the-uploader-adr-0005`) against the ids mdbook
+    actually generated.
+- **Deliberately left alone**: `requirements/*.sdoc` still contains a requirement worded
+  around matching samples to destinations "using tags". That register describes intended
+  capability (routing a Record to a chosen Destination), which still holds — only the
+  configuration syntax changed — and rewriting requirements is not a docs overhaul.
+  `dc_bridge/README.md` keeps saying "Fluent Forward" where it describes the wire format
+  at the implementation level, which is what CONTEXT.md permits.

--- a/tools/ci/pre-commit/build_doc.sh
+++ b/tools/ci/pre-commit/build_doc.sh
@@ -1,70 +1,47 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-# Build the documentation.
+# Build the documentation site (mdbook) and the strictdoc requirements export.
 #
-# Pulls a published minipada/ros2_data_collection:<ROS_VERSION>-doc image; nothing
-# currently builds/pushes a fresh one (the workflow job that did, docker.yaml's `doc`
-# job, was removed as humble-line dead weight — see containers/doc/Containerfile's
-# header). A live jazzy docs build is tracked at #252 (DC 2.0 S11), not this script.
+# Called by both the `build-doc` pre-commit hook and .github/workflows/doc.yaml, so a
+# local docs build and the CI docs build run the same toolchain — there is no CI-only
+# docs script. The toolchain lives in a Podman image built from
+# containers/doc/Containerfile with pinned mdbook/strictdoc versions (mdbook's
+# preprocessor ABI is not stable across minor versions).
+#
+# Output: doc/book/html (site) and doc/src/dc/requirements/html (requirements export,
+# generated before mdbook runs so mdbook copies it into the site).
+#
+# Environment:
+#   IMAGE_TAG   Tag for the builder image (default dc-doc:local; CI passes dc-doc:<sha>)
+#   ENGINE      Container engine (default podman)
 
-# Arguments parsing
-# Example:
-# ./build_doc.sh -ros-version="humble"
-help() {
-usage="$(basename "$0") --ros-version=<ROS_VERSION> [ --help ]
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+IMAGE_TAG="${IMAGE_TAG:-dc-doc:local}"
+ENGINE="${ENGINE:-podman}"
 
-Build documentation
+echo "==> Building the docs toolchain image ${IMAGE_TAG}"
+"${ENGINE}" build -t "${IMAGE_TAG}" -f "${REPO_ROOT}/containers/doc/Containerfile" \
+    "${REPO_ROOT}/containers/doc"
 
-Arguments:
---help          Show this help text
---ros-version   ROS version to use, will use different containers (mandatory)
-"
-    echo "${usage}"
+run_in_image() {
+    "${ENGINE}" run --rm \
+        -v "${REPO_ROOT}:/ws:z" \
+        --workdir "/ws${1}" \
+        "${IMAGE_TAG}" \
+        "${@:2}"
 }
 
-for i in "$@"
-do
-case $i in
-    --ros-version=*)
-    ROS_VERSION="${i#*=}"
-    shift # past argument=value
-    ;;
-    --help)
-    HELP=YES
-    shift # past argument with no value
-    ;;
-    *)
-    # unknown option
-    ;;
-esac
-done
-
-# Arguments check
-if [ -n "${HELP}" ]; then
-    help
-    exit 0
-fi
-
-if [ -z "${ROS_VERSION}" ]; then
-    help
-    exit 1
-fi
-
-docker run \
-    --rm \
-    -v "${PWD}:/ws" \
-    --workdir /ws/doc "minipada/ros2_data_collection:${ROS_VERSION}-doc" \
-    mdbook build
-
-docker run \
-    --rm \
-    -v "${PWD}:/ws" \
-    --workdir /ws "minipada/ros2_data_collection:${ROS_VERSION}-doc" \
-   strictdoc export requirements \
+echo "==> Exporting the strictdoc requirements"
+run_in_image "" strictdoc export requirements \
     --experimental-enable-file-traceability \
     --enable-mathjax \
     --format=html \
-    --output-dir /ws/doc/book/html/dc/requirements \
+    --output-dir doc/src/dc/requirements \
     --project-title "ROS 2 Data Collection"
+
+echo "==> Building the book"
+run_in_image "/doc" mdbook build
+
+echo "==> Documentation built in doc/book/html"


### PR DESCRIPTION
Closes #252

## What this does

### Migration guide (new page: `doc/src/dc/migration.md`)

A DC 1.x → DC 2.0 migration guide with before/after YAML for **every** Humble
Destination. The issue says eleven; the authoritative list
(`origin/humble:dc_destinations/destination_plugin.xml`) registers 12 `flb_*` classes
plus `rcl`, and all 13 are covered:

| Humble | DC 2.0 |
|---|---|
| `flb_stdout`, `flb_pgsql`, `flb_s3`, `flb_file` | blessed `console` / `postgres` / `s3` / `file` |
| `rcl` | `console` (Records leave the ROS graph at the Bridge; no logging equivalent) |
| `flb_minio` + `flb_files_metrics` | one `receives: files` Destination + one `files:` block |
| `flb_http`, `flb_influxdb`, `flb_kinesis_streams`, `flb_slack`, `flb_tcp`, `flb_null` | passthrough Vector snippets (`http`, `influxdb_logs`, `aws_kinesis_streams`, `http` + `remap`, `socket`, `blackhole`) |

Plus the `flb.*` → `shipper.*` service-parameter mapping, the `tags` → `inputs` routing
inversion, the `remote_keys` → Destination-name rename (a mismatch silently uploads
nothing), and a migration checklist.

### Setup page

Rewritten to the actual install: clone → register `rosdep/dc.yaml` → `rosdep install` →
`colcon build`. No Fluent Bit fork, no Go, no root. The `humble-*` Docker image section
is gone (nothing publishes those on this branch); `-Dvector_path=` covers air-gapped
builds. Also fixes the launch file name — the old page said `bringup.launch.py`, which
does not exist.

### Vocabulary overhaul

`concepts.md`, `data_pipeline.md` and `destinations.md` moved onto the CONTEXT.md
glossary (Measurement, Record, Group, File, Bridge, Shipper, Destination, Tag), with
"shipper ingest protocol" replacing "Fluent Forward" as a component name. `data_pipeline`
grew from startup-ordering-only into the full path of a Record, including the separate
File path and an honest statement of the one lossy window (Records published while the
Bridge is down) and at-least-once delivery. Same pass over measurements, groups,
configuration examples, introduction/README, FAQ, future work and infrastructure setup.

### Public API

`destinations.md` now states the three stable contracts explicitly — the
`destinations`/`type`/`receives`/`inputs` config shape, the `dc.<tag>` route names, and
the File status Record fields — and what is *not* stable. Documents the
previously-undocumented case that a `files.metadata_destination` Destination may declare
no `inputs` (the shape both demos already use).

### `tags` is documented as dead, not silently kept

Verified in source: `measurement.hpp::addTags` still injects a `tags` field into the
Record, but `render.cpp` routes purely on the topic-derived Forward tag, never on that
field. The docs now say exactly that — read and written as data, no routing effect,
remove it — and the parameter tables and examples drop it.

### Docs build wired into CI (`.github/workflows/doc.yaml`)

This is the "#252 is the tracked place to re-wire a live jazzy docs build" note in
`containers/doc/Containerfile` coming due:

- `containers/doc/Containerfile`: fully-qualified base + **pinned** mdbook toolchain.
  Not cosmetic — mdbook's preprocessor ABI is unstable, and current-latest mdbook 0.5.4
  fails outright against every preprocessor `book.toml` declares.
- `tools/ci/pre-commit/build_doc.sh`: `docker run` against a never-published image →
  `podman build` + `podman run` against a locally built `dc-doc:<tag>`.
- `doc.yaml`: humble-branch `container: image:` → jazzy-branch Podman job calling that
  same script (no CI-only docs script, matching `ci.yaml`), artifact upload, Pages deploy
  on push.
- `book.toml` fixes needed to make it pass: dropped the removed `multilingual` key,
  bumped the checked-in mdbook-admonish assets 2.0.0 → 3.1.0, `edit-url-template` →
  `jazzy`, and `follow-web-links = false` (github.com 403s the checker; internal links,
  which a docs change can actually break, still fail the build).

### Small code fix

Removed `dc_cli`'s `list_plugins destinations` command — it read `dc_destinations`,
deleted in #250, so it could only ever raise, while `cli.md` documented it as working.

## Verification

- `mdbook build` passes with html + linkcheck backends (zero broken internal links;
  `create-missing = false` also catches bad SUMMARY entries).
- The full containerized `IMAGE_TAG=dc-doc:local ./tools/ci/pre-commit/build_doc.sh` —
  the exact command CI runs — completes strictdoc export + mdbook build + linkcheck
  cleanly.
- `pre-commit run` over all 25 changed files passes everything including `build-doc`,
  `hadolint`, `shellcheck`, `codespell`, `black`, `isort`, `check-yaml`. Only the three
  long-standing environment-gap hooks fail locally (`pycln`/`flake8` broken installs,
  `poetry-requirements` needs poetry) — same as every prior DC 2.0 slice.
- Grepped the generated HTML for unprocessed `admonish` blocks and caught two rendering
  bugs a build-only check would have missed: mdbook-admonish silently leaves a block as
  literal text (exit 0, no error) when its `title="…"` contains backticks or `→`, and a
  code fence nested in an admonition needs a 4-backtick outer fence. Cross-page anchors
  verified against the ids mdbook actually generated.

## Left alone deliberately

`requirements/*.sdoc` still words a requirement around "using tags" — that register
describes intended capability, which still holds; only the syntax changed, and rewriting
requirements is not a docs overhaul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtketjyeFWMr49Tgk3krMb