### PR TITLE
fix(tools/e2e): skip aws-sdk-cpp's CBMC submodule + isolate aws_sdk_vendor's build layer

### DIFF
--- a/aws_sdk_vendor/CMakeLists.txt
+++ b/aws_sdk_vendor/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.17)  # GIT_SUBMODULES_RECURSE (see below)
 project(aws_sdk_vendor)
 
 find_package(ament_cmake REQUIRED)
@@ -15,12 +15,29 @@ set(_aws_install "${CMAKE_CURRENT_BINARY_DIR}/aws_sdk_install")
 # only external system libraries needed are curl/openssl/zlib (the package.xml
 # build_depends). Zlib request compression is optional per the SDK and disabled to keep
 # the build minimal (S3-compatible stores don't need it).
+#
+# aws-sdk-cpp itself declares exactly one top-level submodule, crt/aws-crt-cpp (verified
+# against its .gitmodules at AWS_SDK_VERSION); of aws-crt-cpp's own 13 submodules, only
+# crt/s2n declares a further nested one — tests/cbmc/aws-verification-model-for-libcrypto,
+# s2n-tls's CBMC formal-verification model repo, needed only for `make cbmc` and unrelated
+# to building `-DBUILD_ONLY=s3` (#271). GIT_SUBMODULES_RECURSE has no way to exclude a
+# single nested submodule while still recursing everything else it's nested under, so the
+# top-level ExternalProject_Add step only checks out aws-crt-cpp itself (no recursion);
+# PATCH_COMMAND then does the real recursive submodule init by hand, skipping just the
+# CBMC one via a `git -c submodule.<name>.update=none` override — verified directly
+# against the real upstream repos (a download-only ExternalProject run: every other
+# submodule the SDK needs — including crt/s2n itself — gets checked out normally, and only
+# tests/cbmc/aws-verification-model-for-libcrypto is reported "Skipping").
 ExternalProject_Add(aws_sdk_cpp_ext
   GIT_REPOSITORY https://github.com/aws/aws-sdk-cpp.git
   GIT_TAG ${AWS_SDK_VERSION}
   GIT_SHALLOW ON
-  GIT_SUBMODULES_RECURSE ON
+  GIT_SUBMODULES "crt/aws-crt-cpp"
+  GIT_SUBMODULES_RECURSE OFF
   GIT_PROGRESS ON
+  PATCH_COMMAND git -C crt/aws-crt-cpp
+    -c submodule.tests/cbmc/aws-verification-model-for-libcrypto.update=none
+    submodule update --init --recursive
   CMAKE_ARGS
     -DCMAKE_INSTALL_PREFIX=${_aws_install}
     -DCMAKE_BUILD_TYPE=Release

--- a/progress.txt
+++ b/progress.txt
@@ -1833,3 +1833,86 @@ first) and pasting back the console output. Two things worth recording:
   whether these two lines print. Recorded here so a future session doesn't re-diagnose
   from scratch — the fix, if one is ever wanted, is in gz-sim's `UserCommands`/GUI-attach
   path, not in `dc_simulation`'s own SDF content.
