### PR TITLE
feat(dc_measurements): add Random measurement plugin

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -146,6 +146,9 @@ list(APPEND dc_measurement_plugin_libs dc_permissions_measurement)
 add_library(dc_position_measurement SHARED plugins/measurements/position.cpp)
 list(APPEND dc_measurement_plugin_libs dc_position_measurement)
 
+add_library(dc_random_measurement SHARED plugins/measurements/random.cpp)
+list(APPEND dc_measurement_plugin_libs dc_random_measurement)
+
 add_library(dc_serial_interface_measurement SHARED plugins/measurements/serial_interface.cpp)
 list(APPEND dc_measurement_plugin_libs dc_serial_interface_measurement)
 
@@ -257,6 +260,7 @@ set(tests
   test_measurement_dummy
   test_measurement_os
   test_measurement_parameters
+  test_measurement_random
   test_measurement_serial_interface
   test_measurement_uptime
 )

--- a/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
@@ -1,0 +1,38 @@
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__RANDOM_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__RANDOM_HPP_
+
+#include <cstdint>
+#include <random>
+#include <string>
+
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "nav2_util/node_utils.hpp"
+
+namespace dc_measurements
+{
+
+class Random : public dc_measurements::Measurement
+{
+public:
+  Random();
+  ~Random() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+protected:
+  /**
+   * @brief Set validation schema used to confirm data before collecting it
+   */
+  void setValidationSchema() override;
+  void onConfigure() override;
+
+  std::string value_type_;
+  double min_;
+  double max_;
+  int64_t seed_;
+  std::mt19937_64 generator_;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__RANDOM_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -103,6 +103,14 @@
         </class>
     </library>
 
+    <library path="dc_random_measurement">
+        <class name="dc_measurements/Random" type="dc_measurements::Random" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_random
+            </description>
+        </class>
+    </library>
+
     <library path="dc_serial_interface_measurement">
         <class name="dc_measurements/SerialInterface" type="dc_measurements::SerialInterface" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/json/random.json
+++ b/dc_measurements/plugins/measurements/json/random.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Random",
+  "description": "Randomly generated value",
+  "properties": {
+    "value": {
+      "description": "Randomly generated value within the configured range",
+      "type": "number"
+    }
+  },
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/random.cpp
+++ b/dc_measurements/plugins/measurements/random.cpp
@@ -1,0 +1,87 @@
+#include "dc_measurements/plugins/measurements/random.hpp"
+
+namespace dc_measurements
+{
+
+Random::Random() : dc_measurements::Measurement()
+{
+}
+
+Random::~Random() = default;
+
+void Random::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "random.json");
+  }
+}
+
+void Random::onConfigure()
+{
+  auto node = getNode();
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".type",
+                                               rclcpp::ParameterValue(std::string("integer")));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".min", rclcpp::ParameterValue(0.0));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".max", rclcpp::ParameterValue(100.0));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".seed", rclcpp::ParameterValue(-1));
+
+  node->get_parameter(measurement_name_ + ".type", value_type_);
+  node->get_parameter(measurement_name_ + ".min", min_);
+  node->get_parameter(measurement_name_ + ".max", max_);
+  node->get_parameter(measurement_name_ + ".seed", seed_);
+
+  if (value_type_ != "integer" && value_type_ != "double")
+  {
+    RCLCPP_ERROR_STREAM(logger_, "Invalid Random type '" << value_type_ << "', expected 'integer' or 'double'");
+    throw std::runtime_error{ "Invalid Random type: " + value_type_ };
+  }
+
+  if (min_ >= max_)
+  {
+    RCLCPP_ERROR_STREAM(logger_, "Random min (" << min_ << ") must be less than max (" << max_ << ")");
+    throw std::runtime_error{ "Random min must be less than max" };
+  }
+
+  // A negative seed means "not set": seed from a real entropy source so runs differ. A
+  // non-negative seed makes the generated sequence reproducible across runs (acceptance
+  // criterion: optional seed parameter).
+  if (seed_ >= 0)
+  {
+    generator_.seed(static_cast<uint64_t>(seed_));
+  }
+  else
+  {
+    std::random_device rd;
+    generator_.seed(rd());
+  }
+}
+
+dc_interfaces::msg::StringStamped Random::collect()
+{
+  auto node = getNode();
+  dc_interfaces::msg::StringStamped msg;
+  msg.header.stamp = node->get_clock()->now();
+  msg.group_key = group_key_;
+  json data_json;
+
+  if (value_type_ == "integer")
+  {
+    std::uniform_int_distribution<int64_t> distribution(static_cast<int64_t>(min_), static_cast<int64_t>(max_));
+    data_json["value"] = distribution(generator_);
+  }
+  else
+  {
+    std::uniform_real_distribution<double> distribution(min_, max_);
+    data_json["value"] = distribution(generator_);
+  }
+
+  msg.data = data_json.dump(-1, ' ', true);
+
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::Random, dc_core::Measurement)

--- a/dc_measurements/test/test_measurement_random.cpp
+++ b/dc_measurements/test/test_measurement_random.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementRandomTest : public ::testing::Test
+{
+protected:
+  MeasurementRandomTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementRandomTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "random" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/random", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementRandomTest::randomDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("random.plugin", std::string("dc_measurements/Random"));
+    ms_node_->declare_parameter("random.group_key", std::string("random"));
+    ms_node_->declare_parameter("random.topic_output", std::string("/dc/measurement/random"));
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void randomDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    nlohmann::json data_json = nlohmann::json::parse(data_str);
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    value_ = data_json["value"].get<double>();
+    random_callback_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  double value_;
+
+public:
+  bool random_callback_{ false };
+};
+
+TEST_F(MeasurementRandomTest, DefaultIntegerWithinRange)
+{
+  declareCommonParameters();
+
+  startLifecycleNode();
+
+  while (!random_callback_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_GE(value_, 0);
+  EXPECT_LE(value_, 100);
+}
+
+TEST_F(MeasurementRandomTest, DoubleWithinConfiguredRange)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("random.type", std::string("double"));
+  ms_node_->declare_parameter("random.min", 5.0);
+  ms_node_->declare_parameter("random.max", 6.0);
+
+  startLifecycleNode();
+
+  while (!random_callback_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_GE(value_, 5.0);
+  EXPECT_LE(value_, 6.0);
+}
+
+TEST_F(MeasurementRandomTest, SameSeedProducesSameSequence)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("random.min", 0.0);
+  ms_node_->declare_parameter("random.max", 1000000.0);
+  ms_node_->declare_parameter("random.seed", 42);
+
+  startLifecycleNode();
+
+  while (!random_callback_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  double first_run_value = value_;
+
+  // Cycle the same node back through configure/activate (parameters stay declared across
+  // lifecycle transitions): the plugin is re-instantiated and re-seeded from the same
+  // `seed` parameter, so its first emitted value must reproduce exactly.
+  ms_node_->deactivate();
+  ms_node_->cleanup();
+  random_callback_ = false;
+  startLifecycleNode();
+
+  while (!random_callback_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_EQ(first_run_value, value_);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_random.cpp
+++ b/dc_measurements/test/test_measurement_random.cpp
@@ -110,20 +110,40 @@ TEST_F(MeasurementRandomTest, SameSeedProducesSameSequence)
   }
   double first_run_value = value_;
 
-  // Cycle the same node back through configure/activate (parameters stay declared across
-  // lifecycle transitions): the plugin is re-instantiated and re-seeded from the same
-  // `seed` parameter, so its first emitted value must reproduce exactly.
-  ms_node_->deactivate();
-  ms_node_->cleanup();
-  random_callback_ = false;
-  startLifecycleNode();
+  // A second, independently-configured node with the same `seed` (remapped to its own node
+  // name/topic so it can't collide with ms_node_'s rosout publisher, lifecycle services, or
+  // Record subscription) must reproduce the exact same first emitted value.
+  rclcpp::NodeOptions second_node_options;
+  second_node_options.arguments({ "--ros-args", "-r", "__node:=measurement_server_2" });
+  auto ms_node_2 = std::make_shared<measurement_server::MeasurementServer>(second_node_options,
+                                                                           std::vector<std::string>{ "random" });
+  bool second_callback = false;
+  double second_run_value = 0;
+  auto sub_data_2 = ms_node_2->create_subscription<dc_interfaces::msg::StringStamped>(
+      "/dc/measurement/random_2", rclcpp::SystemDefaultsQoS(), [&](const dc_interfaces::msg::StringStamped& msg) {
+        std::string data_str = msg.data.c_str();
+        boost::replace_all(data_str, "'", "\"");
+        nlohmann::json data_json = nlohmann::json::parse(data_str);
+        second_run_value = data_json["value"].get<double>();
+        second_callback = true;
+      });
+  ms_node_2->declare_parameter("random.plugin", std::string("dc_measurements/Random"));
+  ms_node_2->declare_parameter("random.group_key", std::string("random"));
+  ms_node_2->declare_parameter("random.topic_output", std::string("/dc/measurement/random_2"));
+  ms_node_2->declare_parameter("random.min", 0.0);
+  ms_node_2->declare_parameter("random.max", 1000000.0);
+  ms_node_2->declare_parameter("random.seed", 42);
+  ms_node_2->configure();
+  ms_node_2->activate();
 
-  while (!random_callback_)
+  while (!second_callback)
   {
-    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    rclcpp::spin_some(ms_node_2->get_node_base_interface());
   }
+  ms_node_2->deactivate();
+  ms_node_2->cleanup();
 
-  EXPECT_EQ(first_run_value, value_);
+  EXPECT_EQ(first_run_value, second_run_value);
 }
 
 int main(int argc, char** argv)

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -27,6 +27,7 @@
   - [OS](./dc/measurements/os.md)
   - [Permissions](./dc/measurements/permissions.md)
   - [Position](./dc/measurements/position.md)
+  - [Random](./dc/measurements/random.md)
   - [Serial interface](./dc/measurements/serial_interface.md)
   - [Speed](./dc/measurements/speed.md)
   - [Storage](./dc/measurements/storage.md)

--- a/doc/src/dc/measurements/random.md
+++ b/doc/src/dc/measurements/random.md
@@ -1,0 +1,47 @@
+# Random
+
+## Description
+Emits a randomly generated value on every polling interval. Useful for exercising the
+pipeline and Destinations without any robot infrastructure — the simplest possible
+Measurement plugin, and a deterministic, infrastructure-free Record source for load and
+backpressure testing.
+
+## Parameters
+
+| Parameter | Description                                                                                                          | Type   | Default               |
+| --------- | --------------------------------------------------------------------------------------------------------------------- | ------ | ---------------------- |
+| **type**  | Type of the generated value: `integer` or `double`                                                                    | str    | "integer" (Optional)   |
+| **min**   | Minimum value (inclusive) of the generated range                                                                       | double | 0.0 (Optional)         |
+| **max**   | Maximum value of the generated range (inclusive for `integer`, effectively exclusive for `double`). Must be greater than **min** | double | 100.0 (Optional) |
+| **seed**  | Seed for the random number generator. A negative value seeds from a non-deterministic source; a non-negative value makes runs reproducible | int    | -1 (Optional)           |
+
+## Schema
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Random",
+    "description": "Randomly generated value",
+    "properties": {
+        "value": {
+            "description": "Randomly generated value within the configured range",
+            "type": "number"
+        }
+    },
+    "type": "object"
+}
+```
+
+## Measurement configuration
+
+```yaml
+...
+random:
+  plugin: "dc_measurements/Random"
+  topic_output: "/dc/measurement/random"
+  tags: ["console"]
+  type: "double"
+  min: 0.0
+  max: 1.0
+  seed: 42
+```

--- a/progress.txt
+++ b/progress.txt
@@ -2244,3 +2244,38 @@ layer invalidates on every source change
   `colcon test` here. `pre-commit` (`clang-format`, `codespell`, JSON/XML lint, etc.) is clean
   on every changed/new file; the `poetry-requirements` hook failure is the same pre-existing,
   unrelated tool-environment gap noted throughout this log (no `poetry` module installed).
+
+### #88 follow-up — real CI round: found and fixed a genuine bug in the seed-reproducibility test
+
+- Real `colcon test` (CI, since no ROS 2/colcon toolchain exists in this sandbox) caught what
+  the sandboxed `pre-commit`-only pass couldn't: `MeasurementRandomTest.SameSeedProducesSameSequence`
+  never produced a result — `[FATAL] Lifecycle node measurement_server does not have error
+  state implemented` after the second `configure()` call threw.
+- Root cause: the test (as originally written) cycled a *single* `MeasurementServer` node
+  through deactivate→cleanup→configure→activate twice to check that the same `seed` parameter
+  reproduces the same first value, on the assumption that ROS parameters stay declared across
+  lifecycle transitions on one node instance. They do, but `MeasurementServer::setBaseSavePath()`
+  (called from `on_configure()`) declares `save_local_base_path`/`all_base_path` with the
+  bare, non-idempotent `declare_parameter` (unlike most of its other parameters, which go
+  through `nav2_util::declare_parameter_if_not_declared`) — so the *second* `configure()` call
+  on the same node threw `rclcpp::exceptions::ParameterAlreadyDeclaredException` ("parameter
+  'save_local_base_path' has already been declared"), which `nav2_util::LifecycleNode` has no
+  error-state transition for, so the node got stuck and the test hung to the CI timeout instead
+  of failing fast.
+- This is a real, narrow pre-existing gap in `MeasurementServer` (repeat configure cycles on
+  one instance aren't supported), not something to route around by "fixing" `setBaseSavePath()`
+  in this PR's scope — production usage never reconfigures a live `MeasurementServer` process,
+  and no other test in this repo has ever exercised that path. Fixed the test instead: it now
+  stands up a *second* `MeasurementServer` node (remapped via `NodeOptions` to
+  `measurement_server_2`, subscribed on a distinct `/dc/measurement/random_2` topic) configured
+  once with the same `seed`, sidestepping repeat-configure entirely while still proving
+  cross-instance reproducibility (the actual acceptance criterion). The two nodes sharing the
+  base name only ever produced a benign "Publisher already registered for node name" rosout
+  warning in the CI log (already visible, harmless, in the other two passing test cases too,
+  from this same test file's constructor-calls-`SetUp()`-explicitly pattern inherited from
+  `test_measurement_uptime.cpp` — gtest also calls `SetUp()` itself, so two node instances
+  transiently exist even in the single-node tests).
+- `pre-commit`'s `clang-format` reformatted the new second-node block on this pass (multi-line
+  argument alignment); committed as formatted. Pushed for CI to re-confirm; still unverified
+  end-to-end in this sandbox (no colcon here, same recurring constraint as every other slice
+  in this log).

--- a/progress.txt
+++ b/progress.txt
@@ -2196,3 +2196,51 @@ layer invalidates on every source change
 - Still unverified end-to-end in this sandbox (same recurring constraint, no ROS/colcon
   install here); pushed for CI to confirm. `pre-commit` (`clang-format`, `codespell`, etc.)
   clean on both changed files.
+
+### #88 - Add Measurement: Random
+
+- Added a new `Random` Measurement plugin (`dc_measurements/plugins/measurements/random.cpp`
+  + `include/dc_measurements/plugins/measurements/random.hpp`), the good-first-issue "good
+  first issue" example: mirrors `uptime.cpp`'s minimal structure (no state beyond the RNG
+  itself) rather than any of the heavier system-info plugins.
+  - Parameters (all optional, declared via `nav2_util::declare_parameter_if_not_declared` in
+    `onConfigure()`, same pattern as `tcp_health.cpp`): `type` (`"integer"` or `"double"`,
+    default `"integer"`), `min`/`max` (doubles, defaulting to `0.0`/`100.0`), `seed` (int,
+    default `-1`). Emits `{"value": <n>}`.
+  - `min >= max` or an unrecognized `type` throws `std::runtime_error` from `onConfigure()` —
+    the base `Measurement::configure()` catches that and disables the plugin
+    (`enabled_ = false`, timer reset) rather than crashing the server, same contract every
+    other plugin's `onConfigure()` relies on.
+  - Seeding (acceptance criterion: "optional seed parameter so runs are reproducible"): a
+    negative `seed` (the default) seeds a `std::mt19937_64` from `std::random_device`; a
+    non-negative `seed` seeds it directly, so two runs with the same `seed` (and same
+    `type`/`min`/`max`) produce the identical value sequence.
+  - Value generation (acceptance criterion: "configurable value range and type, at minimum
+    integer and double"): `std::uniform_int_distribution<int64_t>` for `type: integer`
+    (inclusive `[min, max]`), `std::uniform_real_distribution<double>` for `type: double`
+    (`[min, max)` per the standard). The JSON schema (`plugins/measurements/json/random.json`)
+    declares `value` as `type: "number"`, which validates both an emitted JSON integer and a
+    JSON float under the same schema — no need for two schemas or a type-conditional one.
+  - Registered in `dc_measurements/measurement_plugin.xml` (alphabetically between `Position`
+    and `SerialInterface`) and `dc_measurements/CMakeLists.txt` (new
+    `dc_random_measurement` library, appended to `dc_measurement_plugin_libs` — picked up
+    automatically by the existing install/export/`ament_target_dependencies` loops, no other
+    CMake changes needed since it has no extra source files or deps beyond what the shared
+    `dependencies` list and `nav2_util` header-only include already cover).
+  - Test: `dc_measurements/test/test_measurement_random.cpp` (registered in `CMakeLists.txt`'s
+    `tests` list as `test_measurement_random`), mirroring `test_measurement_uptime.cpp`'s
+    `MeasurementServer`-in-process harness. Three cases: default params produce an integer
+    `value` in `[0, 100]`; an explicit `type: double`/`min: 5.0`/`max: 6.0` config produces a
+    value in `[5.0, 6.0]`; and a same-`seed` reproducibility check that cycles one
+    `MeasurementServer` node through deactivate→cleanup→configure→activate twice (rather than
+    standing up a second node instance with the same default lifecycle-node name in the same
+    process/context, which risked colliding lifecycle-service names) and asserts the first
+    emitted value is bit-identical across both configure cycles.
+  - Docs: `doc/src/dc/measurements/random.md` (new, parameter table + schema + example config,
+    following `tcp_health.md`'s layout since Random has multiple parameters like TCPHealth
+    does) and linked from `doc/src/SUMMARY.md` alphabetically next to the other Measurements.
+- **Not done / left for CI**: no ROS 2/colcon toolchain in this sandbox (same recurring
+  constraint as every other slice in this log) — could not run an actual `colcon build`/
+  `colcon test` here. `pre-commit` (`clang-format`, `codespell`, JSON/XML lint, etc.) is clean
+  on every changed/new file; the `poetry-requirements` hook failure is the same pre-existing,
+  unrelated tool-environment gap noted throughout this log (no `poetry` module installed).


### PR DESCRIPTION
## Summary
- Adds a `Random` Measurement plugin emitting `{"value": <n>}` each polling interval — a deterministic, infrastructure-free Record source for exercising the pipeline and Destinations, and for the E2E harness's load/backpressure testing.
- Configurable `type` (`integer`/`double`), `min`/`max` range, and an optional `seed` for reproducible runs, mirroring `uptime.cpp` (the issue's suggested minimal template) plus the parameterized `onConfigure()` pattern used by `tcp_health.cpp`.
- New JSON schema, gtest suite, and docs page (linked from `SUMMARY.md`), per the issue's "How to add a Measurement plugin" checklist.

## Test plan
- [x] `pre-commit run` clean on all changed/new files (clang-format, codespell, JSON/XML lint, XML doc build) — only the pre-existing, unrelated `poetry-requirements` hook fails (no `poetry` installed in this sandbox, same gap noted throughout `progress.txt`).
- [ ] `colcon build --packages-select dc_measurements` + `colcon test --packages-select dc_measurements` (no ROS 2/colcon toolchain available in this sandbox; left for CI, same as prior slices in `progress.txt`).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GVeesH3ymzhuEpLhJTPm9c