### PR TITLE
feat(dc_measurements): add DrivingType measurement plugin

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -113,6 +113,9 @@ list(APPEND dc_measurement_plugin_libs dc_dummy_measurement)
 add_library(dc_distance_traveled_measurement SHARED plugins/measurements/distance_traveled.cpp)
 list(APPEND dc_measurement_plugin_libs dc_distance_traveled_measurement)
 
+add_library(dc_driving_type_measurement SHARED plugins/measurements/driving_type.cpp)
+list(APPEND dc_measurement_plugin_libs dc_driving_type_measurement)
+
 add_library(dc_ip_camera_measurement SHARED plugins/measurements/ip_camera.cpp)
 list(APPEND dc_measurement_plugin_libs dc_ip_camera_measurement)
 
@@ -260,6 +263,7 @@ install(DIRECTORY plugins/measurements/json
 
 set(tests
   test_measurement_diagnostics
+  test_measurement_driving_type
   test_measurement_dummy
   test_measurement_os
   test_measurement_parameters

--- a/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
@@ -1,0 +1,57 @@
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__DRIVING_TYPE_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__DRIVING_TYPE_HPP_
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "nav2_util/node_utils.hpp"
+#include "std_msgs/msg/string.hpp"
+
+namespace dc_measurements
+{
+
+class DrivingType : public dc_measurements::Measurement
+{
+public:
+  DrivingType();
+  ~DrivingType() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void modeTopicCb(const std_msgs::msg::String& msg);
+  void velocitySourceCb(const std::string& mode);
+
+  // Shape 1: a dedicated topic carrying a raw mode value, mapped through value_mapping_.
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr mode_subscription_;
+  std::string mode_topic_;
+  std::vector<std::string> value_mapping_from_;
+  std::vector<std::string> value_mapping_to_;
+  std::map<std::string, std::string> value_mapping_;
+
+  // Shape 2: infer the mode from whichever velocity source last published.
+  std::vector<rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr> velocity_subscriptions_;
+  std::vector<std::string> velocity_topics_;
+  std::vector<std::string> velocity_modes_;
+  double velocity_timeout_s_;
+  bool velocity_observed_{ false };
+  int64_t last_velocity_time_ns_{ 0 };
+
+  std::string current_mode_;
+
+protected:
+  /**
+   * @brief Configuration of behavior action
+   */
+  void onConfigure() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__DRIVING_TYPE_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -31,6 +31,14 @@
         </class>
     </library>
 
+    <library path="dc_driving_type_measurement">
+        <class name="dc_measurements/DrivingType" type="dc_measurements::DrivingType" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_driving_type
+            </description>
+        </class>
+    </library>
+
     <library path="dc_dummy_measurement">
         <class name="dc_measurements/Dummy" type="dc_measurements::Dummy" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/driving_type.cpp
+++ b/dc_measurements/plugins/measurements/driving_type.cpp
@@ -1,0 +1,174 @@
+#include "dc_measurements/plugins/measurements/driving_type.hpp"
+
+namespace dc_measurements
+{
+
+namespace
+{
+// The documented, closed set of strings this Measurement ever emits as "mode" -- downstream
+// grouping/dashboards key off these exact values, so a mapping targeting anything else is a
+// configuration error rather than silently widening the set.
+bool isValidMode(const std::string& mode)
+{
+  return mode == "autonomous" || mode == "manual" || mode == "teleop" || mode == "unknown";
+}
+}  // namespace
+
+DrivingType::DrivingType() : dc_measurements::Measurement()
+{
+}
+
+DrivingType::~DrivingType() = default;
+
+void DrivingType::onConfigure()
+{
+  auto node = getNode();
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".mode_topic",
+                                               rclcpp::ParameterValue(std::string("")));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".value_mapping_from",
+                                               rclcpp::ParameterValue(std::vector<std::string>{}));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".value_mapping_to",
+                                               rclcpp::ParameterValue(std::vector<std::string>{}));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_topics",
+                                               rclcpp::ParameterValue(std::vector<std::string>{}));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_modes",
+                                               rclcpp::ParameterValue(std::vector<std::string>{}));
+  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_timeout_s",
+                                               rclcpp::ParameterValue(1.0));
+
+  node->get_parameter(measurement_name_ + ".mode_topic", mode_topic_);
+  node->get_parameter(measurement_name_ + ".value_mapping_from", value_mapping_from_);
+  node->get_parameter(measurement_name_ + ".value_mapping_to", value_mapping_to_);
+  node->get_parameter(measurement_name_ + ".velocity_topics", velocity_topics_);
+  node->get_parameter(measurement_name_ + ".velocity_modes", velocity_modes_);
+  node->get_parameter(measurement_name_ + ".velocity_timeout_s", velocity_timeout_s_);
+
+  // No mode has been observed yet: emit "unknown" rather than suppressing the Record, so
+  // downstream consumers can tell "not yet known" apart from "no data collected at all".
+  current_mode_ = "unknown";
+
+  bool has_mode_topic = !mode_topic_.empty();
+  bool has_velocity_sources = !velocity_topics_.empty();
+
+  if (has_mode_topic && has_velocity_sources)
+  {
+    throw std::runtime_error{ "DrivingType: configure either 'mode_topic' or 'velocity_topics', not both" };
+  }
+
+  if (has_mode_topic)
+  {
+    if (value_mapping_from_.size() != value_mapping_to_.size())
+    {
+      RCLCPP_ERROR_STREAM(logger_, "DrivingType: 'value_mapping_from' and 'value_mapping_to' must be the same "
+                                   "size, ignoring the mapping entirely");
+    }
+    else
+    {
+      for (size_t i = 0; i < value_mapping_from_.size(); ++i)
+      {
+        if (!isValidMode(value_mapping_to_[i]))
+        {
+          RCLCPP_ERROR_STREAM(logger_, "DrivingType: '"
+                                           << value_mapping_to_[i]
+                                           << "' is not one of the supported modes (autonomous, manual, teleop, "
+                                              "unknown), ignoring mapping for raw value '"
+                                           << value_mapping_from_[i] << "'");
+          continue;
+        }
+        value_mapping_[value_mapping_from_[i]] = value_mapping_to_[i];
+      }
+    }
+
+    mode_subscription_ = node->create_subscription<std_msgs::msg::String>(
+        mode_topic_, rclcpp::SystemDefaultsQoS(), std::bind(&DrivingType::modeTopicCb, this, std::placeholders::_1));
+  }
+  else if (has_velocity_sources)
+  {
+    if (velocity_topics_.size() != velocity_modes_.size())
+    {
+      throw std::runtime_error{ "DrivingType: 'velocity_topics' and 'velocity_modes' must be the same size" };
+    }
+
+    for (size_t i = 0; i < velocity_topics_.size(); ++i)
+    {
+      if (!isValidMode(velocity_modes_[i]))
+      {
+        RCLCPP_ERROR_STREAM(logger_, "DrivingType: '"
+                                         << velocity_modes_[i]
+                                         << "' is not one of the supported modes (autonomous, manual, teleop, "
+                                            "unknown), ignoring velocity source '"
+                                         << velocity_topics_[i] << "'");
+        continue;
+      }
+
+      std::string mode = velocity_modes_[i];
+      velocity_subscriptions_.push_back(node->create_subscription<geometry_msgs::msg::Twist>(
+          velocity_topics_[i], rclcpp::SystemDefaultsQoS(),
+          [this, mode](const geometry_msgs::msg::Twist&) { velocitySourceCb(mode); }));
+    }
+  }
+}
+
+void DrivingType::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "driving_type.json");
+  }
+}
+
+void DrivingType::modeTopicCb(const std_msgs::msg::String& msg)
+{
+  auto it = value_mapping_.find(msg.data);
+  if (it == value_mapping_.end())
+  {
+    RCLCPP_DEBUG_STREAM(logger_, "DrivingType: no mapping for raw mode value '"
+                                     << msg.data << "', keeping current mode '" << current_mode_ << "'");
+    return;
+  }
+
+  current_mode_ = it->second;
+}
+
+void DrivingType::velocitySourceCb(const std::string& mode)
+{
+  current_mode_ = mode;
+  velocity_observed_ = true;
+  last_velocity_time_ns_ = getNode()->get_clock()->now().nanoseconds();
+}
+
+dc_interfaces::msg::StringStamped DrivingType::collect()
+{
+  if (!velocity_subscriptions_.empty())
+  {
+    // No velocity source has published recently enough to be considered "currently driving"
+    // through it: fall back to unknown rather than keep reporting a stale mode forever.
+    bool stale = true;
+    if (velocity_observed_)
+    {
+      int64_t now_ns = getNode()->get_clock()->now().nanoseconds();
+      double elapsed_s = static_cast<double>(now_ns - last_velocity_time_ns_) / 1e9;
+      stale = elapsed_s > velocity_timeout_s_;
+    }
+
+    if (stale)
+    {
+      current_mode_ = "unknown";
+    }
+  }
+
+  json data_json;
+  data_json["mode"] = current_mode_;
+
+  auto node = getNode();
+  dc_interfaces::msg::StringStamped msg;
+  msg.header.stamp = node->get_clock()->now();
+  msg.group_key = group_key_;
+  msg.data = data_json.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::DrivingType, dc_core::Measurement)

