### PR TITLE
feat(dc_measurements): gate all collection until a condition first becomes true

### DIFF
--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -46,24 +46,29 @@ public:
    * @param  if_all_conditions Collect only if all conditions are activated
    * @param  if_any_conditions Collect if any conditions is activated
    * @param  if_none_conditions Collect only if all conditions are not activated
+   * @param  gate_condition Name of a Condition that must become true once before any collection is published; empty
+   * disables gating. Once true, the gate latches open permanently and the condition is no longer consulted -- distinct
+   * from if_all/if_any/if_none, which are re-evaluated on every collection
    * @param  run_id Unique ID of the current run
    * @param  run_id Whether Run Id is enabled
    * @param  custom_params Vector of JSON with custom parameters
    */
-  virtual void
-  configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
-            const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
-            std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin, const std::string& group_key,
-            const std::string& topic_output, const int& polling_interval, const bool& debug,
-            const bool& enable_validator, const std::string& json_schema_path, const std::vector<std::string>& tags,
-            const bool& init_collect, const int& init_max_measurements, const bool& include_measurement_name,
-            const bool& include_measurement_plugin, const int& condition_max_measurements,
-            const std::vector<std::string>& if_all_conditions, const std::vector<std::string>& if_any_conditions,
-            const std::vector<std::string>& if_none_conditions, const std::vector<std::string>& remote_keys,
-            const std::vector<std::string>& remote_prefixes, const bool& nest, const bool& flatten,
-            const std::string& save_local_base_path, const std::string& all_base_path,
-            const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
-            const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_params) = 0;
+  virtual void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
+                         const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
+                         std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin,
+                         const std::string& group_key, const std::string& topic_output, const int& polling_interval,
+                         const bool& debug, const bool& enable_validator, const std::string& json_schema_path,
+                         const std::vector<std::string>& tags, const bool& init_collect,
+                         const int& init_max_measurements, const bool& include_measurement_name,
+                         const bool& include_measurement_plugin, const int& condition_max_measurements,
+                         const std::vector<std::string>& if_all_conditions,
+                         const std::vector<std::string>& if_any_conditions,
+                         const std::vector<std::string>& if_none_conditions, const std::string& gate_condition,
+                         const std::vector<std::string>& remote_keys, const std::vector<std::string>& remote_prefixes,
+                         const bool& nest, const bool& flatten, const std::string& save_local_base_path,
+                         const std::string& all_base_path, const std::string& all_base_path_expanded,
+                         const std::string& save_local_base_path_expanded, const std::string& run_id,
+                         const bool& run_id_enabled, const std::vector<json>& custom_params) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -271,6 +271,7 @@ set(tests
   test_measurement_diagnostics
   test_measurement_driving_type
   test_measurement_dummy
+  test_measurement_gate_condition
   test_measurement_os
   test_measurement_parameters
   test_measurement_random

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -228,6 +228,36 @@ public:
     return (!if_all_conditions_.empty() || !if_any_conditions_.empty() || !if_none_conditions_.empty());
   }
 
+  // Whether every collection should currently be held back by the gate condition.
+  //
+  // Semantics (distinct from if_all/if_any/if_none, which are re-evaluated on every collection):
+  // gate_condition_ names a Condition that must become true once; from then on the gate latches
+  // open permanently for the lifetime of this Measurement instance and the condition is never
+  // consulted again, even if it later becomes false again.
+  bool isGateArmed(const dc_interfaces::msg::StringStamped& msg)
+  {
+    if (gate_condition_.empty() || gate_armed_)
+    {
+      return true;
+    }
+
+    auto condition_it = conditions_.find(gate_condition_);
+    if (condition_it == conditions_.end())
+    {
+      RCLCPP_ERROR_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
+                                                  << "' is not a configured condition; holding all collection back.");
+      return false;
+    }
+
+    gate_armed_ = condition_it->second->getState(msg);
+    if (gate_armed_)
+    {
+      RCLCPP_INFO_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
+                                                 << "' became true, collection will proceed normally from now on.");
+    }
+    return gate_armed_;
+  }
+
   void addTags(dc_interfaces::msg::StringStamped& msg)
   {
     // Only put the tags in if the conditions are ok. This way, we still publish the data
@@ -397,6 +427,13 @@ public:
     }
     if (!msg.data.empty() && msg.data != "null")
     {
+      if (!isGateArmed(msg_copy))
+      {
+        RCLCPP_DEBUG_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
+                                                    << "' not yet true, dropping collection.");
+        return;
+      }
+
       // Init publish
       if (init_max_measurements_ != -1 &&
           (init_max_measurements_ == 0 || init_counter_published_ < init_max_measurements_))
