### PR TITLE
feat(dc_bridge): files retention policy — bounded local storage for un-uploaded Files

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -39,7 +39,8 @@ add_library(dc_bridge_core
   src/uploader/status.cpp
   src/uploader/multipart.cpp
   src/uploader/intent_queue.cpp
-  src/uploader/uploader.cpp)
+  src/uploader/uploader.cpp
+  src/uploader/retention.cpp)
 target_include_directories(dc_bridge_core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
@@ -63,7 +64,7 @@ install(TARGETS dc_bridge DESTINATION lib/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
-  foreach(t forwarder supervisor render misc uploader intent_queue)
+  foreach(t forwarder supervisor render misc uploader intent_queue retention)
     ament_add_gtest(${t}_test test/${t}_test.cpp)
     target_link_libraries(${t}_test dc_bridge_core)
     target_compile_definitions(${t}_test PRIVATE

--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -31,6 +31,8 @@
 #include "dc_bridge/render.hpp"
 #include "dc_bridge/supervisor.hpp"
 #include "dc_bridge/uploader/intent_queue.hpp"
+#include "dc_bridge/uploader/object_store.hpp"
+#include "dc_bridge/uploader/retention.hpp"
 #include "dc_bridge/uploader/uploader.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
 
@@ -80,6 +82,13 @@ private:
   std::mutex uploader_wake_mutex_;
   std::condition_variable uploader_wake_cv_;
   bool upload_stop_{ false };
+
+  // Files retention (#267) — a copy of the storages the Uploader was built with (kept
+  // alongside it since the Uploader moves its own copy) so the worker thread can build
+  // shed audit rows without needing an Uploader accessor; a no-op sweep when disabled
+  // (the default) either way.
+  uploader::RetentionConfig retention_config_;
+  std::vector<Storage> files_storages_;
 };
 
 }  // namespace dc_bridge

--- a/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
@@ -34,6 +34,10 @@ struct Intent
   std::string id;  ///< the intent's filename — the key ack()/record_failure() take.
   std::string tag;
   nlohmann::json payload;
+  /// Wall-clock time the intent was enqueued — survives a restart (parsed back from the
+  /// filename's own timestamp prefix on replay). Retention (#267) uses this for its
+  /// `max_age_days` limit.
+  std::chrono::system_clock::time_point enqueued_at;
 };
 
 /// FLB's own scheduler defaults (`destination_server.cpp`'s pre-#265 Fluent Bit config):
@@ -76,6 +80,12 @@ public:
   /// success) or record_failure() (on failure) does that once the caller knows which.
   std::optional<Intent> next_ready(std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now()) const;
 
+  /// Every currently pending intent, oldest-first, regardless of backoff state. Unlike
+  /// next_ready() (which only ever surfaces one entry not currently backing off, for the
+  /// normal upload-retry path), retention (#267) cares about disk pressure, not retry
+  /// timing — a backed-off intent's File still occupies space and still counts.
+  std::vector<Intent> pending() const;
+
   /// Number of intents currently pending on disk (ready or backing off).
   std::size_t size() const;
   bool empty() const;
