### PR TITLE
feat(dc_bridge): confirmed delivery from Bridge to Vector via shipper ingest acks

### DIFF
--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -2,10 +2,15 @@
 
 The Bridge (ADRs 0001/0003/0005/0006/0007): a C++ (`rclcpp`) node that subscribes to
 `dc_interfaces/msg/StringStamped` Record topics and
-forwards every Record to the [Vector](https://vector.dev) shipper over the Fluent Forward
-protocol. It renders Vector's configuration from ROS parameters for the blessed
-Destination set (`postgres`, `s3`, `file`, `console` — ADR-0003) and passes raw Vector
-snippets (`custom_config_files`) through for everything else. It also hosts the
+forwards every Record to the [Vector](https://vector.dev) shipper over the shipper
+ingest protocol (the open Fluentd "Forward" wire format — no Fluentd/Fluent Bit software
+runs anywhere in the pipeline; see CONTEXT.md). Delivery is confirmed end-to-end (#266):
+every frame carries a `chunk` id and Vector's `ack` response for it clears that Record
+from an in-memory unacked window, so a Record is only forgotten once the Shipper has
+actually durably buffered it — see "Delivery guarantees" below. It renders Vector's
+configuration from ROS parameters for the blessed Destination set (`postgres`, `s3`,
+`file`, `console` — ADR-0003) and passes raw Vector snippets (`custom_config_files`)
+through for everything else. It also hosts the
 **Uploader** (ADR-0005): `receives: files` Destinations are served by the Bridge itself —
 Records referencing Files get their Files uploaded to S3-compatible object storage
 (multipart + resumable), verified, and reported as status/metadata Records under the
@@ -21,13 +26,15 @@ install` + `colcon build` as every other `dc_*` package. See
 
 - **`include/dc_bridge/` + `src/`** — the ROS-independent core, built as `dc_bridge_core`
   and unit-tested with plain gtest (no ROS or cloud needed):
-  - `forwarder` — Fluent Forward msgpack framing (msgpack-cxx), socket lifecycle, lazy
-    reconnection, and backpressure, behind one `send(record)` call.
+  - `forwarder` — shipper ingest protocol msgpack framing (msgpack-cxx), socket
+    lifecycle, lazy reconnection, backpressure, and confirmed delivery (#266: `chunk`/
+    `ack`, an in-memory unacked window, resend on reconnect/ack-timeout), behind one
+    `send(record)` call plus a `poll()` for idle draining.
   - `supervisor` — spawns and restarts the vendored Vector binary; sets
     `PR_SET_PDEATHSIG(SIGKILL)` so Vector can never outlive the Bridge, even on a
     SIGKILL/crash.
-  - `readiness` — a TCP-connect probe against Vector's Forward port + a shared ready flag.
-  - `topic_config` — derives a Fluent Forward tag from a ROS topic name.
+  - `readiness` — a TCP-connect probe against Vector's ingest port + a shared ready flag.
+  - `topic_config` — derives a shipper ingest protocol Tag from a ROS topic name.
   - `render` — the ADR-0003 config renderer: ROS parameters → a complete Vector TOML
     config (toml++). Pure, gold-file tested.
   - `vector_binary` — locates the vendored Vector binary on `AMENT_PREFIX_PATH`.
@@ -75,13 +82,49 @@ dc_bridge:
       time_format: "double"      # double | iso8601
 ```
 
-It renders: the Fluent Forward source; one `remap` (VRL) transform normalizing each
-destination's timestamp into its `time_key`; one `route` transform whose branches expose
-every distinct Tag at the public `dc.<tag>` output (ADR-0003's passthrough contract, see
-`doc/src/dc/destinations.md`); a disk buffer per persistent sink; and the blessed sinks.
+It renders: the shipper ingest protocol source (with global acknowledgements enabled,
+#266); one `remap` (VRL) transform normalizing each destination's timestamp into its
+`time_key`; one `route` transform whose branches expose every distinct Tag at the public
+`dc.<tag>` output (ADR-0003's passthrough contract, see `doc/src/dc/destinations.md`); a
+disk buffer per persistent sink; and the blessed sinks.
 `validate_custom_config_files` collision-checks passthrough snippets, and `main.cpp` runs
 `vector validate --no-environment` over the merged config before starting Vector, so a
 bad config fails loudly at startup rather than crash-looping.
+
+## Delivery guarantees (#266)
+
+The Bridge→Shipper hop is **at-least-once**, not exactly-once. Every frame the Forwarder
+sends carries a unique `chunk` id (the shipper ingest protocol's built-in
+acknowledgement option); Vector's `fluent` source is configured with global
+`acknowledgements.enabled = true` and replies with an `ack` for each chunk once the
+Record has been durably buffered (confirmed against the real pinned Vector binary with
+its sink completely unreachable: the `ack` still comes back immediately, because
+acknowledgement happens at the disk buffer, not at final delivery to the Destination).
+The Forwarder keeps every sent-but-unacked Record in an in-memory window and resends it:
+
+- unconditionally, after any reconnect (the peer may never have seen it), and
+- after `ack_timeout` (default 5s) with no response (the ack itself may have been lost).
+
+Duplicates can result from either path — a Record acked right as the Forwarder decided to
+resend it lands twice — so consumers that care about exact counts (dashboards, joins)
+should dedupe downstream on their own key, same as Humble/Fluent Bit's chunk-retry
+semantics. What this **does** guarantee: a Record is never silently forgotten just
+because Vector was mid-restart or the TCP link blipped.
+
+Two independent bounds protect the Bridge itself:
+
+- **The unacked window** (`ForwarderConfig::max_unacked_records` /
+  `max_unacked_bytes`, default 10 000 records / 16 MiB): if Vector is unreachable *and*
+  its own disk buffer is also full for long enough that acks stop arriving at all, the
+  window drops the oldest unacked record to make room, with a rate-limited
+  `RCLCPP_WARN`. Reaching this means the outage has outlasted what
+  `shipper.buffer_max_bytes` (below) can absorb — the window is a bounded safety net for
+  *in-flight* data, not a substitute for sizing the real buffer.
+- **Vector's own disk buffer** (`shipper.buffer_max_bytes`, ADR-0002): sized for how long
+  a Destination can be down before the Bridge's window above starts shedding data. A
+  Bridge crash *concurrent with* a Vector/Destination outage still loses the in-memory
+  window (out of scope here, tracked as a known double-failure — see ADR-0002 and #265's
+  durable Uploader intent queue for how the File-upload side handles the analogous case).
 
 ## Dependencies
 

--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -6,9 +6,10 @@
 // `shipper`/`destinations` parameters; this node declares those parameters, expands the
 // $HOME/$DC_PG_PASSWORD-style env references the config contract uses, hands the result
 // to the Supervisor, subscribes to the union of every Records-Destination's `inputs`
-// topics, and forwards each Record to Vector over Fluent Forward. Raw Vector snippets in
-// `custom_config_files` (ADR-0003 passthrough) are collision-checked and `vector
-// validate`d together with the rendered config so a bad snippet fails loudly at startup.
+// topics, and forwards each Record to Vector over the shipper ingest protocol. Raw
+// Vector snippets in `custom_config_files` (ADR-0003 passthrough) are collision-checked
+// and `vector validate`d together with the rendered config so a bad snippet fails loudly
+// at startup.
 //
 // `receives: files` Destinations (ADR-0005, the Uploader) are handled in Phase 2.
 #ifndef DC_BRIDGE__BRIDGE_NODE_HPP_

--- a/dc_bridge/include/dc_bridge/forwarder.hpp
+++ b/dc_bridge/include/dc_bridge/forwarder.hpp
@@ -1,11 +1,13 @@
-// Forwarder: send(record) hides Fluent Forward msgpack framing, socket lifecycle,
-// reconnection, and backpressure behind one call. The wire protocol is the interface;
-// nothing else about Vector or the transport leaks past this class.
+// Forwarder: send(record) hides shipper ingest protocol msgpack framing, socket
+// lifecycle, reconnection, backpressure, and delivery confirmation behind one call.
 #ifndef DC_BRIDGE__FORWARDER_HPP_
 #define DC_BRIDGE__FORWARDER_HPP_
 
 #include <chrono>
 #include <cstdint>
+#include <deque>
+#include <functional>
+#include <msgpack.hpp>
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <stdexcept>
@@ -14,9 +16,9 @@
 namespace dc_bridge
 {
 
-/// A DC Record ready to be forwarded: a Fluent Forward tag, a Unix timestamp (seconds
-/// since the epoch, matching Fluent Forward's integer time), and the Record's JSON
-/// payload (StringStamped.data, already parsed).
+/// A DC Record ready to be forwarded: a shipper ingest protocol tag, a Unix timestamp
+/// (seconds since the epoch, matching the protocol's integer time), and the Record's
+/// JSON payload (StringStamped.data, already parsed).
 struct Record
 {
   std::string tag;
@@ -30,6 +32,20 @@ struct ForwarderConfig
   std::uint16_t port;
   std::chrono::milliseconds connect_timeout{ 2000 };
   std::chrono::milliseconds write_timeout{ 200 };
+  /// A sent-but-unacked record is resent if no `ack` for it arrives within this window
+  /// (in addition to being resent unconditionally after a reconnect).
+  std::chrono::milliseconds ack_timeout{ 5000 };
+  /// Bounds on the in-memory unacked window (#266): once either is exceeded, the oldest
+  /// unacked record is dropped to make room. Sizing this is the lever for how much
+  /// in-flight data survives a Bridge crash concurrent with a Vector outage (the
+  /// documented double-failure this window does NOT cover) — it is not a substitute for
+  /// `shipper.buffer_max_bytes`, which is Vector's own disk buffer for sink outages.
+  std::size_t max_unacked_records{ 10000 };
+  std::size_t max_unacked_bytes{ 16ULL * 1024 * 1024 };
+  /// Called (at most once per `warn_interval`) when the unacked window drops records to
+  /// stay within bounds. ROS-independent, so the Bridge node wires this to RCLCPP_WARN.
+  std::function<void(const std::string&)> on_warning;
+  std::chrono::milliseconds warn_interval{ 5000 };
 };
 
 /// Error categories a send() can fail with, so callers (and tests) can distinguish
@@ -57,10 +73,19 @@ private:
   ForwarderErrorKind kind_;
 };
 
-/// Sends Records to a Fluent Forward peer (Vector's `fluent` source) over TCP.
+/// Sends Records to the shipper ingest protocol peer (Vector's `fluent` source) over
+/// TCP, with confirmed delivery (#266): each frame carries a unique `chunk` id (the
+/// protocol's acknowledgement option); Vector's `ack` response for a chunk removes it
+/// from an in-memory "unacked window" of sent-but-unconfirmed records. Anything still in
+/// the window is resent after a reconnect (the peer may never have seen it) or after
+/// ack_timeout elapses with no response (the ack may have been lost, not just delayed).
+/// This makes delivery at-least-once: a record acked after the sender already resent it
+/// (e.g. a reconnect racing a slow ack) can land twice — never zero times short of the
+/// window itself overflowing (see max_unacked_records/max_unacked_bytes) or a
+/// Bridge-crash-during-outage double failure (out of scope, see ADR-0002).
 ///
 /// Reconnects lazily: a dead connection is dropped on write failure and re-established
-/// on the next send(). A write that blocks past write_timeout is reported as
+/// on the next send()/poll(). A write that blocks past write_timeout is reported as
 /// Backpressure without dropping the connection, since the peer may just be slow to
 /// drain, not gone.
 class Forwarder
@@ -77,19 +102,67 @@ public:
     return fd_ >= 0;
   }
 
-  /// Sends one Record. Throws ForwarderError on failure (see ForwarderErrorKind).
+  /// Sends one Record. Throws ForwarderError on failure (see ForwarderErrorKind). The
+  /// record is added to the unacked window before the wire write is attempted, so it is
+  /// still eligible for resend even if this particular write fails.
   void send(const Record& record);
 
-  /// The Fluent Forward "Forward Mode" frame `[tag, [[time, record]]]` for `record`,
-  /// as msgpack bytes. Exposed for the wire-format tests.
-  static std::string frame(const Record& record);
+  /// Opportunistically drains any pending acks and resends anything past ack_timeout (or
+  /// resends everything if a reconnect just happened), without sending a new Record.
+  /// Lets a caller (e.g. a periodic prober thread) keep the unacked window converging
+  /// even while no new Records are being published. A no-op if there is nothing
+  /// connected and nothing pending. Never throws.
+  void poll() noexcept;
+
+  /// Number of sent-but-unacked records currently held in the window. Exposed for tests
+  /// and observability.
+  std::size_t unacked_count() const noexcept
+  {
+    return window_.size();
+  }
+
+  /// Total frame bytes currently held in the unacked window.
+  std::size_t unacked_bytes() const noexcept
+  {
+    return window_bytes_;
+  }
+
+  /// The shipper ingest protocol "Forward Mode" frame `[tag, [[time, record]], {"chunk":
+  /// chunk_id}]` for `record`, as msgpack bytes. Exposed for the wire-format tests.
+  static std::string frame(const Record& record, const std::string& chunk_id);
 
 private:
+  struct PendingRecord
+  {
+    std::string chunk_id;
+    std::string frame_bytes;
+    std::chrono::steady_clock::time_point sent_at;
+  };
+
   void ensure_connected();
   void close_connection() noexcept;
+  /// Writes `bytes` fully to the current connection. Throws ForwarderError (Backpressure
+  /// or Io) on failure; Io drops the connection.
+  void write_bytes(const std::string& bytes);
+  /// Non-blocking drain of any `ack` responses currently available on the socket,
+  /// removing their records from the window. A peer close or io error drops the
+  /// connection (mirrors write_bytes's Io handling) but does not throw.
+  void drain_acks() noexcept;
+  void handle_ack_object(const msgpack::object& obj) noexcept;
+  /// Resends every window entry (force_all) or only those past ack_timeout, oldest
+  /// first. Stops at the first write failure (connection issue), leaving the remainder
+  /// for the next poll()/send(). Never throws.
+  void resend(bool force_all) noexcept;
+  void enqueue_pending(std::string chunk_id, std::string frame_bytes);
+  static std::string generate_chunk_id();
 
   ForwarderConfig config_;
   int fd_{ -1 };
+  msgpack::unpacker ack_unpacker_;
+  std::deque<PendingRecord> window_;
+  std::size_t window_bytes_{ 0 };
+  std::chrono::steady_clock::time_point last_warn_at_{};
+  bool warned_once_{ false };
 };
 
 }  // namespace dc_bridge

--- a/dc_bridge/include/dc_bridge/readiness.hpp
+++ b/dc_bridge/include/dc_bridge/readiness.hpp
@@ -1,6 +1,7 @@
-// Readiness: tracks whether Vector is currently accepting Fluent Forward connections,
-// shared between a background prober and the ROS readiness service (ADR-0006 — the
-// Bridge has no lifecycle state beyond "process up + ready service answers").
+// Readiness: tracks whether Vector is currently accepting shipper ingest protocol
+// connections, shared between a background prober and the ROS readiness service
+// (ADR-0006 — the Bridge has no lifecycle state beyond "process up + ready service
+// answers").
 #ifndef DC_BRIDGE__READINESS_HPP_
 #define DC_BRIDGE__READINESS_HPP_
 
@@ -35,8 +36,8 @@ private:
   std::shared_ptr<std::atomic<bool>> ready_;
 };
 
-/// A plain TCP connect probe against Vector's Fluent Forward listen address: true means
-/// "accepting connections", false means it doesn't (yet, or anymore).
+/// A plain TCP connect probe against Vector's shipper ingest protocol listen address:
+/// true means "accepting connections", false means it doesn't (yet, or anymore).
 bool probe(const std::string& host, std::uint16_t port, std::chrono::milliseconds timeout);
 
 }  // namespace dc_bridge

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -1,6 +1,7 @@
 // Config renderer (ADR-0003): a pure, I/O-free mapping from Bridge/Destination
 // parameters to a complete Vector configuration. `render()` produces Vector TOML with:
