### PR TITLE
fix(bridge): send Record timestamps at nanosecond resolution

### DIFF
--- a/dc_bridge/include/dc_bridge/forwarder.hpp
+++ b/dc_bridge/include/dc_bridge/forwarder.hpp
@@ -17,12 +17,20 @@ namespace dc_bridge
 {
 
 /// A DC Record ready to be forwarded: a shipper ingest protocol tag, a Unix timestamp
-/// (seconds since the epoch, matching the protocol's integer time), and the Record's
+/// split into whole seconds plus the nanoseconds within that second, and the Record's
 /// JSON payload (StringStamped.data, already parsed).
+///
+/// The split mirrors the ingest protocol's **EventTime** extension (4 bytes of seconds,
+/// 4 of nanoseconds), which is what the Forwarder emits. The protocol's older integer
+/// time carries whole seconds only; sending that rounded every Record's timestamp to the
+/// second, so a Measurement polling faster than 1 Hz produced Records that were
+/// indistinguishable in time (#308).
 struct Record
 {
   std::string tag;
   std::uint64_t timestamp_secs;
+  /// Nanoseconds within `timestamp_secs`; always < 1'000'000'000.
+  std::uint32_t timestamp_nanos{ 0 };
   nlohmann::json payload;
 };
 

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -36,8 +36,16 @@ inline constexpr std::uint64_t MIN_DISK_BUFFER_BYTES = 268435488ULL;
 /// route transform id, rest = the Tag verbatim).
 std::string route_output_for_tag(const std::string& tag);
 
+/// How a Destination's normalized time field is written.
+///
+/// `EpochNanos` is the default: an exact integer count of nanoseconds since the epoch.
+/// `Double` divides that by 1e9 into a float64, which has ~15-16 significant digits and
+/// spends 10 of them on the seconds — so it cannot represent better than roughly
+/// microseconds, and rounds. It stays available for consumers that want a fractional
+/// seconds column, but it is lossy by construction, not by implementation (#308).
 enum class TimeFormat
 {
+  EpochNanos,
   Double,
   Iso8601,
 };

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -39,6 +39,19 @@ std::string expand_with_env(const std::string& input)
   return expand_env(input, env_lookup);
 }
 
+// Stamps a Bridge-generated Record (File status, retention audit) with the current time,
+// split into the seconds/nanoseconds pair the ingest protocol's EventTime carries. These
+// Records have no ROS header to take a stamp from, unlike the ones forwarded from a
+// Measurement's topic. Truncating this to whole seconds was part of #308.
+void stamp_now(Record& record)
+{
+  const auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
+  const auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
+  record.timestamp_secs = static_cast<std::uint64_t>(secs.count());
+  record.timestamp_nanos =
+      static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(since_epoch - secs).count());
+}
+
 // Declares `name` with dynamic typing and a PARAMETER_NOT_SET default, so a value the
 // user didn't provide reads back as nullopt (rather than forcing a sentinel/default).
 std::optional<std::string> declare_optional_string(rclcpp::Node* node, const std::string& name)
@@ -419,7 +432,11 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
           {
             Record record;
             record.tag = tag;
+            // Both halves of the ROS stamp. The nanoseconds used to be dropped here,
+            // which rounded every Record to the second and left a Measurement polling
+            // faster than 1 Hz with Records indistinguishable in time (#308).
             record.timestamp_secs = static_cast<std::uint64_t>(std::max<std::int32_t>(0, msg.header.stamp.sec));
+            record.timestamp_nanos = msg.header.stamp.nanosec;
             record.payload = std::move(payload);
             try
             {
@@ -465,8 +482,7 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
   auto emit = [&forwarder](const nlohmann::json& row) {
     Record record;
     record.tag = uploader::FILE_STATUS_TAG;
-    record.timestamp_secs = static_cast<std::uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    stamp_now(record);
     record.payload = row;
     // Vector may be briefly down (restart, backpressure); keep trying for a while before
     // handing the whole Record back for an idempotent retry.
@@ -493,8 +509,7 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
   auto retention_emit = [&forwarder](const nlohmann::json& row) {
     Record record;
     record.tag = uploader::FILE_STATUS_TAG;
-    record.timestamp_secs = static_cast<std::uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    stamp_now(record);
     record.payload = row;
     forwarder.send(record);
   };

--- a/dc_bridge/src/forwarder.cpp
+++ b/dc_bridge/src/forwarder.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <ctime>
@@ -87,6 +88,29 @@ void pack_record_map(Packer& pk, const nlohmann::json& payload)
   }
 }
 
+// Packs a timestamp as the ingest protocol's **EventTime** extension: msgpack ext type
+// 0x00 with an 8-byte body — 4 bytes of seconds then 4 of nanoseconds, both big-endian
+// (network order), exactly as the protocol specifies.
+//
+// The alternative the protocol allows is a plain integer of whole seconds, which is what
+// DC sent until #308. That silently rounded every Record's timestamp down to the second,
+// so five Records from a 5 Hz Measurement all claimed the same instant. Seconds are
+// narrowed to 32 bits here because the extension's layout is fixed at 4 bytes; that field
+// overflows in 2106, long after the int32 ROS header stamp this is built from.
+template <typename Packer>
+void pack_event_time(Packer& pk, std::uint64_t seconds, std::uint32_t nanos)
+{
+  std::array<char, 8> body{};
+  const auto secs32 = static_cast<std::uint32_t>(seconds);
+  for (int i = 0; i < 4; ++i)
+  {
+    body[i] = static_cast<char>((secs32 >> (8 * (3 - i))) & 0xFF);
+    body[4 + i] = static_cast<char>((nanos >> (8 * (3 - i))) & 0xFF);
+  }
+  pk.pack_ext(body.size(), 0x00);
+  pk.pack_ext_body(body.data(), body.size());
+}
+
 }  // namespace
 
 Forwarder::Forwarder(ForwarderConfig config) : config_(std::move(config))