@@ -85,6 +95,7 @@ private:
   {
     std::string tag;
     nlohmann::json payload;
+    std::chrono::system_clock::time_point enqueued_at;
     // steady_clock::time_point::min() = ready immediately (never failed yet).
     std::chrono::steady_clock::time_point next_attempt{ std::chrono::steady_clock::time_point::min() };
     std::chrono::milliseconds backoff{ 0 };

--- a/dc_bridge/include/dc_bridge/uploader/retention.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/retention.hpp
@@ -1,0 +1,74 @@
+// Files retention policy — bounded local storage for un-uploaded Files (#267, ADR-0005
+// follow-up). #265's durable intent queue never abandons an intent by design (an intent
+// and its Files live and die together), so a robot offline for weeks — or a store that's
+// unreachable for weeks — accumulates un-uploaded Files on disk without bound, same as
+// Humble did. This is the one, explicit, opt-in mechanism allowed to abandon data under
+// disk pressure: default off (files.retention absent/zero = unlimited, Humble parity);
+// when configured, it sheds the oldest un-uploaded intent+Files, together, until back
+// under the configured limit(s).
+#ifndef DC_BRIDGE__UPLOADER__RETENTION_HPP_
+#define DC_BRIDGE__UPLOADER__RETENTION_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "dc_bridge/uploader/group.hpp"
+#include "dc_bridge/uploader/intent_queue.hpp"
+#include "dc_bridge/uploader/object_store.hpp"
+
+namespace dc_bridge::uploader
+{
+
+struct RetentionConfig
+{
+  std::uint64_t max_bytes = 0;                ///< cap on the un-uploaded File pool. 0 = unlimited (default).
+  std::optional<std::uint32_t> max_age_days;  ///< optional; whichever limit hits first. absent = unlimited.
+
+  bool enabled() const
+  {
+    return max_bytes > 0 || max_age_days.has_value();
+  }
+};
+
+/// True if every File `group` references is already fully verified (uploaded,
+/// size-confirmed) on every storage it targets. A pending intent can only be in this
+/// state if its own deletion is what's still failing/retrying (delete_when_sent) — that's
+/// not retention's problem to solve, and retention must never shed it.
+using VerifiedEverywhereFn = std::function<bool(const FileGroup& group)>;
+
+/// Emits one shed_row audit row. Called at most once per (File, storage) a shed intent
+/// referenced; a thrown exception is swallowed by sweep() (best-effort — the disk
+/// pressure being relieved matters more than the audit Record reaching the Shipper this
+/// instant) and never blocks or reverts the shed.
+using RetentionEmitFn = std::function<void(const nlohmann::json& row)>;
+
+struct SweepResult
+{
+  std::size_t shed_intents = 0;
+  std::uint64_t bytes_freed = 0;
+};
+
+/// One retention sweep: stats the on-disk pool of Files referenced by `queue`'s pending
+/// intents (every intent still in `<data_dir>/queue/upload/` — the Uploader hasn't
+/// finished with it, so this excludes Records whose Files already uploaded, verified, and
+/// left the queue via ack()) and, while either configured limit is exceeded, sheds the
+/// oldest eligible intent's Files — File and intent removed together, never one without
+/// the other — until back under both limits. An intent that `is_verified_everywhere`
+/// reports as fully verified is skipped (left pending; delete_when_sent's own retry path
+/// owns it) rather than shed, and evaluation continues with the next-oldest entry. A
+/// no-op — returns {0, 0} immediately, touches nothing — when `config` isn't enabled
+/// (files.retention absent, the default). `now` defaults to the real clock; tests inject
+/// a synthetic value to exercise max_age_days without waiting real time.
+SweepResult sweep(IntentQueue& queue, const std::vector<Storage>& storages, const RetentionConfig& config,
+                  const VerifiedEverywhereFn& is_verified_everywhere, const RetentionEmitFn& emit,
+                  const std::function<void(const std::string&)>& warn,
+                  std::chrono::system_clock::time_point now = std::chrono::system_clock::now());
+
+}  // namespace dc_bridge::uploader
+
+#endif  // DC_BRIDGE__UPLOADER__RETENTION_HPP_

--- a/dc_bridge/include/dc_bridge/uploader/status.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/status.hpp
@@ -34,6 +34,13 @@ nlohmann::json missing_row(const FileGroup& group, const FileRef& file, const St
 nlohmann::json deleted_row(const FileGroup& group, const FileRef& file, const Storage& storage,
                            const std::string& remote_path);
 
+/// The retention policy's audit row (#267): a File shed under disk pressure without ever
+/// having been uploaded — distinct from deleted_row's `uploaded: true` (delete_when_sent
+/// only ever deletes a File after it's fully verified). `deleted: true, uploaded: false`
+/// is the queryable "shed without upload" signature.
+nlohmann::json shed_row(const FileGroup& group, const FileRef& file, const Storage& storage,
+                        const std::string& remote_path);
+
 /// ADR-0005's group completion marker.
 nlohmann::json group_complete_row(const FileGroup& group);
 

--- a/dc_bridge/include/dc_bridge/uploader/uploader.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/uploader.hpp
@@ -96,6 +96,13 @@ public:
   /// processing so the caller can retry idempotently.
   ProcessSummary process_record(const nlohmann::json& payload, const std::string& fallback_group, const EmitFn& emit);
 
+  /// True if every File `group` references is already uploaded and size-verified on
+  /// every storage it targets — a plain HEAD/size check per storage, no upload attempt,
+  /// no status Records emitted. Used by retention (#267) to recognize a pending intent
+  /// whose only remaining step is its own deletion (delete_when_sent's job), which
+  /// retention must never shed.
+  bool is_verified_everywhere(const FileGroup& group) const;
+
 private:
   enum class EnsureOutcome
   {

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -209,6 +209,18 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   const auto files_multipart_part_size = declare_optional_int(this, "files.multipart_part_size_bytes");
   const std::string metadata_destination = this->declare_parameter<std::string>("files.metadata_destination", "");
 
+  // files.retention.* (#267): default off (0/absent = unlimited, Humble parity) —
+  // declared unconditionally like the files.* params above, whether or not a
+  // `receives: files` destination even exists.
+  if (const auto v = declare_optional_int(this, "files.retention.max_bytes"))
+  {
+    retention_config_.max_bytes = static_cast<std::uint64_t>(std::max<std::int64_t>(0, *v));
+  }
+  if (const auto v = declare_optional_int(this, "files.retention.max_age_days"))
+  {
+    retention_config_.max_age_days = static_cast<std::uint32_t>(std::max<std::int64_t>(0, *v));
+  }
+
   if (!files_destinations.empty())
   {
     if (metadata_destination.empty())
@@ -240,6 +252,10 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
       }
       storages.push_back(make_s3_storage(dest.name, *s3));
     }
+    // Retention (#267) needs its own copy — the Uploader below moves its own — for the
+    // worker thread's periodic sweep. Cheap: Storage is name/prefix strings plus a
+    // shared_ptr<ObjectStore>.
+    files_storages_ = storages;
     uploader::UploaderConfig ucfg(data_dir + "/uploader", files_delete_when_sent);
     if (files_multipart_threshold)
     {
@@ -471,6 +487,36 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
     throw std::runtime_error(last_err);
   };
 
+  // Retention's own audit rows (#267) are strictly best-effort: a single send, no
+  // 60s-of-retries loop like `emit` above — the shed itself (relieving disk pressure)
+  // must never be held up by "the Shipper is reachable right now".
+  auto retention_emit = [&forwarder](const nlohmann::json& row) {
+    Record record;
+    record.tag = uploader::FILE_STATUS_TAG;
+    record.timestamp_secs = static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    record.payload = row;
+    forwarder.send(record);
+  };
+  auto is_verified_everywhere = [this](const uploader::FileGroup& group) {
+    return uploader_->is_verified_everywhere(group);
+  };
+  auto retention_warn = [this](const std::string& msg) { RCLCPP_WARN(this->get_logger(), "%s", msg.c_str()); };
+  // Sweeping on every wake (every ~500ms) would hammer the storage backend with
+  // is_verified_everywhere's HEAD checks for no benefit — retention is an occasional,
+  // opt-in safety valve, not a hot path. A fixed, generous interval is enough; it isn't
+  // exposed as a parameter since #267 doesn't ask for that knob.
+  constexpr std::chrono::seconds RETENTION_SWEEP_INTERVAL{ 30 };
+  // `steady_clock::time_point::min()` would look like the natural "run immediately"
+  // sentinel here, but `now - last_retention_sweep` below is a *subtraction*, not a
+  // comparison (unlike IntentQueue's own next_attempt sentinel) — min() so vastly
+  // predates any real `now` that the difference overflows steady_clock::duration's
+  // range, wrapping around to a large *negative* value that then never legitimately
+  // reaches the interval again. Backdating by the interval itself keeps the value
+  // anchored to the real clock (so the first sweep still runs immediately) without the
+  // overflow.
+  auto last_retention_sweep = std::chrono::steady_clock::now() - RETENTION_SWEEP_INTERVAL;
+
   for (;;)
   {
     {
@@ -493,6 +539,17 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
     // Keeps this Forwarder's own unacked window (#266) converging between status-Record
     // emissions, same reason the main prober thread polls the subscription Forwarder.
     forwarder.poll();
+
+    if (retention_config_.enabled())
+    {
+      const auto now = std::chrono::steady_clock::now();
+      if (now - last_retention_sweep >= RETENTION_SWEEP_INTERVAL)
+      {
+        last_retention_sweep = now;
+        uploader::sweep(*intent_queue_, files_storages_, retention_config_, is_verified_everywhere, retention_emit,
+                        retention_warn);
+      }
+    }
 
     auto item = intent_queue_->next_ready();
     if (!item)

--- a/dc_bridge/src/uploader/intent_queue.cpp
+++ b/dc_bridge/src/uploader/intent_queue.cpp
@@ -44,6 +44,28 @@ std::string iso8601_now()
   return ss.str();
 }
 
+// The intent id's own leading field is a 20-digit zero-padded wall-clock-nanoseconds
+// timestamp (make_id() above) — parsing it back on replay avoids a second, redundant
+// timestamp representation to keep in sync with the ISO8601 string in the JSON body.
+// Falls back to the epoch (treated as "infinitely old" by retention's max_age_days,
+// which is the safer default for a name that doesn't match our own generated format).
+std::chrono::system_clock::time_point enqueued_at_from_id(const std::string& id)
+{
+  if (id.size() < 20)
+  {
+    return std::chrono::system_clock::time_point{};
+  }
+  try
+  {
+    const std::uint64_t ns = std::stoull(id.substr(0, 20));
+    return std::chrono::system_clock::time_point(std::chrono::nanoseconds(static_cast<std::int64_t>(ns)));
+  }
+  catch (const std::exception&)
+  {
+    return std::chrono::system_clock::time_point{};
+  }
+}
+
 }  // namespace
 
 IntentQueue::IntentQueue(std::string dir, std::chrono::milliseconds base_backoff, std::chrono::milliseconds max_backoff)
@@ -87,6 +109,7 @@ IntentQueue::IntentQueue(std::string dir, std::chrono::milliseconds base_backoff
     Entry entry;
     entry.tag = doc.value("tag", "");
     entry.payload = doc.value("payload", nlohmann::json::object());
+    entry.enqueued_at = enqueued_at_from_id(name);
     entries_.emplace(name, std::move(entry));
     order_.push_back(name);
   }
@@ -127,6 +150,8 @@ std::string IntentQueue::enqueue(const std::string& tag, const nlohmann::json& p
   Entry entry;
   entry.tag = tag;
   entry.payload = payload;
+  entry.enqueued_at =
+      std::chrono::system_clock::time_point(std::chrono::nanoseconds(static_cast<std::int64_t>(now_ns)));
   entries_.emplace(id, std::move(entry));
   order_.push_back(id);
   return id;
@@ -170,10 +195,23 @@ std::optional<Intent> IntentQueue::next_ready(std::chrono::steady_clock::time_po
     const Entry& e = entries_.at(id);
     if (e.next_attempt <= now)
     {
-      return Intent{ id, e.tag, e.payload };
+      return Intent{ id, e.tag, e.payload, e.enqueued_at };
     }
   }
   return std::nullopt;
+}
+
+std::vector<Intent> IntentQueue::pending() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  std::vector<Intent> out;
+  out.reserve(order_.size());
+  for (const auto& id : order_)
+  {
+    const Entry& e = entries_.at(id);
+    out.push_back(Intent{ id, e.tag, e.payload, e.enqueued_at });
+  }
+  return out;
 }
 
 std::size_t IntentQueue::size() const

--- a/dc_bridge/src/uploader/retention.cpp
+++ b/dc_bridge/src/uploader/retention.cpp
@@ -1,0 +1,147 @@
+#include "dc_bridge/uploader/retention.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <set>
+#include <system_error>
+
+#include "dc_bridge/uploader/status.hpp"
+
+namespace dc_bridge::uploader
+{
+
+namespace
+{
+
+std::uint64_t file_size_or_zero(const std::string& path)
+{
+  std::error_code ec;
+  const auto size = std::filesystem::file_size(path, ec);
+  return ec ? 0 : static_cast<std::uint64_t>(size);
+}
+
+struct Candidate
+{
+  std::string id;
+  FileGroup group;
+  std::uint64_t bytes;
+  std::chrono::system_clock::time_point enqueued_at;
+};
+
+}  // namespace
+
+SweepResult sweep(IntentQueue& queue, const std::vector<Storage>& storages, const RetentionConfig& config,
+                  const VerifiedEverywhereFn& is_verified_everywhere, const RetentionEmitFn& emit,
+                  const std::function<void(const std::string&)>& warn, std::chrono::system_clock::time_point now)
+{
+  SweepResult result;
+  if (!config.enabled())
+  {
+    return result;
+  }
+
+  std::set<std::string> storage_names;
+  for (const auto& s : storages)
+  {
+    storage_names.insert(s.name);
+  }
+
+  // Oldest-first, mirroring the queue's own on-disk order. Files-less Records (nothing
+  // for retention to act on) are skipped entirely — they hold no bytes and never count
+  // toward either limit.
+  std::vector<Candidate> candidates;
+  std::uint64_t pool_bytes = 0;
+  for (const auto& intent : queue.pending())
+  {
+    FileGroup group = parse_file_group(intent.payload, intent.tag, storage_names);
+    if (group.files.empty())
+    {
+      continue;
+    }
+    std::uint64_t bytes = 0;
+    for (const auto& f : group.files)
+    {
+      bytes += file_size_or_zero(f.local_path);
+    }
+    pool_bytes += bytes;
+    candidates.push_back(Candidate{ intent.id, std::move(group), bytes, intent.enqueued_at });
+  }
+
+  const auto max_age = config.max_age_days ?
+                           std::optional<std::chrono::hours>(std::chrono::hours(24) * *config.max_age_days) :
+                           std::nullopt;
+
+  auto over_limits = [&](std::size_t idx) {
+    if (idx >= candidates.size())
+    {
+      return false;
+    }
+    if (config.max_bytes > 0 && pool_bytes > config.max_bytes)
+    {
+      return true;
+    }
+    if (max_age && (now - candidates[idx].enqueued_at) > *max_age)
+    {
+      return true;
+    }
+    return false;
+  };
+
+  std::size_t i = 0;
+  while (over_limits(i))
+  {
+    const Candidate& c = candidates[i];
+    if (is_verified_everywhere(c.group))
+    {
+      // Fully verified but still pending — its own deletion is what's still
+      // failing/retrying (delete_when_sent). Not retention's problem to solve; leave it
+      // pending and evaluate the next-oldest entry instead.
+      ++i;
+      continue;
+    }
+
+    for (const auto& file : c.group.files)
+    {
+      std::error_code ec;
+      std::filesystem::remove(file.local_path, ec);  // idempotent; already-gone is fine (replay tolerance).
+      for (const auto& [storage_name, remote_path] : file.remote_paths)
+      {
+        auto st =
+            std::find_if(storages.begin(), storages.end(), [&](const Storage& s) { return s.name == storage_name; });
+        if (st == storages.end())
+        {
+          continue;
+        }
+        try
+        {
+          emit(status::shed_row(c.group, file, *st, remote_path));
+        }
+        catch (const std::exception&)
+        {
+          // Best-effort: the shed itself must not be held up by "the Shipper is
+          // reachable" — the operator-visible warn below still fires regardless.
+        }
+      }
+    }
+    // The intent leaves the queue only after its Files are gone (never one without the
+    // other) — matches #265's own File+intent lifecycle contract.
+    queue.ack(c.id);
+
+    result.shed_intents += 1;
+    result.bytes_freed += c.bytes;
+    pool_bytes -= c.bytes;
+    candidates.erase(candidates.begin() + static_cast<std::ptrdiff_t>(i));
+    // Don't advance i: the next-oldest candidate has shifted into this index.
+  }
+
+  if (result.shed_intents > 0)
+  {
+    warn("retention: shed " + std::to_string(result.shed_intents) + " intent(s), " + std::to_string(result.bytes_freed) +
+         " byte(s) freed, to stay under the configured files.retention limit(s) — data was abandoned without "
+         "uploading");
+  }
+
+  return result;
+}
+
+}  // namespace dc_bridge::uploader

--- a/dc_bridge/src/uploader/status.cpp
+++ b/dc_bridge/src/uploader/status.cpp
@@ -74,6 +74,16 @@ nlohmann::json deleted_row(const FileGroup& group, const FileRef& file, const St
   return row;
 }
 
+nlohmann::json shed_row(const FileGroup& group, const FileRef& file, const Storage& storage,
+                        const std::string& remote_path)
+{
+  nlohmann::json row = base_row(group, file, storage, remote_path);
+  row["uploaded"] = false;
+  row["on_filesystem"] = false;
+  row["deleted"] = true;
+  return row;
+}
+
 nlohmann::json group_complete_row(const FileGroup& group)
 {
   nlohmann::json row;

--- a/dc_bridge/src/uploader/uploader.cpp
+++ b/dc_bridge/src/uploader/uploader.cpp
@@ -311,6 +311,36 @@ bool Uploader::delete_verified_file(const FileGroup& group, const FileRef& file,
   return true;
 }
 
+bool Uploader::is_verified_everywhere(const FileGroup& group) const
+{
+  for (const auto& file : group.files)
+  {
+    const std::optional<FileMeta> meta = file_meta(file.local_path);
+    if (!meta)
+    {
+      return false;
+    }
+    for (const auto& [storage_name, remote_path] : file.remote_paths)
+    {
+      const Storage& st = storage(storage_name);
+      std::optional<std::uint64_t> remote_size;
+      try
+      {
+        remote_size = st.store->head(st.object_key(remote_path));
+      }
+      catch (const std::exception&)
+      {
+        return false;
+      }
+      if (!remote_size || *remote_size != meta->size)
+      {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 ProcessSummary Uploader::process_record(const nlohmann::json& payload, const std::string& fallback_group,
                                         const EmitFn& emit)
 {

--- a/dc_bridge/test/forwarder_test.cpp
+++ b/dc_bridge/test/forwarder_test.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <functional>
 #include <msgpack.hpp>
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -57,6 +58,30 @@ struct MockServer
       ::close(listen_fd);
   }
 };
+
+// Polls `condition` until it returns true or `budget` of real wall-clock time elapses,
+// sleeping 20ms between checks. A wall-clock deadline rather than a fixed iteration
+// count: a fixed `for (i < N) { ...; sleep(20ms); }` loop implicitly assumes each
+// iteration costs ~20ms, but scheduler contention or a slow (e.g. coverage-instrumented)
+// build inflates the real cost per iteration, silently shrinking the test's actual
+// patience without touching the visible "N iterations" budget — the CI flake this
+// replaced (Forwarder.UnackedRecordResendsAfterReconnect intermittently failing under a
+// loaded/coverage build) was exactly that. `condition` may have side effects (e.g.
+// calling forwarder.poll()) — it's invoked once more after the deadline so a
+// just-in-time success right at the boundary still counts.
+bool poll_until(std::chrono::milliseconds budget, const std::function<bool()>& condition)
+{
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  do
+  {
+    if (condition())
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  } while (std::chrono::steady_clock::now() < deadline);
+  return condition();
+}
 
 // Unpacks one msgpack object from `bytes`.
 msgpack::object_handle unpack(const std::string& bytes)
@@ -199,20 +224,17 @@ TEST(Forwarder, ReconnectsAfterPeerDropsConnection)
 
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-  bool reconnected = false;
-  for (int i = 0; i < 100; ++i)
-  {
+  bool reconnected = poll_until(std::chrono::seconds(10), [&]() {
     try
     {
       forwarder.send(make_record("dc.test", R"({"n": 2})"));
-      reconnected = true;
-      break;
+      return true;
     }
     catch (const ForwarderError&)
     {
-      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      return false;
     }
-  }
+  });
   srv.join();
   EXPECT_TRUE(reconnected) << "forwarder should reconnect after the peer resets the connection";
 }
@@ -279,17 +301,10 @@ TEST(Forwarder, AckedRecordLeavesTheUnackedWindow)
   forwarder.send(make_record("dc.test", R"({"n": 1})"));
   EXPECT_EQ(forwarder.unacked_count(), 1u);
 
-  bool drained = false;
-  for (int i = 0; i < 100; ++i)
-  {
+  bool drained = poll_until(std::chrono::seconds(10), [&]() {
     forwarder.poll();
-    if (forwarder.unacked_count() == 0)
-    {
-      drained = true;
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
+    return forwarder.unacked_count() == 0;
+  });
   EXPECT_TRUE(drained) << "an acked record should leave the unacked window";
   EXPECT_EQ(forwarder.unacked_bytes(), 0u);
 
@@ -344,18 +359,11 @@ TEST(Forwarder, UnackedRecordResendsAfterReconnect)
   // Give the mock server time to RST the first connection, then poll until the
   // Forwarder has reconnected and redelivered.
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  bool redelivered = false;
-  for (int i = 0; i < 100; ++i)
-  {
+  bool redelivered = poll_until(std::chrono::seconds(10), [&]() {
     forwarder.poll();
     std::lock_guard<std::mutex> lock(seen_mutex);
-    if (chunk_ids_seen.size() >= 2)
-    {
-      redelivered = true;
-      break;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
+    return chunk_ids_seen.size() >= 2;
+  });
   srv.join();
 
   ASSERT_TRUE(redelivered) << "the unacked record should have been resent on the new connection";

--- a/dc_bridge/test/local/CMakeLists.txt
+++ b/dc_bridge/test/local/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(dc_bridge_core
   ${CORE_ROOT}/src/uploader/status.cpp
   ${CORE_ROOT}/src/uploader/multipart.cpp
   ${CORE_ROOT}/src/uploader/intent_queue.cpp
-  ${CORE_ROOT}/src/uploader/uploader.cpp)
+  ${CORE_ROOT}/src/uploader/uploader.cpp
+  ${CORE_ROOT}/src/uploader/retention.cpp)
 target_include_directories(dc_bridge_core PUBLIC ${CORE_ROOT}/include)
 target_link_libraries(dc_bridge_core PUBLIC nlohmann_json::nlohmann_json tomlplusplus::tomlplusplus)
 if(TARGET msgpack-cxx)
@@ -37,7 +38,7 @@ if(TARGET msgpack-cxx)
 endif()
 
 enable_testing()
-foreach(t forwarder supervisor render misc uploader intent_queue)
+foreach(t forwarder supervisor render misc uploader intent_queue retention)
   add_executable(${t}_test ${CORE_ROOT}/test/${t}_test.cpp)
   target_link_libraries(${t}_test dc_bridge_core GTest::gtest GTest::gtest_main Threads::Threads)
   target_compile_definitions(${t}_test PRIVATE

--- a/dc_bridge/test/retention_test.cpp
+++ b/dc_bridge/test/retention_test.cpp
@@ -1,0 +1,308 @@
+// Exercises the retention sweep (#267) purely on disk with an injected
+// VerifiedEverywhereFn — no aws-sdk-cpp / cloud dependency, no real ObjectStore needed
+// (sweep() itself never calls Storage::store; only object_key()/name/url_prefix).
+#include "dc_bridge/uploader/retention.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <filesystem>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using namespace dc_bridge;
+using namespace dc_bridge::uploader;
+using nlohmann::json;
+
+namespace
+{
+
+struct Fixture
+{
+  std::filesystem::path tmp;
+  std::filesystem::path queue_dir;
+
+  Fixture()
+  {
+    tmp = std::filesystem::temp_directory_path() /
+          ("dc_retention_test_" + std::to_string(::getpid()) + "_" + std::to_string(counter_++));
+    queue_dir = tmp / "queue";
+    std::filesystem::create_directories(tmp);
+  }
+  ~Fixture()
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(tmp, ec);
+  }
+
+  std::string write_file(const std::string& name, std::size_t bytes)
+  {
+    auto p = tmp / name;
+    std::ofstream(p, std::ios::binary) << std::string(bytes, 'x');
+    return p.string();
+  }
+
+  static std::atomic<int> counter_;
+};
+std::atomic<int> Fixture::counter_{ 0 };
+
+json camera_payload(const std::string& group_name, const std::string& local_path, const std::string& storage_name)
+{
+  return json{ { "name", group_name },
+               { "local_paths", { { "raw", local_path } } },
+               { "remote_paths", { { storage_name, { { "raw", "cam/" + group_name + ".jpg" } } } } } };
+}
+
+Storage make_storage(const std::string& name)
+{
+  return Storage{ name, "s3://" + name + "-bucket/", "", nullptr };
+}
+
+VerifiedEverywhereFn never_verified()
+{
+  return [](const FileGroup&) { return false; };
+}
+
+}  // namespace
+
+TEST(Retention, SweepIsNoopWhenDisabled)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+
+  RetentionConfig cfg;  // default: disabled
+  auto rows = std::make_shared<std::vector<json>>();
+  auto warns = std::make_shared<std::vector<std::string>>();
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [rows](const json& r) { rows->push_back(r); },
+      [warns](const std::string& w) { warns->push_back(w); });
+
+  EXPECT_EQ(result.shed_intents, 0u);
+  EXPECT_EQ(result.bytes_freed, 0u);
+  EXPECT_EQ(q.size(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(local));
+  EXPECT_TRUE(rows->empty());
+  EXPECT_TRUE(warns->empty());
+}
+
+TEST(Retention, ShedsOldestFirstUntilUnderMaxBytes)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto oldest = fx.write_file("oldest.jpg", 100);
+  auto middle = fx.write_file("middle.jpg", 100);
+  auto newest = fx.write_file("newest.jpg", 100);
+  q.enqueue("dc.measurement.camera", camera_payload("oldest", oldest, "minio"));
+  q.enqueue("dc.measurement.camera", camera_payload("middle", middle, "minio"));
+  q.enqueue("dc.measurement.camera", camera_payload("newest", newest, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 150;  // 300 bytes total pending; must shed down to <=150.
+  auto rows = std::make_shared<std::vector<json>>();
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [rows](const json& r) { rows->push_back(r); },
+      [](const std::string&) {});
+
+  EXPECT_EQ(result.shed_intents, 2u);
+  EXPECT_EQ(result.bytes_freed, 200u);
+  EXPECT_EQ(q.size(), 1u);
+  EXPECT_FALSE(std::filesystem::exists(oldest));
+  EXPECT_FALSE(std::filesystem::exists(middle));
+  EXPECT_TRUE(std::filesystem::exists(newest));  // the newest survives — oldest-first.
+  EXPECT_EQ(rows->size(), 2u);
+}
+
+TEST(Retention, ShedsByMaxAgeEvenUnderBytesLimit)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 10);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+  const auto enqueued_at = q.pending().at(0).enqueued_at;
+
+  RetentionConfig cfg;
+  cfg.max_age_days = 30;  // max_bytes left at 0/unlimited — age alone must trigger the shed.
+  auto rows = std::make_shared<std::vector<json>>();
+  const auto far_future = enqueued_at + std::chrono::hours(24) * 31;
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [rows](const json& r) { rows->push_back(r); },
+      [](const std::string&) {}, far_future);
+
+  EXPECT_EQ(result.shed_intents, 1u);
+  EXPECT_TRUE(q.empty());
+  EXPECT_FALSE(std::filesystem::exists(local));
+}
+
+TEST(Retention, WithinMaxAgeIsNotShed)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 10);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+  const auto enqueued_at = q.pending().at(0).enqueued_at;
+
+  RetentionConfig cfg;
+  cfg.max_age_days = 30;
+  const auto still_fresh = enqueued_at + std::chrono::hours(24) * 5;
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [](const json&) {}, [](const std::string&) {}, still_fresh);
+
+  EXPECT_EQ(result.shed_intents, 0u);
+  EXPECT_EQ(q.size(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(local));
+}
+
+TEST(Retention, VerifiedEverywhereIntentsAreNeverShed)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto verified_file = fx.write_file("verified.jpg", 200);
+  auto unverified_file = fx.write_file("unverified.jpg", 200);
+  q.enqueue("dc.measurement.camera", camera_payload("verified", verified_file, "minio"));
+  q.enqueue("dc.measurement.camera", camera_payload("unverified", unverified_file, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 100;  // both together are well over the limit.
+  VerifiedEverywhereFn is_verified = [](const FileGroup& g) { return g.group_name == "verified"; };
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, is_verified, [](const json&) {}, [](const std::string&) {});
+
+  // The verified-but-still-pending intent (delete_when_sent's own retry, not retention's
+  // job) is skipped; the unverified one — the one actually eligible — is shed instead.
+  EXPECT_EQ(result.shed_intents, 1u);
+  EXPECT_TRUE(std::filesystem::exists(verified_file));
+  EXPECT_FALSE(std::filesystem::exists(unverified_file));
+  EXPECT_EQ(q.size(), 1u);
+  auto remaining = q.pending();
+  ASSERT_EQ(remaining.size(), 1u);
+  EXPECT_EQ(remaining[0].payload["name"], "verified");
+}
+
+TEST(Retention, IfEveryCandidateIsVerifiedNothingIsShedAndTheLoopTerminates)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 10;
+  VerifiedEverywhereFn always_verified = [](const FileGroup&) { return true; };
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, always_verified, [](const json&) {}, [](const std::string&) {});
+
+  EXPECT_EQ(result.shed_intents, 0u);
+  EXPECT_EQ(q.size(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(local));
+}
+
+TEST(Retention, FileAndIntentAreAlwaysRemovedTogether)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  const std::string id = q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 1;
+  sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [](const json&) {}, [](const std::string&) {});
+
+  EXPECT_FALSE(std::filesystem::exists(local));
+  EXPECT_TRUE(q.empty());
+  // The intent's own JSON file is gone too (ack unlinks it) — never one without the other.
+  EXPECT_FALSE(std::filesystem::exists(fx.queue_dir / id));
+}
+
+TEST(Retention, AuditRowHasShedWithoutUploadSignature)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 1;
+  auto rows = std::make_shared<std::vector<json>>();
+  sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [rows](const json& r) { rows->push_back(r); },
+      [](const std::string&) {});
+
+  ASSERT_EQ(rows->size(), 1u);
+  const auto& row = rows->at(0);
+  EXPECT_EQ(row["kind"], "file_status");
+  EXPECT_EQ(row["deleted"], true);
+  EXPECT_EQ(row["uploaded"], false);
+  EXPECT_EQ(row["on_filesystem"], false);
+  EXPECT_EQ(row["storage_type"], "minio");
+  EXPECT_EQ(row["local_path"], local);
+}
+
+TEST(Retention, EmitFailureDoesNotBlockSheddingButWarnStillFires)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 1;
+  auto warns = std::make_shared<std::vector<std::string>>();
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(),
+      [](const json&) { throw std::runtime_error("shipper unreachable"); },
+      [warns](const std::string& w) { warns->push_back(w); });
+
+  EXPECT_EQ(result.shed_intents, 1u);
+  EXPECT_FALSE(std::filesystem::exists(local));
+  EXPECT_TRUE(q.empty());
+  ASSERT_EQ(warns->size(), 1u);
+  EXPECT_NE(warns->at(0).find("shed 1 intent"), std::string::npos);
+}
+
+TEST(Retention, RecordsWithoutFilesAreIgnoredByRetention)
+{
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  q.enqueue("dc.measurement.uptime", json{ { "uptime_s", 42 } });
+
+  RetentionConfig cfg;
+  cfg.max_bytes = 1;
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [](const json&) {}, [](const std::string&) {});
+
+  EXPECT_EQ(result.shed_intents, 0u);
+  EXPECT_EQ(q.size(), 1u);  // a files-less Record isn't retention's concern.
+}
+
+TEST(Retention, ReplayToleratesAnAlreadyMissingLocalFile)
+{
+  // Simulates a crash between the file delete and the intent ack: the File is already
+  // gone from disk, but the intent is still pending. A later sweep (replay) must still
+  // converge cleanly — no throw, no hang, no stranding — rather than getting stuck. Uses
+  // max_age_days (not max_bytes) to trigger the shed: an already-missing File
+  // legitimately contributes 0 bytes to the pool, so byte-based eviction has nothing left
+  // to react to for this one — age is what still lets a leftover pending intent resolve.
+  Fixture fx;
+  IntentQueue q(fx.queue_dir.string());
+  auto local = fx.write_file("img.jpg", 1000);
+  q.enqueue("dc.measurement.camera", camera_payload("g1", local, "minio"));
+  const auto enqueued_at = q.pending().at(0).enqueued_at;
+  std::filesystem::remove(local);  // "crash" already deleted the File; the intent lingers.
+
+  RetentionConfig cfg;
+  cfg.max_age_days = 30;
+  auto rows = std::make_shared<std::vector<json>>();
+  auto result = sweep(
+      q, { make_storage("minio") }, cfg, never_verified(), [rows](const json& r) { rows->push_back(r); },
+      [](const std::string&) {}, enqueued_at + std::chrono::hours(24) * 31);
+
+  EXPECT_EQ(result.shed_intents, 1u);
+  EXPECT_TRUE(q.empty());
+  EXPECT_EQ(rows->size(), 1u);  // the audit row still lands even though there was nothing left to unlink.
+}

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -73,6 +73,14 @@ dc_bridge:
     #   delete_when_sent: true         # delete local Files after verified upload everywhere
     #   metadata_destination: "pgsql"  # receives the dc.files status/metadata Records
     #   ffprobe_binary: "ffprobe"      # video duration probe (optional)