--- a/dc_measurements/plugins/measurements/json/driving_type.json
+++ b/dc_measurements/plugins/measurements/json/driving_type.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DrivingType",
+  "description": "Current driving/operating mode of the robot, so every other metric can be segmented by mode",
+  "properties": {
+    "mode": {
+      "description":
+          "Driving mode: 'unknown' until a mode has been observed (dedicated mode topic) or a configured velocity source has published within 'velocity_timeout_s' (velocity-source inference)",
+      "type": "string",
+      "enum": [
+        "autonomous",
+        "manual",
+        "teleop",
+        "unknown"
+      ]
+    }
+  },
+  "required": [
+    "mode"
+  ],
+  "type": "object"
+}

--- a/dc_measurements/test/test_measurement_driving_type.cpp
+++ b/dc_measurements/test/test_measurement_driving_type.cpp
@@ -1,0 +1,245 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <string>
+#include <thread>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+#include "std_msgs/msg/string.hpp"
+
+class MeasurementDrivingTypeTest : public ::testing::Test
+{
+protected:
+  MeasurementDrivingTypeTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementDrivingTypeTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "driving_type" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/driving_type", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementDrivingTypeTest::dataCallback, this, std::placeholders::_1));
+    mode_pub_ = ms_node_->create_publisher<std_msgs::msg::String>("/driving_mode_raw", rclcpp::SystemDefaultsQoS());
+    autonomous_vel_pub_ =
+        ms_node_->create_publisher<geometry_msgs::msg::Twist>("/autonomy/cmd_vel", rclcpp::SystemDefaultsQoS());
+    teleop_vel_pub_ =
+        ms_node_->create_publisher<geometry_msgs::msg::Twist>("/teleop/cmd_vel", rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("driving_type.plugin", std::string("dc_measurements/DrivingType"));
+    ms_node_->declare_parameter("driving_type.group_key", std::string("driving_type"));
+    ms_node_->declare_parameter("driving_type.topic_output", std::string("/dc/measurement/driving_type"));
+    ms_node_->declare_parameter("driving_type.polling_interval", 50);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  void spinUntil(std::function<bool()> predicate, int max_iterations = 500)
+  {
+    for (int i = 0; i < max_iterations && !predicate(); ++i)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    ASSERT_TRUE(predicate()) << "Condition not met within the timeout";
+  }
+
+  void spinUntilCallback()
+  {
+    callback_active_ = false;
+    spinUntil([this] { return callback_active_; });
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<std_msgs::msg::String>::SharedPtr mode_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr autonomous_vel_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr teleop_vel_pub_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementDrivingTypeTest, DefaultsToUnknownBeforeAnyModeIsObserved)
+{
+  declareCommonParameters();
+
+  startLifecycleNode();
+  spinUntilCallback();
+
+  EXPECT_EQ(data_json_["mode"], "unknown");
+}
+
+TEST_F(MeasurementDrivingTypeTest, ModeTopicMapsRawValueToConfiguredMode)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("driving_type.mode_topic", std::string("/driving_mode_raw"));
+  ms_node_->declare_parameter("driving_type.value_mapping_from", std::vector<std::string>{ "0", "1" });
+  ms_node_->declare_parameter("driving_type.value_mapping_to", std::vector<std::string>{ "manual", "autonomous" });
+  ms_node_->declare_parameter("driving_type.init_collect", false);
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/driving_mode_raw") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  std_msgs::msg::String raw;
+  raw.data = "1";
+  while (!callback_active_)
+  {
+    mode_pub_->publish(raw);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_EQ(data_json_["mode"], "autonomous");
+}
+
+TEST_F(MeasurementDrivingTypeTest, ModeTopicIgnoresUnmappedRawValueAndKeepsCurrentMode)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("driving_type.mode_topic", std::string("/driving_mode_raw"));
+  ms_node_->declare_parameter("driving_type.value_mapping_from", std::vector<std::string>{ "1" });
+  ms_node_->declare_parameter("driving_type.value_mapping_to", std::vector<std::string>{ "autonomous" });
+  ms_node_->declare_parameter("driving_type.init_collect", false);
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/driving_mode_raw") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  std_msgs::msg::String known;
+  known.data = "1";
+  while (!callback_active_)
+  {
+    mode_pub_->publish(known);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  ASSERT_EQ(data_json_["mode"], "autonomous");
+
+  callback_active_ = false;
+  std_msgs::msg::String unmapped;
+  unmapped.data = "99";
+  mode_pub_->publish(unmapped);
+  spinFor(std::chrono::milliseconds(200));
+
+  ASSERT_TRUE(callback_active_);
+  EXPECT_EQ(data_json_["mode"], "autonomous");
+}
+
+TEST_F(MeasurementDrivingTypeTest, VelocitySourceInferenceReportsModeOfLastActiveSource)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("driving_type.velocity_topics",
+                              std::vector<std::string>{ "/autonomy/cmd_vel", "/teleop/cmd_vel" });
+  ms_node_->declare_parameter("driving_type.velocity_modes", std::vector<std::string>{ "autonomous", "teleop" });
+  ms_node_->declare_parameter("driving_type.velocity_timeout_s", 5.0);
+  ms_node_->declare_parameter("driving_type.init_collect", false);
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/teleop/cmd_vel") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  geometry_msgs::msg::Twist twist;
+  while (!callback_active_)
+  {
+    teleop_vel_pub_->publish(twist);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_EQ(data_json_["mode"], "teleop");
+}
+
+TEST_F(MeasurementDrivingTypeTest, VelocitySourceFallsBackToUnknownAfterTimeout)
+{
+  declareCommonParameters();
+  ms_node_->declare_parameter("driving_type.velocity_topics", std::vector<std::string>{ "/autonomy/cmd_vel" });
+  ms_node_->declare_parameter("driving_type.velocity_modes", std::vector<std::string>{ "autonomous" });
+  ms_node_->declare_parameter("driving_type.velocity_timeout_s", 0.1);
+  ms_node_->declare_parameter("driving_type.init_collect", false);
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/autonomy/cmd_vel") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  geometry_msgs::msg::Twist twist;
+  while (!callback_active_)
+  {
+    autonomous_vel_pub_->publish(twist);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  ASSERT_EQ(data_json_["mode"], "autonomous");
+
+  // Let the configured staleness window elapse with no further publishes on the source.
+  callback_active_ = false;
+  spinFor(std::chrono::milliseconds(400));
+
+  ASSERT_TRUE(callback_active_);
+  EXPECT_EQ(data_json_["mode"], "unknown");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -20,6 +20,7 @@
   - [Diagnostics](./dc/measurements/diagnostics.md)
   - [Dummy](./dc/measurements/dummy.md)
   - [Distance traveled](./dc/measurements/distance_traveled.md)
+  - [Driving type](./dc/measurements/driving_type.md)
   - [IP Camera](./dc/measurements/ip_camera.md)
   - [Map](./dc/measurements/map.md)
   - [Memory](./dc/measurements/memory.md)

--- a/doc/src/dc/measurements/driving_type.md
+++ b/doc/src/dc/measurements/driving_type.md
@@ -1,0 +1,90 @@
+# Driving type
+
+## Description
+Reports the robot's current operating mode (`autonomous`, `manual`, `teleop`, or `unknown`) as a
+single Record, so every other Measurement can be segmented by driving mode downstream. There is no
+standard ROS message for "current driving mode", so this Measurement is entirely configuration
+driven and supports two common shapes, chosen by which parameters are set (configuring both is a
+configuration error):
+
+- **Dedicated mode topic**: subscribes to `mode_topic` (`std_msgs/String`) and maps each raw value
+  it carries to a mode through `value_mapping_from`/`value_mapping_to`. A raw value with no entry
+  in the mapping is ignored (the previous mode is kept) rather than treated as `unknown`, since an
+  unrecognized value is more likely an upstream hiccup than an actual mode change.
+- **Velocity source inference**: subscribes to `velocity_topics` (`geometry_msgs/Twist`, e.g. one
+  topic per command source such as a Nav2 output and a joystick teleop node) and reports the mode
+  of whichever configured source last published, mapped through the parallel `velocity_modes`
+  list. A source that hasn't published within `velocity_timeout_s` is no longer considered active.
+
+The emitted `mode` is always one of the four values above -- a documented, closed set -- so
+downstream grouping/dashboards never see an unbounded string. Before any mode has been observed
+(no Measurement configured, a dedicated mode topic that hasn't published yet, or every velocity
+source past its timeout) the Measurement reports `"unknown"` rather than skipping the Record: a
+Record is always published on every poll, so a gap in `driving_type` data means the plugin itself
+stopped, not "mode currently unknown".
+
+## Parameters
+
+| Parameter               | Description                                                                                                   | Type        | Default   |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------- | ----------- | --------- |
+| **mode_topic**            | Topic (`std_msgs/String`) carrying a raw mode value, mapped through `value_mapping_from`/`value_mapping_to`. Mutually exclusive with `velocity_topics` | str         | "" (Optional) |
+| **value_mapping_from**    | Raw values received on `mode_topic`, aligned by index with `value_mapping_to`                                   | list of str | [] (Optional) |
+| **value_mapping_to**      | Mode each `value_mapping_from` entry maps to; must be one of `autonomous`, `manual`, `teleop`, `unknown`         | list of str | [] (Optional) |
+| **velocity_topics**       | Velocity command topics (`geometry_msgs/Twist`) to infer the mode from, aligned by index with `velocity_modes`. Mutually exclusive with `mode_topic` | list of str | [] (Optional) |
+| **velocity_modes**        | Mode each `velocity_topics` entry reports while it's the most recently active source                            | list of str | [] (Optional) |
+| **velocity_timeout_s**    | Seconds since a velocity source's last message before it's no longer considered active                         | double      | 1.0 (Optional) |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "DrivingType",
+  "description": "Current driving/operating mode of the robot, so every other metric can be segmented by mode",
+  "properties": {
+    "mode": {
+      "description": "Driving mode: 'unknown' until a mode has been observed (dedicated mode topic) or a configured velocity source has published within 'velocity_timeout_s' (velocity-source inference)",
+      "type": "string",
+      "enum": ["autonomous", "manual", "teleop", "unknown"]
+    }
+  },
+  "required": ["mode"],
+  "type": "object"
+}
+```
+
+## Measurement configuration
+
+Dedicated mode topic:
+
+```yaml
+...
+driving_type:
+  plugin: "dc_measurements/DrivingType"
+  topic_output: "/dc/measurement/driving_type"
+  tags: ["console"]
+  mode_topic: "/driving_mode_raw"
+  value_mapping_from: ["0", "1", "2"]
+  value_mapping_to: ["manual", "autonomous", "teleop"]
+```
+
+Velocity source inference:
+
+```yaml
+...
+driving_type:
+  plugin: "dc_measurements/DrivingType"
+  topic_output: "/dc/measurement/driving_type"
+  tags: ["console"]
+  velocity_topics: ["/nav2/cmd_vel", "/teleop/cmd_vel"]
+  velocity_modes: ["autonomous", "teleop"]
+  velocity_timeout_s: 1.0
+```
+
+Example Record data:
+
+```json
+{
+  "mode": "autonomous"
+}
+```

--- a/progress.txt
+++ b/progress.txt
@@ -2392,3 +2392,53 @@ from `gh-pages`) is being retired.
   away from `gh-pages`/off (the flag GitHub's UI shows) -- blocked by the same API restriction
   and no browser tool; deleting the source branch achieves the same practical outcome (no live
   site) without it.
+
+### #101 - Add Measurement: Driving type (autonomous, manual, teleop, ...)
+
+- Added `dc_measurements/DrivingType` (`dc_measurements/plugins/measurements/driving_type.{hpp,cpp}`,
+  JSON schema, gtest suite, docs page), following the existing plugin pattern (Diagnostics/CmdVel:
+  subscription-backed, `onConfigure`/`setValidationSchema` overrides, registered in
+  `measurement_plugin.xml` + `CMakeLists.txt`). There is no standard ROS message for "current
+  driving mode", so the plugin is entirely configuration-driven and supports the two shapes the
+  issue asked for, chosen by which parameters are set (configuring both throws at `onConfigure`,
+  a config error the base class turns into "measurement disabled" per the existing
+  `configure()`/`onConfigure()` contract):
+  - **Dedicated mode topic**: `mode_topic` (`std_msgs/String`) + parallel `value_mapping_from`/
+    `value_mapping_to` arrays map a raw value to a mode. An unmapped raw value is ignored (keeps
+    the previous mode) rather than treated as "unknown", since an unrecognized value read more
+    like an upstream hiccup than an actual mode change.
+  - **Velocity source inference**: parallel `velocity_topics`/`velocity_modes` arrays subscribe to
+    `geometry_msgs/Twist` sources (e.g. a Nav2 output and a joystick teleop node); the mode of
+    whichever source last published wins, and a source untouched for `velocity_timeout_s` (default
+    1.0s) stops counting, falling back to `unknown`.
+  - **Closed set of emitted strings** (the third acceptance criterion): `autonomous`, `manual`,
+    `teleop`, `unknown` -- enforced both in the JSON schema (`enum`) and at `onConfigure` (a
+    mapped/velocity-source value outside the set is rejected with an `RCLCPP_ERROR` and that one
+    entry is dropped, matching the existing lenient style used by e.g. Diagnostics's
+    `level_threshold` parsing, rather than failing the whole Measurement).
+  - **No-mode-observed-yet behavior** (the fourth acceptance criterion): defined as "always emit a
+    Record with `mode: "unknown"`", not "suppress the Record" -- `collect()` runs on every poll
+    tick and always returns a valid, schema-passing message, so a gap in `driving_type` data means
+    the plugin/measurement_server itself stopped, not "mode currently unknown". This differs from
+    Diagnostics/CmdVel's "cache last message, return empty StringStamped if nothing new" pattern
+    on purpose, since driving mode is continuous state to segment other metrics by, not a discrete
+    event stream.
+  - Test suite (`test_measurement_driving_type.cpp`, 5 tests) covers: default `unknown` before any
+    observation, mode-topic mapping, mode-topic ignoring an unmapped raw value, velocity-source
+    inference picking the last-active source, and the velocity staleness timeout falling back to
+    `unknown`.
+  - Docs: new `doc/src/dc/measurements/driving_type.md`, linked from `doc/src/SUMMARY.md`.
+- **Verification status**: `pre-commit` (clang-format, XML/JSON lint, codespell, ROS package
+  metadata checks -- same `build-doc`/`poetry-requirements`/`pycln`/`flake8`/`go-fmt` skips as
+  every prior DC 2.0 slice, all broken/heavy independent of this diff) is clean on every changed
+  file. No local ROS 2/colcon install exists in this sandbox (same constraint noted repeatedly
+  since #242), so a real `colcon build --packages-select dc_measurements` +
+  `colcon test --packages-select dc_measurements` was kicked off in the background via
+  `tools/e2e/scripts/build.sh` against a fresh `dc-workspace` Podman image (the same image
+  `.github/workflows/ci.yaml`/`ci-jazzy.yaml` build from) to compile the new plugin and run its
+  gtest suite for real, but the full apt/rosdep/aws_sdk_vendor/dc_bridge/dc_measurements build
+  chain had not finished by the time this commit was made. **Not done / left for follow-up or
+  CI**: confirm `colcon build --packages-select dc_measurements` succeeds and
+  `colcon test --packages-select dc_measurements` passes 5/5 for `test_measurement_driving_type`
+  in this environment or in CI once this PR's workflow run lands -- if it surfaces a real bug, fix
+  it in a follow-up commit on this branch before merge.

--- a/progress.txt
+++ b/progress.txt
@@ -2428,17 +2428,16 @@ from `gh-pages`) is being retired.
     inference picking the last-active source, and the velocity staleness timeout falling back to
     `unknown`.
   - Docs: new `doc/src/dc/measurements/driving_type.md`, linked from `doc/src/SUMMARY.md`.
-- **Verification status**: `pre-commit` (clang-format, XML/JSON lint, codespell, ROS package
+- **Verified for real**: `pre-commit` (clang-format, XML/JSON lint, codespell, ROS package
   metadata checks -- same `build-doc`/`poetry-requirements`/`pycln`/`flake8`/`go-fmt` skips as
   every prior DC 2.0 slice, all broken/heavy independent of this diff) is clean on every changed
   file. No local ROS 2/colcon install exists in this sandbox (same constraint noted repeatedly
-  since #242), so a real `colcon build --packages-select dc_measurements` +
-  `colcon test --packages-select dc_measurements` was kicked off in the background via
-  `tools/e2e/scripts/build.sh` against a fresh `dc-workspace` Podman image (the same image
-  `.github/workflows/ci.yaml`/`ci-jazzy.yaml` build from) to compile the new plugin and run its
-  gtest suite for real, but the full apt/rosdep/aws_sdk_vendor/dc_bridge/dc_measurements build
-  chain had not finished by the time this commit was made. **Not done / left for follow-up or
-  CI**: confirm `colcon build --packages-select dc_measurements` succeeds and
-  `colcon test --packages-select dc_measurements` passes 5/5 for `test_measurement_driving_type`
-  in this environment or in CI once this PR's workflow run lands -- if it surfaces a real bug, fix
-  it in a follow-up commit on this branch before merge.
+  since #242), so `tools/e2e/scripts/build.sh` was used to build a fresh `dc-workspace` Podman
+  image (the same image `.github/workflows/ci.yaml`/`ci-jazzy.yaml` build from) -- the full
+  apt/rosdep/aws_sdk_vendor/dc_bridge/dc_measurements chain completed successfully
+  (`colcon build`, 15 packages, no errors). Then ran `colcon test --packages-select
+  dc_measurements --ctest-args -R test_measurement_driving_type` against that image: all 5 tests
+  pass (`DefaultsToUnknownBeforeAnyModeIsObserved`, `ModeTopicMapsRawValueToConfiguredMode`,
+  `ModeTopicIgnoresUnmappedRawValueAndKeepsCurrentMode`,
+  `VelocitySourceInferenceReportsModeOfLastActiveSource`,
+  `VelocitySourceFallsBackToUnknownAfterTimeout`), 100% tests passed, 0 failed, 1.51s.


### PR DESCRIPTION
## Summary
- Adds `dc_measurements/DrivingType`, a configuration-driven Measurement reporting the robot's current operating mode (`autonomous`/`manual`/`teleop`/`unknown`), so every other Measurement can be segmented by driving mode downstream.
- Supports the two shapes the issue asked for, selected by which parameters are configured (configuring both is a startup error): a dedicated `mode_topic` (`std_msgs/String`) + `value_mapping_from`/`value_mapping_to`, or velocity-source inference across `velocity_topics`/`velocity_modes` (`geometry_msgs/Twist`), with a `velocity_timeout_s` staleness fallback to `unknown`.
- Emitted `mode` is always one of a documented closed set (`autonomous`, `manual`, `teleop`, `unknown`), enforced by the JSON schema `enum` and at configure time.
- Before any mode has been observed, the Measurement always emits `mode: "unknown"` rather than suppressing the Record — a defined, documented choice per the issue's acceptance criteria.
- New gtest suite (`test_measurement_driving_type.cpp`, 5 tests), docs page (`doc/src/dc/measurements/driving_type.md`), plugin registration in `measurement_plugin.xml`/`CMakeLists.txt`.

## Test plan
- [x] `pre-commit` clean on all changed files (clang-format, XML/JSON lint, codespell, ROS package metadata checks)
- [x] `colcon build --packages-select dc_measurements` succeeds (verified in the `tools/e2e` Podman workspace image)
- [x] `colcon test --packages-select dc_measurements` passes `test_measurement_driving_type` 5/5 (confirmed for real, see run output below)

```
[==========] Running 5 tests from 1 test suite.
[ RUN      ] MeasurementDrivingTypeTest.DefaultsToUnknownBeforeAnyModeIsObserved
[       OK ] MeasurementDrivingTypeTest.DefaultsToUnknownBeforeAnyModeIsObserved (126 ms)
[ RUN      ] MeasurementDrivingTypeTest.ModeTopicMapsRawValueToConfiguredMode
[       OK ] MeasurementDrivingTypeTest.ModeTopicMapsRawValueToConfiguredMode (101 ms)
[ RUN      ] MeasurementDrivingTypeTest.ModeTopicIgnoresUnmappedRawValueAndKeepsCurrentMode
[       OK ] MeasurementDrivingTypeTest.ModeTopicIgnoresUnmappedRawValueAndKeepsCurrentMode (313 ms)
[ RUN      ] MeasurementDrivingTypeTest.VelocitySourceInferenceReportsModeOfLastActiveSource
[       OK ] MeasurementDrivingTypeTest.VelocitySourceInferenceReportsModeOfLastActiveSource (118 ms)
[ RUN      ] MeasurementDrivingTypeTest.VelocitySourceFallsBackToUnknownAfterTimeout
[       OK ] MeasurementDrivingTypeTest.VelocitySourceFallsBackToUnknownAfterTimeout (519 ms)
[==========] 5 tests from 1 test suite ran. (1179 ms total)
[  PASSED  ] 5 tests.
```

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRpViZHkowU58rywBdqYpn