@@ -153,7 +177,7 @@ std::string Forwarder::frame(const Record& record, const std::string& chunk_id)
   pk.pack(record.tag);
   pk.pack_array(1);  // one entry
   pk.pack_array(2);  // [time, record]
-  pk.pack(record.timestamp_secs);
+  pack_event_time(pk, record.timestamp_secs, record.timestamp_nanos);
   pack_record_map(pk, record.payload);
   pk.pack_map(1);
   pk.pack(std::string("chunk"));

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -134,7 +134,14 @@ std::string render_normalize_source(const RenderConfig& config)
   for (const auto& dest : config.destinations)
   {
     out += "if " + tag_condition(destination_tags(dest)) + " {\n";
-    if (dest.time_format == TimeFormat::Double)
+    if (dest.time_format == TimeFormat::EpochNanos)
+    {
+      // Exact: an i64 of nanoseconds since the epoch, no float rounding anywhere. Good
+      // until the year 2262, and the only format here that can round-trip the full
+      // resolution the Forwarder now sends (#308).
+      out += "  ." + dest.time_key + " = to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")\n";
+    }
+    else if (dest.time_format == TimeFormat::Double)
     {
       out +=
           "  ." + dest.time_key + " = to_float(to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")) / 1000000000.0\n";
@@ -430,9 +437,13 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   }
 
   std::string time_key = optional_field(raw.time_key).value_or("date");
-  std::string tf = raw.time_format && !raw.time_format->empty() ? *raw.time_format : "double";
+  std::string tf = raw.time_format && !raw.time_format->empty() ? *raw.time_format : "epoch_nanos";
   TimeFormat time_format;
-  if (tf == "double")
+  if (tf == "epoch_nanos")
+  {
+    time_format = TimeFormat::EpochNanos;
+  }
+  else if (tf == "double")
   {
     time_format = TimeFormat::Double;
   }
@@ -442,9 +453,10 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   }
   else
   {
-    throw RenderError(
-        RenderErrorKind::InvalidTimeFormat,
-        "destination '" + name + "': time_format '" + tf + "' is invalid (expected 'double' or 'iso8601')", name, tf);
+    throw RenderError(RenderErrorKind::InvalidTimeFormat,
+                      "destination '" + name + "': time_format '" + tf +
+                          "' is invalid (expected 'epoch_nanos', 'double' or 'iso8601')",
+                      name, tf);
   }
 
   DestinationKind kind;

--- a/dc_bridge/test/forwarder_test.cpp
+++ b/dc_bridge/test/forwarder_test.cpp
@@ -25,9 +25,29 @@ using namespace dc_bridge;
 namespace
 {
 
-Record make_record(const std::string& tag, const std::string& json)
+Record make_record(const std::string& tag, const std::string& json, std::uint32_t nanos = 0)
 {
-  return Record{ tag, 1700000000ULL, nlohmann::json::parse(json) };
+  return Record{ tag, 1700000000ULL, nanos, nlohmann::json::parse(json) };
+}
+
+// The EventTime extension the frame carries the timestamp in: msgpack ext type 0x00,
+// 8-byte body of big-endian seconds then big-endian nanoseconds (#308). Built here
+// independently of the packing code so the test pins the wire bytes rather than
+// re-deriving them the same way the implementation does.
+std::string expected_event_time_bytes(std::uint32_t secs, std::uint32_t nanos)
+{
+  std::string out;
+  out.push_back(static_cast<char>(0xd7));  // fixext8
+  out.push_back(static_cast<char>(0x00));  // ext type 0 = EventTime
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((secs >> (8 * (3 - i))) & 0xFF));
+  }
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((nanos >> (8 * (3 - i))) & 0xFF));
+  }
+  return out;
 }
 
 // A mock shipper ingest protocol server: binds :0, hands back the chosen port, and runs