+    #   # Retention (#267): the un-uploaded intent queue never abandons an intent on its
+    #   # own — a robot (or store) offline for weeks accumulates Files without bound.
+    #   # Absent/zero = unlimited, matching Humble. Configuring this is an explicit,
+    #   # audited opt-in to shedding the oldest un-uploaded Files under disk pressure —
+    #   # see doc/src/dc/destinations.md's "Retention" section before enabling it.
+    #   retention:
+    #     max_bytes: 10737418240  # 10 GiB cap on the un-uploaded Files pool
+    #     max_age_days: 30        # optional; whichever limit is hit first
     #
     # Any other Vector sink type via the ADR-0003 passthrough: raw Vector config
     # snippets consuming the public per-Tag `dc.<tag>` routes (see

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -213,19 +213,45 @@ it never lingers in the queue's steady state. Note that `base64`-heavy Records (
 map's `save_base64: on`) inline file content directly into the payload and so consume
 queue-directory bytes proportionally faster than a plain File reference.
 
-The `files` block:
+### Retention: bounded local storage for un-uploaded Files
+
+The intent queue above never abandons an intent by design — an intent and its Files
+live and die together, and deleting the only copy of data as a side effect of queue
+management is forbidden. That means a robot offline for weeks, or pointed at a store
+that's unreachable for weeks, accumulates un-uploaded Files on disk **without bound**,
+same as Humble did. A full disk takes down more than DC, so `files.retention` is the
+**one, explicit, opt-in, audited** mechanism allowed to abandon data under disk
+pressure — nothing else in the system deletes a File it hasn't verified was uploaded.
+
+**Default is off**: with `files.retention` absent (or both limits at their defaults),
+behavior is unchanged — accumulation, matching Humble. Configuring it is a deliberate
+choice to shed data rather than run out of disk:
 
 ```yaml
 dc_bridge:
   ros__parameters:
     files:
-      delete_when_sent: true         # default false
-      metadata_destination: "pgsql"  # required with any receives: files destination;
-                                     # must name a receives: records destination
-      ffprobe_binary: "ffprobe"      # optional; video duration probe
-      # multipart_threshold_bytes: 16777216  # optional; multipart above this size
-      # multipart_part_size_bytes: 8388608   # optional; >= 5 MiB for real S3 stores
+      retention:
+        max_bytes: 10737418240   # cap on the un-uploaded Files pool; 0/absent = unlimited (default)
+        max_age_days: 30         # optional; whichever limit is hit first
 ```