-// the Fluent Forward source, one VRL transform normalizing each blessed destination's
+// the shipper ingest protocol source (global acknowledgements enabled — #266, delivery
+// is confirmed end-to-end), one VRL transform normalizing each blessed destination's
 // timestamp, one `route` transform exposing the public per-Tag `dc.<tag>` routes (the
 // passthrough contract — see route_output_for_tag), disk-buffer settings, and the
 // blessed sinks (postgres, s3, file, console).
@@ -92,11 +93,11 @@ struct Destination
 {
   std::string name;
   Receives receives;
-  /// ROS topic names feeding this Destination; the Fluent Forward tag each is routed
-  /// under is derived the same way TopicConfig derives it for subscriptions.
+  /// ROS topic names feeding this Destination; the Tag each is routed under is derived
+  /// the same way TopicConfig derives it for subscriptions.
   std::vector<std::string> inputs;
-  /// Extra Fluent Forward Tags routed here that don't come from a topic (Bridge-internal
-  /// producers — today just the Uploader's dc.files Tag).
+  /// Extra Tags routed here that don't come from a topic (Bridge-internal producers —
+  /// today just the Uploader's dc.files Tag).
   std::vector<std::string> extra_tags;
   std::string time_key;
   TimeFormat time_format;

--- a/dc_bridge/include/dc_bridge/topic_config.hpp
+++ b/dc_bridge/include/dc_bridge/topic_config.hpp
@@ -1,6 +1,6 @@
-// Bridge configuration: which topics to subscribe to and the Fluent Forward tag each
-// one is sent under. Kept separate from `forwarder` so the wire protocol code never has
-// to know about ROS topic names.
+// Bridge configuration: which topics to subscribe to and the shipper ingest protocol Tag
+// each one is sent under. Kept separate from `forwarder` so the wire protocol code never
+// has to know about ROS topic names.
 #ifndef DC_BRIDGE__TOPIC_CONFIG_HPP_
 #define DC_BRIDGE__TOPIC_CONFIG_HPP_
 
@@ -10,14 +10,14 @@
 namespace dc_bridge
 {
 
-/// One subscribed topic and the Fluent Forward tag its Records are sent under.
+/// One subscribed topic and the shipper ingest protocol Tag its Records are sent under.
 struct TopicConfig
 {
   std::string topic;
   std::string tag;
 
-  /// Build a topic config, deriving the Fluent Forward tag from the topic name (leading
-  /// `/` stripped, remaining `/` replaced with `.`) when no explicit tag is given.
+  /// Build a topic config, deriving the Tag from the topic name (leading `/` stripped,
+  /// remaining `/` replaced with `.`) when no explicit tag is given.
   static TopicConfig make(const std::string& topic, std::optional<std::string> tag = std::nullopt);
 
   /// The tag derivation on its own (leading `/` stripped, `/`→`.`, `/` alone → "dc").

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -336,6 +336,7 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   ForwarderConfig fcfg;
   fcfg.host = vector_host;
   fcfg.port = forward_port;
+  fcfg.on_warning = [this](const std::string& msg) { RCLCPP_WARN(this->get_logger(), "%s", msg.c_str()); };
   forwarder_ = std::make_shared<Forwarder>(fcfg);
 
   // Background prober: respawns Vector if it dies and keeps the readiness flag current.
@@ -442,6 +443,7 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
   ForwarderConfig fcfg;
   fcfg.host = forward_host;
   fcfg.port = forward_port;
+  fcfg.on_warning = [this](const std::string& msg) { RCLCPP_WARN(this->get_logger(), "%s", msg.c_str()); };
   Forwarder forwarder(fcfg);
 
   auto emit = [&forwarder](const nlohmann::json& row) {
@@ -488,6 +490,10 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
       }
     }
 
+    // Keeps this Forwarder's own unacked window (#266) converging between status-Record
+    // emissions, same reason the main prober thread polls the subscription Forwarder.
+    forwarder.poll();
+
     auto item = intent_queue_->next_ready();
     if (!item)
     {
@@ -526,6 +532,13 @@ void BridgeNode::run_prober(std::string forward_host, std::uint16_t forward_port
     }
     const bool ready = probe(forward_host, forward_port, std::chrono::milliseconds(200));
     readiness_.set_ready(ready);
+    {
+      // Keeps the unacked window (#266) converging — draining fresh acks, resending
+      // anything past ack_timeout, and redelivering after a reconnect — even while no
+      // new Record is being published to trigger it via send().
+      std::lock_guard<std::mutex> lock(forwarder_mutex_);
+      forwarder_->poll();
+    }
     std::this_thread::sleep_for(std::chrono::milliseconds(250));
   }
 }

--- a/dc_bridge/src/forwarder.cpp
+++ b/dc_bridge/src/forwarder.cpp
@@ -12,7 +12,9 @@
 #include <cerrno>
 #include <cstring>
 #include <ctime>
+#include <fstream>
 #include <msgpack.hpp>
+#include <random>
 
 namespace dc_bridge
 {
@@ -67,9 +69,9 @@ void pack_json(Packer& pk, const nlohmann::json& value)
   }
 }
 