@@ -147,7 +167,8 @@ TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
   msgpack::object entries = top.via.array.ptr[1];
   ASSERT_EQ(entries.via.array.size, 1u);
   msgpack::object entry = entries.via.array.ptr[0];  // [time, record]
-  EXPECT_EQ(entry.via.array.ptr[0].as<std::uint64_t>(), 1700000000ULL);
+  // The time element is the EventTime extension, not a bare integer of seconds (#308).
+  EXPECT_EQ(entry.via.array.ptr[0].type, msgpack::type::EXT);
 
   msgpack::object rec = entry.via.array.ptr[1];
   ASSERT_EQ(rec.type, msgpack::type::MAP);
@@ -161,6 +182,36 @@ TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
     }
   }
   EXPECT_TRUE(found);
+}
+
+// #308: sub-second resolution must survive the wire. Before this, the frame carried a
+// plain integer of whole seconds, so a Measurement polling faster than 1 Hz produced
+// Records that all claimed the same instant.
+TEST(Forwarder, FrameCarriesSubSecondPrecisionAsEventTime)
+{
+  const std::uint32_t nanos = 123456789u;
+  const std::string frame = Forwarder::frame(make_record("dc.test", R"({"n": 1})", nanos), "chunk-ns");
+  EXPECT_NE(frame.find(expected_event_time_bytes(1700000000u, nanos)), std::string::npos)
+      << "frame does not carry the EventTime extension for 1700000000.123456789";
+}
+
+// Two Records one nanosecond apart must not collapse onto the same wire timestamp —
+// the property that makes a timestamp usable as part of an identity.
+TEST(Forwarder, FramesWithinTheSameSecondAreDistinguishable)
+{
+  const std::string a = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 1u), "c1");
+  const std::string b = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 2u), "c1");
+  EXPECT_NE(a, b);
+  EXPECT_NE(a.find(expected_event_time_bytes(1700000000u, 1u)), std::string::npos);
+  EXPECT_NE(b.find(expected_event_time_bytes(1700000000u, 2u)), std::string::npos);
+}
+
+// A whole-second Record still encodes as EventTime, with a zero nanosecond half, rather
+// than falling back to the integer form.
+TEST(Forwarder, WholeSecondTimestampStillUsesEventTime)
+{
+  const std::string frame = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 0u), "c0");
+  EXPECT_NE(frame.find(expected_event_time_bytes(1700000000u, 0u)), std::string::npos);
 }
 
 TEST(Forwarder, FrameCarriesTheChunkOption)
@@ -258,7 +309,7 @@ TEST(Forwarder, ReturnsBackpressureWhenPeerStalls)
 
   nlohmann::json big;
   big["blob"] = std::string(1000000, 'x');
-  Record big_record{ "dc.test", 1700000000ULL, big };
+  Record big_record{ "dc.test", 1700000000ULL, 0u, big };
 
   bool saw_backpressure = false;
   for (int i = 0; i < 20; ++i)

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -417,6 +417,33 @@ TEST(Render, DestinationFromRawRejectsInvalidTimeFormat)
   }
 }
 