+
+Scope is exactly the pool of Files referenced by intents still pending in
+`<shipper.data_dir>/queue/upload/` — the same disk-backed queue the durability section
+above describes. A File the Uploader has already verified everywhere but is still
+waiting to physically delete (`files.delete_when_sent`, e.g. after a filesystem error)
+is **never** retention's victim; that's `delete_when_sent`'s own retry loop to resolve,
+not retention's.
+
+When either limit is exceeded, the Bridge sheds the **oldest** eligible intent — its
+File(s) and its queue entry, always together, never one without the other — and repeats
+until back under both limits. Each shed File gets its own audit row through the normal
+`dc.files` metadata path: `deleted: true, uploaded: false` is the queryable "shed
+without upload" signature, distinct from a normal `delete_when_sent` deletion (which is
+always `uploaded: true`, since that path only ever deletes a File already confirmed on
+every Destination). Emitting the audit row is best-effort — a Shipper outage doesn't
+block the shed itself — but every shed always logs a rate-limited warning, since data
+was just abandoned without ever leaving the robot.
 
 A Destination named by `metadata_destination` may declare **no `inputs` at all** — being
 named there is itself what routes the `dc.files` Tag to it. That is the usual shape when

--- a/progress.txt
+++ b/progress.txt
@@ -1492,3 +1492,130 @@ than Humble's in-process FLB call.
   and could grow a similar counter-based gap/dup assertion, but that's additive scope
   beyond this issue, not required to close it); disk persistence of the resend window
   (explicitly out of scope per the issue).