-// The Fluent Forward wire record must be a map. A Record's JSON payload usually is one;
-// anything else (bare string/number/array) is wrapped in {"message": ...} rather than
-// dropped.
+// The shipper ingest protocol's wire record must be a map. A Record's JSON payload
+// usually is one; anything else (bare string/number/array) is wrapped in
+// {"message": ...} rather than dropped.
 template <typename Packer>
 void pack_record_map(Packer& pk, const nlohmann::json& payload)
 {
@@ -103,19 +105,59 @@ void Forwarder::close_connection() noexcept
     ::close(fd_);
     fd_ = -1;
   }
+  ack_unpacker_.reset();
 }
 
-std::string Forwarder::frame(const Record& record)
+std::string Forwarder::generate_chunk_id()
+{
+  // 16 random bytes, base64-encoded — the protocol only requires a unique-enough opaque
+  // id that the server echoes back verbatim in its ack response.
+  static thread_local std::mt19937_64 rng{ std::random_device{}() };
+  std::uint8_t bytes[16];
+  for (std::size_t i = 0; i < sizeof(bytes); i += sizeof(std::uint64_t))
+  {
+    const std::uint64_t v = rng();
+    std::memcpy(bytes + i, &v, std::min(sizeof(v), sizeof(bytes) - i));
+  }
+
+  static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  out.reserve(24);
+  for (std::size_t i = 0; i < sizeof(bytes); i += 3)
+  {
+    const std::uint32_t n0 = bytes[i];
+    const std::uint32_t n1 = (i + 1 < sizeof(bytes)) ? bytes[i + 1] : 0;
+    const std::uint32_t n2 = (i + 2 < sizeof(bytes)) ? bytes[i + 2] : 0;
+    const std::uint32_t triple = (n0 << 16) | (n1 << 8) | n2;
+    out.push_back(alphabet[(triple >> 18) & 0x3F]);
+    out.push_back(alphabet[(triple >> 12) & 0x3F]);
+    if (i + 1 < sizeof(bytes))
+    {
+      out.push_back(alphabet[(triple >> 6) & 0x3F]);
+    }
+    if (i + 2 < sizeof(bytes))
+    {
+      out.push_back(alphabet[triple & 0x3F]);
+    }
+  }
+  return out;
+}
+
+std::string Forwarder::frame(const Record& record, const std::string& chunk_id)
 {
   msgpack::sbuffer buf;
   msgpack::packer<msgpack::sbuffer> pk(buf);
-  // [tag, [[time, record]]]
-  pk.pack_array(2);
+  // [tag, [[time, record]], {"chunk": chunk_id}] — the "option" third element is what
+  // asks the peer to ack this chunk (#266).
+  pk.pack_array(3);
   pk.pack(record.tag);
   pk.pack_array(1);  // one entry
   pk.pack_array(2);  // [time, record]
   pk.pack(record.timestamp_secs);
   pack_record_map(pk, record.payload);
+  pk.pack_map(1);
+  pk.pack(std::string("chunk"));
+  pk.pack(chunk_id);
   return std::string(buf.data(), buf.size());
 }
 