@@ -494,11 +531,11 @@ public:
                  const bool& include_measurement_name, const bool& include_measurement_plugin,
                  const int& condition_max_measurements, const std::vector<std::string>& if_all_conditions,
                  const std::vector<std::string>& if_any_conditions, const std::vector<std::string>& if_none_conditions,
-                 const std::vector<std::string>& remote_keys, const std::vector<std::string>& remote_prefixes,
-                 const bool& nested, const bool& flatten, const std::string& save_local_base_path,
-                 const std::string& all_base_path, const std::string& all_base_path_expanded,
-                 const std::string& save_local_base_path_expanded, const std::string& run_id,
-                 const bool& run_id_enabled, const std::vector<json>& custom_params) override
+                 const std::string& gate_condition, const std::vector<std::string>& remote_keys,
+                 const std::vector<std::string>& remote_prefixes, const bool& nested, const bool& flatten,
+                 const std::string& save_local_base_path, const std::string& all_base_path,
+                 const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
+                 const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_params) override
   {
     node_ = parent;
     auto node = node_.lock();
@@ -538,6 +575,10 @@ public:
     if_all_conditions_ = if_all_conditions;
     if_any_conditions_ = if_any_conditions;
     if_none_conditions_ = if_none_conditions;
+
+    gate_condition_ = gate_condition;
+    // No gate configured means collection is never held back.
+    gate_armed_ = gate_condition_.empty();
 
     if (topic_output_.empty())
     {
@@ -651,6 +692,10 @@ protected:
   std::vector<std::string> if_none_conditions_;
   int condition_max_measurements_;
   int condition_counter_published_ = 0;
+
+  // Gate: one-shot arming latch, distinct from if_all/if_any/if_none above.
+  std::string gate_condition_;
+  bool gate_armed_{ true };
 
   // Logger
   rclcpp::Logger logger_{ rclcpp::get_logger("dc_measurements") };

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -120,6 +120,7 @@ protected:
   std::vector<std::vector<std::string>> measurement_if_all_conditions_;
   std::vector<std::vector<std::string>> measurement_if_any_conditions_;
   std::vector<std::vector<std::string>> measurement_if_none_conditions_;
+  std::vector<std::string> measurement_gate_condition_;
   std::vector<std::vector<std::string>> measurement_remote_keys_;
   std::vector<std::vector<std::string>> measurement_remote_prefixes_;
   std::vector<bool> measurement_nested_;

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -175,6 +175,7 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   measurement_if_all_conditions_.resize(measurement_ids_.size());
   measurement_if_any_conditions_.resize(measurement_ids_.size());
   measurement_if_none_conditions_.resize(measurement_ids_.size());
+  measurement_gate_condition_.resize(measurement_ids_.size());
   measurement_condition_max_measurements_.resize(measurement_ids_.size());
 
   condition_types_.resize(condition_ids_.size());
@@ -259,6 +260,7 @@ bool MeasurementServer::loadMeasurementPlugins()
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_any_conditions", std::vector<std::string>());
     measurement_if_none_conditions_[i] =
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_none_conditions", std::vector<std::string>());
+    measurement_gate_condition_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "gate_condition", "");
     measurement_condition_max_measurements_[i] =
         dc_util::get_int_type_param(node, measurement_ids_[i], "condition_max_measurements", 0);
 
@@ -283,7 +285,8 @@ bool MeasurementServer::loadMeasurementPlugins()
                              << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
                              << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
                              << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
-                             << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ","));
+                             << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
+                             << ", Gate condition: " << measurement_gate_condition_[i]);
 
       measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(measurement_types_[i]));
       measurements_.back()->configure(
@@ -293,9 +296,9 @@ bool MeasurementServer::loadMeasurementPlugins()
           measurement_init_collect_[i], measurement_init_max_measurements_[i], measurement_include_measurement_name_[i],
           measurement_include_measurement_plugin_[i], measurement_condition_max_measurements_[i],
           measurement_if_all_conditions_[i], measurement_if_any_conditions_[i], measurement_if_none_conditions_[i],
-          measurement_remote_keys_[i], measurement_remote_prefixes_[i], measurement_nested_[i], measurement_flatten_[i],
-          save_local_base_path_, all_base_path_, all_base_path_expanded_, save_local_base_path_expanded_, run_id_,
-          run_id_enabled_, custom_params_);
+          measurement_gate_condition_[i], measurement_remote_keys_[i], measurement_remote_prefixes_[i],
+          measurement_nested_[i], measurement_flatten_[i], save_local_base_path_, all_base_path_,
+          all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_params_);
     }
     catch (const pluginlib::PluginlibException& ex)
     {

--- a/dc_measurements/test/test_measurement_gate_condition.cpp
+++ b/dc_measurements/test/test_measurement_gate_condition.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+class MeasurementGateConditionTest : public ::testing::Test
+{
+protected:
+  MeasurementGateConditionTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementGateConditionTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    // condition_plugins is declared by the constructor itself, so it must be supplied as a
+    // parameter override rather than via ms_node_->declare_parameter afterwards.
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "moving" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementGateConditionTest::dummyDataCallback, this, std::placeholders::_1));
+    odom_pub_ = ms_node_->create_publisher<nav_msgs::msg::Odometry>("/odom", rclcpp::QoS(10));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.record", std::string("{\"message\": \"hello\"}"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.gate_condition", std::string("moving"));
+
+    ms_node_->declare_parameter("moving.plugin", std::string("dc_conditions/Moving"));
+    ms_node_->declare_parameter("moving.odom_topic", std::string("/odom"));
+    // A single Odometry message flips the Condition, keeping the test deterministic and fast.
+    ms_node_->declare_parameter("moving.count_hysteresis", 1);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void publishOdom(double linear_x)
+  {
+    nav_msgs::msg::Odometry msg;
+    msg.twist.twist.linear.x = linear_x;
+    odom_pub_->publish(msg);
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: "condition never becomes true" -- with the gate condition never
+// satisfied, nothing is ever published, including the init_collect Record normally fired on
+// activation.
+TEST_F(MeasurementGateConditionTest, ConditionNeverBecomingTrueNeverPublishesAnything)
+{
+  ms_node_->declare_parameter("dummy.init_collect", true);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: latching semantics -- once armed by the gate condition becoming true,
+// collection proceeds normally and keeps proceeding even after the condition becomes false
+// again (no re-arming).
+TEST_F(MeasurementGateConditionTest, ArmsOnceThenLatchesOpenEvenAfterConditionBecomesFalseAgain)
+{
+  ms_node_->declare_parameter("dummy.init_collect", false);
+
+  startLifecycleNode();
+
+  // Before the robot ever moves, no measurement is published.
+  spinFor(polling_interval_ * 3);
+  EXPECT_EQ(dummy_callback_count_, 0);
+
+  // Arm the gate: one Odometry message above the speed threshold flips Moving to active.
+  publishOdom(1.0);
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+
+  // Stop moving again: two below-threshold messages flip Moving back to inactive.
+  publishOdom(0.0);
+  publishOdom(0.0);
+  spinFor(polling_interval_);
+
+  int count_after_arming = dummy_callback_count_;
+  spinFor(polling_interval_ * 3);
+
+  // Collection keeps happening on every subsequent tick even though the underlying condition
+  // is false again -- the gate never re-closes.
+  EXPECT_GT(dummy_callback_count_, count_after_arming);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -73,8 +73,22 @@ Each measurement is collected through a node and has these configuration paramet
 | **if_all_conditions**          | Collect only if all conditions are activated                                                 | list\[str\] | N/A (optional)                       |
 | **if_any_conditions**          | Collect if any conditions is activated                                                       | list\[str\] | N/A (optional)                       |
 | **if_none_conditions**         | Collect only if all conditions are not activated                                             | list\[str\] | N/A (optional)                       |
+| **gate_condition**             | Name of a Condition that must become true once before any collection is published; then latches open permanently and is never consulted again | str | N/A (optional) |
 | **include_measurement_name**   | Include measurement name in the JSON data                                                    | bool        | false                                |
 | **include_measurement_plugin** | Include measurement plugin name in the JSON data                                             | bool        | false                                |
+
+```admonish info title="gate_condition vs. if_all/if_any/if_none_conditions"
+`gate_condition` is a one-shot arming latch, not a per-collection gate: it names a single
+Condition plugin (any type under `dc_measurements/plugins/conditions/`) that suppresses
+**every** collection — including the `init_collect` Record normally published on
+activation — until that Condition becomes true for the first time. Once armed, the
+Condition is never consulted again for the lifetime of the node, even if it later becomes
+false again; re-arming does not happen. This is unlike `if_all_conditions`/
+`if_any_conditions`/`if_none_conditions`, which are re-evaluated on every collection and can
+suppress publishing again once their Conditions change. If the named Condition doesn't
+exist among `condition_plugins`, collection is held back permanently and an error is
+logged.
+```
 
 ## Available plugins:
 

--- a/progress.txt
+++ b/progress.txt
@@ -2578,3 +2578,77 @@ from `gh-pages`) is being retired.
   than scope-creeping into this detection-library swap. `poetry.lock`'s `content-hash` is stale
   relative to `pyproject.toml` until a real `poetry lock` can run (poetry itself is broken in
   this sandbox, same gap noted above).
+
+### #124 - Measurement: gate all collection until a condition first becomes true
+
+- Added a new `gate_condition` Measurement parameter (`dc_measurements/include/
+  dc_measurements/measurement.hpp`): a one-shot arming latch, deliberately distinct from the
+  existing `if_all_conditions`/`if_any_conditions`/`if_none_conditions` (which are
+  re-evaluated on every collection and can suppress publishing again once their Conditions
+  change). `gate_condition` names a single Condition plugin (any type under
+  `dc_measurements/plugins/conditions/`, since it's just looked up in the same
+  `conditions_` map the existing condition params already use); once that Condition's
+  `getState()` returns true one time, a new `gate_armed_` bool latches permanently for the
+  lifetime of the Measurement instance and the Condition is never consulted again -- covers
+  the "latching semantics explicit: re-arming never happens once triggered" acceptance
+  criterion. Empty string (the default) disables gating entirely, so this is fully
+  backwards compatible.
+- **`init_collect` interaction (the issue's flagged open question), resolved by construction
+  rather than a special case**: the gate check (`isGateArmed()`) lives inside `publish()`,
+  not before `collect()` -- the same place the existing `if_all`/`if_any`/`if_none` gating
+  already lives, and for the same reason: several Condition plugins (`Exist`, `IntegerEqual`,
+  etc.) evaluate the Measurement's own just-collected data, so the msg has to exist before any
+  condition, gate included, can be checked against it. Since `activate()`'s `init_collect_`
+  path already just calls `collectAndPublish()` -- the same function every polling tick calls
+  -- routing the gate through `publish()` means `init_collect`'s fire is held back by an unarmed
+  gate for free, with no separate code path to keep in sync. Documented explicitly in
+  `doc/src/dc/measurements.md` (new `gate_condition` table row + an admonish-info block
+  contrasting it with `if_all/if_any/if_none_conditions`) per the "documented alongside the
+  existing condition parameters" and "interaction with init_collect defined and documented"
+  acceptance criteria.
+- If `gate_condition` names a Condition not present in `condition_plugins`, `isGateArmed()`
+  logs an `RCLCPP_ERROR` and returns false forever (fails closed, not open) -- collection stays
+  permanently suppressed rather than silently behaving as if ungated.
+- **Blast radius of the `dc_core::Measurement::configure()` signature change** (adding
+  `gate_condition` as a new parameter): the pure virtual declaration
+  (`dc_core/include/dc_core/measurement.hpp`), its one concrete override
+  (`dc_measurements/include/dc_measurements/measurement.hpp`), the one call site
+  (`dc_measurements/src/measurement_server.cpp`'s `loadMeasurementPlugins()`), and a new
+  parallel `measurement_gate_condition_` member vector in `measurement_server.hpp`/`.cpp`
+  (mirroring `measurement_if_all_conditions_` etc.) were the full set -- confirmed via a
+  targeted codebase search that none of the 23 concrete measurement plugins or any test file
+  override `configure()` themselves (they all inherit it through
+  `dc_measurements::Measurement`), so no other file needed touching.
+- New test `dc_measurements/test/test_measurement_gate_condition.cpp` (registered in
+  `CMakeLists.txt`), covering the two acceptance criteria a single collect/publish trace can't:
+  using the real `Moving` condition plugin (state-based, driven by publishing
+  `nav_msgs/Odometry` independently of the Dummy measurement's own data, with
+  `count_hysteresis: 1` for determinism) against a `dummy` Measurement with
+  `gate_condition: moving`:
+  - `ConditionNeverBecomingTrueNeverPublishesAnything` -- with `init_collect: true` and no
+    Odometry ever published, zero Records are received over several polling intervals,
+    proving both the periodic gate and the `init_collect` interaction hold indefinitely (the
+    "condition never becomes true" acceptance criterion).
+  - `ArmsOnceThenLatchesOpenEvenAfterConditionBecomesFalseAgain` -- with `init_collect: false`,
+    confirms zero Records before the robot moves, one Record after a single above-threshold
+    Odometry message arms the gate, then publishes two below-threshold Odometry messages to
+    flip the real `Moving` Condition back to inactive and asserts the callback count keeps
+    increasing anyway -- the gate does not re-close.
+- **Verified for real**, same methodology as prior DC 2.0 slices: `pre-commit` clean on every
+  changed file (`SKIP=poetry-requirements,build-doc` -- both known environment gaps unrelated
+  to this diff, poetry itself broken in this sandbox and `build-doc`'s image copy hit `no space
+  left on device` on the host's separately-tracked, unrelated-to-this-diff nearly-full root
+  partition; `graphRoot` for the workspace image build below lives on `/home`, which has
+  headroom, so that build was unaffected); `clang-format` auto-reformatted the two touched
+  header files, re-ran clean after. Built a fresh `dc-workspace` Podman image via
+  `tools/e2e/scripts/build.sh` (all 15 packages, ~15.5 min, zero errors -- `dc_measurements`
+  compiled clean against the new `configure()` signature, confirming the blast-radius analysis
+  above was complete). Ran `colcon test --packages-select dc_measurements --ctest-args -R
+  test_measurement_gate_condition` against that image: both new tests pass (`ctest -V` output
+  shows the real `"gate_condition 'moving' became true, collection will proceed normally from
+  now on"` log line firing exactly once, at the arm point, never again). Then ran the full
+  `colcon test --packages-select dc_measurements`: 34/34 tests pass, 0 failures --
+  `colcon test-result --all` shows this as the pre-existing 9 test binaries/22 gtest cases (31,
+  matching #123's last reported count) plus this change's 1 new test binary + 2 new gtest
+  cases (+3 = 34), confirming no regression from the `configure()` signature change across
+  every other measurement plugin's test.


### PR DESCRIPTION
## Summary
- Adds a `gate_condition` Measurement parameter: a one-shot arming latch that suppresses all collection (including the `init_collect` Record fired on activation) until a named Condition plugin becomes true once, then latches open permanently and is never consulted again -- distinct from `if_all_conditions`/`if_any_conditions`/`if_none_conditions`, which are re-evaluated on every collection.
- Works with any existing Condition plugin (`dc_measurements/plugins/conditions/`), including content-based ones (`Exist`, `IntegerEqual`, ...) and state-based ones (`Moving`, ...), since the gate check reuses the same `conditions_` map and evaluation point (`publish()`) as the existing condition parameters.
- If the named condition isn't a configured `condition_plugins` entry, collection is held back permanently and an `RCLCPP_ERROR` is logged (fail closed).
- Documented alongside the existing condition parameters in `doc/src/dc/measurements.md` (new table row + an admonish-info block contrasting it with `if_all/if_any/if_none_conditions` and explaining the `init_collect` interaction).

## Test plan
- [x] New `dc_measurements/test/test_measurement_gate_condition.cpp` (2 gtest cases), using the real `Moving` condition driven by published `nav_msgs/Odometry`:
  - `ConditionNeverBecomingTrueNeverPublishesAnything` -- covers the "condition never becomes true" acceptance criterion.
  - `ArmsOnceThenLatchesOpenEvenAfterConditionBecomesFalseAgain` -- covers the latching/no-re-arming acceptance criterion.
- [x] Built a fresh `dc-workspace` Podman image via `tools/e2e/scripts/build.sh` (all 15 packages, zero errors).
- [x] `colcon test --packages-select dc_measurements --ctest-args -R test_measurement_gate_condition`: both new tests pass.
- [x] Full `colcon test --packages-select dc_measurements`: 34/34 tests pass, 0 failures -- no regression from the `dc_core::Measurement::configure()` signature change across every other measurement plugin's test.
- [x] `pre-commit` clean on every changed file (`SKIP=poetry-requirements,build-doc` -- both known environment gaps unrelated to this diff).

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X5Pn3VY73Ldy77PZXr21ye