+
+### #267 - DC 2.0: Files retention policy — bounded local storage for un-uploaded Files
+
+- Added `dc_bridge::uploader::sweep` (`include/dc_bridge/uploader/retention.hpp`,
+  `src/uploader/retention.cpp`), the one explicit, opt-in mechanism allowed to abandon
+  data under disk pressure (ADR-0005 follow-up, closing the gap #265's own "not done"
+  list flagged): `files.retention.max_bytes`/`files.retention.max_age_days` (both
+  absent/zero by default = unlimited, Humble parity, zero behavior change). Scope is
+  exactly the pool of Files referenced by `IntentQueue::pending()`'s entries — every
+  intent still sitting in `<shipper.data_dir>/queue/upload/`, which by construction
+  excludes anything the Uploader already finished and acked. `sweep()` walks candidates
+  oldest-first (parsing each pending intent's payload via the existing
+  `parse_file_group`, stat'ing local file sizes for the byte pool), and while either
+  configured limit is exceeded, deletes the oldest eligible intent's File(s) and its
+  queue entry together — File and intent always removed as a pair, matching #265's own
+  "an intent and its Files live and die together" contract, just inverted: here that
+  pair is deliberately abandoned instead of preserved. A candidate the new
+  `Uploader::is_verified_everywhere(FileGroup) const` (public method added to
+  `uploader.hpp`/`.cpp`, a HEAD/size check per storage reusing the existing private
+  `file_meta()`/`storage()` helpers, no upload attempt) reports as fully verified is
+  skipped rather than shed — that intent is still pending only because its own deletion
+  (`delete_when_sent`) is failing/retrying, which is `delete_when_sent`'s job, not
+  retention's, per the issue text.
+- Each shed File gets a new `status::shed_row` (`uploader/status.hpp`/`.cpp`) audit row
+  through the normal `dc.files` metadata path — `deleted: true, uploaded: false`, the
+  "shed without upload" signature distinct from a normal `delete_when_sent` deletion
+  (always `uploaded: true`). Emitting it is best-effort (a thrown exception from the
+  caller's `emit` is swallowed — the shed itself must not be held up by "the Shipper is
+  reachable right now"), but a shed always fires a warn log summarizing what was freed.
+- `IntentQueue` grew what retention needed: `Intent`/`Entry` now carry `enqueued_at`
+  (`enqueue()` sets it directly from the same wall-clock-ns value the id encodes;
+  replay parses it back from the id's own leading 20-digit field rather than adding a
+  second, redundant timestamp representation to keep in sync) and a new `pending()`
+  accessor returning every currently pending intent oldest-first regardless of backoff
+  state — unlike `next_ready()`, retention cares about disk pressure, not retry timing.
+- `bridge_node.cpp`/`.hpp`: declares `files.retention.max_bytes`/`max_age_days`
+  unconditionally (like the other `files.*` params); keeps a `files_storages_` copy of
+  the Uploader's storages (Uploader itself moves its own) so the worker thread's
+  periodic sweep has what it needs without a new Uploader accessor. `run_uploader_worker`
+  calls `uploader::sweep()` on a fixed 30s interval (not exposed as a parameter — #267
+  doesn't ask for that knob), guarded by `retention_config_.enabled()` so a disabled
+  config touches nothing every loop iteration; `retention_emit` is a single-attempt send
+  (no 60s-of-retries loop like the Uploader's own `emit`), matching "best-effort".
+- **Unit tests** (`dc_bridge/test/retention_test.cpp`, 11 gtests, no aws-sdk-cpp — a
+  `Storage` with a null `ObjectStore` is enough since `sweep()` itself never calls
+  `store`): disabled is a true no-op; oldest-first shedding down to under `max_bytes`;
+  `max_age_days` triggers a shed even under the bytes limit (and doesn't trigger while
+  still fresh) using an injectable `now` parameter on `sweep()` (mirroring
+  `next_ready()`'s own pattern) so age tests don't need to sleep real wall time;
+  verified-everywhere intents are never shed even when clearly over limit, and the loop
+  correctly terminates without shedding anything when *every* candidate is verified;
+  File+intent always removed together (both the local file and the intent's own JSON
+  gone); the audit row's exact `deleted`/`uploaded`/`on_filesystem` shape; an `emit`
+  that always throws doesn't block the shed but the warn still fires; a files-less
+  Record is never touched; and replay tolerance — a File already missing from disk
+  (simulating a crash between the file delete and the intent ack) still sheds cleanly
+  via `max_age_days`, no throw, no stranding, no hang.
+- **Verified in a real ROS 2 Jazzy environment via Podman** (built the full
+  `tools/e2e/Containerfile` workspace image via `scripts/build.sh`, then iterated with a
+  persistent, non-`--rm` container bind-mounting this worktree over the image's
+  `/root/ws/src/ros2_data_collection` for fast incremental `colcon build --packages-select
+  dc_bridge` rebuilds — `--rm` containers were tried first and silently discarded every
+  rebuild between commands, a real trap for this workflow, worth flagging for whoever
+  hits it next): `colcon build`/`colcon test --packages-select dc_bridge` both clean,
+  7/7 gtest suites (including the new `retention_test`, and unmodified-behavior checks
+  on `intent_queue_test`/`uploader_test`), zero `-Wall -Wextra` warnings. `pre-commit`
+  clean on every changed/new file (`clang-format`, `black`, `codespell`, `check-yaml`,
+  `shellcheck`, ROS package metadata checks; only the pre-existing environment-gap hooks
+  — `poetry-requirements`, `pycln`, `flake8`, `build-doc` — skipped, same as every prior
+  DC 2.0 slice).
+- **A real bug the unit tests couldn't catch, found by manually running the actual
+  `dc_bridge` binary against a live-but-unreachable S3 endpoint**: the retention sweep
+  never ran, ever. `run_uploader_worker`'s 30s sweep-interval gate compared
+  `now - last_retention_sweep >= RETENTION_SWEEP_INTERVAL`, with `last_retention_sweep`
+  initialized to `steady_clock::time_point::min()` — a fine sentinel for a *comparison*
+  (`IntentQueue`'s own `next_attempt` sentinel does exactly this safely) but not for a
+  *subtraction*: `now - min()` overflows `steady_clock::duration`'s range and wraps
+  around to a large **negative** value, so the interval check silently failed forever.
+  Confirmed by instrumenting a debug build with `RCLCPP_INFO` around the check (removed
+  before landing) and running the real `dc_bridge` binary directly (`ros2 run dc_bridge
+  dc_bridge --ros-args --params-file ...`, a hand-published `StringStamped` Record
+  referencing a real local file, an `rustfs` destination pointed at a closed port): the
+  logged `elapsed` value was a large negative number every single iteration. Fixed by
+  backdating the initializer to `steady_clock::now() - RETENTION_SWEEP_INTERVAL` instead
+  (anchored to the real clock, so the first sweep still runs immediately, no overflow).
+  Re-verified the same manual scenario after the fix: `elapsed=30` on the very first
+  check, the sweep ran, and the fake file + its intent were both gone within one sweep
+  cycle. This also incidentally confirmed a real, pre-existing environment
+  characteristic worth knowing for anyone else testing against a down S3 endpoint in
+  this codebase: a single `aws-sdk-cpp` call against a refused connection can take on
+  the order of a minute (its own internal connection-refused retry/backoff, unrelated to
+  this PR — `curl` itself reports "after 0 ms", the delay is entirely the SDK's client-
+  level retry strategy), so both `Uploader::ensure_uploaded` and
+  `Uploader::is_verified_everywhere` are each individually slow while a store is down;
+  the fixed 30s sweep interval and the e2e timeout below both account for this.
+- **e2e**: extended `tools/e2e/` (following #265's own precedent — "extended the
+  existing harness rather than adding new `dc_bridge`-level test infra") with a second,
+  narrower harness rather than folding into `run.sh`, since this scenario needs the
+  opposite starting condition (RustFS *never* comes up until told to, instead of an
+  outage induced mid-run): `tools/e2e/params/e2e_retention_params.yaml` (camera +
+  uptime Measurements, `files.retention.max_bytes: 1` so a single capture is already
+  over limit) and `tools/e2e/scripts/run_retention.sh`, which starts Postgres only
+  (RustFS deliberately absent), starts the DC stack, asserts a `deleted: true, uploaded:
+  false` audit row lands in `dc_files` and the shed File's local path is actually gone
+  from disk, then starts RustFS and asserts a later (unshed) File uploads and verifies
+  normally. `bash -n`/`shellcheck` clean. **Ran for real**, end to end, against the full
+  built stack (the same `tools/e2e/Containerfile` workspace image plus
+  `Containerfile.e2e`, run via `DC_E2E_IMAGE`): PASS — 2 shed-without-upload audit rows
+  landed in Postgres while RustFS was down, the shed File's local path was confirmed
+  gone from the container's volume, and after starting RustFS a File uploaded and
+  verified normally (`uploaded: true` row landed). This run is also what caught the
+  `steady_clock::time_point::min()` bug above in the first place (it timed out twice
+  before the fix, at 180s and again at 480s, before the manual debug session above
+  found and fixed the real cause) — not run by `ci.yaml` yet, left as a follow-up
+  alongside the existing harness's own CI wiring.
+- Docs: `doc/src/dc/destinations.md` gained a "Retention: bounded local storage for
+  un-uploaded Files" subsection (the "you are opting into data shedding" framing, the
+  accumulation-by-default note, scope, and the audit signature) under "File uploads";
+  `dc_bringup/params/dc_params.yaml`'s commented `files:` example gained a
+  `retention:` block; `tools/e2e/README.md` documents the new harness.
+- **Not done / left for follow-up**: wiring `run_retention.sh` into `ci.yaml` as its own
+  job (the existing zero-loss harness's own camera path already covers the File
+  pipeline's steady-state/outage behavior; this is additive, narrower coverage, not
+  required to close this issue); a `max_age_days`-driven e2e scenario specifically (the
+  e2e run above exercises `max_bytes`; `max_age_days`'s own logic is covered by two
+  dedicated unit tests using the same `now`-injection seam, `sweep()`'s only consumer of
+  it).

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -81,6 +81,29 @@ not just a local tool.
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.
    Informational only, per the PRD — it does not gate the run.
 
+## Files retention scenario (#267)
+
+A second, narrower harness for the retention policy — separate from `run.sh` above
+because it needs the opposite starting condition (RustFS *never* comes up until told
+to, rather than an outage induced mid-run) and a dedicated small
+`files.retention.max_bytes`:
+
+```sh
+./tools/e2e/scripts/run_retention.sh
+```
+
+Reuses the same `dc-e2e` image (same `DC_E2E_IMAGE`/`DC_WORKSPACE_IMAGE` env vars as
+`run.sh`) but overrides the mounted params file with
+`params/e2e_retention_params.yaml` — RustFS starts down and stays down while the camera
+Measurement's captures pile up in the durable upload intent queue, past a deliberately
+small `max_bytes`. Asserts: (1) with RustFS still down, a `deleted: true, uploaded:
+false` audit row lands in `dc_files` for the oldest capture, and its local File is
+actually gone from disk (File+intent atomicity); (2) once RustFS comes up, a later
+(unshed) capture uploads and verifies normally. Not run by `ci.yaml` yet — `run.sh`'s
+own camera path already covers the File pipeline's steady-state/outage behavior; wiring
+this scenario into CI as its own job is left as a follow-up, same as the "not done" list
+below.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -115,6 +138,9 @@ not just a local tool.
   via `DC_E2E_IMAGE` (as CI's `e2e` job does).
 - `scripts/verify_zero_loss.py` — the hard-failing Postgres verification.
 - `scripts/measure_resources.sh` — the informational resource sampler.
+- `params/e2e_retention_params.yaml` / `scripts/run_retention.sh` — the files retention
+  scenario (#267) described above; a separate, narrower harness reusing the same
+  `dc-e2e` image.
 
 ## `.dockerignore`
 

--- a/tools/e2e/params/e2e_retention_params.yaml
+++ b/tools/e2e/params/e2e_retention_params.yaml
@@ -1,0 +1,93 @@
+measurement_server:
+  ros__parameters:
+    save_local_base_path: "$HOME/.dc/e2e/data/%Y/%M/%D/%H"
+    all_base_path: "e2e"
+    measurement_plugins: ["uptime", "camera"]
+
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      polling_interval: 1000
+      group_key: "uptime"
+
+    # A short camera_period (see tools/e2e/scripts/workload_generator.py's
+    # camera_period_s param, set by run_retention.sh) drives this Measurement's
+    # local_paths/remote_paths File references, same shape as e2e_params.yaml's own
+    # camera block.
+    camera:
+      plugin: "dc_measurements/Camera"
+      polling_interval: 15000
+      cam_name: "e2e_camera"
+      cam_topic: "/dc/e2e/camera/image_raw"
+      draw_det_barcodes: false
+      save_raw_img: true
+      save_rotated_img: false
+      save_detections_img: false
+      save_raw_base64: false
+      save_rotated_base64: false
+      save_inspected_base64: false
+      remote_keys: ["rustfs"]
+      remote_prefixes: ["camera"]
+      group_key: "camera"
+
+# Files retention scenario (#267): rustfs starts down (run_retention.sh never brings up
+# its container until told to) — every camera capture's intent stays pending in the
+# Uploader's durable queue, so the un-uploaded File pool grows every camera_period_s
+# seconds. files.retention.max_bytes is small enough that a couple of captures exceed
+# it, forcing a shed with an audit row in Postgres — before RustFS ever comes up.
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/e2e/buffer"
+    destinations: ["pgsql_records", "pgsql_files", "rustfs"]
+    pgsql_records:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_records"
+      time_key: "date"
+      time_format: "double"
+
+    pgsql_files:
+      type: postgres
+      receives: records
+      # No `inputs`: the Files metadata_destination, fed internally by the Uploader
+      # (see dc_params.yaml's own pgsql_files block for why `inputs: []` can't be used).
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_files"
+      time_key: "date"
+      time_format: "double"
+
+    rustfs:
+      type: s3
+      receives: files
+      inputs: ["/dc/measurement/camera"]
+      bucket: "dc-e2e"
+      endpoint: "http://127.0.0.1:9000"
+      region: "us-east-1"
+      access_key_id: "rustfsadmin"
+      secret_access_key: "rustfsadmin"
+      force_path_style: true
+
+    files:
+      delete_when_sent: false
+      metadata_destination: "pgsql_files"
+      retention:
+        max_bytes: 1  # any single captured File exceeds this — one capture is enough
+        # max_age_days intentionally unset — this scenario exercises the bytes limit.
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224
+
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]

--- a/tools/e2e/scripts/run_retention.sh
+++ b/tools/e2e/scripts/run_retention.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+# Files retention E2E scenario (#267). From the repo root:
+#
+#   ./tools/e2e/scripts/run_retention.sh
+#
+# Reuses the same dc-e2e image tools/e2e/scripts/run.sh builds/uses (see its own header
+# for the build/prebuilt-image env vars this script shares: DC_E2E_IMAGE,
+# DC_WORKSPACE_IMAGE), but drives the DC stack against
+# tools/e2e/params/e2e_retention_params.yaml instead of the zero-loss harness's own
+# params — a small `files.retention.max_bytes` and RustFS deliberately never started
+# until told to, so the un-uploaded File pool the camera Measurement feeds is guaranteed
+# to exceed the limit purely from the store being unreachable (ADR-0005's #267 scenario:
+# "store down, publish Files past a small max_bytes").
+#
+# Asserts, against real Postgres/RustFS containers and the real dc_bridge binary:
+#   1. with RustFS down, an audit row (`deleted: true, uploaded: false` — the "shed
+#      without upload" signature) lands in `dc_files` for the oldest camera capture,
+#      once the pool exceeds max_bytes.
+#   2. once RustFS comes up, a later (unshed) camera capture uploads and verifies
+#      normally (`uploaded: true` row in `dc_files`, object present in the bucket).
+#
+# Env vars: DC_E2E_IMAGE / DC_WORKSPACE_IMAGE (see run.sh); DC_E2E_KEEP ("true" to leave
+# the stack up after a failure for debugging); DC_E2E_SHED_TIMEOUT_SECONDS (default 480
+# — genuinely needed, not just generous padding: the camera Measurement's 15s poll and
+# the workload generator's 15s publish period aren't phase-locked, so a capture can take
+# a couple of poll cycles to land; and with RustFS down, aws-sdk-cpp's own
+# connection-refused retry/backoff makes a single Uploader attempt take on the order of
+# a minute — verified empirically in this environment, same pre-existing characteristic
+# #265's own notes call out — not something this scenario's timeout should race against);
+# DC_E2E_UPLOAD_TIMEOUT_SECONDS (default 60, once RustFS is up connections are fast).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_DIR="$E2E_DIR/.run"
+
+SHED_TIMEOUT_SECONDS="${DC_E2E_SHED_TIMEOUT_SECONDS:-480}"
+UPLOAD_TIMEOUT_SECONDS="${DC_E2E_UPLOAD_TIMEOUT_SECONDS:-60}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+PG_C=dc_e2e_ret_postgres
+RUSTFS_C=dc_e2e_ret_rustfs
+DC_C=dc_e2e_ret_dc
+VOLUMES=(dc_e2e_ret_pgdata dc_e2e_ret_rustfs_data dc_e2e_ret_buffer dc_e2e_ret_data)
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-retention $(date -u +%H:%M:%S)] $*"; }
+
+remove_stack() {
+  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
+  for v in "${VOLUMES[@]}"; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+}
+
+pg_exec() {
+  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  if podman container exists "$DC_C"; then
+    podman logs "$DC_C" > "$RUN_DIR/dc_retention.log" 2>&1
+  fi
+  remove_stack
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- obtain the DC stack image (shared with run.sh — see its header) ----------------
+if [ -n "${DC_E2E_IMAGE:-}" ]; then
+  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+  DC_IMAGE="$DC_E2E_IMAGE"
+else
+  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
+  else
+    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+    "$SCRIPT_DIR/build.sh"
+    WORKSPACE_IMAGE="dc-workspace:latest"
+  fi
+  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
+  DC_IMAGE="dc-e2e:latest"
+fi
+
+remove_stack
+
+# --- bring up Postgres only — RustFS deliberately stays down ------------------------
+log "starting Postgres (RustFS deliberately NOT started yet — this scenario's 'store down')"
+podman run -d --network host --name "$PG_C" \
+  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+  -v dc_e2e_ret_pgdata:/var/lib/postgresql/data \
+  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+  docker.io/library/postgres:13 >/dev/null
+
+timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
+  || { log "Postgres never became ready"; exit 1; }
+
+# --- start the DC stack against the retention params ---------------------------------
+log "starting the DC stack (files.retention.max_bytes configured small; RustFS unreachable)"
+podman run -d --network host --name "$DC_C" \
+  -v dc_e2e_ret_buffer:/root/.dc/e2e/buffer \
+  -v dc_e2e_ret_data:/root/.dc/e2e/data \
+  -v "$E2E_DIR/params/e2e_retention_params.yaml:/opt/e2e/e2e_params.yaml:ro" \
+  "$DC_IMAGE" >/dev/null
+
+# --- verify the shed happens while the store is down ---------------------------------
+log "waiting up to ${SHED_TIMEOUT_SECONDS}s for a shed audit row (deleted=true, uploaded=false) in dc_files"
+DEADLINE=$(( $(date +%s) + SHED_TIMEOUT_SECONDS ))
+SHED_COUNT=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  SHED_COUNT="$(pg_exec "SELECT count(*) FROM dc_files WHERE deleted = true AND uploaded = false" 2>/dev/null || echo 0)"
+  if [ "${SHED_COUNT:-0}" -gt 0 ] 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${SHED_COUNT:-0}" -eq 0 ]; then
+  log "FAIL: no shed-without-upload audit row landed within ${SHED_TIMEOUT_SECONDS}s"
+  exit 1
+fi
+log "PASS: ${SHED_COUNT} shed-without-upload audit row(s) — the oldest un-uploaded File(s) were shed while RustFS was down"
+
+# The shed local File must actually be gone (File+intent atomicity) — not just the row.
+SHED_LOCAL_PATH="$(pg_exec "SELECT local_path FROM dc_files WHERE deleted = true AND uploaded = false ORDER BY updated_at ASC LIMIT 1" 2>/dev/null || true)"
+if [ -n "$SHED_LOCAL_PATH" ]; then
+  # Same mount path the DC container itself uses (not a fresh /vol) so the absolute
+  # local_path Postgres recorded resolves directly, no prefix rewriting needed.
+  if podman run --rm --entrypoint bash -v dc_e2e_ret_data:/root/.dc/e2e/data:ro "$DC_IMAGE" \
+       -c "[ ! -e '$SHED_LOCAL_PATH' ]"; then
+    log "PASS: the shed File's local path no longer exists on disk"
+  else
+    log "FAIL: shed audit row exists but the local File is still on disk: $SHED_LOCAL_PATH"
+    exit 1
+  fi
+fi
+
+# --- bring RustFS up; remaining (unshed) Files must upload normally ------------------
+log "starting RustFS — remaining/future Files must now upload and verify normally"
+podman run -d --network host --name "$RUSTFS_C" \
+  -v dc_e2e_ret_rustfs_data:/data \
+  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+timeout 60 bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
+  || { log "RustFS never became ready"; exit 1; }
+podman run --rm --network host \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-e2e >/dev/null
+
+log "waiting up to ${UPLOAD_TIMEOUT_SECONDS}s for a normal upload (uploaded=true) in dc_files now that RustFS is up"
+DEADLINE=$(( $(date +%s) + UPLOAD_TIMEOUT_SECONDS ))
+UPLOADED_COUNT=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  UPLOADED_COUNT="$(pg_exec "SELECT count(*) FROM dc_files WHERE uploaded = true" 2>/dev/null || echo 0)"
+  if [ "${UPLOADED_COUNT:-0}" -gt 0 ] 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${UPLOADED_COUNT:-0}" -eq 0 ]; then
+  log "FAIL: no File uploaded/verified within ${UPLOAD_TIMEOUT_SECONDS}s of RustFS coming up"
+  exit 1
+fi
+log "PASS: ${UPLOADED_COUNT} File(s) uploaded and verified normally once the store came back"
+
+log "PASS: files retention E2E scenario (#267)"


### PR DESCRIPTION
## Summary

- Adds `files.retention.max_bytes`/`files.retention.max_age_days` (default off, Humble parity — accumulation unless explicitly configured): the one, explicit, opt-in mechanism allowed to abandon data under disk pressure. Sheds the oldest un-uploaded intent's File(s) and its durable intent-queue entry together, oldest-first, until back under the configured limit(s).
- Each shed File gets a `deleted: true, uploaded: false` audit row through the normal `dc.files` metadata path (best-effort emit, always a warn log). Files the Uploader has already verified everywhere but is still failing to delete (`delete_when_sent` retrying) are never retention's victim.
- Found and fixed a real bug via manual testing against a live `dc_bridge` process: `steady_clock::time_point::min()` subtraction overflow was silently disabling the periodic retention sweep forever — see `progress.txt` for the full diagnosis.

## Test plan

- [x] 11 new unit tests (`dc_bridge/test/retention_test.cpp`): disabled no-op, oldest-first `max_bytes` shedding, `max_age_days` shedding (with/without triggering), verified-everywhere intents never shed (including the all-verified termination case), File+intent atomicity, audit row shape, best-effort emit failure tolerance, files-less Records ignored, crash/replay tolerance.
- [x] `colcon build`/`colcon test --packages-select dc_bridge` — real ROS 2 Jazzy + Podman environment, 7/7 gtest suites green (including unmodified `intent_queue_test`/`uploader_test`), zero `-Wall -Wextra` warnings.
- [x] `pre-commit` clean on every changed/new file.
- [x] New e2e scenario (`tools/e2e/scripts/run_retention.sh`) run for real against the full built stack: store down → shed audit row lands in Postgres + local File confirmed gone; store up → later File uploads and verifies normally. PASS.

Closes #267