### PR TITLE
docs(pipeline): add C4 context/container/component diagrams

### DIFF
--- a/doc/src/dc/data_pipeline.md
+++ b/doc/src/dc/data_pipeline.md
@@ -5,6 +5,137 @@ system that stores it. The vocabulary — Measurement, Record, Group, File, Brid
 Shipper, Destination, Tag — is defined in [Concepts](./concepts.md) and used
 consistently throughout.
 
+## C4 model
+
+Three levels, each zooming further into the pipeline: DC as a single system among
+external actors and destinations (Context), the processes that make it up (Container),
+and the pieces inside the Bridge (Component). The flowchart in
+[the next section](#the-path-of-a-record) stays as the at-a-glance narrative view of a
+single Record's journey; these diagrams complement it rather than replace it.
+
+### Context (C1)
+
+DC runs as one system on the robot. A robot operator configures it; analytics and
+dashboard consumers read from whatever Destinations it was configured to write to —
+PostgreSQL, S3-compatible object storage, and (via passthrough, ADR-0003) any other
+Shipper-supported sink.
+
+```mermaid
+C4Context
+    title System context for DC (Data Collection)
+
+    Person(operator, "Robot Operator", "Configures Measurements, Conditions, Groups, and Destinations via ROS params")
+    Person(consumer, "Analytics / Dashboard Consumer", "Queries Destinations for fleet dashboards and alerting")
+
+    System(dc, "DC (Data Collection)", "Collects operational data from the robot's ROS 2 graph, validates it, and routes it to external infrastructure")
+
+    SystemDb_Ext(postgres, "PostgreSQL", "Blessed Destination for structured Records")
+    System_Ext(objectStorage, "S3-compatible object storage", "RustFS / MinIO / S3 — blessed Destination for Files, and for Records")
+    System_Ext(otherSinks, "Other passthrough sinks", "Any Shipper-supported destination not natively blessed by DC (Kafka, InfluxDB, Slack, HTTP, ...)")
+
+    Rel(operator, dc, "Configures")
+    Rel(dc, postgres, "Delivers Records")
+    Rel(dc, objectStorage, "Uploads Files, delivers Records")
+    Rel(dc, otherSinks, "Delivers Records (passthrough, ADR-0003)")
+    Rel(consumer, postgres, "Queries")
+    Rel(consumer, objectStorage, "Retrieves Files")
+```
+
+### Container (C2)
+
+Inside DC, only three nodes are lifecycle-managed by `dc_lifecycle_manager`:
+`measurement_server` and `group_server`. The Bridge (`dc_bridge`) and its supervised
+Shipper child are deliberately outside that boundary (ADR-0006) — the Bridge has no
+meaningful deactivated state, so its readiness comes from launch ordering
+(`bridge_ready_gate`) instead of a lifecycle transition. See
+[Deterministic startup ordering](#deterministic-startup-ordering) for the sequence this
+diagram's `bridge_ready_gate` → `dc_lifecycle_manager` relationship summarizes.
+
+```mermaid
+C4Container
+    title Container diagram for DC (Data Collection)
+
+    Person(operator, "Robot Operator")
+
+    System_Boundary(dc, "DC (Data Collection)") {
+        Boundary(lifecycle, "Lifecycle-managed by dc_lifecycle_manager (ADR-0006)") {
+            Container(measurementServer, "measurement_server", "C++ / rclcpp lifecycle node", "Hosts Measurement and Condition plugins; publishes Records")
+            Container(groupServer, "group_server", "C++ / rclcpp lifecycle node", "Merges Records from several Measurements by time proximity")
+        }
+        Container(lifecycleManager, "dc_lifecycle_manager", "C++ / rclcpp, nav2-style", "Configures then activates the lifecycle-managed nodes once the readiness gate passes")
+        Container(gate, "bridge_ready_gate", "Python / rclpy, launch-time process", "Blocks launch until dc_bridge's ~/ready service reports success")
+        Container(bridge, "dc_bridge", "C++ / rclcpp, plain node outside lifecycle (ADR-0006, ADR-0007)", "Forwards Records to the Shipper, uploads Files, renders Shipper config, owns readiness")
+        Container(shipper, "Shipper (Vector)", "external process, supervised child of dc_bridge (ADR-0001, ADR-0002)", "Routes, buffers, and retries delivery to Destinations")
+    }
+
+    SystemDb_Ext(postgres, "PostgreSQL")
+    System_Ext(objectStorage, "S3-compatible object storage")
+    System_Ext(otherSinks, "Other passthrough sinks")
+
+    Rel(operator, lifecycleManager, "ros2 launch dc_bringup")
+    Rel(bridge, shipper, "Spawns and supervises (fork/exec/waitpid, PR_SET_PDEATHSIG)")
+    Rel(gate, bridge, "Polls ~/ready")
+    Rel(gate, lifecycleManager, "Unblocks launch once ready (OnProcessExit)")
+    Rel(lifecycleManager, measurementServer, "Configure, then activate")
+    Rel(lifecycleManager, groupServer, "Configure, then activate")
+    Rel(measurementServer, bridge, "Records (StringStamped topics)")
+    Rel(measurementServer, groupServer, "Records (StringStamped topics)")
+    Rel(groupServer, bridge, "Merged Records (StringStamped topics)")
+    Rel(measurementServer, bridge, "Files on disk (local_paths / remote_paths)")
+    Rel(bridge, shipper, "Records over the shipper ingest protocol (msgpack, :24224)")
+    Rel(shipper, postgres, "Delivers Records")
+    Rel(shipper, otherSinks, "Delivers Records (passthrough)")
+    Rel(bridge, objectStorage, "Uploads Files, delivers Records")
+```
+
+### Component (C3) — the Bridge
+
+The pieces added across #244–#267, now invisible from the outside: `BridgeNode` wires a
+Forwarder (Records → Shipper), a Supervisor (owns the Vector child process), a Config
+renderer (ADR-0003's `shipper`/`destinations` params → Vector TOML, including
+passthrough snippet validation), Readiness (backs `~/ready`), and — for
+`receives: files` Destinations (ADR-0005) — a durable IntentQueue feeding the Uploader,
+which verifies File uploads against an S3-compatible ObjectStore and reports status
+Records back through the same Forwarder under the `dc.files` Tag.
+
+```mermaid
+C4Component
+    title Component diagram for dc_bridge (the Bridge)
+
+    Container(measurementServer, "measurement_server", "external container")
+    Container(shipper, "Shipper (Vector)", "external process")
+    System_Ext(objectStorage, "S3-compatible object storage")
+
+    Container_Boundary(bridge, "dc_bridge") {
+        Component(node, "BridgeNode", "rclcpp::Node", "Wires the components together; owns the ~/ready service and topic subscriptions")
+        Component(renderer, "Config renderer", "C++ (render.*)", "Renders shipper/destinations ROS params into Vector TOML (ADR-0003); validates custom_config_files passthrough snippets")
+        Component(supervisor, "Supervisor", "C++", "fork/exec/waitpid + PR_SET_PDEATHSIG; restarts Vector on crash with backoff")
+        Component(readiness, "Readiness", "C++", "Shared ready flag plus a TCP probe against Vector's ingest port; backs the ~/ready service")
+        Component(forwarder, "Forwarder", "C++", "Sends Records to Vector over the shipper ingest protocol (msgpack), with reconnection and backpressure")
+        Component(topicConfig, "TopicConfig", "C++", "Derives a Tag from a ROS topic name")
+        Component(uploader, "Uploader", "C++ (ADR-0005)", "Per File x storage verify-or-upload, group-completion marker, delete_when_sent")
+        Component(intentQueue, "IntentQueue", "C++ (#265)", "Disk-backed durable FIFO of pending upload intents; crash-atomic enqueue/ack, oldest-first with per-entry backoff")
+        Component(objectStoreClient, "ObjectStore client", "C++, AWS SDK for C++", "Uploads and verifies File bytes on S3-compatible storage")
+        Component(retention, "Retention", "C++ (#267)", "Sheds the oldest unverified intents under disk pressure; a no-op sweep when disabled")
+    }
+
+    Rel(measurementServer, node, "Records (StringStamped topic subscriptions)")
+    Rel(node, renderer, "Renders Vector config at startup")
+    Rel(node, supervisor, "Starts and supervises")
+    Rel(supervisor, shipper, "spawn / waitpid / restart")
+    Rel(node, readiness, "Reads and writes the ready flag")
+    Rel(readiness, shipper, "TCP probe of the ingest port")
+    Rel(node, forwarder, "Records from Records-Destination topics")
+    Rel(forwarder, topicConfig, "Derives each topic's Tag")
+    Rel(forwarder, shipper, "shipper ingest protocol")
+    Rel(node, intentQueue, "Enqueues Records from Files-Destination topics")
+    Rel(intentQueue, uploader, "Replays the oldest ready intent")
+    Rel(uploader, objectStoreClient, "Upload / verify")
+    Rel(objectStoreClient, objectStorage, "PutObject, multipart, HEAD")
+    Rel(uploader, forwarder, "Status Records under dc.files")
+    Rel(retention, intentQueue, "Sheds oldest unverified intents under disk pressure")
+```
+
 ## The path of a Record
 
 ```mermaid

--- a/doc/src/dc/data_pipeline.md
+++ b/doc/src/dc/data_pipeline.md
@@ -20,26 +20,7 @@ dashboard consumers read from whatever Destinations it was configured to write t
 PostgreSQL, S3-compatible object storage, and (via passthrough, ADR-0003) any other
 Shipper-supported sink.
 
-```mermaid
-C4Context
-    title System context for DC (Data Collection)
-
-    Person(operator, "Robot Operator", "Configures Measurements, Conditions, Groups, and Destinations via ROS params")
-    Person(consumer, "Analytics / Dashboard Consumer", "Queries Destinations for fleet dashboards and alerting")
-
-    System(dc, "DC (Data Collection)", "Collects operational data from the robot's ROS 2 graph, validates it, and routes it to external infrastructure")
-
-    SystemDb_Ext(postgres, "PostgreSQL", "Blessed Destination for structured Records")
-    System_Ext(objectStorage, "S3-compatible object storage", "RustFS / MinIO / S3 — blessed Destination for Files, and for Records")
-    System_Ext(otherSinks, "Other passthrough sinks", "Any Shipper-supported destination not natively blessed by DC (Kafka, InfluxDB, Slack, HTTP, ...)")
-
-    Rel(operator, dc, "Configures")
-    Rel(dc, postgres, "Delivers Records")
-    Rel(dc, objectStorage, "Uploads Files, delivers Records")
-    Rel(dc, otherSinks, "Delivers Records (passthrough, ADR-0003)")
-    Rel(consumer, postgres, "Queries")
-    Rel(consumer, objectStorage, "Retrieves Files")
-```
+![System context for DC (Data Collection)](../images/dc-c4-context.svg)
 
 ### Container (C2)
 
@@ -51,42 +32,7 @@ meaningful deactivated state, so its readiness comes from launch ordering
 [Deterministic startup ordering](#deterministic-startup-ordering) for the sequence this
 diagram's `bridge_ready_gate` → `dc_lifecycle_manager` relationship summarizes.
 
-```mermaid
-C4Container
-    title Container diagram for DC (Data Collection)
-
-    Person(operator, "Robot Operator")
-
-    System_Boundary(dc, "DC (Data Collection)") {
-        Boundary(lifecycle, "Lifecycle-managed by dc_lifecycle_manager (ADR-0006)") {
-            Container(measurementServer, "measurement_server", "C++ / rclcpp lifecycle node", "Hosts Measurement and Condition plugins; publishes Records")
-            Container(groupServer, "group_server", "C++ / rclcpp lifecycle node", "Merges Records from several Measurements by time proximity")
-        }
-        Container(lifecycleManager, "dc_lifecycle_manager", "C++ / rclcpp, nav2-style", "Configures then activates the lifecycle-managed nodes once the readiness gate passes")
-        Container(gate, "bridge_ready_gate", "Python / rclpy, launch-time process", "Blocks launch until dc_bridge's ~/ready service reports success")
-        Container(bridge, "dc_bridge", "C++ / rclcpp, plain node outside lifecycle (ADR-0006, ADR-0007)", "Forwards Records to the Shipper, uploads Files, renders Shipper config, owns readiness")
-        Container(shipper, "Shipper (Vector)", "external process, supervised child of dc_bridge (ADR-0001, ADR-0002)", "Routes, buffers, and retries delivery to Destinations")
-    }
-
-    SystemDb_Ext(postgres, "PostgreSQL")
-    System_Ext(objectStorage, "S3-compatible object storage")
-    System_Ext(otherSinks, "Other passthrough sinks")
-
-    Rel(operator, lifecycleManager, "ros2 launch dc_bringup")
-    Rel(bridge, shipper, "Spawns and supervises (fork/exec/waitpid, PR_SET_PDEATHSIG)")
-    Rel(gate, bridge, "Polls ~/ready")
-    Rel(gate, lifecycleManager, "Unblocks launch once ready (OnProcessExit)")
-    Rel(lifecycleManager, measurementServer, "Configure, then activate")
-    Rel(lifecycleManager, groupServer, "Configure, then activate")
-    Rel(measurementServer, bridge, "Records (StringStamped topics)")
-    Rel(measurementServer, groupServer, "Records (StringStamped topics)")
-    Rel(groupServer, bridge, "Merged Records (StringStamped topics)")
-    Rel(measurementServer, bridge, "Files on disk (local_paths / remote_paths)")
-    Rel(bridge, shipper, "Records over the shipper ingest protocol (msgpack, :24224)")
-    Rel(shipper, postgres, "Delivers Records")
-    Rel(shipper, otherSinks, "Delivers Records (passthrough)")
-    Rel(bridge, objectStorage, "Uploads Files, delivers Records")
-```
+![Container diagram for DC (Data Collection)](../images/dc-c4-container.svg)
 
 ### Component (C3) — the Bridge
 
@@ -98,43 +44,7 @@ passthrough snippet validation), Readiness (backs `~/ready`), and — for
 which verifies File uploads against an S3-compatible ObjectStore and reports status
 Records back through the same Forwarder under the `dc.files` Tag.
 
-```mermaid
-C4Component
-    title Component diagram for dc_bridge (the Bridge)
-
-    Container(measurementServer, "measurement_server", "external container")
-    Container(shipper, "Shipper (Vector)", "external process")
-    System_Ext(objectStorage, "S3-compatible object storage")
-
-    Container_Boundary(bridge, "dc_bridge") {
-        Component(node, "BridgeNode", "rclcpp::Node", "Wires the components together; owns the ~/ready service and topic subscriptions")
-        Component(renderer, "Config renderer", "C++ (render.*)", "Renders shipper/destinations ROS params into Vector TOML (ADR-0003); validates custom_config_files passthrough snippets")
-        Component(supervisor, "Supervisor", "C++", "fork/exec/waitpid + PR_SET_PDEATHSIG; restarts Vector on crash with backoff")
-        Component(readiness, "Readiness", "C++", "Shared ready flag plus a TCP probe against Vector's ingest port; backs the ~/ready service")
-        Component(forwarder, "Forwarder", "C++", "Sends Records to Vector over the shipper ingest protocol (msgpack), with reconnection and backpressure")
-        Component(topicConfig, "TopicConfig", "C++", "Derives a Tag from a ROS topic name")
-        Component(uploader, "Uploader", "C++ (ADR-0005)", "Per File x storage verify-or-upload, group-completion marker, delete_when_sent")
-        Component(intentQueue, "IntentQueue", "C++ (#265)", "Disk-backed durable FIFO of pending upload intents; crash-atomic enqueue/ack, oldest-first with per-entry backoff")
-        Component(objectStoreClient, "ObjectStore client", "C++, AWS SDK for C++", "Uploads and verifies File bytes on S3-compatible storage")
-        Component(retention, "Retention", "C++ (#267)", "Sheds the oldest unverified intents under disk pressure; a no-op sweep when disabled")
-    }
-
-    Rel(measurementServer, node, "Records (StringStamped topic subscriptions)")
-    Rel(node, renderer, "Renders Vector config at startup")
-    Rel(node, supervisor, "Starts and supervises")
-    Rel(supervisor, shipper, "spawn / waitpid / restart")
-    Rel(node, readiness, "Reads and writes the ready flag")
-    Rel(readiness, shipper, "TCP probe of the ingest port")
-    Rel(node, forwarder, "Records from Records-Destination topics")
-    Rel(forwarder, topicConfig, "Derives each topic's Tag")
-    Rel(forwarder, shipper, "shipper ingest protocol")
-    Rel(node, intentQueue, "Enqueues Records from Files-Destination topics")
-    Rel(intentQueue, uploader, "Replays the oldest ready intent")
-    Rel(uploader, objectStoreClient, "Upload / verify")
-    Rel(objectStoreClient, objectStorage, "PutObject, multipart, HEAD")
-    Rel(uploader, forwarder, "Status Records under dc.files")
-    Rel(retention, intentQueue, "Sheds oldest unverified intents under disk pressure")
-```
+![Component diagram for dc_bridge (the Bridge)](../images/dc-c4-component.svg)
 
 ## The path of a Record
 

--- a/doc/src/images/dc-c4-component.svg
+++ b/doc/src/images/dc-c4-component.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1200" width="1600" height="1200" font-family="'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+        <defs>
+          <marker id="d3ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0.5,1 L9,5 L0.5,9 Z" fill="#94A0B0"></path></marker>
+          <marker id="d3ahf" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0.5,1 L9,5 L0.5,9 Z" fill="#B0714E"></path></marker>
+        </defs>
+        <rect x="0" y="0" width="1600" height="1200" fill="#F7F8FA"></rect>
+
+        <text x="56" y="84" font-size="38" font-weight="600" fill="#1B2430" letter-spacing="-0.5">Component</text>
+        <text x="56" y="120" font-size="21" fill="#6B7688">Inside the bridge container</text>
+
+        <rect x="300" y="170" width="1000" height="950" rx="22" fill="#EDF1F6" fill-opacity="0.55" stroke="#A8BFD0" stroke-width="2" stroke-dasharray="9 7"></rect>
+        <text x="326" y="208" font-size="15" font-weight="600" fill="#8A94A3" letter-spacing="1.8">BRIDGE</text>
+
+        <rect x="56" y="250" width="170" height="120" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="141" y="296" font-size="15" font-weight="600" fill="#3D4756" text-anchor="middle" font-family="'IBM Plex Mono', monospace">measurement_server</text>
+        <text x="141" y="320" font-size="14" fill="#8A94A3" text-anchor="middle">[Container]</text>
+        <text x="141" y="346" font-size="14" fill="#6B7688" text-anchor="middle">Publishes records</text>
+
+        <polyline points="230,310 324,310" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="278" y="286" font-size="18" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">records</text>
+
+        <rect x="330" y="250" width="940" height="140" rx="8" fill="#2B5A82"></rect>
+        <text x="800" y="302" font-size="28" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">Node</text>
+        <text x="800" y="328" font-size="17" fill="#A9CBE4" text-anchor="middle">[Component]</text>
+        <text x="800" y="362" font-size="18" fill="#D9E8F3" text-anchor="middle">Entry point — owns the readiness endpoint and fans records out to the right path</text>
+
+        <polyline points="416,390 416,464" fill="none" stroke="#B0714E" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="8 6" marker-end="url(#d3ahf)"></polyline>
+        <text x="430" y="436" font-size="18" fill="#A0663F" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">file records</text>
+
+        <polyline points="608,390 608,464" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="622" y="436" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">renders config</text>
+
+        <polyline points="800,390 800,464" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="814" y="436" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">records</text>
+
+        <polyline points="992,390 992,464" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="1006" y="436" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">starts + monitors</text>
+
+        <polyline points="1184,390 1184,464" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="1198" y="436" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">ready state</text>
+
+        <rect x="330" y="470" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="416" y="514" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Intent</text>
+        <text x="416" y="538" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">queue</text>
+        <text x="416" y="564" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="522" y="470" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="608" y="514" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Config</text>
+        <text x="608" y="538" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">renderer</text>
+        <text x="608" y="564" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="714" y="470" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="800" y="524" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Forwarder</text>
+        <text x="800" y="550" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="906" y="470" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="992" y="524" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Supervisor</text>
+        <text x="992" y="550" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="1098" y="470" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="1184" y="524" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Readiness</text>
+        <text x="1184" y="550" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="330" y="770" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="416" y="824" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Uploader</text>
+        <text x="416" y="850" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="714" y="770" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="800" y="814" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Topic</text>
+        <text x="800" y="838" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">mapper</text>
+        <text x="800" y="864" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="522" y="970" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="608" y="1014" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Object store</text>
+        <text x="608" y="1038" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">client</text>
+        <text x="608" y="1064" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="522" y="770" width="172" height="110" rx="7" fill="#4585B0"></rect>
+        <text x="608" y="824" font-size="19" font-weight="600" fill="#FFFFFF" text-anchor="middle">Retention</text>
+        <text x="608" y="850" font-size="15" fill="#D3E5F0" text-anchor="middle">[Component]</text>
+
+        <rect x="1350" y="620" width="194" height="280" rx="7" fill="#FFFFFF" stroke="#2B5A82" stroke-width="2" stroke-dasharray="7 5"></rect>
+        <text x="1447" y="700" font-size="22" font-weight="600" fill="#2B5A82" text-anchor="middle" font-family="'IBM Plex Mono', monospace">shipper</text>
+        <text x="1447" y="726" font-size="16" fill="#8A94A3" text-anchor="middle">[Container]</text>
+        <text x="1447" y="762" font-size="15" fill="#5C6779" text-anchor="middle">Vector — routes,</text>
+        <text x="1447" y="784" font-size="15" fill="#5C6779" text-anchor="middle">buffers, delivers</text>
+        <text x="1447" y="806" font-size="15" fill="#5C6779" text-anchor="middle">records</text>
+
+        <rect x="56" y="970" width="200" height="110" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="156" y="1008" font-size="18" font-weight="600" fill="#3D4756" text-anchor="middle">S3-compatible</text>
+        <text x="156" y="1030" font-size="18" font-weight="600" fill="#3D4756" text-anchor="middle">storage</text>
+        <text x="156" y="1056" font-size="14" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+
+        <polyline points="1270,525 1320,525 1320,650 1344,650" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d3ah)"></polyline>
+        <text x="1210" y="612" font-size="18" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">checks if accepting</text>
+
+        <polyline points="992,580 992,720 1344,720" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d3ah)"></polyline>
+        <text x="1171" y="700" font-size="18" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">spawn / restart</text>
+
+        <polyline points="860,580 860,628 940,628 940,850 1344,850" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d3ah)"></polyline>
+        <text x="1120" y="830" font-size="18" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">sends records</text>
+
+        <polyline points="800,580 800,764" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d3ah)"></polyline>
+        <text x="818" y="700" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">looks up tag</text>
+
+        <polyline points="416,580 416,764" fill="none" stroke="#B0714E" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="8 6" marker-end="url(#d3ahf)"></polyline>
+        <text x="434" y="638" font-size="18" fill="#A0663F" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">oldest pending</text>
+
+        <polyline points="460,880 460,920 630,920 630,964" fill="none" stroke="#B0714E" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="8 6" marker-end="url(#d3ahf)"></polyline>
+        <text x="614" y="948" font-size="18" fill="#A0663F" text-anchor="end" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">upload / verify</text>
+
+        <polyline points="516,1025 262,1025" fill="none" stroke="#B0714E" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="8 6" marker-end="url(#d3ahf)"></polyline>
+        <text x="392" y="1001" font-size="18" fill="#A0663F" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">stores files</text>
+
+        <polyline points="460,770 460,656 770,656 770,586" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d3ah)"></polyline>
+        <text x="594" y="700" font-size="18" fill="#5C6779" text-anchor="end" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">reports status</text>
+
+        <polyline points="608,770 608,600 470,600 470,586" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d3ah)"></polyline>
+        <text x="626" y="700" font-size="18" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">clears old entries</text>
+      </svg>

--- a/doc/src/images/dc-c4-container.svg
+++ b/doc/src/images/dc-c4-container.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1200" width="1600" height="1200" font-family="'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+        <defs>
+          <marker id="d2ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0.5,1 L9,5 L0.5,9 Z" fill="#94A0B0"></path></marker>
+          <marker id="d2ahf" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0.5,1 L9,5 L0.5,9 Z" fill="#B0714E"></path></marker>
+        </defs>
+        <rect x="0" y="0" width="1600" height="1200" fill="#F7F8FA"></rect>
+
+        <text x="56" y="84" font-size="38" font-weight="600" fill="#1B2430" letter-spacing="-0.5">Container</text>
+        <text x="56" y="120" font-size="21" fill="#6B7688">Inside DC (Data Collection)</text>
+
+        <rect x="300" y="168" width="1170" height="808" rx="22" fill="#EDF1F6" fill-opacity="0.55" stroke="#A8BFD0" stroke-width="2" stroke-dasharray="9 7"></rect>
+        <text x="326" y="206" font-size="15" font-weight="600" fill="#8A94A3" letter-spacing="1.8">DC (DATA COLLECTION)</text>
+
+        <circle cx="130" cy="268" r="22" fill="#6E6494"></circle>
+        <path d="M92 338 C92 314 109 300 130 300 C151 300 168 314 168 338 Z" fill="#6E6494"></path>
+        <text x="130" y="372" font-size="21" font-weight="600" fill="#1B2430" text-anchor="middle">Robot Operator</text>
+        <text x="130" y="394" font-size="16" fill="#8A94A3" text-anchor="middle">[Person]</text>
+
+        <polyline points="200,320 334,320" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="268" y="296" font-size="19" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">launches DC</text>
+
+        <rect x="340" y="240" width="320" height="160" rx="8" fill="#2B5A82"></rect>
+        <text x="500" y="296" font-size="25" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">lifecycle_manager</text>
+        <text x="500" y="322" font-size="17" fill="#A9CBE4" text-anchor="middle">[Container]</text>
+        <text x="500" y="356" font-size="18" fill="#D9E8F3" text-anchor="middle">Starts and activates the</text>
+        <text x="500" y="378" font-size="18" fill="#D9E8F3" text-anchor="middle">lifecycle-managed pipeline</text>
+
+        <rect x="900" y="240" width="280" height="160" rx="8" fill="#2B5A82"></rect>
+        <text x="1040" y="296" font-size="25" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">readiness_gate</text>
+        <text x="1040" y="322" font-size="17" fill="#A9CBE4" text-anchor="middle">[Container]</text>
+        <text x="1040" y="356" font-size="18" fill="#D9E8F3" text-anchor="middle">Blocks startup until the</text>
+        <text x="1040" y="378" font-size="18" fill="#D9E8F3" text-anchor="middle">bridge reports ready</text>
+
+        <polyline points="900,320 666,320" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="780" y="296" font-size="19" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">unblocks startup</text>
+
+        <polyline points="1040,400 1040,530" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="1058" y="470" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">polls readiness</text>
+
+        <rect x="336" y="500" width="364" height="450" rx="16" fill="#E2EAF2" fill-opacity="0.6" stroke="#A8BFD0" stroke-width="1.75" stroke-dasharray="7 5"></rect>
+        <text x="358" y="536" font-size="14" font-weight="600" fill="#8A94A3" letter-spacing="1.6">LIFECYCLE-MANAGED</text>
+
+        <polyline points="420,400 420,494" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="438" y="458" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">creates and activates</text>
+
+        <rect x="356" y="566" width="324" height="140" rx="8" fill="#2B5A82"></rect>
+        <text x="518" y="614" font-size="23" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">measurement_server</text>
+        <text x="518" y="638" font-size="16" fill="#A9CBE4" text-anchor="middle">[Container]</text>
+        <text x="518" y="668" font-size="17" fill="#D9E8F3" text-anchor="middle">Collects sensor data,</text>
+        <text x="518" y="688" font-size="17" fill="#D9E8F3" text-anchor="middle">publishes records and files</text>
+
+        <rect x="356" y="790" width="324" height="140" rx="8" fill="#2B5A82"></rect>
+        <text x="518" y="838" font-size="23" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">group_server</text>
+        <text x="518" y="862" font-size="16" fill="#A9CBE4" text-anchor="middle">[Container]</text>
+        <text x="518" y="892" font-size="17" fill="#D9E8F3" text-anchor="middle">Merges records from many</text>
+        <text x="518" y="912" font-size="17" fill="#D9E8F3" text-anchor="middle">sources by time</text>
+
+        <polyline points="450,706 450,784" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="468" y="754" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">records</text>
+
+        <rect x="800" y="536" width="450" height="200" rx="8" fill="#2B5A82"></rect>
+        <text x="1025" y="594" font-size="27" font-weight="600" fill="#FFFFFF" text-anchor="middle" font-family="'IBM Plex Mono', monospace">bridge</text>
+        <text x="1025" y="620" font-size="17" fill="#A9CBE4" text-anchor="middle">[Container]</text>
+        <text x="1025" y="656" font-size="18" fill="#D9E8F3" text-anchor="middle">Forwards records to the shipper, uploads</text>
+        <text x="1025" y="678" font-size="18" fill="#D9E8F3" text-anchor="middle">files, renders the shipper's config</text>
+
+        <rect x="800" y="800" width="450" height="140" rx="8" fill="#FFFFFF" stroke="#2B5A82" stroke-width="2" stroke-dasharray="7 5"></rect>
+        <text x="1025" y="852" font-size="27" font-weight="600" fill="#2B5A82" text-anchor="middle" font-family="'IBM Plex Mono', monospace">shipper</text>
+        <text x="1025" y="878" font-size="17" fill="#8A94A3" text-anchor="middle">[Container]</text>
+        <text x="1025" y="912" font-size="18" fill="#5C6779" text-anchor="middle">Vector — routes, buffers, and delivers records</text>
+
+        <polyline points="680,606 794,606" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="740" y="582" font-size="19" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">records</text>
+
+        <polyline points="680,666 794,666" fill="none" stroke="#B0714E" stroke-width="2.2" stroke-linecap="round" stroke-dasharray="8 6" marker-end="url(#d2ahf)"></polyline>
+        <text x="721" y="694" font-size="19" fill="#A0663F" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">files</text>
+
+        <polyline points="680,860 762,860 762,706 794,706" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d2ah)"></polyline>
+        <text x="780" y="778" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">merged records</text>
+
+        <polyline points="950,736 950,794" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="968" y="774" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">spawns and supervises</text>
+
+        <polyline points="1200,736 1200,794" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="1218" y="774" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">records</text>
+
+        <rect x="570" y="1040" width="260" height="128" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="700" y="1082" font-size="22" font-weight="600" fill="#3D4756" text-anchor="middle">PostgreSQL</text>
+        <text x="700" y="1106" font-size="16" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="700" y="1138" font-size="17" fill="#6B7688" text-anchor="middle">Structured records</text>
+
+        <rect x="880" y="1040" width="260" height="128" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="1010" y="1082" font-size="22" font-weight="600" fill="#3D4756" text-anchor="middle">Other destinations</text>
+        <text x="1010" y="1106" font-size="16" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="1010" y="1138" font-size="17" fill="#6B7688" text-anchor="middle">Any configured sink</text>
+
+        <rect x="1190" y="1040" width="260" height="128" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="1320" y="1082" font-size="22" font-weight="600" fill="#3D4756" text-anchor="middle">S3-compatible storage</text>
+        <text x="1320" y="1106" font-size="16" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="1320" y="1138" font-size="17" fill="#6B7688" text-anchor="middle">Files and records</text>
+
+        <polyline points="860,940 860,1000 700,1000 700,1034" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d2ah)"></polyline>
+        <text x="780" y="982" font-size="19" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+
+        <polyline points="1010,940 1010,1034" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d2ah)"></polyline>
+        <text x="1028" y="996" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+
+        <polyline points="1250,680 1320,680 1320,1034" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d2ah)"></polyline>
+        <text x="1338" y="848" font-size="19" fill="#A0663F" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">uploads files</text>
+        <text x="1338" y="872" font-size="19" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+      </svg>

--- a/doc/src/images/dc-c4-context.svg
+++ b/doc/src/images/dc-c4-context.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 1200" width="1600" height="1200" font-family="'IBM Plex Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif">
+        <defs>
+          <marker id="d1ah" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse"><path d="M0.5,1 L9,5 L0.5,9 Z" fill="#94A0B0"></path></marker>
+        </defs>
+        <rect x="0" y="0" width="1600" height="1200" fill="#F7F8FA"></rect>
+
+        <text x="56" y="84" font-size="38" font-weight="600" fill="#1B2430" letter-spacing="-0.5">System Context</text>
+        <text x="56" y="120" font-size="21" fill="#6B7688">DC (Data Collection) and the systems it exchanges data with</text>
+
+        <circle cx="430" cy="196" r="26" fill="#6E6494"></circle>
+        <path d="M386 272 C386 244 405 228 430 228 C455 228 474 244 474 272 Z" fill="#6E6494"></path>
+        <text x="430" y="322" font-size="28" font-weight="600" fill="#1B2430" text-anchor="middle">Robot Operator</text>
+        <text x="430" y="350" font-size="19" fill="#8A94A3" text-anchor="middle">[Person]</text>
+        <text x="430" y="380" font-size="20" fill="#6B7688" text-anchor="middle">Configures collection and delivery</text>
+
+        <polyline points="430,400 430,458" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d1ah)"></polyline>
+        <text x="448" y="436" font-size="21" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">configures</text>
+
+        <rect x="180" y="460" width="820" height="260" rx="8" fill="#2B5A82"></rect>
+        <text x="590" y="540" font-size="40" font-weight="600" fill="#FFFFFF" text-anchor="middle">DC (Data Collection)</text>
+        <text x="590" y="574" font-size="20" fill="#A9CBE4" text-anchor="middle">[Software System]</text>
+        <text x="590" y="622" font-size="22" fill="#D9E8F3" text-anchor="middle">Collects operational data from a robot, processes it,</text>
+        <text x="590" y="652" font-size="22" fill="#D9E8F3" text-anchor="middle">and routes it to external infrastructure</text>
+
+        <polyline points="225,720 225,828" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d1ah)"></polyline>
+        <text x="243" y="782" font-size="21" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+
+        <polyline points="580,720 580,828" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d1ah)"></polyline>
+        <text x="598" y="770" font-size="21" fill="#A0663F" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">uploads files</text>
+        <text x="598" y="798" font-size="21" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+
+        <polyline points="935,720 935,828" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d1ah)"></polyline>
+        <text x="953" y="782" font-size="21" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">delivers records</text>
+
+        <rect x="70" y="830" width="310" height="220" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="225" y="900" font-size="26" font-weight="600" fill="#3D4756" text-anchor="middle">Other destinations</text>
+        <text x="225" y="930" font-size="18" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="225" y="968" font-size="19" fill="#6B7688" text-anchor="middle">Any configured sink —</text>
+        <text x="225" y="994" font-size="19" fill="#6B7688" text-anchor="middle">Kafka, InfluxDB, HTTP</text>
+
+        <rect x="425" y="830" width="310" height="220" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="580" y="900" font-size="26" font-weight="600" fill="#3D4756" text-anchor="middle">S3-compatible storage</text>
+        <text x="580" y="930" font-size="18" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="580" y="968" font-size="19" fill="#6B7688" text-anchor="middle">Images, video, maps</text>
+        <text x="580" y="994" font-size="19" fill="#6B7688" text-anchor="middle">and records</text>
+
+        <rect x="780" y="830" width="310" height="220" rx="7" fill="#FFFFFF" stroke="#C3C9D4" stroke-width="1.75"></rect>
+        <text x="935" y="900" font-size="26" font-weight="600" fill="#3D4756" text-anchor="middle">PostgreSQL</text>
+        <text x="935" y="930" font-size="18" fill="#8A94A3" text-anchor="middle">[Software System]</text>
+        <text x="935" y="972" font-size="19" fill="#6B7688" text-anchor="middle">Structured records storage</text>
+
+        <circle cx="1300" cy="876" r="26" fill="#6E6494"></circle>
+        <path d="M1256 952 C1256 924 1275 908 1300 908 C1325 908 1344 924 1344 952 Z" fill="#6E6494"></path>
+        <text x="1300" y="1000" font-size="26" font-weight="600" fill="#1B2430" text-anchor="middle">Analytics Consumer</text>
+        <text x="1300" y="1026" font-size="18" fill="#8A94A3" text-anchor="middle">[Person]</text>
+        <text x="1300" y="1056" font-size="19" fill="#6B7688" text-anchor="middle">Queries DC's destinations</text>
+
+        <polyline points="1150,940 1094,940" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" marker-end="url(#d1ah)"></polyline>
+        <text x="1104" y="916" font-size="21" fill="#5C6779" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">queries</text>
+
+        <polyline points="1300,1078 1300,1130 580,1130 580,1054" fill="none" stroke="#94A0B0" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#d1ah)"></polyline>
+        <text x="940" y="1106" font-size="21" fill="#5C6779" text-anchor="middle" paint-order="stroke" stroke="#F7F8FA" stroke-width="7" stroke-linejoin="round">retrieves files</text>
+      </svg>

--- a/progress.txt
+++ b/progress.txt
@@ -2706,3 +2706,39 @@ from `gh-pages`) is being retired.
   criterion literally names it as the hard gate) once host disk space is available or in CI --
   the local `mdbook build` above exercises the identical toolchain/preprocessor versions and
   is believed equivalent, but wasn't run through the container itself.
+
+### #125 follow-up - swap C4 mermaid diagrams for hand-designed SVGs
+
+- The user had a matching C4 diagram set (System Context / Container / Component) already
+  drafted in a Claude Design project (`a4399355-762f-4c03-af40-ab9430c0b6e8`,
+  `DC Architecture C4.dc.html`), styled with a dedicated legend and IBM Plex type rather than
+  mermaid's default C4 renderer. Content matches the mermaid diagrams it replaces one-for-one
+  (same actors: Robot Operator/Analytics Consumer; same containers:
+  `lifecycle_manager`/`readiness_gate`/`measurement_server`/`group_server`/`bridge`/`shipper`;
+  same Bridge components: Node/Config renderer/Supervisor/Readiness/Forwarder/Topic
+  mapper/Intent queue/Uploader/Retention/Object store client) -- verified by reading the raw
+  SVG through the `DesignSync` MCP tool (`get_file` on the project's flattened
+  `dc-1-system-context.svg`/`dc-2-container.svg`/`dc-3-component.svg` exports) before using it.
+- Read via `DesignSync` MCP (`list_projects`/`get_project`/`list_files`/`get_file`), since the
+  live `.dc.html` document itself embeds a JS runtime (`support.js`, `<sc-if>` conditionals)
+  that isn't standalone HTML -- the pre-exported flat SVGs are what got copied into the repo,
+  not the `.dc.html` source.
+- Saved the three SVGs to `doc/src/images/dc-c4-{context,container,component}.svg`, matching
+  the existing flat `doc/src/images/*.png` convention (see `../../images/*.png` refs in
+  `doc/src/dc/demos/*.md`), and swapped the three ```mermaid C4Context/C4Container/C4Component
+  code blocks in `doc/src/dc/data_pipeline.md` for `![...](../images/dc-c4-*.svg)` markdown
+  image embeds at the same three headings (Context (C1) / Container (C2) / Component (C3)).
+  The narrative flowchart mermaid block later in the same file (`flowchart LR`, "The path of a
+  Record") is untouched -- mermaid is still needed for that one, so no book.toml/preprocessor
+  changes.
+- Rebuilt with local `mdbook build` (same toolchain versions as `book.toml` pins) --
+  confirmed all three `<img src="../images/dc-c4-*.svg">` tags and copied SVG files land in
+  `book/html/dc/data_pipeline.html` / `book/html/images/`. Only the same two pre-existing
+  linkcheck warnings as before (`list[str]` false positives in `diagnostics.md`/
+  `serial_interface.md`), unrelated to this change.
+- `pre-commit run --files` on the four changed files: this time host disk space allowed the
+  full Podman-backed `build-doc` hook to run and pass (unlike #125's own initial pass, which
+  had to fall back to a bare `mdbook build` -- see above), plus xmllint on the new SVGs,
+  codespell, trailing-whitespace/EOF-newline, and all package-metadata hooks. Only
+  `poetry-requirements` failed, the same pre-existing `ModuleNotFoundError: No module named
+  'poetry'` noted for #123/#124/#125 above -- environment issue, unrelated to this diff.

--- a/progress.txt
+++ b/progress.txt
@@ -2652,3 +2652,57 @@ from `gh-pages`) is being retired.
   matching #123's last reported count) plus this change's 1 new test binary + 2 new gtest
   cases (+3 = 34), confirming no regression from the `configure()` signature change across
   every other measurement plugin's test.
+
+### #125 - Detail the data pipeline with C4 diagrams (context/container/component)
+
+- `doc/src/dc/data_pipeline.md` already had a `flowchart LR` (added by #252) showing the
+  right DC 2.0 shape but only one level, no external actors/systems, and nothing inside
+  the Bridge. Added a new "C4 model" section above it with the three levels the issue
+  asked for, keeping the flowchart as the at-a-glance view per the issue's explicit
+  instruction not to replace it:
+  - **Context (C1)** (`C4Context`): DC as one system, its two actors (robot operator,
+    analytics/dashboard consumer), and the external systems it writes to (PostgreSQL,
+    S3-compatible object storage, other passthrough sinks per ADR-0003).
+  - **Container (C2)** (`C4Container`): the running processes -- `measurement_server` and
+    `group_server` (lifecycle-managed), `dc_lifecycle_manager`, `bridge_ready_gate`,
+    `dc_bridge`, and the Vector Shipper -- with a nested `Boundary(...)` explicitly
+    showing the lifecycle-manager boundary from ADR-0006 (the Bridge and its Shipper
+    child are outside it, matching the "Bridge has no lifecycle state" decision) that the
+    existing flowchart omits entirely.
+  - **Component (C3), Bridge only** (`C4Component`): read the actual current `dc_bridge`
+    source tree first (it's plain C++/`rclcpp` post-ADR-0007, not the Rust `dc_bridge_core`
+    layout described in this file's own #244-#248 entries) -- `bridge_node.hpp`,
+    `forwarder.hpp`, `supervisor.hpp`, `readiness.hpp`, `render.hpp`, `topic_config.hpp`,
+    and everything under `uploader/` (`uploader.hpp`, `intent_queue.hpp`,
+    `object_store.hpp`, `retention.hpp`) -- so the component boxes and their relationships
+    (BridgeNode owns Forwarder/Supervisor/Readiness/Config-renderer; Files-Destination
+    Records go through the disk-backed IntentQueue into the Uploader, which verifies
+    against an S3 ObjectStore and reports status Records back through the Forwarder under
+    `dc.files`) match the real #244-#267 code, not a stale mental model.
+  - Also read all 7 ADRs (`docs/adr/0001`-`0007`) and `CONTEXT.md` before writing labels,
+    so terminology (Record/Destination/Shipper/Tag/shipper ingest protocol, never
+    "Fluent Forward" as a component name) matches the glossary throughout.
+- **Verified the vendored mermaid actually supports C4 diagrams before writing any**:
+  grepped `doc/js/mermaid.min.js` for `C4_CONTEXT`/`C4_CONTAINER` grammar tokens -- present,
+  so `C4Context`/`C4Container`/`C4Component` render with the pinned mermaid build DC ships
+  (`additional-js` in `book.toml`), no version bump needed.
+- **Validated the actual mdbook build locally**, since `tools/ci/pre-commit/build_doc.sh`'s
+  own Podman path failed in this sandbox on `no space left on device` (the same pre-existing,
+  unrelated-to-this-diff full root partition noted repeatedly elsewhere in this file, e.g.
+  #123/#124): `mdbook`, `mdbook-mermaid`, `mdbook-admonish`, and `mdbook-open-on-gh` were all
+  already installed locally (matching the versions `book.toml` configures), so ran `mdbook
+  build` directly from `doc/` instead of through the container. Exit code 0; the only
+  linkcheck warnings are two pre-existing "Potential incomplete link" false positives on
+  `list[str]` markdown in `diagnostics.md`/`serial_interface.md`, unrelated to this change.
+  Confirmed all three new `C4Context`/`C4Container`/`C4Component` code blocks made it into
+  the rendered `book/html/dc/data_pipeline.html` (`doc/book` is gitignored, nothing from the
+  build was staged).
+- `pre-commit run --files doc/src/dc/data_pipeline.md` with `build-doc`/`poetry-requirements`/
+  `pycln` skipped (same known-broken-in-this-sandbox set as #242-#249: `build-doc` needs the
+  disk space just described, `poetry-requirements` needs a `poetry` module not installed
+  here) -- everything else that touched the file passed, including `codespell` and the
+  "empty line at end of file" / trailing-whitespace hooks.
+- **Not done / left for follow-up**: a real Podman-backed `build_doc.sh` run (the acceptance
+  criterion literally names it as the hard gate) once host disk space is available or in CI --
+  the local `mdbook build` above exercises the identical toolchain/preprocessor versions and
+  is believed equivalent, but wasn't run through the container itself.


### PR DESCRIPTION
## Summary

- Adds a "C4 model" section to `doc/src/dc/data_pipeline.md` with the three levels the existing `flowchart LR` (from #252) didn't cover, kept as the at-a-glance view per the issue's explicit instruction not to replace it:
  - **Context (C1)** — DC as one system, its actors (robot operator, analytics/dashboard consumer), and the external systems it writes to (PostgreSQL, S3-compatible object storage, other passthrough sinks per ADR-0003).
  - **Container (C2)** — the running processes (`measurement_server`, `group_server`, `dc_lifecycle_manager`, `bridge_ready_gate`, `dc_bridge`, the Vector Shipper), with the lifecycle-manager boundary from ADR-0006 shown explicitly via a nested boundary (the Bridge and its Shipper child are outside it).
  - **Component (C3), Bridge only** — BridgeNode, Forwarder, Supervisor, Config renderer, Readiness, and the Uploader/IntentQueue/ObjectStore pieces added across #244–#267, read from the actual current `dc_bridge` C++ source tree (post-ADR-0007 revert from the Rust pilot).
- Terminology cross-checked against `CONTEXT.md` and all 7 ADRs.

## Test plan

- [x] Confirmed the vendored `doc/js/mermaid.min.js` grammar includes `C4_CONTEXT`/`C4_CONTAINER` tokens, so `C4Context`/`C4Container`/`C4Component` render with DC's pinned mermaid build.
- [x] Ran `mdbook build` directly from `doc/` (mdbook/mdbook-mermaid/mdbook-admonish/mdbook-open-on-gh installed locally at matching versions) since `build_doc.sh`'s Podman path hit `no space left on device` in this sandbox (pre-existing, unrelated to this diff). Exit 0; only pre-existing, unrelated linkcheck warnings in other files. Confirmed all three new diagrams render in `book/html/dc/data_pipeline.html`.
- [x] `pre-commit run --files doc/src/dc/data_pipeline.md` (with the known-broken-in-this-sandbox `build-doc`/`poetry-requirements`/`pycln` skipped, same as prior sessions) — everything else passes.
- [ ] A real Podman-backed `build_doc.sh` run once disk space/CI is available — the local `mdbook build` above exercises the same toolchain and is believed equivalent but wasn't run through the container itself.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeaQpSRUSDPpUUTNoWHVfx