### PR TITLE
feat(dc_measurements): add Thermal measurement plugin

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,5 +1,6 @@
-# DC 2.0 (Jazzy) documentation build and deploy (#252). Builds the mdbook site and the
-# strictdoc requirements export, and publishes to GitHub Pages on pushes to `jazzy`.
+# DC 2.0 (Jazzy) documentation build (#252). Builds the mdbook site and the strictdoc
+# requirements export as a CI gate; does not publish anywhere. GitHub Pages for this repo
+# has been taken down (gh-pages branch deleted) and this job no longer deploys to it.
 #
 # Like ci.yaml, this runs the same script a developer runs locally
 # (tools/ci/pre-commit/build_doc.sh, also the `build-doc` pre-commit hook) inside a Podman
@@ -37,7 +38,7 @@ on:
       - .github/workflows/doc.yaml
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -62,10 +63,3 @@ jobs:
         with:
           name: doc-site
           path: doc/book/html
-
-      - name: Deploy to GitHub Pages
-        if: github.event_name == 'push'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/book/html

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -164,6 +164,9 @@ list(APPEND dc_measurement_plugin_libs dc_string_stamped_measurement)
 add_library(dc_tcp_health_measurement SHARED plugins/measurements/tcp_health.cpp)
 list(APPEND dc_measurement_plugin_libs dc_tcp_health_measurement)
 
+add_library(dc_thermal_measurement SHARED plugins/measurements/thermal.cpp)
+list(APPEND dc_measurement_plugin_libs dc_thermal_measurement)
+
 add_library(dc_uptime_measurement SHARED
   plugins/measurements/uptime.cpp
   plugins/measurements/system/linux_parser.cpp
@@ -262,6 +265,7 @@ set(tests
   test_measurement_parameters
   test_measurement_random
   test_measurement_serial_interface
+  test_measurement_thermal
   test_measurement_uptime
 )
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
@@ -1,0 +1,38 @@
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__THERMAL_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__THERMAL_HPP_
+
+#include <string>
+#include <vector>
+
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "nav2_util/node_utils.hpp"
+
+namespace dc_measurements
+{
+
+class Thermal : public dc_measurements::Measurement
+{
+public:
+  Thermal();
+  ~Thermal() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  std::vector<std::string> discoverZones();
+
+  std::string base_path_;
+  std::vector<std::string> zones_;
+
+protected:
+  /**
+   * @brief Configuration of behavior action
+   */
+  void onConfigure() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__THERMAL_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -151,6 +151,14 @@
         </class>
     </library>
 
+    <library path="dc_thermal_measurement">
+        <class name="dc_measurements/Thermal" type="dc_measurements::Thermal" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_thermal
+            </description>
+        </class>
+    </library>
+
     <library path="dc_uptime_measurement">
         <class name="dc_measurements/Uptime" type="dc_measurements::Uptime" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/json/thermal.json
+++ b/dc_measurements/plugins/measurements/json/thermal.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Thermal",
+  "description": "Temperature readings from /sys/class/thermal, keyed by each zone's type string",
+  "additionalProperties": {
+    "description": "Temperature of the zone in degrees Celsius",
+    "type": "number"
+  },
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/thermal.cpp
+++ b/dc_measurements/plugins/measurements/thermal.cpp
@@ -1,0 +1,123 @@
+#include "dc_measurements/plugins/measurements/thermal.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+namespace dc_measurements
+{
+
+namespace
+{
+bool readZone(const std::string& zone_path, std::string& type_out, double& temp_celsius_out)
+{
+  std::ifstream type_file(zone_path + "/type");
+  std::ifstream temp_file(zone_path + "/temp");
+  if (!type_file.is_open() || !temp_file.is_open())
+  {
+    return false;
+  }
+
+  std::getline(type_file, type_out);
+  std::string temp_line;
+  std::getline(temp_file, temp_line);
+
+  try
+  {
+    // /sys/class/thermal/thermal_zone*/temp is in millidegrees Celsius.
+    temp_celsius_out = std::stol(temp_line) / 1000.0;
+  }
+  catch (const std::exception&)
+  {
+    return false;
+  }
+
+  return !type_out.empty();
+}
+}  // namespace
+
+Thermal::Thermal() : dc_measurements::Measurement()
+{
+}
+
+Thermal::~Thermal() = default;
+
+void Thermal::onConfigure()
+{
+  auto node = getNode();
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".base_path",
+                                               rclcpp::ParameterValue(std::string("/sys/class/thermal")));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".zones",
+                                               rclcpp::ParameterValue(std::vector<std::string>{}));
+  node->get_parameter(measurement_name_ + ".base_path", base_path_);
+  node->get_parameter(measurement_name_ + ".zones", zones_);
+
+  // Deliberately don't touch the filesystem (or throw) here: a missing/unreadable
+  // /sys/class/thermal (e.g. a container without the host's thermal sysfs mounted, or a
+  // platform that doesn't expose one) must not fail activation. collect() re-discovers zones
+  // on every poll instead, and simply reports whatever zones it can currently read.
+}
+
+void Thermal::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "thermal.json");
+  }
+}
+
+std::vector<std::string> Thermal::discoverZones()
+{
+  std::vector<std::string> zones;
+  std::error_code ec;
+  for (auto it = std::filesystem::directory_iterator(base_path_, ec);
+       !ec && it != std::filesystem::directory_iterator(); it.increment(ec))
+  {
+    std::string name = it->path().filename().string();
+    if (name.rfind("thermal_zone", 0) == 0)
+    {
+      zones.push_back(name);
+    }
+  }
+
+  return zones;
+}
+
+dc_interfaces::msg::StringStamped Thermal::collect()
+{
+  std::vector<std::string> zones = zones_.empty() ? discoverZones() : zones_;
+
+  json data_json = json::object();
+  for (const auto& zone : zones)
+  {
+    std::string type;
+    double temp_celsius;
+    if (readZone(base_path_ + "/" + zone, type, temp_celsius))
+    {
+      data_json[type] = temp_celsius;
+    }
+    else
+    {
+      RCLCPP_DEBUG_STREAM(logger_, "Could not read thermal zone '" << zone << "' under '" << base_path_ << "'");
+    }
+  }
+
+  if (data_json.empty())
+  {
+    // No zone could be read (e.g. base_path missing/unreadable, or every zone failed):
+    // nothing to report this cycle, same "silent, will retry next poll" contract as other
+    // hardware-optional plugins (SerialInterface) use for a not-currently-available source.
+    return dc_interfaces::msg::StringStamped();
+  }
+
+  auto node = getNode();
+  dc_interfaces::msg::StringStamped msg;
+  msg.header.stamp = node->get_clock()->now();
+  msg.group_key = group_key_;
+  msg.data = data_json.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::Thermal, dc_core::Measurement)

--- a/dc_measurements/test/test_measurement_thermal.cpp
+++ b/dc_measurements/test/test_measurement_thermal.cpp
@@ -1,0 +1,188 @@
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Builds a fake /sys/class/thermal-shaped directory tree under /tmp so the plugin can be
+// exercised for real (auto-discovery, zone `type` as Record key, ARM-style non-numeric-suffix
+// naming) without depending on whatever thermal zones (if any) the test host/container exposes.
+class FakeThermalTree
+{
+public:
+  FakeThermalTree()
+  {
+    root_ = std::filesystem::temp_directory_path() / ("dc_test_thermal_" + std::to_string(::getpid()));
+    std::filesystem::create_directories(root_);
+  }
+
+  ~FakeThermalTree()
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(root_, ec);
+  }
+
+  void addZone(const std::string& zone_dir_name, const std::string& type, long temp_millidegrees)
+  {
+    std::filesystem::path zone_path = root_ / zone_dir_name;
+    std::filesystem::create_directories(zone_path);
+
+    std::ofstream type_file(zone_path / "type");
+    type_file << type << "\n";
+
+    std::ofstream temp_file(zone_path / "temp");
+    temp_file << temp_millidegrees << "\n";
+  }
+
+  std::string path() const
+  {
+    return root_.string();
+  }
+
+private:
+  std::filesystem::path root_;
+};
+
+class MeasurementThermalTest : public ::testing::Test
+{
+protected:
+  MeasurementThermalTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementThermalTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "thermal" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/thermal", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementThermalTest::dataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("thermal.plugin", std::string("dc_measurements/Thermal"));
+    ms_node_->declare_parameter("thermal.group_key", std::string("thermal"));
+    ms_node_->declare_parameter("thermal.topic_output", std::string("/dc/measurement/thermal"));
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  void spinUntilCallback()
+  {
+    for (int i = 0; i < 500 && !callback_active_; ++i)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(callback_active_) << "No Record received within the timeout";
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementThermalTest, AutoDiscoversZonesKeyedByType)
+{
+  FakeThermalTree tree;
+  // Non-sequential, non-x86-style zone directory names (ARM platforms often skip indices or
+  // name them differently) -- acceptance criterion: don't hardcode `thermal_zone0`.
+  tree.addZone("thermal_zone0", "cpu-thermal", 45123);
+  tree.addZone("thermal_zone2", "gpu-thermal", 52000);
+
+  declareCommonParameters();
+  ms_node_->declare_parameter("thermal.base_path", tree.path());
+
+  startLifecycleNode();
+  spinUntilCallback();
+
+  EXPECT_DOUBLE_EQ(data_json_["cpu-thermal"].get<double>(), 45.123);
+  EXPECT_DOUBLE_EQ(data_json_["gpu-thermal"].get<double>(), 52.0);
+}
+
+TEST_F(MeasurementThermalTest, ExplicitZoneListOverridesAutoDiscovery)
+{
+  FakeThermalTree tree;
+  tree.addZone("thermal_zone0", "cpu-thermal", 40000);
+  tree.addZone("thermal_zone1", "board-thermal", 30000);
+
+  declareCommonParameters();
+  ms_node_->declare_parameter("thermal.base_path", tree.path());
+  ms_node_->declare_parameter("thermal.zones", std::vector<std::string>{ "thermal_zone1" });
+
+  startLifecycleNode();
+  spinUntilCallback();
+
+  EXPECT_FALSE(data_json_.contains("cpu-thermal"));
+  EXPECT_DOUBLE_EQ(data_json_["board-thermal"].get<double>(), 30.0);
+}
+
+TEST_F(MeasurementThermalTest, ActivatesSuccessfullyWithMissingBasePath)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("thermal.base_path", std::string("/tmp/dc_test_thermal_does_not_exist"));
+
+  // Must not throw: a missing/unreadable /sys/class/thermal should not fail activation. No
+  // zone can be read, so (like SerialInterface with no port) nothing is published either --
+  // this loop just proves the node keeps spinning without crashing.
+  ASSERT_NO_THROW(startLifecycleNode());
+
+  for (int i = 0; i < 5; ++i)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+
+  EXPECT_FALSE(callback_active_);
+  SUCCEED();
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [Storage](./dc/measurements/storage.md)
   - [String stamped](./dc/measurements/string_stamped.md)
   - [TCP Health](./dc/measurements/tcp_health.md)
+  - [Thermal](./dc/measurements/thermal.md)
   - [Uptime](./dc/measurements/uptime.md)
 - [Conditions](./dc/conditions.md)
   - [Bool equal](./dc/conditions/bool_equal.md)

--- a/doc/src/dc/measurements/thermal.md
+++ b/doc/src/dc/measurements/thermal.md
@@ -1,0 +1,54 @@
+# Thermal
+
+## Description
+Reports temperatures (CPU, GPU, board, ...) from the kernel's thermal sysfs interface
+(`/sys/class/thermal/thermal_zone*/`), so overheating trends reach dashboards before they
+become failures. Zones are auto-discovered by default; each zone's `type` string (e.g.
+`x86_pkg_temp`, `cpu-thermal`) is used as the Record key, not its numeric index, since zone
+numbering is platform-specific and differs between x86_64 and ARM targets. A missing or
+unreadable `/sys/class/thermal` (e.g. a container without the host's thermal sysfs mounted)
+degrades gracefully: activation still succeeds, and if no zone can currently be read the
+Measurement publishes nothing that cycle (the same "silent, retry next poll" contract other
+hardware-optional Measurements like Serial interface use) instead of failing or publishing an
+empty Record.
+
+## Parameters
+
+| Parameter     | Description                                                                                              | Type        | Default                |
+| ------------- | --------------------------------------------------------------------------------------------------------- | ----------- | ------------------------ |
+| **base_path** | Directory to scan for `thermal_zone*` entries                                                              | str         | "/sys/class/thermal" (Optional) |
+| **zones**     | Explicit list of zone directory names (e.g. `["thermal_zone0", "thermal_zone2"]`) to read instead of auto-discovering every `thermal_zone*` entry under **base_path** | list of str | [] (Optional)             |
+
+## Schema
+
+```json
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Thermal",
+    "description": "Temperature readings from /sys/class/thermal, keyed by each zone's type string",
+    "additionalProperties": {
+        "description": "Temperature of the zone in degrees Celsius",
+        "type": "number"
+    },
+    "type": "object"
+}
+```
+
+## Measurement configuration
+
+```yaml
+...
+thermal:
+  plugin: "dc_measurements/Thermal"
+  topic_output: "/dc/measurement/thermal"
+  tags: ["console"]
+```
+
+Example Record data, on a host exposing a CPU package zone and a GPU zone:
+
+```json
+{
+  "x86_pkg_temp": 52.0,
+  "gpu-thermal": 61.5
+}
+```

--- a/progress.txt
+++ b/progress.txt
@@ -2279,3 +2279,116 @@ layer invalidates on every source change
   argument alignment); committed as formatted. Pushed for CI to re-confirm; still unverified
   end-to-end in this sandbox (no colcon here, same recurring constraint as every other slice
   in this log).
+
+### #100 - Add Measurement: Thermal
+
+- Added a new `Thermal` Measurement plugin (`dc_measurements/plugins/measurements/thermal.cpp`
+  + `include/dc_measurements/plugins/measurements/thermal.hpp`), reading
+  `/sys/class/thermal/thermal_zone*/` (`type` + `temp`) per the issue's pointer at
+  `cpu.cpp`/`memory.cpp` as prior art for `/sys` parsing in this repo, though structurally it
+  mirrors the simpler `Storage`/`SerialInterface` plugins (no shared `System`/`LinuxParser`
+  state needed).
+  - Parameters (both optional, `nav2_util::declare_parameter_if_not_declared` in
+    `onConfigure()`): `base_path` (default `/sys/class/thermal`, override for testing or a
+    non-standard sysfs mount) and `zones` (list of str, default empty = auto-discover).
+  - Zone auto-discovery (acceptance criterion): `discoverZones()` scans `base_path` for
+    entries named `thermal_zone*` via `std::filesystem::directory_iterator` with an
+    `std::error_code` overload (never throws on a missing/unreadable directory — returns an
+    empty list instead). The explicit `zones` parameter, when non-empty, is used verbatim
+    instead of auto-discovering, satisfying the "explicit zone list as an override" criterion.
+  - Zone `type` string as the Record key (acceptance criterion, so dashboards get named zones
+    like `x86_pkg_temp`/`cpu-thermal` instead of a `thermal_zone0` index that's meaningless
+    across reboots/platforms): each zone's `type` file content becomes the JSON key, `temp`
+    (millidegrees Celsius) is converted to degrees Celsius. Works identically on x86_64 and
+    ARM (acceptance criterion) since nothing hardcodes a zone index or count -- only the
+    `thermal_zone` directory-name prefix is assumed, which is the kernel's own stable naming
+    convention on both architectures.
+  - Missing/unreadable `/sys/class/thermal` degrades gracefully (acceptance criterion):
+    `onConfigure()` never touches the filesystem or throws, so activation always succeeds
+    (mirrors `SerialInterface::onConfigure()`'s "never fail activation for an unavailable
+    hardware source" contract). `collect()` re-discovers zones fresh on every poll rather than
+    caching a possibly-stale list; a zone whose `type`/`temp` file can't be opened or parsed
+    is skipped (`RCLCPP_DEBUG`, not fatal) rather than aborting the whole collection. If zero
+    zones could be read this cycle, `collect()` returns a default (empty-`data`) Record --
+    the same "nothing to report, will retry next poll" contract `SerialInterface::collect()`
+    uses for a not-yet-connected device -- rather than publishing a content-free `{}` Record
+    every second.
+  - JSON schema (`plugins/measurements/json/thermal.json`): `additionalProperties: {type:
+    number}` rather than fixed `properties`, since zone names are dynamic/platform-specific
+    and unknown ahead of time.
+  - Registered in `dc_measurements/measurement_plugin.xml` (alphabetically between
+    `TCPHealth` and `Uptime`) and `dc_measurements/CMakeLists.txt` (new
+    `dc_thermal_measurement` library appended to `dc_measurement_plugin_libs`, picked up
+    automatically by the existing install/export/`ament_target_dependencies` loops).
+  - Test: `dc_measurements/test/test_measurement_thermal.cpp` (registered in `CMakeLists.txt`'s
+    `tests` list), following the `MeasurementServer`-in-process harness pattern from
+    `test_measurement_random.cpp`/`test_measurement_serial_interface.cpp`. A `FakeThermalTree`
+    helper builds a throwaway `/sys/class/thermal`-shaped directory tree under `/tmp` (no
+    dependency on whatever real thermal zones, if any, the test host/container exposes).
+    Three cases: auto-discovery across non-sequential zone directory names (`thermal_zone0`,
+    `thermal_zone2` -- deliberately skipping `thermal_zone1` to catch any accidental
+    index-based assumption) with values keyed by `type` and converted to Celsius correctly;
+    an explicit `zones` list restricting collection to one zone even though others exist;
+    and a missing-`base_path` case asserting activation doesn't throw and (per the
+    silent-when-unavailable design above) no Record is ever published.
+  - Docs: `doc/src/dc/measurements/thermal.md` (new, parameter table + schema + example
+    config/output, following `random.md`'s layout) and linked from `doc/src/SUMMARY.md`
+    alphabetically between TCP Health and Uptime.
+- **Verified in the real ROS 2 Jazzy environment**: this sandbox still has no
+  colcon/ROS 2 install (same recurring constraint as every other slice in this log), but a
+  cached `localhost/dc-workspace:latest` Podman image from an earlier session's Jazzy build
+  was still present with a full pre-built workspace at `/root/ws`. Bind-mounted this
+  worktree's `dc_measurements/` and `doc/` over the image's copies and ran a real
+  `colcon build --packages-select dc_measurements` + `colcon test` there (not just
+  `pre-commit`), rather than leaving it as an unverified caveat.
+  - First `colcon test` pass caught a real bug the sandbox couldn't: the
+    `ActivatesSuccessfullyWithMissingBasePath` test initially expected `data_json_.empty()`
+    after activation with a missing `base_path`, but `Measurement::publish()` decorates every
+    non-empty-`data` Record with `name`/`nested`/`flattened`/`run_id` regardless of whether
+    the plugin itself measured anything -- so a `collect()` that returned `{}` (valid,
+    zone-less JSON) was still published as a decorated, non-empty Record, failing the test.
+    Fixed by changing `collect()` to return a fully empty `StringStamped` (empty `data`) when
+    no zone could be read at all, which `publish()` already treats as "nothing to send" and
+    skips -- the same behavior `SerialInterface` already relies on for "device not connected"
+    -- rather than loosening the test assertion. Updated the test and `thermal.md` to describe
+    this silent-when-unavailable contract.
+  - After that fix, `colcon test --packages-select dc_measurements --ctest-args -R thermal`:
+    3/3 tests pass (`AutoDiscoversZonesKeyedByType`, `ExplicitZoneListOverridesAutoDiscovery`,
+    `ActivatesSuccessfullyWithMissingBasePath`), confirmed via the full gtest log (zone values
+    correctly keyed by `type` and converted to Celsius, the override list excluding
+    non-listed zones, and the missing-path case producing zero Records with no thrown
+    exception).
+  - `pre-commit` (`clang-format`, `codespell`, JSON/XML lint, ROS package metadata checks,
+    etc., same `build-doc`/`poetry-requirements`/`pycln`/`flake8`/`go-fmt` skips as every
+    other entry in this log for pre-existing, unrelated tool-environment gaps) clean on every
+    changed/new file.
+
+### Repo housekeeping (same session, not issue #100 itself) - GitHub Pages taken down, doc.yaml no longer deploys
+
+Prompted by a direct request to bundle this into the same PR: this repo's public docs site
+(`https://minipada.github.io/ros2_data_collection/`, legacy branch-based GitHub Pages sourced
+from `gh-pages`) is being retired.
+
+- `DELETE /repos/{owner}/{repo}/pages` (the documented way to disable Pages via the GitHub
+  API) was tried first and refused outright: `422 Deactivating GitHub Pages for this
+  repository is not allowed` -- a known API restriction for some legacy branch-sourced Pages
+  configurations, confirmed with a valid `repo`-scoped token (not a permissions gap on this
+  end). No browser tool is available in this environment to use the Settings UI instead.
+- Deleted the `gh-pages` branch itself instead (`git push origin --delete gh-pages`) --
+  removes the content the legacy Pages source serves from, so the site starts 404ing shortly
+  even though the repository's Pages "enabled" flag can't be flipped off via API. This is a
+  direct, irreversible-ish action on a shared/remote branch, so it was confirmed with the
+  user before running (two explicit confirmations: unpublish-now vs. leave-it, then
+  API-blocked vs. delete-the-branch).
+- `.github/workflows/doc.yaml`: removed the "Deploy to GitHub Pages" step
+  (`peaceiris/actions-gh-pages@v4`) so CI no longer pushes anything to `gh-pages` going
+  forward; downgraded the job's `permissions` from `contents: write` (only ever needed for
+  that push) to `contents: read`. The build + `actions/upload-artifact` steps are left in
+  place -- the docs build stays a real CI gate (broken links / missing `SUMMARY.md` pages
+  still fail the job per `doc/book.toml`'s settings), it just no longer publishes anywhere.
+  Header comment updated to describe the new state instead of the stale "(#252) ... publishes
+  to GitHub Pages" description.
+- Not done: actually flipping the repository's Settings > Pages "Build and deployment" source
+  away from `gh-pages`/off (the flag GitHub's UI shows) -- blocked by the same API restriction
+  and no browser tool; deleting the source branch achieves the same practical outcome (no live
+  site) without it.


### PR DESCRIPTION
## Summary
- Adds a `Thermal` Measurement plugin reading `/sys/class/thermal/thermal_zone*/` (`type` + `temp`), keyed by each zone's `type` string so dashboards get named zones instead of platform-specific indices.
- Zones are auto-discovered by default, with an explicit `zones` parameter as an override.
- A missing/unreadable `/sys/class/thermal` degrades gracefully (activation still succeeds; simply nothing is published that cycle), matching the existing `SerialInterface` "hardware not currently available" contract.
- Also, per direct request bundled into this PR: retires the repo's GitHub Pages docs site (`gh-pages` branch deleted; GitHub's Pages API refuses to disable the site directly for this repo) and removes the "Deploy to GitHub Pages" step from `.github/workflows/doc.yaml` so CI no longer pushes docs anywhere. The docs build itself stays a CI gate.

Closes #100

## Test plan
- [x] `pre-commit` (clang-format, codespell, JSON/XML lint, ROS package metadata checks) clean on all changed/new files
- [x] Verified with a real `colcon build --packages-select dc_measurements` + `colcon test` against ROS 2 Jazzy (cached container from an earlier session's build): 3/3 new gtest cases pass (`AutoDiscoversZonesKeyedByType`, `ExplicitZoneListOverridesAutoDiscovery`, `ActivatesSuccessfullyWithMissingBasePath`)
- [x] Docs page added under `doc/src/dc/measurements/thermal.md` and linked from `doc/src/SUMMARY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UrSonEm6hoXwWD6WrE522F