@@ -131,7 +173,7 @@ void Forwarder::ensure_connected()
   int fd = ::socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0)
   {
-    throw ForwarderError(ForwarderErrorKind::Connect, "failed to connect to Fluent Forward peer at " + addr_str +
+    throw ForwarderError(ForwarderErrorKind::Connect, "failed to connect to the shipper ingest peer at " + addr_str +
                                                           ": socket(): " + std::strerror(errno));
   }
 
@@ -142,7 +184,7 @@ void Forwarder::ensure_connected()
   {
     ::close(fd);
     throw ForwarderError(ForwarderErrorKind::Connect,
-                         "failed to connect to Fluent Forward peer at " + addr_str + ": invalid host address");
+                         "failed to connect to the shipper ingest peer at " + addr_str + ": invalid host address");
   }
 
   // Non-blocking connect + poll for connect_timeout, so a black-holed peer doesn't
@@ -158,7 +200,7 @@ void Forwarder::ensure_connected()
     {
       ::close(fd);
       throw ForwarderError(ForwarderErrorKind::Connect,
-                           "failed to connect to Fluent Forward peer at " + addr_str + ": connect timed out");
+                           "failed to connect to the shipper ingest peer at " + addr_str + ": connect timed out");
     }
     int soerr = 0;
     socklen_t len = sizeof(soerr);
@@ -167,14 +209,14 @@ void Forwarder::ensure_connected()
     {
       ::close(fd);
       throw ForwarderError(ForwarderErrorKind::Connect,
-                           "failed to connect to Fluent Forward peer at " + addr_str + ": " + std::strerror(soerr));
+                           "failed to connect to the shipper ingest peer at " + addr_str + ": " + std::strerror(soerr));
     }
   }
   else if (rc < 0)
   {
     ::close(fd);
     throw ForwarderError(ForwarderErrorKind::Connect,
-                         "failed to connect to Fluent Forward peer at " + addr_str + ": " + std::strerror(errno));
+                         "failed to connect to the shipper ingest peer at " + addr_str + ": " + std::strerror(errno));
   }
   ::fcntl(fd, F_SETFL, flags);  // back to blocking; write_timeout is enforced below
 
@@ -188,19 +230,17 @@ void Forwarder::ensure_connected()
   ::setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &one, sizeof(one));
 
   fd_ = fd;
+  ack_unpacker_.reset();  // a fresh connection is a fresh msgpack byte stream
 }
 
-void Forwarder::send(const Record& record)
+void Forwarder::write_bytes(const std::string& bytes)
 {
-  ensure_connected();
-  const std::string frame_bytes = frame(record);
-
   std::size_t written = 0;
-  while (written < frame_bytes.size())
+  while (written < bytes.size())
   {
     // MSG_NOSIGNAL: a dead peer must surface as EPIPE (Io), never a process-killing
     // SIGPIPE.
-    ssize_t n = ::send(fd_, frame_bytes.data() + written, frame_bytes.size() - written, MSG_NOSIGNAL);
+    ssize_t n = ::send(fd_, bytes.data() + written, bytes.size() - written, MSG_NOSIGNAL);
     if (n > 0)
     {
       written += static_cast<std::size_t>(n);
@@ -218,6 +258,192 @@ void Forwarder::send(const Record& record)
     close_connection();
     throw ForwarderError(ForwarderErrorKind::Io, msg);
   }
+}
+
+void Forwarder::handle_ack_object(const msgpack::object& obj) noexcept
+{
+  if (obj.type != msgpack::type::MAP)
+  {
+    return;
+  }
+  for (std::uint32_t i = 0; i < obj.via.map.size; ++i)
+  {
+    const msgpack::object_kv& kv = obj.via.map.ptr[i];
+    if (kv.key.type != msgpack::type::STR)
+    {
+      continue;
+    }
+    try
+    {
+      if (kv.key.as<std::string>() != "ack" || kv.val.type != msgpack::type::STR)
+      {
+        continue;
+      }
+      const std::string acked = kv.val.as<std::string>();
+      for (auto it = window_.begin(); it != window_.end(); ++it)
+      {
+        if (it->chunk_id == acked)
+        {
+          window_bytes_ -= it->frame_bytes.size();
+          window_.erase(it);
+          break;
+        }
+      }
+    }
+    catch (const std::exception&)
+    {
+      // Malformed ack payload from the peer; nothing in the window matched, ignore.
+    }
+  }
+}
+
+void Forwarder::drain_acks() noexcept
+{
+  if (fd_ < 0)
+  {
+    return;
+  }
+  char buf[4096];
+  for (;;)
+  {
+    ssize_t n = ::recv(fd_, buf, sizeof(buf), MSG_DONTWAIT);
+    if (n > 0)
+    {
+      try
+      {
+        ack_unpacker_.reserve_buffer(static_cast<std::size_t>(n));
+        std::memcpy(ack_unpacker_.buffer(), buf, static_cast<std::size_t>(n));
+        ack_unpacker_.buffer_consumed(static_cast<std::size_t>(n));
+        msgpack::object_handle oh;
+        while (ack_unpacker_.next(oh))
+        {
+          handle_ack_object(oh.get());
+        }
+      }
+      catch (const std::exception&)
+      {
+        // Corrupt ack stream; drop the connection so the next send()/poll() starts
+        // clean rather than getting stuck on a desynced unpacker.
+        close_connection();
+        return;
+      }
+      continue;
+    }
+    if (n == 0)
+    {
+      close_connection();  // peer closed
+      return;
+    }
+    if (errno == EAGAIN || errno == EWOULDBLOCK)
+    {
+      return;  // no more data available right now
+    }
+    close_connection();  // real socket error
+    return;
+  }
+}
+
+void Forwarder::resend(bool force_all) noexcept
+{
+  const auto now = std::chrono::steady_clock::now();
+  for (auto& entry : window_)
+  {
+    if (!force_all && (now - entry.sent_at) < config_.ack_timeout)
+    {
+      continue;
+    }
+    try
+    {
+      write_bytes(entry.frame_bytes);
+      entry.sent_at = now;
+    }
+    catch (const ForwarderError&)
+    {
+      return;  // connection dropped or stalled; retry the rest on the next opportunity
+    }
+  }
+}
+
+void Forwarder::enqueue_pending(std::string chunk_id, std::string frame_bytes)
+{
+  window_bytes_ += frame_bytes.size();
+  window_.push_back(PendingRecord{ std::move(chunk_id), std::move(frame_bytes), std::chrono::steady_clock::now() });
+
+  std::size_t dropped = 0;
+  while (!window_.empty() && (window_.size() > config_.max_unacked_records || window_bytes_ > config_.max_unacked_bytes))
+  {
+    window_bytes_ -= window_.front().frame_bytes.size();
+    window_.pop_front();
+    ++dropped;
+  }
+
+  if (dropped == 0)
+  {
+    return;
+  }
+  const auto now = std::chrono::steady_clock::now();
+  if (warned_once_ && (now - last_warn_at_) < config_.warn_interval)
+  {
+    return;  // rate-limited
+  }
+  warned_once_ = true;
+  last_warn_at_ = now;
+  if (config_.on_warning)
+  {
+    config_.on_warning("unacked record window exceeded its bound (" + std::to_string(config_.max_unacked_records) +
+                       " records / " + std::to_string(config_.max_unacked_bytes) +
+                       " bytes); dropped the oldest unacked record(s) to make room");
+  }
+}
+
+void Forwarder::send(const Record& record)
+{
+  const bool was_disconnected = (fd_ < 0);
+  ensure_connected();
+  if (was_disconnected)
+  {
+    resend(/*force_all=*/true);
+  }
+  drain_acks();
+  resend(/*force_all=*/false);
+
+  // drain_acks()/resend() above may have dropped the connection on a stale peer; make
+  // sure a fresh one is up (and, if it's genuinely new, redeliver the window) before
+  // sending the record this call is actually for.
+  const bool reconnected_for_send = (fd_ < 0);
+  ensure_connected();
+  if (reconnected_for_send)
+  {
+    resend(/*force_all=*/true);
+  }
+
+  const std::string chunk_id = generate_chunk_id();
+  const std::string frame_bytes = frame(record, chunk_id);
+  enqueue_pending(chunk_id, frame_bytes);
+  write_bytes(frame_bytes);
+}
+
+void Forwarder::poll() noexcept
+{
+  if (fd_ < 0 && window_.empty())
+  {
+    return;  // nothing connected and nothing to flush
+  }
+  try
+  {
+    const bool was_disconnected = (fd_ < 0);
+    ensure_connected();
+    if (was_disconnected)
+    {
+      resend(/*force_all=*/true);
+    }
+  }
+  catch (const ForwarderError&)
+  {
+    return;  // still unreachable; try again next poll()/send()
+  }
+  drain_acks();
+  resend(/*force_all=*/false);
 }
 
 }  // namespace dc_bridge

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -95,9 +95,9 @@ std::string trim(const std::string& s)
   return s.substr(begin, end - begin + 1);
 }
 