+
+### #271 - tools/e2e: aws-sdk-cpp clone pulls unneeded submodules + full workspace
+layer invalidates on every source change
+
+- **Problem 1 fix** (`aws_sdk_vendor/CMakeLists.txt`): `ExternalProject_Add`'s
+  `GIT_SUBMODULES_RECURSE ON` with no path restriction recursed into every submodule
+  nested anywhere under aws-sdk-cpp, including s2n-tls's CBMC formal-verification model
+  repo (`crt/aws-crt-cpp/crt/s2n/tests/cbmc/aws-verification-model-for-libcrypto`) —
+  needed only for `make cbmc`, unrelated to `-DBUILD_ONLY=s3`. Fixed by restricting the
+  top-level submodule checkout to `GIT_SUBMODULES "crt/aws-crt-cpp"` with
+  `GIT_SUBMODULES_RECURSE OFF` (aws-sdk-cpp's only top-level submodule, confirmed via
+  its real `.gitmodules` at the pinned tag), then doing the actual recursive submodule
+  init by hand in a new `PATCH_COMMAND`, using `git -c
+  submodule.tests/cbmc/aws-verification-model-for-libcrypto.update=none submodule
+  update --init --recursive` to skip just that one nested submodule (its name inside
+  s2n-tls's own `.gitmodules`, confirmed via a real fetch) — `ExternalProject_Add`'s
+  built-in `GIT_CONFIG` option does **not** work for this: read CMake 3.31's own
+  `ExternalProject/gitupdate.cmake.in`/`shared_internal_commands.cmake` sources
+  directly and confirmed `GIT_CONFIG`'s `-c` overrides are only threaded through to the
+  submodule-update step for the two hardcoded TLS options, never for arbitrary
+  user-supplied config — ruling out the naive approach before writing the real fix.
+  `cmake_minimum_required` bumped 3.16 → 3.17 for `GIT_SUBMODULES_RECURSE` (added in
+  3.17; ROS Jazzy's toolchain ships far newer, no compat concern on this jazzy-only
+  package).
+- **Verified for real, not just read**: resolved the exact pinned commit chain by
+  hand (aws-sdk-cpp `1.11.600` → its `crt/aws-crt-cpp` gitlink → that commit's
+  `crt/s2n` gitlink → s2n-tls's own `.gitmodules`) via real shallow clones/fetches
+  against the live GitHub repos, confirming aws-sdk-cpp has exactly one top-level
+  submodule and s2n-tls has exactly one nested submodule (the CBMC one) — none of the
+  other 12 aws-crt-cpp submodules (`aws-c-common`, `aws-c-io`, `aws-c-auth`, `aws-lc`,
+  etc.) declare any nested submodules of their own, confirmed by checking each one's
+  `.gitmodules` at its pinned commit (all 404, i.e. absent). Then ran the real fixed
+  `CMakeLists.txt` logic end-to-end in a throwaway `ExternalProject_Add` test project
+  (`CONFIGURE_COMMAND`/`BUILD_COMMAND`/`INSTALL_COMMAND` all empty, so it only
+  exercises download+update+patch — real compilation of the vendored SDK was already
+  verified working in the original #249-era Bridge Phase 2 session, not something this
+  fix touches) against the real upstream repos: all 13 needed submodules (including
+  `crt/s2n` itself) checked out normally, and the log shows exactly one line —
+  `Skipping submodule 'crt/s2n/tests/cbmc/aws-verification-model-for-libcrypto'` —
+  confirming the fix does what the issue asks, with the CBMC directory left empty on
+  disk afterward.
+- **Important finding, called out honestly rather than overclaimed**: the issue's own
+  diagnosis ("this is what actually produces the ~1GB / 1.5M-object fetch, not the
+  clone depth") doesn't hold up under measurement. `git count-objects -v` on the
+  top-level aws-sdk-cpp clone alone (before any submodule work) showed 1,513,370
+  objects / ~1.07 GB in its pack — matching the issue's numbers almost exactly — and
+  that cost is entirely aws-sdk-cpp's own shallow (`--depth 1`) clone of its single
+  commit's tree (the whole monorepo's ~300+ per-service source directories, not just
+  core+s3), independent of submodules entirely. The CBMC skip is real and correctly
+  targets the literal, unambiguous acceptance criterion ("no longer pulls CBMC/test-
+  only submodule content"), but it will not measurably move total clone size/time on
+  its own — that would need a sparse/partial top-level checkout of just
+  core+s3+cmake/, which is a materially bigger change (bypassing `ExternalProject_Add`'s
+  built-in git download entirely) not covered by this issue's "What to build" bullets.
+  Left as a candidate follow-up, not attempted here.
+- **Problem 2 fix** (`tools/e2e/Containerfile`): split the single `COPY . ` +
+  one-`RUN` layer into three: (1) the existing apt/toolchain `RUN` layer, unchanged;
+  (2) a new layer — `COPY rosdep/` + `COPY aws_sdk_vendor/` (both keyed only on their
+  own content, so unrelated changes elsewhere don't invalidate this layer), registers
+  the `rosdep/dc.yaml` local source, runs `rosdep update`, and does `colcon build
+  --packages-select aws_sdk_vendor` — the ~20-minute aws-sdk-cpp build now lives in a
+  layer that stays a cache hit unless `aws_sdk_vendor/` or `rosdep/` themselves change;
+  (3) the full-workspace `COPY .` + `RUN rosdep install` + `colcon build --packages-
+  skip aws_sdk_vendor`, which reuses layer (2)'s already-built `install/aws_sdk_vendor`
+  (colcon's standard incremental-Docker-layer pattern: a skipped package's install
+  output is still picked up for downstream `find_package`/environment setup, only its
+  own build step is skipped) instead of rebuilding it from source on every commit.
+  `rosdep update`'s index fetch now happens once (in layer 2) instead of once per
+  layer.
+- Ran `pre-commit run --files aws_sdk_vendor/CMakeLists.txt tools/e2e/Containerfile`:
+  `Lint Dockerfiles` (hadolint) and every other hook touching these files passed; the
+  only failure was `poetry-requirements` (module missing in this sandbox, unrelated to
+  this diff and already a known-broken hook per #242-#248's own notes).
+- **Not done / left for follow-up**: could not run a real `podman build`/`colcon
+  build --packages-select aws_sdk_vendor`/`colcon test` in this sandbox (no
+  ROS/ament_cmake install here, and a full aws-sdk-cpp source build takes ~20 minutes
+  — same constraint noted repeatedly in #242-#249's own verification sections). The
+  git-fetch behavior (Problem 1's actual bug) was verified for real as described above;
+  Problem 2's layer restructuring follows the standard, well-documented colcon/Docker
+  incremental-layer pattern but has not been exercised against a real `podman build`
+  run — needs verification in CI or a machine with more resources before being fully
+  trusted. A sparse/partial top-level aws-sdk-cpp checkout (see finding above) is a
+  candidate follow-up if the ~1GB clone cost itself needs to come down.

--- a/tools/e2e/Containerfile
+++ b/tools/e2e/Containerfile
@@ -11,8 +11,9 @@
 # `COPY --from` a subset into), so there's nothing for a second stage to earn. CI's
 # `--cache-from`/`--cache-to` (a registry-backed build cache — see ci.yaml) still gets
 # full value: Podman caches each RUN layer independently, so the apt/toolchain layer
-# below (no DC source) is a near-permanent cache hit while only the source-dependent
-# rosdep+colcon layer invalidates on a code change.
+# below (no DC source) is a near-permanent cache hit; `aws_sdk_vendor` (its own layer,
+# #271) is a cache hit unless it or rosdep/ change; only the full-workspace
+# rosdep+colcon layer invalidates on a code change elsewhere.
 
 ARG ROS_DISTRO=jazzy
 
@@ -36,15 +37,35 @@ RUN echo "apt cache bust: ${APT_CACHEBUST}" && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/ws
-COPY . src/ros2_data_collection
 
+# aws_sdk_vendor built in its own layer, isolated from the rest of the workspace (#271):
+# `COPY <path>` keys Podman's layer cache on that path's own content, so copying only
+# `aws_sdk_vendor/` (plus the rosdep source it needs registered) here means this layer —
+# and its ~20-minute aws-sdk-cpp ExternalProject source build — stays a cache hit for a
+# source change anywhere *else* in the repo, instead of invalidating on every commit like
+# the old single `COPY . ` + one `RUN` layer did. The full-workspace build below reuses
+# this layer's already-built install/ via `colcon build --packages-skip aws_sdk_vendor`.
+#
 # rosdep/dc.yaml is registered as a local rosdep source so `rosdep install` resolves
 # tomlplusplus / msgpack-cxx (header-only C++ libs dc_bridge uses that upstream
-# rosdistro has no key for — see dc_bridge/package.xml).
+# rosdistro has no key for — see dc_bridge/package.xml). It's registered here, not in the
+# full-workspace layer below, so `rosdep update`'s index fetch only happens once.
+COPY rosdep src/ros2_data_collection/rosdep
+COPY aws_sdk_vendor src/ros2_data_collection/aws_sdk_vendor
 RUN echo "yaml file:///root/ws/src/ros2_data_collection/rosdep/dc.yaml" \
       > /etc/ros/rosdep/sources.list.d/10-dc.list && \
     apt-get -q update && \
     rosdep update --include-eol-distros && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
+    # shellcheck disable=SC1091
+    . /opt/ros/jazzy/setup.sh && \
+    colcon build --packages-select aws_sdk_vendor --event-handlers desktop_notification- status- && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY . src/ros2_data_collection
+
+RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive \
     rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
     # shellcheck disable=SC1091
@@ -54,7 +75,7 @@ RUN echo "yaml file:///root/ws/src/ros2_data_collection/rosdep/dc.yaml" \
     else \
       CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"; \
     fi && \
-    eval colcon build --cmake-args "$CMAKE_ARGS" --event-handlers desktop_notification- status- && \
+    eval colcon build --packages-skip aws_sdk_vendor --cmake-args "$CMAKE_ARGS" --event-handlers desktop_notification- status- && \
     rm -rf /var/lib/apt/lists/*
 
 ENV ROS_UNDERLAY=/root/ws/install


### PR DESCRIPTION
## Summary
- `aws_sdk_vendor/CMakeLists.txt`: restrict the ExternalProject's submodule recursion so it no longer pulls s2n-tls's CBMC formal-verification model repo (`crt/aws-crt-cpp/crt/s2n/tests/cbmc/aws-verification-model-for-libcrypto`), which is unrelated to building `-DBUILD_ONLY=s3`. Verified end-to-end against the real upstream repos with a download-only `ExternalProject_Add` test run — every needed submodule (13, including `crt/s2n` itself) checks out normally, and only the CBMC one is skipped.
- `tools/e2e/Containerfile`: split the single `COPY . ` + one-`RUN` layer into a dedicated `aws_sdk_vendor`-only layer (keyed on `aws_sdk_vendor/` + `rosdep/` content) followed by the full-workspace layer, which now reuses the vendor layer's already-built install via `colcon build --packages-skip aws_sdk_vendor` instead of rebuilding the ~20-minute aws-sdk-cpp source build on every unrelated source change.

**Honest caveat on scope**: the issue's own diagnosis attributes the ~1GB/1.5M-object fetch to the CBMC submodule. Measurement shows otherwise — that cost is entirely aws-sdk-cpp's own top-level shallow clone (its whole ~300+-service monorepo tree at one commit), independent of submodules. The CBMC fix is real and satisfies the literal acceptance criterion, but won't measurably move total clone size on its own. A sparse/partial top-level checkout would be needed for that, and is a bigger change out of scope here — noted in `progress.txt` as a follow-up candidate.

## Verification
- Real, live-repo verification of the submodule-skip logic via a throwaway `ExternalProject_Add` project (download+update+patch steps only, no compile) against the actual `aws/aws-sdk-cpp` `1.11.600` tag — confirmed correct submodule set checked out, CBMC directory empty.
- Confirmed (via `.gitmodules` at each pinned commit) that `crt/aws-crt-cpp` is aws-sdk-cpp's only top-level submodule, and `crt/s2n`'s CBMC submodule is the only nested submodule across all 13 CRT dependencies.
- `pre-commit run --files aws_sdk_vendor/CMakeLists.txt tools/e2e/Containerfile`: hadolint (`Lint Dockerfiles`) and every other applicable hook passed; the only failure (`poetry-requirements`) is a known-broken hook in this sandbox, unrelated to this diff.
- **Not done**: no ROS/ament_cmake install in this sandbox, so no real `podman build` / `colcon build --packages-select aws_sdk_vendor` / `colcon test` run here — needs verification in CI or a machine with more resources.

## Test plan
- [ ] CI: `podman build` for this PR succeeds and `colcon build --packages-select aws_sdk_vendor` + the full workspace build both succeed
- [ ] CI: `colcon test` still passes
- [ ] A follow-up docs/progress.txt-only commit's CI run reuses the `aws_sdk_vendor` layer (no aws-sdk-cpp rebuild) — confirms Problem 2's fix
- [ ] Spot-check CI logs for the aws-sdk-cpp clone step: only `crt/s2n/tests/cbmc/aws-verification-model-for-libcrypto` is skipped, all other submodules present

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)