+TEST(Render, DestinationFromRawAcceptsEveryTimeFormat)
+{
+  const std::vector<std::pair<std::string, TimeFormat>> cases = { { "epoch_nanos", TimeFormat::EpochNanos },
+                                                                  { "double", TimeFormat::Double },
+                                                                  { "iso8601", TimeFormat::Iso8601 } };
+  for (const auto& c : cases)
+  {
+    RawDestinationParams raw;
+    raw.time_format = c.first;
+    auto dest = destination_from_raw("debug_console", "console", "records", { "/dc/measurement/map" }, raw);
+    EXPECT_EQ(dest.time_format, c.second) << "time_format '" << c.first << "'";
+  }
+}
+
+// The normalize transform must emit the timestamp with no float arithmetic in it —
+// `to_float(...) / 1000000000.0` is precisely what loses resolution below ~1 us.
+TEST(Render, EpochNanosNormalizesWithoutFloatRounding)
+{
+  auto config =
+      config_with({ make_destination("pgsql", { "/dc/group/robot" }, TimeFormat::EpochNanos, postgres_kind()) });
+  const std::string rendered = render(config);
+  EXPECT_NE(rendered.find(".date = to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")"), std::string::npos)
+      << rendered;
+  EXPECT_EQ(rendered.find("to_float("), std::string::npos)
+      << "epoch_nanos must not round through a float: " << rendered;
+}
+
 TEST(Render, PostgresFromRawRejectsMissingRequiredFields)
 {
   RawDestinationParams raw;
@@ -465,11 +492,13 @@ TEST(Render, PostgresFromRawAppliesDefaults)
   EXPECT_EQ(pg.port, 5432);
 }
 
+// #308: the default is the exact integer format, not the lossy float one. A Destination
+// that says nothing about time must not silently round its timestamps.
 TEST(Render, DestinationFromRawAppliesTimeDefaults)
 {
   auto dest = destination_from_raw("debug_console", "console", "records", { "/dc/group/robot" }, {});
   EXPECT_EQ(dest.time_key, "date");
-  EXPECT_EQ(dest.time_format, TimeFormat::Double);
+  EXPECT_EQ(dest.time_format, TimeFormat::EpochNanos);
 }
 
 TEST(Render, S3FromRawRejectsMissingBucket)

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -25,7 +25,10 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
+      # epoch_nanos (default) = exact integer nanoseconds since the epoch; iso8601 =
+      # "…T11:36:28.123456789" string; double = fractional seconds, which is a float64
+      # and rounds below ~1 us. Match the column type: bigint for epoch_nanos.
+      time_format: "epoch_nanos"
     # The other blessed destination types (add the name to `destinations` to enable):
     #
     # rustfs:                     # S3-compatible object storage (self-hosted: RustFS

--- a/dc_demos/params/qrcodes_minio_pgsql.yaml
+++ b/dc_demos/params/qrcodes_minio_pgsql.yaml
@@ -20,7 +20,6 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
     pgsql_files:
       type: postgres
       receives: records
@@ -31,7 +30,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
     rustfs:
       type: s3
       receives: files

--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -31,7 +31,6 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
     pgsql_files:
       type: postgres
       receives: records
@@ -42,7 +41,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
     rustfs:
       type: s3
       receives: files

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -71,8 +71,9 @@ The `data` string **must** be valid JSON:
 
 The timestamp is the time the Record was created. Measurements convert ROS time to a
 UTC timestamp. Each Destination normalizes it into one field before delivery, controlled
-by `time_key` (default `date`) and `time_format` (`double` for Unix epoch seconds, or
-`iso8601`).
+by `time_key` (default `date`) and `time_format` (`epoch_nanos`, the default, for exact
+integer nanoseconds since the epoch; `iso8601` for a string; `double` for fractional
+seconds, which rounds — see [Destinations](./destinations.md#time_format)).
 
 ### JSON validation
 

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -59,7 +59,7 @@ dc_bridge:
       receives: records
       inputs: ["/dc/measurement/uptime"]
       time_key: "date"                       # Field the normalized timestamp is written to
-      time_format: "iso8601"                 # "double" (Unix epoch seconds) or "iso8601"
+      time_format: "iso8601"                 # "epoch_nanos" (default) | "iso8601" | "double"
 
 measurement_server:
   ros__parameters:

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -84,8 +84,32 @@ deployments work identically: set `endpoint`, explicit credentials, and (typical
 
 Common parameters for every blessed type: `type`, `receives` (`records` | `files`, see
 the File uploads section below), `inputs` (ROS topic names), `time_key` (default
-`date`) and `time_format` (`double` | `iso8601`, default `double`) controlling the
-normalized timestamp field written into each Record before routing.
+`date`) and `time_format` (default `epoch_nanos`) controlling the normalized timestamp
+field written into each Record before routing.
+
+### `time_format`
+
+The Bridge forwards each Record's timestamp at full nanosecond resolution, taken from the
+ROS message header. `time_format` decides how that is written into the Record:
+
+| Value         | Written as                                     | Resolution kept |
+| ------------- | ---------------------------------------------- | --------------- |
+| `epoch_nanos` | integer nanoseconds since the epoch (default)  | nanosecond — exact |
+| `iso8601`     | `2026-08-09T11:36:28.123456789` string         | nanosecond |
+| `double`      | fractional seconds as a float64                | ~microsecond, rounds |
+
+`double` is lossy by construction, not by implementation: a float64 has ~15–16 significant
+digits and current epoch seconds already consume 10 of them. It remains available for
+consumers that want a fractional-seconds column, but it cannot represent the resolution
+the pipeline delivers.
+
+```admonish warning
+The destination's own column type can truncate independently of `time_format`. A
+`double precision` column rounds an `epoch_nanos` value back off; PostgreSQL's native
+`timestamptz` is microseconds internally; Elasticsearch's `date` type is milliseconds
+(use `date_nanos` for the full value). Choose the column to match — `bigint` for
+`epoch_nanos` is exact, sortable and indexable.
+```
 
 Type-specific parameters:
 

--- a/doc/src/dc/migration.md
+++ b/doc/src/dc/migration.md
@@ -136,7 +136,7 @@ console:
   receives: records
   inputs: ["/dc/group/data"]
   time_key: "date"          # was json_date_key
-  time_format: "iso8601"    # was json_date_format; "double" | "iso8601"
+  time_format: "iso8601"    # was json_date_format; "epoch_nanos" (default) | "iso8601" | "double"
 ```
 
 `format` is gone: the `console` Destination always writes JSON.
@@ -591,9 +591,33 @@ dc_bridge:
 See [Setup](./setup.md) for the resulting install, which is now `rosdep install` +
 `colcon build`.
 
+## Timestamps: `time_format` now defaults to `epoch_nanos`
+
+Records carry their ROS header timestamp at full nanosecond resolution, and the default
+`time_format` writes it as an exact integer count of nanoseconds since the epoch rather
+than fractional seconds in a float64.
+
+```admonish warning title="Schema change"
+The column receiving `time_key` must be **`bigint`**, not `double precision`. A double
+rounds the value back off below roughly microsecond resolution — which is what stopped
+timestamps telling two Records of a fast Measurement apart in the first place.
+
+If you already have a populated `dc_records` from an earlier `jazzy` checkout:
+
+    ALTER TABLE dc_records ALTER COLUMN date TYPE bigint USING (date * 1e9)::bigint;
+
+and update any query that treated the column as seconds — `to_timestamp(date)` becomes
+`to_timestamp(date / 1e9)`.
+```
+
+Set `time_format: "double"` explicitly to keep the old fractional-seconds column. It
+remains supported, and remains lossy: a float64 has ~15-16 significant digits and current
+epoch seconds already spend 10 of them. `iso8601` is the other lossless option.
+
 ## Migration checklist
 
 - [ ] `destination_server:` renamed to `dc_bridge:`, `destination_plugins:` to `destinations:`
+- [ ] The column behind `time_key` is `bigint` (or `time_format: "double"` is set explicitly)
 - [ ] Every destination has a `type:` and a `receives:` instead of a `plugin:`
 - [ ] The `flb:` block is deleted; `shipper.data_dir` is set
 - [ ] Every `tags:` entry under `measurement_server` / `group_server` is deleted

--- a/progress.txt
+++ b/progress.txt
@@ -2951,3 +2951,69 @@ patch was local-only and is not committed.
 - Interior Record deleted -> **FAIL**, naming the value.
 - Contiguous tail 85..96 deleted, no interior gap -> **old check PASSES, new check FAILS**.
   That is the whole point of the issue, shown side by side.
+### #308 - Record timestamps were truncated to whole seconds on the wire
+
+Found while investigating #309's duplicate Records: `(tag, date, run_id)` looked like a
+free dedup key until the timestamps turned out not to be unique.
+
+- **The bug.** `bridge_node.cpp` read only `msg.header.stamp.sec` and dropped
+  `.nanosec`; the struct field was `std::uint64_t timestamp_secs`, so there was nowhere
+  to put it, and the Forwarder packed it as a plain msgpack integer. Measured before the
+  fix, a `Memory` Measurement at `polling_interval: 200`: **8 Records, 3 distinct
+  timestamps.** Everything downstream was faithful to an already-rounded number — not a
+  Vector problem.
+- **The wire already supported it.** Fluent Forward has an EventTime extension (ext type
+  `0x00`, 4 bytes seconds + 4 nanoseconds). Verified against the vendored Vector 0.57.0
+  by hand-rolling both frame shapes at its `fluent` source: integer seconds gave
+  `"timestamp":"...T11:36:28Z"`, EventTime gave `"...T11:36:28.123456789Z"`. Same source,
+  same config — only the Bridge needed to change.
+- Fix: `Record` carries seconds + nanoseconds, the Forwarder packs EventTime, all three
+  forwarding sites fill both halves (the two Bridge-generated ones via a new `stamp_now`
+  helper, since they have no ROS header to read).
+- **New `epoch_nanos` time_format, now the default.** `double` cannot carry nanoseconds:
+  a float64 has ~15-16 significant digits and current epoch seconds spend 10 of them, so
+  it tops out near microseconds. That is IEEE 754, not an implementation choice.
+  `epoch_nanos` is an exact i64 — and exactness is what makes it usable as part of the
+  identity #309 needs. `double`/`iso8601` remain available.
+- Schema follows: `date double precision` -> `bigint` in both `tools/e2e/sql/init.sql`
+  and the demos' `postgresql/init.sql`, `to_timestamp(date)` -> `to_timestamp(date / 1e9)`
+  in the Grafana dashboard, and the params files that write to those tables dropped their
+  explicit `time_format: "double"`. Console/stdout-only demos keep theirs — harmless
+  there, and it keeps the docs' example of the option honest.
+
+**Verified, not assumed:**
+- 58 unit tests pass, up from a 53-test baseline I ran on pristine `origin/jazzy` to be
+  sure the delta was mine. 5 new: EventTime bytes for a sub-second stamp, two stamps one
+  nanosecond apart producing different frames, a whole-second stamp still using EventTime,
+  every `time_format` string parsing, and `epoch_nanos` rendering with no `to_float(` in
+  the VRL at all.
+- **A trap worth recording.** Adding `timestamp_nanos` between `timestamp_secs` and
+  `payload` silently broke `Record big_record{ "dc.test", 1700000000ULL, big }` in
+  `forwarder_test.cpp` — it still *compiled*, because `nlohmann::json` has an implicit
+  conversion to `uint32_t`, then threw at runtime and took the test binary down with
+  `terminate called without an active exception` (an exception escaping past a joinable
+  `std::thread`). It looked like a crash in an unrelated backpressure test. The baseline
+  run is what proved it was mine rather than pre-existing.
+- End to end with the rebuilt Bridge, same 5 Hz Measurement as the "before" measurement:
+  `date=1786279421087842889 / ...287875768 / ...487844760 / ...` — **8 of 8 distinct**,
+  exactly 200 ms apart, all integers, all with a nanosecond remainder.
+- New `check_timestamp_resolution` in `verify_zero_loss.py` guards the regression in CI,
+  and `e2e_params.yaml`'s `memory` Measurement now polls at 5 Hz specifically so several
+  Records land inside one second — at 1 Hz a return to whole-second stamps would not
+  collide and would pass unnoticed. The check asserts a nanosecond remainder exists, that
+  some second holds 2+ Records (so it cannot pass vacuously), and that no two Records
+  share an instant. Exercised against a **real Postgres** with the new `bigint` schema
+  (`podman exec`, so no host port needed): good 5 Hz data passes; whole-second data,
+  colliding stamps, 1 Hz-only data, and an empty table all fail.
+- `pre-commit`: clang-format clean; flake8 back to the pre-existing baseline (E221x2 /
+  E231x2 / VNE001x2, all in the untouched `main()`); a JSON hook reflowed `robot.json`'s
+  long `rawSql` lines, including two I had not touched. `pycln` and the two
+  `poetry-requirements` hooks fail identically on an untouched file. `build_doc.sh` could
+  not finish its image-**tag** step (`/` is at 0 bytes free, podman's image copy needs
+  `/var/tmp`), so the two content steps were run in the cached image directly — clean,
+  linkcheck included.
+- **Not run locally**: the full `tools/e2e/scripts/run.sh`. A rootless-Docker Postgres
+  holds port 5432 on this host and the harness binds its stores on `--network host`. CI
+  gates it. (Superseded by the #312 entry above: the harness *can* be run locally by
+  giving the containers a private netns via an anchor container, which is how #312 was
+  verified. This entry is left as written for the record.)

--- a/tools/e2e/params/e2e_params.yaml
+++ b/tools/e2e/params/e2e_params.yaml
@@ -6,7 +6,11 @@ measurement_server:
 
     memory:
       plugin: "dc_measurements/Memory"
-      polling_interval: 1000
+      # 5 Hz, unlike every other Measurement here. Deliberate: it is the only topic that
+      # puts several Records inside the same wall-clock second, which is what makes the
+      # timestamp-resolution check in verify_zero_loss.py meaningful. At 1 Hz a
+      # regression to whole-second timestamps (#308) would not collide and would pass.
+      polling_interval: 200
       group_key: "memory"
 
     os:
@@ -172,7 +176,6 @@ dc_bridge:
       database: "dc"
       table: "dc_records"
       time_key: "date"
-      time_format: "double"
 
     pgsql_files:
       type: postgres
@@ -189,7 +192,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
 
     rustfs:
       type: s3

--- a/tools/e2e/params/e2e_retention_params.yaml
+++ b/tools/e2e/params/e2e_retention_params.yaml
@@ -50,7 +50,6 @@ dc_bridge:
       database: "dc"
       table: "dc_records"
       time_key: "date"
-      time_format: "double"
 
     pgsql_files:
       type: postgres
@@ -64,7 +63,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
 
     rustfs:
       type: s3

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -256,6 +256,73 @@ def check_files(pg_container: str, violations: list, notes: list, details: dict)
         )
 
 
+# The Measurement configured above 1 Hz in params/e2e_params.yaml. It is the only topic
+# that puts several Records inside one wall-clock second, which is what gives the
+# resolution check below something to actually collide on.
+FAST_TAG = "dc.measurement.memory"
+
+
+def check_timestamp_resolution(
+    pg_container: str, tag: str, violations: list, notes: list, details: dict
+) -> None:
+    """Assert sub-second timestamps survive the pipeline (#308).
+
+    `date` is epoch_nanos, an exact integer of nanoseconds. If the Bridge went back to
+    sending whole seconds, every value would be an exact multiple of 1e9 and the Records
+    of a 5 Hz Measurement would collapse onto shared timestamps.
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        tag: Tag of the faster-than-1-Hz Measurement to check.
+        violations: hard failures, appended to in place.
+        notes: informational observations, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
+    total = scalar_int(pg_container, f"SELECT count(*) FROM dc_records WHERE tag='{tag}'")
+    distinct = scalar_int(
+        pg_container, f"SELECT count(DISTINCT date) FROM dc_records WHERE tag='{tag}'"
+    )
+    sub_second = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM dc_records WHERE tag='{tag}' AND date % 1000000000 <> 0",
+    )
+    # Seconds holding more than one Record — proves the Measurement really ran above
+    # 1 Hz, so "no two Records share a timestamp" is a real assertion, not a vacuous one.
+    shared_seconds = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM (SELECT date / 1000000000 AS sec FROM dc_records "
+        f"WHERE tag='{tag}' GROUP BY sec HAVING count(*) > 1) t",
+    )
+    details["timestamp_resolution"] = {
+        "tag": tag,
+        "total": total,
+        "distinct_timestamps": distinct,
+        "sub_second_timestamps": sub_second,
+        "seconds_holding_multiple_records": shared_seconds,
+    }
+
+    if total == 0:
+        violations.append(f"timestamps: zero Records for {tag} — cannot check resolution")
+        return
+    if sub_second == 0:
+        violations.append(
+            f"timestamps: every {tag} Record has a whole-second timestamp ({total} Records, "
+            "none with a nanosecond remainder) — sub-second resolution was lost on the "
+            "wire (#308)"
+        )
+    if shared_seconds == 0:
+        violations.append(
+            f"timestamps: no wall-clock second holds more than one {tag} Record, so this "
+            "check proves nothing — is that Measurement still polling above 1 Hz?"
+        )
+    elif distinct < total:
+        violations.append(
+            f"timestamps: {total - distinct} {tag} Record(s) share a timestamp with another "
+            f"({distinct} distinct out of {total}) — Records taken at different instants "
+            "must be distinguishable in time"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -293,6 +360,7 @@ def main() -> int:
     for tag in REAL_TAGS:
         check_real_tag(pg, tag, violations, notes, details)
     check_files(pg, violations, notes, details)
+    check_timestamp_resolution(pg, FAST_TAG, violations, notes, details)
 
     report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
     if args.report:

--- a/tools/e2e/sql/init.sql
+++ b/tools/e2e/sql/init.sql
@@ -6,8 +6,13 @@
 -- lands here. `tag` (added to every event by Vector's fluent source) + `date` (the
 -- normalized event timestamp, per the destination's time_key/time_format) are the
 -- verification key tools/e2e/scripts/verify_zero_loss.py uses.
+--
+-- `date` is bigint, not double precision: the default time_format is epoch_nanos, an
+-- exact integer count of nanoseconds since the epoch (#308). A double would round it
+-- back off below roughly microsecond resolution, which is what made timestamps useless
+-- for telling two Records of a fast Measurement apart.
 CREATE TABLE IF NOT EXISTS dc_records (
-  date double precision,
+  date bigint,
   tag text,
   group_key text,
   -- memory
@@ -39,7 +44,7 @@ CREATE TABLE IF NOT EXISTS dc_records (
 -- column set proven against real dc_bridge behavior in
 -- dc_bridge/dc_bridge_core/tests/uploader_tests.rs and dc_bridge/tests/end_to_end.rs.
 CREATE TABLE IF NOT EXISTS dc_files (
-  date double precision,
+  date bigint,
   kind text,
   group_name text,
   robot_name text,

--- a/tools/infrastructure/docker/config/grafana/dashboards/robot.json
+++ b/tools/infrastructure/docker/config/grafana/dashboards/robot.json
@@ -62,7 +62,8 @@
           },
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(date) AS \"time\", (speed->>'computed')::double precision AS speed FROM dc WHERE name = 'robot' AND speed IS NOT NULL ORDER BY 1",
+          "rawSql":
+              "SELECT to_timestamp(date / 1e9) AS \"time\", (speed->>'computed')::double precision AS speed FROM dc WHERE name = 'robot' AND speed IS NOT NULL ORDER BY 1",
           "refId": "A"
         },
         {
@@ -72,7 +73,8 @@
           },
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(date) AS \"time\", (cmd_vel->'linear'->>'x')::double precision AS cmd_vel_linear_x, (cmd_vel->'angular'->>'z')::double precision AS cmd_vel_angular_z FROM dc WHERE name = 'robot' AND cmd_vel IS NOT NULL ORDER BY 1",
+          "rawSql":
+              "SELECT to_timestamp(date / 1e9) AS \"time\", (cmd_vel->'linear'->>'x')::double precision AS cmd_vel_linear_x, (cmd_vel->'angular'->>'z')::double precision AS cmd_vel_angular_z FROM dc WHERE name = 'robot' AND cmd_vel IS NOT NULL ORDER BY 1",
           "refId": "B"
         }
       ],
@@ -106,7 +108,8 @@
           },
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, storage_type, remote_path, content_type, size, uploaded FROM dc_files WHERE kind = 'file_status' ORDER BY updated_at DESC LIMIT 100",
+          "rawSql":
+              "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, storage_type, remote_path, content_type, size, uploaded FROM dc_files WHERE kind = 'file_status' ORDER BY updated_at DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -140,7 +143,8 @@
           },
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, file_count, complete FROM dc_files WHERE kind = 'group_complete' ORDER BY updated_at DESC LIMIT 20",
+          "rawSql":
+              "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, file_count, complete FROM dc_files WHERE kind = 'group_complete' ORDER BY updated_at DESC LIMIT 20",
           "refId": "A"
         }
       ],

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -25,7 +25,7 @@
 -- wire up a CPU panel.
 CREATE TABLE IF NOT EXISTS dc (
   -- Common (every Record)
-  date double precision,
+  date bigint,
   name text,
   robot_name text,
   id text,


### PR DESCRIPTION
Closes #308

The Bridge read only `msg.header.stamp.sec` and dropped `.nanosec`, then packed it as the ingest protocol's plain integer time. Every Record's timestamp was rounded to the second.

## Before / after

Same `Memory` Measurement at `polling_interval: 200` (5 Hz), console Destination:

```
# before
date=1786275388.0   timestamp=2026-08-09T11:36:28Z   used=98.0783
date=1786275388.0   timestamp=2026-08-09T11:36:28Z   used=98.1031
date=1786275389.0   timestamp=2026-08-09T11:36:29Z   used=98.1441
...
distinct date values: 3 out of 8

# after
date=1786279421087842889   timestamp=2026-08-09T12:43:41.087842889Z   used=90.4075
date=1786279421287875768   timestamp=2026-08-09T12:43:41.287875768Z   used=90.3758
date=1786279421487844760   timestamp=2026-08-09T12:43:41.487844760Z   used=90.3774
...
distinct date values: 8 out of 8, exactly 200 ms apart
```

## The wire format already supported it

Fluent Forward has an **EventTime** extension (msgpack ext type `0x00`, 4 bytes seconds + 4 nanoseconds). I fed both frame shapes to the vendored Vector 0.57.0 `fluent` source by hand — same source, same config:

```
integer seconds  ->  "timestamp":"2026-08-09T11:36:28Z"
EventTime ext    ->  "timestamp":"2026-08-09T11:36:28.123456789Z"
```

So only the Bridge changed: `Record` carries seconds and nanoseconds, and the Forwarder packs EventTime.

## New default `time_format: epoch_nanos`

`double` cannot represent nanoseconds — a float64 has ~15-16 significant digits and current epoch seconds already spend 10 of them, so it tops out near microseconds. That is IEEE 754, not an implementation limit. `epoch_nanos` is an exact i64; `double` and `iso8601` remain available.

Exactness matters beyond precision: it is what makes the timestamp usable as part of a Record identity, which #309 needs. Keying on the old rounded `date` would have merged genuinely distinct Records above 1 Hz — turning a visible over-counting bug into silent data loss.

Schema follows: `date` becomes `bigint` in both `init.sql` files, `to_timestamp(date)` becomes `to_timestamp(date / 1e9)` in the Grafana dashboard, and params writing to those tables drop their explicit `time_format: "double"`. Console-only demos keep theirs. `migration.md` documents the column change and the `ALTER TABLE` for anyone already tracking `jazzy`.

## Testing

- **58 unit tests pass**, against a **53-test baseline I ran on pristine `origin/jazzy`** to confirm the delta was mine. 5 new: EventTime bytes for a sub-second stamp; two stamps one nanosecond apart producing different frames; a whole-second stamp still using EventTime; every `time_format` string parsing; and `epoch_nanos` rendering with no `to_float(` anywhere in the VRL.
- **Regression guard in CI**: `e2e_params.yaml`'s `memory` Measurement now polls at 5 Hz specifically so several Records land inside one wall-clock second — at 1 Hz a return to whole-second stamps would not collide and would pass unnoticed. `check_timestamp_resolution` asserts a nanosecond remainder exists, that some second holds 2+ Records (so it cannot pass vacuously), and that no two Records share an instant.
- That check was **exercised against a real Postgres** with the new `bigint` schema (via `podman exec`, so no host port needed): good 5 Hz data passes; whole-second data, colliding stamps, 1 Hz-only data and an empty table all fail.

### A trap worth flagging for review

Adding `timestamp_nanos` between `timestamp_secs` and `payload` silently broke an aggregate initialisation in `forwarder_test.cpp`. It still **compiled**, because `nlohmann::json` has an implicit conversion to `uint32_t` — then threw at runtime and took the whole test binary down with `terminate called without an active exception`, surfacing as a crash in an unrelated backpressure test. The pristine-baseline run is what proved it was mine. Worth knowing if anyone adds fields to `Record` later.

### Not run locally

The full `tools/e2e/scripts/run.sh` — a rootless-Docker Postgres holds port 5432 on this machine and the harness binds its stores on `--network host`. CI gates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5JwZEZrxEtYJdQUfsZRVo