-// The distinct Fluent Forward tags a Destination's inputs topics derive to, plus its
-// Bridge-internal extra_tags — sorted+unique (std::set) so rendered arrays/VRL are
-// deterministic.
+// The distinct shipper ingest protocol Tags a Destination's inputs topics derive to,
+// plus its Bridge-internal extra_tags — sorted+unique (std::set) so rendered arrays/VRL
+// are deterministic.
 std::set<std::string> destination_tags(const Destination& dest)
 {
   std::set<std::string> tags;
@@ -604,6 +604,16 @@ std::string render(const RenderConfig& config)
 
   toml::table root;
   root.insert("data_dir", config.data_dir);
+
+  // Global acknowledgements (#266): the Bridge's Forwarder tags every frame with a
+  // `chunk` id and expects an `ack` in return, so the fluent source's chunk/ack support
+  // must actually be switched on. Enabled globally rather than per-source: Vector 0.57
+  // deprecates enabling acknowledgements on the source itself in favor of this form
+  // (verified against the pinned binary — the source-level knob logs a deprecation
+  // warning where this one doesn't, with identical ack behavior either way).
+  toml::table acknowledgements;
+  acknowledgements.insert("enabled", true);
+  root.insert("acknowledgements", std::move(acknowledgements));
 
   // sources
   toml::table source;

--- a/dc_bridge/test/fixtures/render/basic_double.toml
+++ b/dc_bridge/test/fixtures/render/basic_double.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.pgsql]
 endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
 inputs = ["dc.dc.group.robot"]

--- a/dc_bridge/test/fixtures/render/file_and_console.toml
+++ b/dc_bridge/test/fixtures/render/file_and_console.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.debug_console]
 inputs = ["dc.dc.group.robot"]
 target = "stdout"

--- a/dc_bridge/test/fixtures/render/iso8601.toml
+++ b/dc_bridge/test/fixtures/render/iso8601.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.pgsql]
 endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
 inputs = ["dc.dc.group.robot"]

--- a/dc_bridge/test/fixtures/render/multiple_destinations.toml
+++ b/dc_bridge/test/fixtures/render/multiple_destinations.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.pgsql]
 endpoint = "postgres://dc:hunter2@127.0.0.1:5432/dc"
 inputs = ["dc.dc.group.robot"]

--- a/dc_bridge/test/fixtures/render/s3_aws.toml
+++ b/dc_bridge/test/fixtures/render/s3_aws.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.s3_archive]
 bucket = "dc-records"
 inputs = ["dc.dc.group.robot"]

--- a/dc_bridge/test/fixtures/render/s3_custom_endpoint.toml
+++ b/dc_bridge/test/fixtures/render/s3_custom_endpoint.toml
@@ -1,5 +1,8 @@
 data_dir = "/home/dc/.dc/buffer"
 
+[acknowledgements]
+enabled = true
+
 [sinks.rustfs]
 bucket = "dc-records"
 endpoint = "http://127.0.0.1:9000"

--- a/dc_bridge/test/forwarder_test.cpp
+++ b/dc_bridge/test/forwarder_test.cpp
@@ -1,5 +1,6 @@
 // Frame correctness / tag handling decode the static frame() bytes directly;
-// reconnection and backpressure use a mock Fluent Forward TCP server.
+// reconnection, backpressure, and ack/window behavior (#266) use a mock shipper ingest
+// protocol TCP server.
 #include "dc_bridge/forwarder.hpp"
 
 #include <arpa/inet.h>
@@ -8,12 +9,15 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <chrono>
 #include <cstring>
 #include <msgpack.hpp>
+#include <mutex>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <thread>
+#include <vector>
 
 using namespace dc_bridge;
 
@@ -25,8 +29,8 @@ Record make_record(const std::string& tag, const std::string& json)
   return Record{ tag, 1700000000ULL, nlohmann::json::parse(json) };
 }
 
-// A mock Fluent Forward server: binds :0, hands back the chosen port, and runs `handler`
-// on the accepted connection in a background thread.
+// A mock shipper ingest protocol server: binds :0, hands back the chosen port, and runs
+// `handler` on the accepted connection in a background thread.
 struct MockServer
 {
   int listen_fd{ -1 };
@@ -60,14 +64,59 @@ msgpack::object_handle unpack(const std::string& bytes)
   return msgpack::unpack(bytes.data(), bytes.size());
 }
 
+// Pulls the "chunk" option's value out of a real on-the-wire frame — used by mock
+// servers that need to echo back whatever chunk id the Forwarder actually generated
+// (its value isn't otherwise observable from outside Forwarder::send()).
+std::string extract_chunk_id(const char* bytes, std::size_t len)
+{
+  msgpack::object_handle oh = msgpack::unpack(bytes, len);
+  msgpack::object top = oh.get();
+  if (top.via.array.size < 3)
+  {
+    return {};
+  }
+  msgpack::object option = top.via.array.ptr[2];
+  if (option.type != msgpack::type::MAP)
+  {
+    return {};
+  }
+  for (std::uint32_t i = 0; i < option.via.map.size; ++i)
+  {
+    if (option.via.map.ptr[i].key.as<std::string>() == "chunk")
+    {
+      return option.via.map.ptr[i].val.as<std::string>();
+    }
+  }
+  return {};
+}
+
+// Reads one full frame off `fd` (a single ::recv is enough for these small test
+// payloads) and sends back `{"ack": <its chunk id>}`.
+void read_frame_and_ack(int fd)
+{
+  char buf[8192];
+  ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+  if (n <= 0)
+  {
+    return;
+  }
+  const std::string chunk_id = extract_chunk_id(buf, static_cast<std::size_t>(n));
+  msgpack::sbuffer ack_buf;
+  msgpack::packer<msgpack::sbuffer> pk(ack_buf);
+  pk.pack_map(1);
+  pk.pack(std::string("ack"));
+  pk.pack(chunk_id);
+  ::send(fd, ack_buf.data(), ack_buf.size(), 0);
+}
+
 }  // namespace
 
 TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
 {
-  auto oh = unpack(Forwarder::frame(make_record("dc.measurement.uptime", R"({"uptime_s": 42})")));
+  auto oh = unpack(Forwarder::frame(make_record("dc.measurement.uptime", R"({"uptime_s": 42})"), "chunk-a"));
   msgpack::object top = oh.get();
   ASSERT_EQ(top.type, msgpack::type::ARRAY);
-  ASSERT_EQ(top.via.array.size, 2u);  // [tag, entries]
+  ASSERT_EQ(top.via.array.size, 3u);  // [tag, entries, option]
   EXPECT_EQ(top.via.array.ptr[0].as<std::string>(), "dc.measurement.uptime");
 
   msgpack::object entries = top.via.array.ptr[1];
@@ -89,9 +138,21 @@ TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
   EXPECT_TRUE(found);
 }
 
