### PR TITLE
feat(dc_bridge): durable Uploader intent queue — File uploads survive Bridge restarts

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(dc_bridge_core
   src/uploader/group.cpp
   src/uploader/status.cpp
   src/uploader/multipart.cpp
+  src/uploader/intent_queue.cpp
   src/uploader/uploader.cpp)
 target_include_directories(dc_bridge_core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -62,7 +63,7 @@ install(TARGETS dc_bridge DESTINATION lib/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
-  foreach(t forwarder supervisor render misc uploader)
+  foreach(t forwarder supervisor render misc uploader intent_queue)
     ament_add_gtest(${t}_test test/${t}_test.cpp)
     target_link_libraries(${t}_test dc_bridge_core)
     target_compile_definitions(${t}_test PRIVATE

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -9,7 +9,9 @@ snippets (`custom_config_files`) through for everything else. It also hosts the
 **Uploader** (ADR-0005): `receives: files` Destinations are served by the Bridge itself —
 Records referencing Files get their Files uploaded to S3-compatible object storage
 (multipart + resumable), verified, and reported as status/metadata Records under the
-`dc.files` Tag.
+`dc.files` Tag. Pending uploads are durable (#265): each is written to a disk-backed
+intent queue before being handed to the Uploader, so a Bridge restart replays whatever
+never got acked instead of forgetting it.
 
 `dc_bridge` is an ordinary `ament_cmake` C++ package. It builds with the same `rosdep
 install` + `colcon build` as every other `dc_*` package. See
@@ -32,9 +34,11 @@ install` + `colcon build` as every other `dc_*` package. See
   - `uploader/` — the Uploader (ADR-0005): `group` (parses the Files a Record
     references), `content_type` (magic-byte sniffing), `status` (the Humble-compatible
     status-row shapes), `multipart` (resumable multipart with a per-part JSON checkpoint
-    sidecar), and `uploader` (the verify-then-delete orchestration). All built on an
-    abstract `ObjectStore` interface, so the logic is tested against an in-memory fake
-    with no cloud dependency.
+    sidecar), `intent_queue` (#265 — the disk-backed durable queue of pending uploads:
+    crash-atomic tmp+rename enqueue, ack-by-unlink, oldest-first sweep with per-entry
+    exponential backoff, replayed on startup), and `uploader` (the verify-then-delete
+    orchestration). All built on an abstract `ObjectStore` interface, so the logic is
+    tested against an in-memory fake with no cloud dependency.
 - **`src/uploader/s3_object_store.cpp`** — the aws-sdk-cpp implementation of
   `ObjectStore` (the only Uploader piece that links the SDK, via `aws_sdk_vendor`).
   Verified against RustFS (PutObject + multipart) before adoption.
@@ -44,8 +48,8 @@ install` + `colcon build` as every other `dc_*` package. See
   every Destination's `inputs` topics, forwards Records, runs the Uploader worker thread,
   and exposes a `~/ready` (`std_srvs/Trigger`) service. `rclcpp` handles SIGINT/SIGTERM
   and `on_shutdown` stops Vector, so it's never orphaned.
-- **`test/`** — gtest suites (`forwarder`, `supervisor`, `render`, `misc`, `uploader`),
-  all linking only the aws-free core.
+- **`test/`** — gtest suites (`forwarder`, `supervisor`, `render`, `misc`, `uploader`,
+  `intent_queue`), all linking only the aws-free core.
 
 ## Config renderer (ADR-0003)
 
@@ -106,7 +110,7 @@ colcon test --packages-select dc_bridge
 
 The ROS-independent core also builds and tests without a ROS install, via a standalone
 CMake project (`test/local/`) — handy for fast iteration on the Forwarder / Supervisor /
-renderer / Uploader logic:
+renderer / Uploader / intent queue logic:
 
 ```bash
 cmake -S dc_bridge/test/local -B build && cmake --build build && ctest --test-dir build

--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -16,7 +16,6 @@
 
 #include <atomic>
 #include <condition_variable>
-#include <deque>
 #include <memory>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -24,13 +23,13 @@
 #include <std_srvs/srv/trigger.hpp>
 #include <string>
 #include <thread>
-#include <utility>
 #include <vector>
 
 #include "dc_bridge/forwarder.hpp"
 #include "dc_bridge/readiness.hpp"
 #include "dc_bridge/render.hpp"
 #include "dc_bridge/supervisor.hpp"
+#include "dc_bridge/uploader/intent_queue.hpp"
 #include "dc_bridge/uploader/uploader.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
 
@@ -50,9 +49,10 @@ public:
 
 private:
   void run_prober(std::string forward_host, std::uint16_t forward_port);
-  // The Uploader worker (ADR-0005): drains the queue, processes each Record (infinite
-  // capped-backoff retry — safe because processing is idempotent), and emits status
-  // Records through its own Forwarder connection under FILE_STATUS_TAG.
+  // The Uploader worker (ADR-0005/#265): sweeps the durable intent queue oldest-first
+  // (per-entry backoff on failure — one permanently-failing intent can't starve the
+  // backlog), processes each Record, acks (unlinks) its intent on success, and emits
+  // status Records through its own Forwarder connection under FILE_STATUS_TAG.
   void run_uploader_worker(std::string forward_host, std::uint16_t forward_port);
 
   std::shared_ptr<Supervisor> supervisor_;
@@ -70,13 +70,14 @@ private:
   std::atomic<bool> stopped_{ false };
 
   // Uploader (ADR-0005) — created only when a `receives: files` destination is
-  // configured. Records on files-destination topics are queued here; the worker thread
-  // uploads their Files and emits status Records.
+  // configured. Records on files-destination topics are enqueued into the durable
+  // intent_queue_ (#265); the worker thread replays/sweeps it, uploads Files, and emits
+  // status Records.
   std::unique_ptr<uploader::Uploader> uploader_;
+  std::unique_ptr<uploader::IntentQueue> intent_queue_;
   std::thread uploader_thread_;
-  std::mutex upload_queue_mutex_;
-  std::condition_variable upload_queue_cv_;
-  std::deque<std::pair<std::string, nlohmann::json>> upload_queue_;
+  std::mutex uploader_wake_mutex_;
+  std::condition_variable uploader_wake_cv_;
   bool upload_stop_{ false };
 };
 

--- a/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
@@ -1,0 +1,106 @@
+// A disk-backed durable intent queue for the Uploader (ADR-0005 follow-up, #265):
+// Humble's embedded Fluent Bit made ingestion and durable buffering atomic (`in_ros2`
+// wrote straight into FLB's own filesystem chunks; chunk retry was the durable upload
+// state). The Bridge/Shipper split broke that for the File pipeline — an in-memory
+// queue forgets every pending upload on a Bridge restart, silently orphaning Files that
+// will never upload, report, or clean up. This restores that durability: every Record a
+// files-Destination's subscription receives is written to disk as one intent file before
+// it's ever handed to the Uploader, and it leaves the queue only via ack() after
+// processing actually succeeds — no cap, no drop-oldest, no dead-letter. An upload
+// intent and its Files live and die together.
+//
+// The in-process wake-up channel (a condition_variable in BridgeNode) is still how the
+// worker learns "there's new work" cheaply; this directory is the crash-recovery state,
+// not the communication path — on startup every unacked intent left over from a
+// previous run is replayed, oldest-first, alongside live traffic.
+#ifndef DC_BRIDGE__UPLOADER__INTENT_QUEUE_HPP_
+#define DC_BRIDGE__UPLOADER__INTENT_QUEUE_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dc_bridge::uploader
+{
+
+/// One pending upload intent, whether freshly enqueued or replayed from a previous run.
+struct Intent
+{
+  std::string id;  ///< the intent's filename — the key ack()/record_failure() take.
+  std::string tag;
+  nlohmann::json payload;
+};
+
+/// FLB's own scheduler defaults (`destination_server.cpp`'s pre-#265 Fluent Bit config):
+/// 5s base, 2000s cap.
+inline constexpr std::chrono::milliseconds DEFAULT_BASE_BACKOFF{ 5000 };
+inline constexpr std::chrono::milliseconds DEFAULT_MAX_BACKOFF{ 2000000 };
+
+/// A crash-atomic, disk-backed FIFO of upload intents with oldest-first scheduling and
+/// per-entry exponential backoff, so one permanently-failing intent can't starve the
+/// rest of the backlog behind it. Thread-safe: enqueue() is expected to run on the
+/// subscription callback's thread while next_ready()/ack()/record_failure() run on the
+/// uploader worker thread.
+class IntentQueue
+{
+public:
+  /// `dir` is created if missing. Every `*.json` file already there — a previous run's
+  /// unacked intents — is loaded immediately, oldest-first by filename, and made
+  /// eligible for next_ready() right away. A `.tmp` file (a crash mid tmp+rename) is
+  /// left untouched and simply not loaded as a pending intent.
+  explicit IntentQueue(std::string dir, std::chrono::milliseconds base_backoff = DEFAULT_BASE_BACKOFF,
+                       std::chrono::milliseconds max_backoff = DEFAULT_MAX_BACKOFF);
+
+  /// Writes one intent — `{version: 1, tag, timestamp, payload}` — to disk via tmp+write
+  /// +rename (crash-atomic; no fsync, matching FLB's `storage.sync normal`) and makes it
+  /// immediately eligible for next_ready(). Returns its id.
+  std::string enqueue(const std::string& tag, const nlohmann::json& payload);
+
+  /// Unlinks the intent's file and drops it from scheduling. Idempotent: acking an id
+  /// that's already gone (or was never known) is a no-op, never a thrown error.
+  void ack(const std::string& id);
+
+  /// Records a failed processing attempt for `id`: its backoff doubles (starting at
+  /// base_backoff, capped at max_backoff) and its next-eligible time moves out from
+  /// `now`. A no-op if `id` isn't currently pending (e.g. it was already acked).
+  void record_failure(const std::string& id,
+                      std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now());
+
+  /// The oldest pending intent whose backoff has elapsed as of `now`, or nullopt if the
+  /// queue is empty or every entry is still backing off. Does not remove it — ack() (on
+  /// success) or record_failure() (on failure) does that once the caller knows which.
+  std::optional<Intent> next_ready(std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const;
+
+  /// Number of intents currently pending on disk (ready or backing off).
+  std::size_t size() const;
+  bool empty() const;
+
+private:
+  struct Entry
+  {
+    std::string tag;
+    nlohmann::json payload;
+    // steady_clock::time_point::min() = ready immediately (never failed yet).
+    std::chrono::steady_clock::time_point next_attempt{ std::chrono::steady_clock::time_point::min() };
+    std::chrono::milliseconds backoff{ 0 };
+  };
+
+  std::string path_for(const std::string& id) const;
+
+  mutable std::mutex mutex_;
+  std::string dir_;
+  std::chrono::milliseconds base_backoff_;
+  std::chrono::milliseconds max_backoff_;
+  std::vector<std::string> order_;        // ids, oldest-first (mirrors on-disk sort order).
+  std::map<std::string, Entry> entries_;  // id -> in-memory scheduling state + payload.
+  std::uint64_t seq_{ 0 };
+};
+
+}  // namespace dc_bridge::uploader
+
+#endif  // DC_BRIDGE__UPLOADER__INTENT_QUEUE_HPP_

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -253,6 +253,10 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
     }
     uploader_ = std::make_unique<uploader::Uploader>(std::move(ucfg), std::move(storages),
                                                      uploader::ffprobe_duration_prober(files_ffprobe));
+    // The durable intent queue (#265): sibling to the Uploader's own
+    // <data_dir>/uploader multipart-resume state, replayed on every startup so a Bridge
+    // restart never forgets a pending upload.
+    intent_queue_ = std::make_unique<uploader::IntentQueue>(data_dir + "/queue/upload");
   }
 
   RenderConfig render_config;
@@ -386,11 +390,12 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
 
           if (feeds_uploader)
           {
-            {
-              std::lock_guard<std::mutex> lock(upload_queue_mutex_);
-              upload_queue_.emplace_back(tag, payload);
-            }
-            upload_queue_cv_.notify_one();
+            // Durable enqueue (#265): the intent lands on disk before this callback
+            // returns, so it survives a Bridge crash/restart even if the worker never
+            // gets to it. The condition variable is only a cheap in-process wake-up
+            // signal, not the source of truth.
+            intent_queue_->enqueue(tag, payload);
+            uploader_wake_cv_.notify_one();
           }
 
           if (forward_to_vector)
@@ -418,6 +423,12 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
                         std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
         response->success = readiness_.is_ready();
         response->message = response->success ? "vector is accepting connections" : "vector is not ready";
+        if (intent_queue_)
+        {
+          // Cheap observability hook (#265): lets an operator see the upload backlog
+          // without a separate metrics path.
+          response->message += " | upload queue depth: " + std::to_string(intent_queue_->size());
+        }
       });
 
   RCLCPP_INFO(this->get_logger(), "dc_bridge up: %zu subscribed topic(s), supervising %s", subscriptions_.size(),
@@ -460,39 +471,47 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
 
   for (;;)
   {
-    std::pair<std::string, nlohmann::json> item;
     {
-      std::unique_lock<std::mutex> lock(upload_queue_mutex_);
-      upload_queue_cv_.wait(lock, [this] { return upload_stop_ || !upload_queue_.empty(); });
-      if (upload_stop_ && upload_queue_.empty())
+      std::unique_lock<std::mutex> lock(uploader_wake_mutex_);
+      if (upload_stop_)
       {
         return;
       }
-      item = std::move(upload_queue_.front());
-      upload_queue_.pop_front();
+      // The condition_variable is only a cheap wake-up signal for a fresh enqueue; the
+      // bounded wait also re-checks periodically so a backed-off intent's retry time
+      // elapsing gets noticed even without a new Record arriving (#265 — the queue
+      // itself has no timer, only next_ready()'s point-in-time check).
+      uploader_wake_cv_.wait_for(lock, std::chrono::milliseconds(500));
+      if (upload_stop_)
+      {
+        return;
+      }
     }
 
-    auto backoff = std::chrono::milliseconds(1000);
-    while (!upload_stop_)
+    auto item = intent_queue_->next_ready();
+    if (!item)
     {
-      try
+      continue;  // empty, or every pending intent is still backing off.
+    }
+
+    try
+    {
+      const auto summary = uploader_->process_record(item->payload, item->tag, emit);
+      intent_queue_->ack(item->id);
+      if (summary.files > 0)
       {
-        const auto summary = uploader_->process_record(item.second, item.first, emit);
-        if (summary.files > 0)
-        {
-          RCLCPP_INFO(this->get_logger(),
-                      "uploader: group '%s': %zu file(s), %zu verified, %zu missing, %zu deleted, complete=%d",
-                      item.first.c_str(), summary.files, summary.verified, summary.missing, summary.deleted,
-                      static_cast<int>(summary.group_complete));
-        }
-        break;
+        RCLCPP_INFO(this->get_logger(),
+                    "uploader: group '%s': %zu file(s), %zu verified, %zu missing, %zu deleted, complete=%d",
+                    item->tag.c_str(), summary.files, summary.verified, summary.missing, summary.deleted,
+                    static_cast<int>(summary.group_complete));
       }
-      catch (const std::exception& e)
-      {
-        RCLCPP_WARN(this->get_logger(), "uploader: %s; retrying", e.what());
-        std::this_thread::sleep_for(backoff);
-        backoff = std::min(backoff * 2, std::chrono::milliseconds(60000));
-      }
+    }
+    catch (const std::exception& e)
+    {
+      // Retryable: the intent stays on disk (ack() never ran), so even a Bridge
+      // crash/restart right after this replays it — processing is idempotent (#248).
+      intent_queue_->record_failure(item->id);
+      RCLCPP_WARN(this->get_logger(), "uploader: %s; will retry intent %s with backoff", e.what(), item->id.c_str());
     }
   }
 }
@@ -523,10 +542,10 @@ void BridgeNode::stop()
     prober_thread_.join();
   }
   {
-    std::lock_guard<std::mutex> lock(upload_queue_mutex_);
+    std::lock_guard<std::mutex> lock(uploader_wake_mutex_);
     upload_stop_ = true;
   }
-  upload_queue_cv_.notify_all();
+  uploader_wake_cv_.notify_all();
   if (uploader_thread_.joinable())
   {
     uploader_thread_.join();

--- a/dc_bridge/src/uploader/intent_queue.cpp
+++ b/dc_bridge/src/uploader/intent_queue.cpp
@@ -1,0 +1,190 @@
+#include "dc_bridge/uploader/intent_queue.hpp"
+
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <system_error>
+
+namespace dc_bridge::uploader
+{
+
+namespace
+{
+
+// Wall-clock nanoseconds since epoch, zero-padded to 20 digits, plus a zero-padded
+// per-process sequence counter: sorts lexicographically in enqueue order both within one
+// run and after a restart (a fresh process starts with a later wall-clock time than
+// anything a previous run left behind; equal-timestamp collisions across restarts are
+// tolerable — the spec only requires *an* order, not a strict one, between those).
+std::string make_id(std::uint64_t now_ns, std::uint64_t seq)
+{
+  char buf[40];
+  std::snprintf(buf, sizeof(buf), "%020llu-%06llu.json", static_cast<unsigned long long>(now_ns),
+                static_cast<unsigned long long>(seq));
+  return std::string(buf);
+}
+
+std::string iso8601_now()
+{
+  const auto now = std::chrono::system_clock::now();
+  const auto secs = std::chrono::system_clock::to_time_t(now);
+  const auto us =
+      std::chrono::duration_cast<std::chrono::microseconds>(now.time_since_epoch()) % std::chrono::seconds(1);
+  std::tm tm{};
+  ::gmtime_r(&secs, &tm);
+  std::ostringstream ss;
+  ss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setfill('0') << std::setw(6) << us.count() << 'Z';
+  return ss.str();
+}
+
+}  // namespace
+
+IntentQueue::IntentQueue(std::string dir, std::chrono::milliseconds base_backoff, std::chrono::milliseconds max_backoff)
+  : dir_(std::move(dir)), base_backoff_(base_backoff), max_backoff_(max_backoff)
+{
+  std::filesystem::create_directories(dir_);
+
+  std::vector<std::string> names;
+  for (const auto& e : std::filesystem::directory_iterator(dir_))
+  {
+    if (!e.is_regular_file())
+    {
+      continue;
+    }
+    // ".json.tmp" leftovers from a crash mid tmp+rename are simply not ".json" and are
+    // left alone rather than loaded as pending intents.
+    if (e.path().extension() != ".json")
+    {
+      continue;
+    }
+    names.push_back(e.path().filename().string());
+  }
+  std::sort(names.begin(), names.end());
+
+  for (auto& name : names)
+  {
+    std::ifstream in(dir_ + "/" + name, std::ios::binary);
+    if (!in.good())
+    {
+      continue;
+    }
+    nlohmann::json doc;
+    try
+    {
+      in >> doc;
+    }
+    catch (const nlohmann::json::exception&)
+    {
+      continue;  // a "final" .json file should always be complete (rename is atomic).
+    }
+    Entry entry;
+    entry.tag = doc.value("tag", "");
+    entry.payload = doc.value("payload", nlohmann::json::object());
+    entries_.emplace(name, std::move(entry));
+    order_.push_back(name);
+  }
+}
+
+std::string IntentQueue::path_for(const std::string& id) const
+{
+  return dir_ + "/" + id;
+}
+
+std::string IntentQueue::enqueue(const std::string& tag, const nlohmann::json& payload)
+{
+  std::uint64_t now_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+  std::uint64_t seq;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    seq = seq_++;
+  }
+  const std::string id = make_id(now_ns, seq);
+
+  nlohmann::json doc{ { "version", 1 }, { "tag", tag }, { "timestamp", iso8601_now() }, { "payload", payload } };
+  const std::string final_path = path_for(id);
+  const std::string tmp_path = final_path + ".tmp";
+  {
+    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
+    out << doc.dump();
+  }
+  // No fsync (FLB `storage.sync normal` parity) — the rename itself is what makes the
+  // write crash-atomic; losing the last few milliseconds of writes on a hard power loss
+  // is an accepted, pre-existing tradeoff this queue doesn't change.
+  if (std::rename(tmp_path.c_str(), final_path.c_str()) != 0)
+  {
+    throw std::runtime_error("failed to rename intent queue entry into place: " + final_path);
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  Entry entry;
+  entry.tag = tag;
+  entry.payload = payload;
+  entries_.emplace(id, std::move(entry));
+  order_.push_back(id);
+  return id;
+}
+
+void IntentQueue::ack(const std::string& id)
+{
+  std::error_code ec;
+  std::filesystem::remove(path_for(id), ec);  // idempotent; an already-gone file is fine.
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  entries_.erase(id);
+  auto it = std::find(order_.begin(), order_.end(), id);
+  if (it != order_.end())
+  {
+    order_.erase(it);
+  }
+}
+
+void IntentQueue::record_failure(const std::string& id, std::chrono::steady_clock::time_point now)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto it = entries_.find(id);
+  if (it == entries_.end())
+  {
+    return;
+  }
+  Entry& e = it->second;
+  e.backoff = (e.backoff.count() == 0) ? base_backoff_ : std::min(e.backoff * 2, max_backoff_);
+  e.next_attempt = now + e.backoff;
+}
+
+std::optional<Intent> IntentQueue::next_ready(std::chrono::steady_clock::time_point now) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Oldest-first sweep, skipping any entry still backing off: a single
+  // permanently-failing intent enters backoff and is passed over so the rest of the
+  // backlog keeps making progress, rather than blocking behind the head of the queue.
+  for (const auto& id : order_)
+  {
+    const Entry& e = entries_.at(id);
+    if (e.next_attempt <= now)
+    {
+      return Intent{ id, e.tag, e.payload };
+    }
+  }
+  return std::nullopt;
+}
+
+std::size_t IntentQueue::size() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return order_.size();
+}
+
+bool IntentQueue::empty() const
+{
+  return size() == 0;
+}
+
+}  // namespace dc_bridge::uploader

--- a/dc_bridge/test/intent_queue_test.cpp
+++ b/dc_bridge/test/intent_queue_test.cpp
@@ -1,0 +1,224 @@
+// Exercises the durable intent queue (ADR-0005 follow-up, #265) purely on disk — no ROS,
+// no Uploader/ObjectStore needed.
+#include "dc_bridge/uploader/intent_queue.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <set>
+#include <string>
+
+using namespace dc_bridge::uploader;
+using nlohmann::json;
+
+namespace
+{
+
+struct Fixture
+{
+  std::filesystem::path dir;
+
+  Fixture()
+  {
+    dir = std::filesystem::temp_directory_path() /
+          ("dc_intent_queue_test_" + std::to_string(::getpid()) + "_" + std::to_string(counter_++));
+    std::filesystem::create_directories(dir);
+  }
+  ~Fixture()
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(dir, ec);
+  }
+
+  static std::atomic<int> counter_;
+};
+std::atomic<int> Fixture::counter_{ 0 };
+
+}  // namespace
+
+TEST(IntentQueue, EnqueueWritesOneJsonFileImmediatelyReady)
+{
+  Fixture fx;
+  IntentQueue q(fx.dir.string());
+  EXPECT_TRUE(q.empty());
+
+  const std::string id = q.enqueue("dc.measurement.camera", json{ { "name", "camera" } });
+
+  EXPECT_EQ(q.size(), 1u);
+  int json_files = 0;
+  for (auto& e : std::filesystem::directory_iterator(fx.dir))
+  {
+    if (e.path().extension() == ".json")
+    {
+      ++json_files;
+    }
+  }
+  EXPECT_EQ(json_files, 1);
+
+  auto ready = q.next_ready();
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_EQ(ready->id, id);
+  EXPECT_EQ(ready->tag, "dc.measurement.camera");
+  EXPECT_EQ(ready->payload["name"], "camera");
+}
+
+TEST(IntentQueue, AckRemovesTheIntentFileAndFromScheduling)
+{
+  Fixture fx;
+  IntentQueue q(fx.dir.string());
+  const std::string id = q.enqueue("dc.measurement.map", json{ { "name", "map" } });
+
+  q.ack(id);
+
+  EXPECT_TRUE(q.empty());
+  EXPECT_FALSE(q.next_ready().has_value());
+  int remaining = 0;
+  for (auto& e : std::filesystem::directory_iterator(fx.dir))
+  {
+    (void)e;
+    ++remaining;
+  }
+  EXPECT_EQ(remaining, 0);
+}
+
+TEST(IntentQueue, AckIsIdempotentForAnUnknownId)
+{
+  Fixture fx;
+  IntentQueue q(fx.dir.string());
+  EXPECT_NO_THROW(q.ack("00000000000000000000-000000.json"));
+  EXPECT_TRUE(q.empty());
+}
+
+TEST(IntentQueue, CrashReplayResumesPendingIntentsOldestFirst)
+{
+  Fixture fx;
+  std::string first_id;
+  {
+    IntentQueue q(fx.dir.string());
+    first_id = q.enqueue("dc.measurement.camera", json{ { "seq", 1 } });
+    q.enqueue("dc.measurement.camera", json{ { "seq", 2 } });
+  }  // "crash" — queue instance destroyed without acking anything
+
+  IntentQueue replayed(fx.dir.string());
+  EXPECT_EQ(replayed.size(), 2u);
+  auto first = replayed.next_ready();
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->id, first_id);
+  EXPECT_EQ(first->payload["seq"], 1);
+}
+
+TEST(IntentQueue, ReplayIsIdempotentAckingAfterReprocessingDropsNoOthers)
+{
+  Fixture fx;
+  std::string id_a, id_b;
+  {
+    IntentQueue q(fx.dir.string());
+    id_a = q.enqueue("dc.measurement.camera", json{ { "seq", 1 } });
+    id_b = q.enqueue("dc.measurement.camera", json{ { "seq", 2 } });
+  }
+
+  IntentQueue replayed(fx.dir.string());
+  // Simulate re-processing both replayed intents idempotently and acking each.
+  auto a = replayed.next_ready();
+  ASSERT_TRUE(a.has_value());
+  replayed.ack(a->id);
+  auto b = replayed.next_ready();
+  ASSERT_TRUE(b.has_value());
+  replayed.ack(b->id);
+
+  EXPECT_TRUE(replayed.empty());
+  EXPECT_EQ(std::set<std::string>({ a->id, b->id }), std::set<std::string>({ id_a, id_b }));
+}
+
+TEST(IntentQueue, TmpLeftoversFromACrashMidWriteAreIgnoredOnReplay)
+{
+  Fixture fx;
+  {
+    IntentQueue q(fx.dir.string());
+    q.enqueue("dc.measurement.camera", json{ { "seq", 1 } });
+  }
+  // A crash mid tmp+rename leaves a stray .tmp file behind.
+  std::ofstream(fx.dir / "99999999999999999999-000001.json.tmp") << "{not even valid json";
+
+  IntentQueue replayed(fx.dir.string());
+  EXPECT_EQ(replayed.size(), 1u);  // the stray .tmp is not counted as a pending intent
+  auto ready = replayed.next_ready();
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_EQ(ready->payload["seq"], 1);
+}
+
+TEST(IntentQueue, RoundRobinBackoffMakesProgressPastAPermanentlyFailingEntry)
+{
+  Fixture fx;
+  IntentQueue q(fx.dir.string(), std::chrono::milliseconds(1000), std::chrono::milliseconds(60000));
+  const std::string bad_id = q.enqueue("dc.measurement.camera", json{ { "seq", "bad" } });
+  const std::string good_id = q.enqueue("dc.measurement.camera", json{ { "seq", "good" } });
+
+  auto now = std::chrono::steady_clock::now();
+
+  // First sweep: the bad entry is oldest, so it's picked first; simulate it failing
+  // forever by immediately recording another failure every time it's returned.
+  auto first = q.next_ready(now);
+  ASSERT_TRUE(first.has_value());
+  EXPECT_EQ(first->id, bad_id);
+  q.record_failure(bad_id, now);
+
+  // The bad entry is now backing off; the sweep must not get stuck behind it — the good
+  // entry, still immediately ready, must be the next thing returned.
+  auto second = q.next_ready(now);
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(second->id, good_id);
+  q.ack(good_id);
+
+  // While still within the backoff window, nothing is ready (the only remaining entry
+  // is the backed-off bad one).
+  EXPECT_FALSE(q.next_ready(now + std::chrono::milliseconds(500)).has_value());
+
+  // Once the backoff elapses, the bad entry becomes ready again (and can fail forever
+  // without ever being dropped — no cap, no dead-letter).
+  auto third = q.next_ready(now + std::chrono::milliseconds(1001));
+  ASSERT_TRUE(third.has_value());
+  EXPECT_EQ(third->id, bad_id);
+}
+
+TEST(IntentQueue, BackoffDoublesAndCapsAtMaxBackoff)
+{
+  Fixture fx;
+  IntentQueue q(fx.dir.string(), std::chrono::milliseconds(1000), std::chrono::milliseconds(3000));
+  const std::string id = q.enqueue("dc.measurement.camera", json{ { "seq", 1 } });
+  auto now = std::chrono::steady_clock::now();
+
+  q.record_failure(id, now);  // backoff -> 1000ms
+  EXPECT_FALSE(q.next_ready(now + std::chrono::milliseconds(999)).has_value());
+  EXPECT_TRUE(q.next_ready(now + std::chrono::milliseconds(1001)).has_value());
+
+  q.record_failure(id, now + std::chrono::milliseconds(1001));  // backoff -> 2000ms
+  EXPECT_FALSE(q.next_ready(now + std::chrono::milliseconds(1001) + std::chrono::milliseconds(1999)).has_value());
+  EXPECT_TRUE(q.next_ready(now + std::chrono::milliseconds(1001) + std::chrono::milliseconds(2001)).has_value());
+
+  q.record_failure(id, now);  // would be 4000ms uncapped; must cap at max_backoff (3000ms)
+  EXPECT_FALSE(q.next_ready(now + std::chrono::milliseconds(2999)).has_value());
+  EXPECT_TRUE(q.next_ready(now + std::chrono::milliseconds(3001)).has_value());
+}
+
+TEST(IntentQueue, RecordsWithoutFilesNeverLingerInSteadyState)
+{
+  // A files-less Record still gets enqueued (the callback that writes to disk doesn't
+  // parse payloads), but a caller that acks immediately after a successful no-op
+  // process_record leaves nothing pending — the queue's steady state never grows for
+  // these Records, matching #265's "never touches the queue's steady-state" criterion.
+  Fixture fx;
+  IntentQueue q(fx.dir.string());
+  const std::string id = q.enqueue("dc.measurement.uptime", json{ { "uptime_s", 42 } });
+  auto ready = q.next_ready();
+  ASSERT_TRUE(ready.has_value());
+  q.ack(ready->id);
+
+  EXPECT_TRUE(q.empty());
+  (void)id;
+}

--- a/dc_bridge/test/local/CMakeLists.txt
+++ b/dc_bridge/test/local/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(dc_bridge_core
   ${CORE_ROOT}/src/uploader/group.cpp
   ${CORE_ROOT}/src/uploader/status.cpp
   ${CORE_ROOT}/src/uploader/multipart.cpp
+  ${CORE_ROOT}/src/uploader/intent_queue.cpp
   ${CORE_ROOT}/src/uploader/uploader.cpp)
 target_include_directories(dc_bridge_core PUBLIC ${CORE_ROOT}/include)
 target_link_libraries(dc_bridge_core PUBLIC nlohmann_json::nlohmann_json tomlplusplus::tomlplusplus)
@@ -36,7 +37,7 @@ if(TARGET msgpack-cxx)
 endif()
 
 enable_testing()
-foreach(t forwarder supervisor render misc uploader)
+foreach(t forwarder supervisor render misc uploader intent_queue)
   add_executable(${t}_test ${CORE_ROOT}/test/${t}_test.cpp)
   target_link_libraries(${t}_test dc_bridge_core GTest::gtest GTest::gtest_main Threads::Threads)
   target_compile_definitions(${t}_test PRIVATE

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -181,6 +181,38 @@ Two guarantees consumers can rely on:
   Retries are idempotent — already-verified objects are not re-uploaded and status rows
   are never duplicated.
 
+### Durability: the disk-backed intent queue
+
+A Bridge restart never forgets a pending upload. Before a files-Destination's Record is
+ever handed to the Uploader, it is written to disk as one **intent** — a JSON file
+(`{version: 1, tag, timestamp, payload}`) at
+`<shipper.data_dir>/queue/upload/<monotonic_ts>-<seq>.json`, via tmp-write-then-rename
+(crash-atomic; no `fsync`, matching Humble Fluent Bit's own `storage.sync normal`). The
+intent leaves the queue **only** when its Record has been fully processed — every File
+verified everywhere, or reported missing — never on a timer, a cap, or a drop-oldest
+policy: an upload intent and its Files live and die together. On startup every intent
+left over from a previous run is replayed, oldest-first, alongside live traffic; because
+processing is idempotent (an already-verified object short-circuits, multipart resumes
+from its checkpointed sidecar), a replayed intent can never re-upload or duplicate a
+status row.
+
+A permanently-failing intent cannot starve the rest of the backlog: each intent gets its
+own exponential backoff (5 s, doubling, capped at 2000 s — Humble Fluent Bit's own
+scheduler defaults) and the worker sweeps oldest-first, skipping whatever is still
+backing off rather than retrying the same head-of-line entry forever. The queue's depth
+is surfaced as a cheap observability hook in the `~/ready` service's message text.
+
+This is **at-least-once**, not exactly-once: a crash between a status Record being
+forwarded and its intent being acked can replay that status Record after restart (the
+Uploader's own dedup set is in-memory, so a fresh process may re-emit one it already
+sent). Consumers should key on the latest row per `(local_path, storage_type)`, same as
+the Records path.
+
+A Record referencing no Files is enqueued and acked in the same pass with no retries, so
+it never lingers in the queue's steady state. Note that `base64`-heavy Records (e.g. a
+map's `save_base64: on`) inline file content directly into the payload and so consume
+queue-directory bytes proportionally faster than a plain File reference.
+
 The `files` block:
 
 ```yaml

--- a/progress.txt
+++ b/progress.txt
@@ -1272,3 +1272,111 @@ the cause, not a real regression.
   configuration syntax changed — and rewriting requirements is not a docs overhaul.
   `dc_bridge/README.md` keeps saying "Fluent Forward" where it describes the wire format
   at the implementation level, which is what CONTEXT.md permits.
+
+### #265 - DC 2.0: durable Uploader intent queue — File uploads survive Bridge restarts
+
+- Added `dc_bridge::uploader::IntentQueue` (`include/dc_bridge/uploader/intent_queue.hpp`,
+  `src/uploader/intent_queue.cpp`), restoring the FLB-filesystem-parity durability the
+  Bridge/Shipper split broke for the File pipeline (#248's in-memory `upload_queue_` —
+  a `std::deque` — forgot every pending upload on a Bridge restart, silently orphaning
+  Files whose deletion only happens after verified upload). Each files-Destination
+  Record is now written to disk as one intent — `{version: 1, tag, timestamp, payload}`
+  — at `<shipper.data_dir>/queue/upload/<20-digit-wall-clock-nanos>-<6-digit-seq>.json`
+  via tmp-write-then-`rename` (crash-atomic; no `fsync`, matching Humble FLB's
+  `storage.sync normal`); the zero-padded filename sorts lexicographically in enqueue
+  order both within one run and across a restart. An intent leaves the queue **only**
+  via `ack()` (unlink) after the caller's own `process_record` succeeds — no cap, no
+  drop-oldest, no dead-letter, matching the issue's "an upload intent and its Files live
+  and die together." `next_ready()` sweeps oldest-first, skipping any entry still
+  backing off (`record_failure()` doubles a per-entry backoff from 5s, capped at
+  2000s — Humble's own FLB scheduler defaults), so one permanently-failing intent can't
+  starve the rest of the backlog. On construction every `*.json` left over from a
+  previous run is loaded immediately (ready right away — replay needs no ordering
+  guarantee beyond oldest-first, since processing is idempotent per #248); a stray
+  `.json.tmp` from a crash mid tmp+rename is simply not `.json` and is left untouched,
+  never loaded as a pending intent.
+- Wired into `BridgeNode` (`bridge_node.hpp`/`.cpp`): replaced the in-memory
+  `upload_queue_`/`upload_queue_mutex_`/`upload_queue_cv_` deque with
+  `intent_queue_` (constructed at `<data_dir>/queue/upload`, sibling to the Uploader's
+  own `<data_dir>/uploader` multipart-resume state) plus a renamed
+  `uploader_wake_mutex_`/`uploader_wake_cv_` pair that's now purely a cheap in-process
+  wake-up signal, not the queue itself — the subscription callback's `enqueue()` call
+  durably persists the intent before the callback even returns. `run_uploader_worker`
+  now: wakes on notify or a bounded 500ms timeout (so a backed-off intent's elapsed
+  retry time is noticed even with no new traffic, since the queue itself has no timer),
+  calls `next_ready()`, and on success `ack()`s the intent or on failure
+  `record_failure()`s it — replacing the old single-item infinite-retry-in-place loop.
+  `~/ready`'s response message gains a cheap observability hook: `intent_queue_->size()`
+  appended as "upload queue depth: N".
+- **Unit tests** (`dc_bridge/test/intent_queue_test.cpp`, 9 gtests, TDD — written and
+  confirmed to fail to compile before `intent_queue.hpp` existed, then implemented to
+  green on the first pass): enqueue writes one immediately-ready `.json` file; ack
+  removes the file and drops it from scheduling; ack is idempotent for an unknown id;
+  a fresh `IntentQueue` instance over the same directory (simulating a crash) replays
+  every unacked intent oldest-first; replaying and re-acking both of two intents drops
+  neither; a stray `.tmp` file from a crash mid tmp+rename is ignored on replay and
+  doesn't count toward `size()`; round-robin-with-backoff is proven to make progress
+  past a permanently-failing entry (a "bad" and a "good" intent enqueued, the bad one
+  fails and enters backoff, the next `next_ready()` call returns the good one instead of
+  blocking behind the bad one — then, once the backoff window elapses, the bad entry is
+  still there and still retryable, never dropped); backoff doubles and caps correctly;
+  a Record with no Files is enqueued-then-acked in one immediate pass, matching "never
+  touches the queue's steady-state." Wired into both `CMakeLists.txt`'s `foreach(t
+  forwarder supervisor render misc uploader intent_queue)` gtest loop and
+  `test/local/CMakeLists.txt`'s mirrored standalone-CMake list.
+- **Verified in a real ROS 2 Jazzy environment** (reused the cached `dc-workspace:latest`
+  Podman image from prior DC 2.0 sessions — bind-mounted this worktree over its
+  `/root/ws/src/ros2_data_collection`, so `aws_sdk_vendor` and every other already-built
+  package didn't need rebuilding): `colcon build --packages-select dc_bridge` and
+  `colcon test --packages-select dc_bridge` both clean (6/6 gtest suites, including the
+  new 9-test `intent_queue_test`), both before and after a `clang-format`/pre-commit
+  pass (only the environment-gap hooks skipped, same as every DC 2.0 slice:
+  `build-doc`, `poetry-requirements`, `pycln`, `flake8`; `shellcheck` and `clang-format`
+  ran for real and passed/auto-fixed cleanly).
+- **Did the actual demo end-to-end, by hand, against a live RustFS** (sharing the
+  workspace container's network namespace): started `dc_bridge` with a `receives: files`
+  RustFS Destination while RustFS was **stopped**, published a camera-shaped Record via
+  `ros2 topic pub` — the `~/ready` service immediately showed "upload queue depth: 1"
+  and the intent JSON landed on disk with the exact `{version, tag, timestamp, payload}`
+  shape. Sent a real `SIGTERM` to the running `dc_bridge` process (confirmed it and its
+  supervised Vector child both exit cleanly, no orphans — the ~30s it took is
+  aws-sdk-cpp's own connection-refused retry/backoff against the down store inside
+  `process_record`, pre-existing and unchanged by this PR, not a new deadlock). The
+  intent file and the local `img.jpg` both survived the restart on disk. Restarted
+  `dc_bridge` against the same `data_dir`, confirmed `~/ready` showed the replayed
+  "upload queue depth: 1", then started RustFS back up: the replayed intent uploaded,
+  verified, and completed automatically — `file_status`/`group_complete` rows appeared
+  on the console sink, the object landed in the RustFS bucket with the right bytes, the
+  local file was deleted (`delete_when_sent: true`), the intent file was unlinked, and
+  `~/ready` went back to "upload queue depth: 0". This is the acceptance criterion's
+  exact scenario (SIGTERM + restart with the store down, then recovery), proven live.
+- **e2e acceptance criterion — extended `tools/e2e/` rather than adding new
+  `dc_bridge`-level test infra** (the issue left this as an explicit either/or): the
+  existing zero-loss harness (#249) already does a full `podman restart` on the whole
+  `dc` container while Postgres+RustFS are down, with a camera Measurement driving the
+  real File-upload pipeline every run, and `verify_zero_loss.py`'s `check_files()`
+  already asserts the post-restart `file_status`/`group_complete` rows landed with no
+  duplicate "uploaded" rows — i.e. it already exercises this issue's scenario at the
+  container level, just without previously being able to prove the *queue itself*
+  drained (the old in-memory queue could have silently orphaned an in-flight intent
+  across that exact restart and nothing would have caught it). Added a new step to
+  `tools/e2e/scripts/run.sh` between the restart/drain sequence and
+  `verify_zero_loss.py`: asserts zero leftover `*.json` files under
+  `dc_e2e_buffer:/vol/queue/upload` (a throwaway container on the same named volume,
+  overriding the `dc-e2e` image's entrypoint for a one-off `find`) — hard-failing if
+  any intent was left orphaned. `bash -n` and `shellcheck` clean on the edited
+  `run.sh`. Documented the new step in `tools/e2e/README.md`'s numbered "What it does"
+  list (renumbered 5-7) and the restart step's cross-reference to #265.
+- **Docs**: `doc/src/dc/destinations.md`'s "File uploads" section gained a new
+  "Durability: the disk-backed intent queue" subsection (queue location and JSON shape,
+  ack-only-on-success lifecycle, replay-on-startup, round-robin+backoff scheduling,
+  the at-least-once caveat, the no-Files-noop and `base64`-Records-eat-queue-bytes-faster
+  notes) ahead of the existing `files:` params block. `dc_bridge/README.md`'s layout
+  section and package summary mention the new `intent_queue` module and gtest suite.
+- **Not done / left for follow-up** (explicitly out of scope per the issue): retention
+  policy for un-uploaded Files under disk pressure (#267); Records-path acks (#266);
+  parallel upload workers / a chunked queue-file format (only relevant if #227 raises
+  Record rates). Also not done: a committed reusable dev container for this
+  toolchain — still the same ad hoc pattern (a cached `dc-workspace:latest` image,
+  rebuilt from scratch by whichever session needs it fresh) every DC 2.0 C++ slice
+  since ADR-0007 has noted as a follow-up.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -60,8 +60,16 @@ not just a local tool.
    synthetic workload) keep running throughout, so Records keep being produced and
    buffered to disk while the destinations are down.
 4. **Full stack restart** while destinations are still down (`podman restart` on the
-   `dc` container), then destinations are restored and the stack drains.
-5. **Verification** (`tools/e2e/scripts/verify_zero_loss.py`): queries Postgres via
+   `dc` container), then destinations are restored and the stack drains. This is this
+   harness's stand-in for #265's own acceptance criterion (a files-Destination Record
+   published with the store down, the Bridge process restarted, the store then
+   restored) — the camera Measurement's File goes through exactly that path every run.
+5. **Durable upload intent queue check** (#265): asserts the on-disk intent queue
+   (`dc_bridge`'s `<shipper.data_dir>/queue/upload/`, on the `dc_e2e_buffer` named
+   volume) is empty once the run stops — proof the queue actually drained rather than
+   silently orphaning a pending upload across the restart above (the pre-#265 in-memory
+   queue would have forgotten it).
+6. **Verification** (`tools/e2e/scripts/verify_zero_loss.py`): queries Postgres via
    `podman exec` on the Postgres container (no host psycopg2/psql needed). The shipper is
    at-least-once (ADR-0002), so it **hard-fails on loss** — a gap in a synth topic's
    counter (checked against the *distinct* values, so a re-send can't hide a gap), or
@@ -69,7 +77,7 @@ not just a local tool.
    record re-sent on recovery) is reported as a note and deduplicated on read
    (exactly-once on read), not failed. Nothing here is a skip-on-missing check — a table
    that doesn't exist or a query that fails is a FAIL, not silence.
-6. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
+7. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.
    Informational only, per the PRD — it does not gate the run.
 

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -210,6 +210,27 @@ if [ -n "$STATS_PID" ] && kill -0 "$STATS_PID" 2>/dev/null; then
 fi
 STATS_PID=""
 
+# --- durable upload intent queue (#265) ----------------------------------------------
+# The outage+restart above is this harness's stand-in for #265's own e2e acceptance
+# criterion (publish a files-Destination Record with the store down, restart the whole
+# Bridge process, bring the store back up, confirm the upload completes) — the camera
+# Measurement's File already goes through that exact path every run, and
+# verify_zero_loss.py's check_files() already asserts its file_status/group_complete
+# rows landed with no duplicate "uploaded" row. What that alone can't prove is that the
+# *queue itself* drained rather than leaving an orphaned intent behind (the pre-#265
+# in-memory queue would have silently forgotten anything pending across the
+# `podman restart` above) — so assert the on-disk queue is empty via the same named
+# volume dc_bridge writes it to, overriding the image's entrypoint for a one-off `find`.
+log "verifying the durable upload intent queue drained (no orphaned intents after the outage+restart)"
+LEFTOVER_INTENTS=$(podman run --rm --entrypoint bash \
+  -v dc_e2e_buffer:/vol:ro "$DC_IMAGE" \
+  -c 'find /vol/queue/upload -maxdepth 1 -name "*.json" 2>/dev/null | wc -l')
+if [ "${LEFTOVER_INTENTS:-0}" -ne 0 ]; then
+  log "FAIL: ${LEFTOVER_INTENTS} orphaned upload intent(s) left in the queue after the run"
+  exit 1
+fi
+log "PASS: upload intent queue empty (0 orphaned intents)"
+
 # --- verify -------------------------------------------------------------------------
 log "verifying zero-loss (duplicates from the at-least-once boundary are deduped on read)"
 python3 "$SCRIPT_DIR/verify_zero_loss.py" \


### PR DESCRIPTION
## Summary

- Adds `dc_bridge::uploader::IntentQueue` (ADR-0005 follow-up): a crash-atomic, disk-backed FIFO of pending upload intents under `<shipper.data_dir>/queue/upload/`, replacing the in-memory `upload_queue_` deque that silently forgot every pending upload across a Bridge restart. Each intent (`{version: 1, tag, timestamp, payload}`) is written via tmp+rename (no fsync — FLB `storage.sync normal` parity) and leaves the queue only via `ack()` after the Uploader's own `process_record` succeeds — no cap, no drop-oldest, no dead-letter.
- Oldest-first sweep with per-entry exponential backoff (5s → 2000s, Humble FLB's own scheduler defaults) so one permanently-failing intent can't starve the rest of the backlog. Every intent left over from a previous run is replayed on startup.
- Wired into `BridgeNode`: the subscription callback durably enqueues before ever handing a Record to the Uploader; the worker thread sweeps `next_ready()`/`ack()`/`record_failure()` instead of the old single-item infinite-retry loop. Queue depth is surfaced as a cheap observability hook in the `~/ready` service message.
- Extended `tools/e2e/`'s zero-loss harness with a new step asserting the on-disk intent queue is empty after its existing outage+restart scenario — proof the durable queue actually drains rather than orphaning an intent across a restart.
- Docs: `doc/src/dc/destinations.md`'s File-uploads section gains a "Durability: the disk-backed intent queue" subsection; `dc_bridge/README.md` updated.

## Test plan

- [x] TDD: 9 new gtests in `dc_bridge/test/intent_queue_test.cpp` (enqueue/ack lifecycle, crash-replay idempotency, `.tmp` leftovers ignored, round-robin+backoff proven to make progress past a permanently-failing entry, backoff doubling/capping, no-Files-noop steady-state) — written first, confirmed to fail to compile before `intent_queue.hpp` existed, then implemented to green.
- [x] `colcon build --packages-select dc_bridge` and `colcon test --packages-select dc_bridge` (6/6 gtest suites) clean in a real ROS 2 Jazzy container, before and after `clang-format`/`pre-commit`.
- [x] Live manual demo against a real RustFS container: published a camera-shaped Record with RustFS down, confirmed the intent queued (`~/ready` showed depth 1, intent JSON on disk), sent a real `SIGTERM` to `dc_bridge` (clean exit, no orphaned Vector), confirmed the intent and local File survived the restart, restarted `dc_bridge`, brought RustFS back up, and confirmed the replayed intent uploaded/verified/completed automatically — object landed in the bucket, status + group-completion rows emitted, local File deleted, intent unlinked, queue depth back to 0.
- [x] `pre-commit` clean on every changed file (only the known environment-gap hooks skipped: `build-doc`, `poetry-requirements`, `pycln`, `flake8` — same as every prior DC 2.0 slice); `shellcheck` and `clang-format` ran for real.

Closes #265