+TEST(Forwarder, FrameCarriesTheChunkOption)
+{
+  auto oh = unpack(Forwarder::frame(make_record("dc.test", R"({"n": 1})"), "my-chunk-id"));
+  msgpack::object top = oh.get();
+  ASSERT_EQ(top.via.array.size, 3u);
+  msgpack::object option = top.via.array.ptr[2];
+  ASSERT_EQ(option.type, msgpack::type::MAP);
+  ASSERT_EQ(option.via.map.size, 1u);
+  EXPECT_EQ(option.via.map.ptr[0].key.as<std::string>(), "chunk");
+  EXPECT_EQ(option.via.map.ptr[0].val.as<std::string>(), "my-chunk-id");
+}
+
 TEST(Forwarder, NonObjectPayloadsWrappedInMessageField)
 {
-  auto oh = unpack(Forwarder::frame(make_record("dc.test", R"("plain string data")")));
+  auto oh = unpack(Forwarder::frame(make_record("dc.test", R"("plain string data")"), "chunk-b"));
   msgpack::object rec = oh.get().via.array.ptr[1].via.array.ptr[0].via.array.ptr[1];
   ASSERT_EQ(rec.type, msgpack::type::MAP);
   ASSERT_EQ(rec.via.map.size, 1u);
@@ -101,12 +162,12 @@ TEST(Forwarder, NonObjectPayloadsWrappedInMessageField)
 
 TEST(Forwarder, DifferentRecordsCarryTheirOwnTag)
 {
-  EXPECT_EQ(unpack(Forwarder::frame(make_record("dc.measurement.cpu", R"({"pct": 1})")))
+  EXPECT_EQ(unpack(Forwarder::frame(make_record("dc.measurement.cpu", R"({"pct": 1})"), "c1"))
                 .get()
                 .via.array.ptr[0]
                 .as<std::string>(),
             "dc.measurement.cpu");
-  EXPECT_EQ(unpack(Forwarder::frame(make_record("dc.measurement.uptime", R"({"uptime_s": 2})")))
+  EXPECT_EQ(unpack(Forwarder::frame(make_record("dc.measurement.uptime", R"({"uptime_s": 2})"), "c2"))
                 .get()
                 .via.array.ptr[0]
                 .as<std::string>(),
@@ -195,4 +256,155 @@ TEST(Forwarder, ReturnsBackpressureWhenPeerStalls)
   }
   srv.join();
   EXPECT_TRUE(saw_backpressure) << "expected a stalled peer to eventually trigger backpressure";
+}
+
+TEST(Forwarder, AckedRecordLeavesTheUnackedWindow)
+{
+  MockServer server;
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    if (c < 0)
+    {
+      return;
+    }
+    read_frame_and_ack(c);  // exactly one Record is sent in this test
+    ::close(c);
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  Forwarder forwarder(cfg);
+
+  forwarder.send(make_record("dc.test", R"({"n": 1})"));
+  EXPECT_EQ(forwarder.unacked_count(), 1u);
+
+  bool drained = false;
+  for (int i = 0; i < 100; ++i)
+  {
+    forwarder.poll();
+    if (forwarder.unacked_count() == 0)
+    {
+      drained = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  EXPECT_TRUE(drained) << "an acked record should leave the unacked window";
+  EXPECT_EQ(forwarder.unacked_bytes(), 0u);
+
+  srv.join();
+}
+
+TEST(Forwarder, UnackedRecordResendsAfterReconnect)
+{
+  MockServer server;
+  std::vector<std::string> chunk_ids_seen;
+  std::mutex seen_mutex;
+
+  std::thread srv([&]() {
+    // First connection: read the frame, note its chunk id, never ack it, then abort the
+    // connection (RST) without responding — simulating Vector dying mid-flight.
+    int c1 = ::accept(server.listen_fd, nullptr, nullptr);
+    char buf[4096];
+    ssize_t n = ::recv(c1, buf, sizeof(buf), 0);
+    {
+      std::lock_guard<std::mutex> lock(seen_mutex);
+      chunk_ids_seen.push_back(extract_chunk_id(buf, static_cast<std::size_t>(n)));
+    }
+    linger lg{ 1, 0 };
+    ::setsockopt(c1, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+    ::close(c1);
+
+    // Second connection: the Forwarder should redeliver the same unacked record before
+    // (or as part of) sending anything new. Ack it this time so the test can also see
+    // the window converge.
+    int c2 = ::accept(server.listen_fd, nullptr, nullptr);
+    ssize_t n2 = ::recv(c2, buf, sizeof(buf), 0);
+    {
+      std::lock_guard<std::mutex> lock(seen_mutex);
+      chunk_ids_seen.push_back(extract_chunk_id(buf, static_cast<std::size_t>(n2)));
+    }
+    const std::string chunk_id = extract_chunk_id(buf, static_cast<std::size_t>(n2));
+    msgpack::sbuffer ack_buf;
+    msgpack::packer<msgpack::sbuffer> pk(ack_buf);
+    pk.pack_map(1);
+    pk.pack(std::string("ack"));
+    pk.pack(chunk_id);
+    ::send(c2, ack_buf.data(), ack_buf.size(), 0);
+    ::close(c2);
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  Forwarder forwarder(cfg);
+  forwarder.send(make_record("dc.test", R"({"n": 1})"));
+
+  // Give the mock server time to RST the first connection, then poll until the
+  // Forwarder has reconnected and redelivered.
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  bool redelivered = false;
+  for (int i = 0; i < 100; ++i)
+  {
+    forwarder.poll();
+    std::lock_guard<std::mutex> lock(seen_mutex);
+    if (chunk_ids_seen.size() >= 2)
+    {
+      redelivered = true;
+      break;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  srv.join();
+
+  ASSERT_TRUE(redelivered) << "the unacked record should have been resent on the new connection";
+  std::lock_guard<std::mutex> lock(seen_mutex);
+  ASSERT_EQ(chunk_ids_seen.size(), 2u);
+  EXPECT_EQ(chunk_ids_seen[0], chunk_ids_seen[1]) << "the resend must carry the SAME chunk id as the original send";
+}
+
+TEST(Forwarder, WindowBoundDropsOldestRecordsWithWarning)
+{
+  MockServer server;
+  std::atomic<bool> stop{ false };
+  std::thread srv([&]() {
+    // Accept the connection but never read/ack anything, so every send() stays
+    // unacked and the window is forced to enforce its bound.
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    while (!stop.load())
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    if (c >= 0)
+    {
+      ::close(c);
+    }
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  cfg.max_unacked_records = 3;
+  cfg.max_unacked_bytes = 1024 * 1024;  // large enough that the record-count bound trips first
+  cfg.warn_interval = std::chrono::milliseconds(0);
+  std::atomic<int> warnings{ 0 };
+  std::string last_warning;
+  cfg.on_warning = [&](const std::string& msg) {
+    ++warnings;
+    last_warning = msg;
+  };
+  Forwarder forwarder(cfg);
+
+  for (int i = 0; i < 5; ++i)
+  {
+    forwarder.send(make_record("dc.test", R"({"n": 1})"));
+  }
+
+  EXPECT_EQ(forwarder.unacked_count(), 3u) << "the window must be capped at max_unacked_records";
+  EXPECT_GT(warnings.load(), 0) << "dropping records past the bound must warn";
+  EXPECT_FALSE(last_warning.empty());
+
+  stop.store(true);
+  srv.join();
 }

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -134,6 +134,19 @@ TEST(Render, ConsoleSinkHasNoDiskBuffer)
   EXPECT_FALSE(parsed["sinks"]["debug_console"].as_table()->contains("buffer"));
 }
 
+// #266: the Forwarder tags every frame with a chunk id and depends on Vector actually
+// acking it, so acknowledgements must be switched on in the rendered config — global,
+// not per-source, since the source-level knob is deprecated in the pinned Vector version
+// (verified against the real binary; see the destinations.md delivery-guarantees note).
+TEST(Render, EnablesGlobalAcknowledgements)
+{
+  auto config = basic_config(TimeFormat::Double);
+  toml::table parsed = toml::parse(render(config));
+  auto* acks = parsed["acknowledgements"].as_table();
+  ASSERT_NE(acks, nullptr);
+  EXPECT_EQ(acks->at("enabled").as_boolean()->get(), true);
+}
+
 TEST(Render, RoutesArePerTagAndSinksConsumeDcDotTag)
 {
   auto config = config_with({

--- a/docs/adr/0001-external-shipper-replaces-embedded-fluent-bit.md
+++ b/docs/adr/0001-external-shipper-replaces-embedded-fluent-bit.md
@@ -1,6 +1,6 @@
 # External shipper process replaces embedded Fluent Bit
 
-The Humble-era design embedded a forked Fluent Bit 2.1.3 as an in-process library, which forced us to maintain `fluent_bit_vendor` (source build of a patched fork), a custom C input plugin (`in_ros2`), and cgo-built Go output plugins — the dominant cause of install pain. For the Jazzy rewrite, the shipper runs as an **external process on localhost**, supervised by DC's bringup, fed by a thin Bridge over the Fluent Forward protocol. Install becomes "drop one prebuilt binary"; the fork, the vendor package, and the Go toolchain are deleted.
+The Humble-era design embedded a forked Fluent Bit 2.1.3 as an in-process library, which forced us to maintain `fluent_bit_vendor` (source build of a patched fork), a custom C input plugin (`in_ros2`), and cgo-built Go output plugins — the dominant cause of install pain. For the Jazzy rewrite, the shipper runs as an **external process on localhost**, supervised by DC's bringup, fed by a thin Bridge over the shipper ingest protocol. Install becomes "drop one prebuilt binary"; the fork, the vendor package, and the Go toolchain are deleted.
 
 ## Considered Options
 

--- a/docs/adr/0002-vector-as-default-shipper.md
+++ b/docs/adr/0002-vector-as-default-shipper.md
@@ -35,3 +35,26 @@ this boundary the **shipper ingest protocol**; the name "fluent" appears only in
 generated Vector config (`type = "fluent"`) and interop documentation. A side effect,
 not a goal: any forward-speaking receiver (including stock upstream Fluent Bit, ~5MB
 RSS vs Vector's ~100MB) can be swapped in behind the boundary without Bridge changes.
+
+## Amendment: confirmed delivery closes the acks half of the promise (#266)
+
+The "sender-visible acks" requirement above was satisfied by *choosing* an ack-capable
+protocol, but until #266 the Bridge's Forwarder never actually used the chunk/ack option
+— every frame was sent bare. Spiked directly against the pinned Vector 0.57.0 binary
+before writing any C++: a hand-rolled msgpack client sending `[tag, entries, {"chunk":
+id}]` got back `{"ack": id}` even with the sink completely unreachable (connection
+refused) and only a disk buffer engaged — confirming acks fire on durable-buffer-write,
+not on final delivery to the Destination, which is the guarantee actually wanted here.
+Also found: Vector 0.57 deprecates enabling `acknowledgements` on the source itself
+in favor of the global `[acknowledgements] enabled = true` form (identical ack
+behavior, no deprecation warning) — the renderer uses the global form.
+
+A second on-disk queue for this window (mirroring the Uploader's intent queue, #265)
+was considered and rejected in review: Vector's own disk buffer
+(`shipper.buffer_max_bytes`) already covers sink/Destination outages, and the
+`bridge_ready_gate` (ADR-0006) already covers "Vector isn't listening yet" at startup.
+What was missing was purely the **in-flight** window — a Record already handed to a
+`send()` call whose ack never arrives (Vector respawning, a TCP hiccup) — which an
+in-memory (not disk-backed) bounded window closes cheaply. The double failure of "Bridge
+crashes while this in-memory window is non-empty" is accepted as out of scope, same as
+this ADR's original ready-gate/disk-buffer split assumed no double failures either.

--- a/docs/adr/0007-bridge-returns-to-cpp.md
+++ b/docs/adr/0007-bridge-returns-to-cpp.md
@@ -6,7 +6,7 @@ ADR-0004 made the new `dc_bridge` node Rust (`rclrs`) as a deliberately containe
 — its own words: *"We want first-party Rust in the project."* The bet was explicitly
 reversible: *"if not, the loss is one small package."* We are exercising that exit
 clause. The Bridge is now plain C++ (`ament_cmake`, `rclcpp`); everything else about the
-DC 2.0 architecture (external Vector shipper, Fluent Forward boundary, blessed
+DC 2.0 architecture (external Vector shipper, shipper ingest protocol boundary, blessed
 Destinations + passthrough, the Uploader's verify-then-delete semantics) is unchanged.
 
 ## Why
@@ -33,7 +33,7 @@ Bridge's own logic:
   *does*.
 
 Against that, none of the Bridge's actual responsibilities need Rust. Talking to Vector
-is Fluent Forward (msgpack over a TCP socket); process supervision is
+is the shipper ingest protocol (msgpack over a TCP socket); process supervision is
 `fork`/`exec`/`waitpid` + `PR_SET_PDEATHSIG`; config rendering is string/TOML
 generation; the File uploads (ADR-0005) are S3 multipart, which the AWS SDK for C++
 provides directly. The Humble line did S3 uploads with a single `minio-go` call and no

--- a/progress.txt
+++ b/progress.txt
@@ -1380,3 +1380,115 @@ the cause, not a real regression.
   toolchain — still the same ad hoc pattern (a cached `dc-workspace:latest` image,
   rebuilt from scratch by whichever session needs it fresh) every DC 2.0 C++ slice
   since ADR-0007 has noted as a follow-up.
+
+### #266 - DC 2.0: shipper ingest acks — confirmed delivery from Bridge to Vector
+
+Closes the one remaining durability gap flagged in ADR-0002/#249: a Record handed to
+the Forwarder while Vector is mid-respawn or its socket is backpressured was previously
+dropped with only an `eprintln`/warn, no retry — the only seam in DC 2.0 less durable
+than Humble's in-process FLB call.
+
+- **Spike first, against the real pinned Vector 0.57.0 binary** (downloaded, SHA-256
+  verified against `vector_vendor/CMakeLists.txt`'s own pin — no guessing): wrote a
+  from-scratch hand-rolled msgpack client (no `msgpack` Python package available in this
+  sandbox, so encoded/decoded the small frames by hand) against a `fluent` source with
+  an unreachable sink and only a disk buffer engaged. Confirmed: (1) the source honors
+  the `chunk` option and returns `{"ack": chunk}`; (2) the ack fires on
+  durable-buffer-write, not final delivery to the Destination — exactly the guarantee
+  wanted, proven by getting the ack back instantly with the sink returning connection-
+  refused; (3) Vector 0.57 **deprecates** enabling `acknowledgements` on the source
+  itself (logs a warning) in favor of the global `[acknowledgements] enabled = true`
+  form, which gives identical ack behavior with no warning — used the global form in
+  the renderer. Spike scripts + configs kept in the session scratchpad, not committed
+  (throwaway verification, not product code).
+- **`dc_bridge_core::Forwarder` (`forwarder.hpp`/`.cpp`) grew confirmed delivery**:
+  - Every frame now carries a `chunk` id (16 random bytes, base64) as the Forward Mode
+    option element (`[tag, entries, {"chunk": id}]`); `frame()`'s signature changed to
+    take the chunk id explicitly (existing wire-format tests updated accordingly).
+  - A non-blocking (`MSG_DONTWAIT`) `drain_acks()` reads any `{"ack": id}` responses off
+    the socket through a per-connection `msgpack::unpacker` (reset on every reconnect,
+    since a fresh TCP connection is a fresh byte stream) and removes the matching
+    Record from an in-memory **unacked window** (`std::deque`, tracked by count and
+    byte size).
+  - Anything still in the window is resent: unconditionally after a reconnect (the peer
+    may never have seen it), or after `ack_timeout` (default 5s) with no response (the
+    ack itself may have been lost). Both paths reuse one `resend(force_all)` helper that
+    never throws — a resend failure just leaves the remainder for the next
+    `poll()`/`send()`.
+  - The window is bounded (`max_unacked_records`=10000 / `max_unacked_bytes`=16MiB,
+    both configurable): past the bound, the oldest unacked record is dropped to make
+    room, with a rate-limited (`warn_interval`, default 5s) callback
+    (`ForwarderConfig::on_warning`) — kept ROS-independent by taking a
+    `std::function<void(const std::string&)>` rather than calling RCLCPP directly, wired
+    to `RCLCPP_WARN` in `bridge_node.cpp`.
+  - New public `poll()`: drains acks / resends timed-out entries / opportunistically
+    reconnects without needing a new Record to send, so the window keeps converging
+    even when publishing goes quiet. Wired into both the existing prober thread (every
+    ~250ms) and the Uploader's own status-Record Forwarder's worker loop (every ~500ms
+    via its existing wait), each under its own existing lock — no new threads.
+  - Delivery is now **at-least-once**, documented as such: a record acked right as a
+    resend was triggered can land twice; duplicates are permitted (matches Humble/FLB
+    chunk-retry semantics) but Records are never silently forgotten just because Vector
+    blipped.
+- **`dc_bridge_core::render`**: rendered config now emits a root-level
+  `[acknowledgements]\nenabled = true` table (global form, per the spike finding) ahead
+  of the `fluent` source. New `Render.EnablesGlobalAcknowledgements` test; all 6
+  existing gold-file fixtures got the same 3-line block hand-inserted (not
+  auto-dumped/reformatted — kept the diff to exactly the new lines rather than letting
+  a different toml++ build reformat quote style/indentation across every fixture) and
+  re-`vector validate`d clean against the real pinned binary.
+- **Unit tests** (`forwarder_test.cpp`): existing frame tests updated for the new
+  3-element `[tag, entries, option]` shape; four new tests against a mock ack-capable
+  TCP server covering every scriptable acceptance criterion — `FrameCarriesTheChunkOption`,
+  `AckedRecordLeavesTheUnackedWindow`, `UnackedRecordResendsAfterReconnect` (asserts the
+  *same* chunk id is retransmitted, not just that the connection recovers), and
+  `WindowBoundDropsOldestRecordsWithWarning`.
+- **Vocabulary cleanup** (agreed in the issue): purged "Fluent Forward" as a
+  component-sounding name from every code comment/error message it remained in
+  (`forwarder.*`, `readiness.hpp`, `topic_config.hpp`, `render.hpp`, `bridge_node.hpp`,
+  `dc_bridge/README.md`, and ADRs 0001/0007 — CONTEXT.md's glossary already flagged this
+  as the target term) in favor of "shipper ingest protocol" / "Tag"; "fluent" now only
+  appears in the generated config's `type = "fluent"` and interop notes, as intended.
+- **Docs**: `dc_bridge/README.md` gained a full "Delivery guarantees" section (mechanism,
+  duplicates, the two independent bounds — the Forwarder's in-memory window vs. Vector's
+  own `shipper.buffer_max_bytes` disk buffer — and what a Bridge-crash-during-outage
+  double failure still loses). `docs/adr/0002-vector-as-default-shipper.md` amended with
+  the spike outcome and the rejected-alternative rationale (a second on-disk queue,
+  mirroring #265's Uploader intent queue, was considered and rejected in review: Vector's
+  own disk buffer already covers sink outages and the ready-gate already covers startup,
+  so only the in-flight window needed closing). **`doc/src/dc/data_pipeline.md` (the
+  published mdbook site) was deliberately left untouched** on user instruction: that
+  site's `doc.yaml` workflow deploys to GitHub Pages on every push to `jazzy`, and jazzy
+  isn't considered ready to be the live-published docs yet — publishing them stays a
+  separate decision from landing this feature. `dc_bridge/README.md` and the ADRs are
+  fine to update (plain repo files, not part of the published site).
+- **Verified for real, no `colcon`/ROS available in this sandbox** (same constraint
+  noted throughout this epic): built `dc_bridge_core` + all six gtest suites against
+  real (not mocked/stubbed) `gtest`/`nlohmann_json`/`tomlplusplus`/`msgpack-cxx` fetched
+  via a scratch CMake `FetchContent` project mirroring `dc_bridge/test/local/`'s own
+  standalone build (`msgpack-cxx`'s bundled CMake needed `MSGPACK_NO_BOOST` to avoid a
+  Boost dependency it doesn't actually need for this). All 41 render tests / 9 forwarder
+  tests / full suite green across repeated runs (no flakiness). Beyond unit tests, ran a
+  real end-to-end zero-loss smoke test: a small client publishing a strictly-
+  incrementing counter through the real `Forwarder` code at ~50/s to the real pinned
+  Vector binary (file sink + disk buffer + global acks), with an orchestration script
+  that `kill -9`s Vector mid-stream and restarts it as a fresh process. Result, 3
+  consecutive runs: **zero missing sequence values** every time (300/300 delivered,
+  duplicates permitted and counted — 0 seen in these particular runs, since the ack
+  round-trip on loopback is fast enough that nothing was usually still in-flight at the
+  exact kill instant; the deterministic mock-server unit test above is what pins down
+  the exact-same-chunk-id resend behavior directly). `pre-commit` clean on every changed
+  file (`clang-format`, `black`, `codespell`, `check-toml`, ROS package metadata checks,
+  and the mdbook `build-doc` hook all passed); only the pre-existing, environment-only
+  `poetry-requirements` failure recurred (no `poetry` binary in this sandbox, unrelated
+  to this diff, same skip as every prior DC 2.0 slice in this file).
+- **Not done / left for follow-up**: an actual `colcon build`/`colcon test` run in a
+  real ROS 2 Jazzy + `aws_sdk_vendor` environment (this sandbox still has no ROS
+  install — every verification above used the ROS-independent core directly, same
+  caveat as prior slices before a Docker/Podman session was available); wiring a
+  `dc_bridge`-level `colcon test`-integrated e2e test for the kill-mid-stream scenario
+  specifically (the zero-loss smoke test above lived in the session scratchpad; the
+  existing `tools/e2e/` harness (#249) already does a full container restart under load
+  and could grow a similar counter-based gap/dup assertion, but that's additive scope
+  beyond this issue, not required to close it); disk persistence of the resend window
+  (explicitly out of scope per the issue).


### PR DESCRIPTION
## Summary

- The Bridge's `Forwarder` now tags every shipper-ingest-protocol frame with a `chunk`
  id and treats Vector's `ack` response as confirmation of durable receipt (verified
  against the real pinned Vector 0.57.0 binary — including with the sink completely
  unreachable, where the ack still fires because it's tied to Vector's disk buffer, not
  final delivery to the Destination).
- Sent-but-unacked Records are held in a bounded in-memory window and resent after a
  reconnect or an ack timeout, closing the one durability gap flagged in ADR-0002/#249:
  a Record arriving while Vector is mid-respawn or backpressured is no longer just
  dropped. Delivery is at-least-once (documented); the window drops the oldest record
  with a rate-limited warning if it's ever exhausted (default bound: 10k records / 16MiB).
- The rendered Vector config now enables global `[acknowledgements] enabled = true`
  (the non-deprecated form in Vector 0.57, confirmed by the spike — the source-level
  knob logs a deprecation warning with identical ack behavior).
- Vocabulary cleanup: purged "Fluent Forward" as a component-sounding name from code
  comments/docs in favor of "shipper ingest protocol" / "Tag", per CONTEXT.md's glossary.

## Test plan

- [x] Spike against the real pinned Vector 0.57.0 binary (hand-rolled msgpack client,
      no library needed): confirmed `chunk`/`ack` support, ack-on-durable-buffer
      behavior with the sink down, and the global-vs-source-level acknowledgements
      deprecation.
- [x] `dc_bridge_core` unit tests (new scratch CMake harness fetching real
      gtest/nlohmann_json/tomlplusplus/msgpack-cxx, mirroring `dc_bridge/test/local/`):
      41 render tests + 9 forwarder tests (4 new: chunk-in-frame, acked-record-leaves-
      window, unacked-resends-with-same-chunk-id-after-reconnect,
      window-bound-drops-oldest-with-warning) + full suite, all green across repeated
      runs.
- [x] All 6 gold-file fixtures re-`vector validate`d clean against the real pinned
      binary after adding the acknowledgements block.
- [x] Real end-to-end zero-loss smoke test: a client publishing an incrementing counter
      through the real `Forwarder` to the real Vector binary while an orchestration
      script `kill -9`s Vector mid-stream and restarts it — 300/300 delivered, zero
      missing, across 3 consecutive runs.
- [x] `pre-commit` clean on every changed file (clang-format, black, codespell,
      check-toml, ROS package metadata, mdbook doc build); only the pre-existing
      environment-only `poetry-requirements` gap recurred (no `poetry` binary in this
      sandbox, unrelated to this diff).
- [ ] Real `colcon build`/`colcon test` in a ROS 2 Jazzy + `aws_sdk_vendor` environment
      (no ROS install available in this sandbox — left for CI/a machine with one, same
      caveat as every prior DC 2.0 C++ slice before its first Docker/Podman pass).

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ST5TaabWPDg7ZHmQ1TEGca