### PR TITLE
fix(destinations): collapse re-delivered Records on write

### DIFF
--- a/dc_bridge/include/dc_bridge/forwarder.hpp
+++ b/dc_bridge/include/dc_bridge/forwarder.hpp
@@ -17,12 +17,20 @@ namespace dc_bridge
 {
 
 /// A DC Record ready to be forwarded: a shipper ingest protocol tag, a Unix timestamp
-/// (seconds since the epoch, matching the protocol's integer time), and the Record's
+/// split into whole seconds plus the nanoseconds within that second, and the Record's
 /// JSON payload (StringStamped.data, already parsed).
+///
+/// The split mirrors the ingest protocol's **EventTime** extension (4 bytes of seconds,
+/// 4 of nanoseconds), which is what the Forwarder emits. The protocol's older integer
+/// time carries whole seconds only; sending that rounded every Record's timestamp to the
+/// second, so a Measurement polling faster than 1 Hz produced Records that were
+/// indistinguishable in time (#308).
 struct Record
 {
   std::string tag;
   std::uint64_t timestamp_secs;
+  /// Nanoseconds within `timestamp_secs`; always < 1'000'000'000.
+  std::uint32_t timestamp_nanos{ 0 };
   nlohmann::json payload;
 };
 

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -36,8 +36,16 @@ inline constexpr std::uint64_t MIN_DISK_BUFFER_BYTES = 268435488ULL;
 /// route transform id, rest = the Tag verbatim).
 std::string route_output_for_tag(const std::string& tag);
 
+/// How a Destination's normalized time field is written.
+///
+/// `EpochNanos` is the default: an exact integer count of nanoseconds since the epoch.
+/// `Double` divides that by 1e9 into a float64, which has ~15-16 significant digits and
+/// spends 10 of them on the seconds — so it cannot represent better than roughly
+/// microseconds, and rounds. It stays available for consumers that want a fractional
+/// seconds column, but it is lossy by construction, not by implementation (#308).
 enum class TimeFormat
 {
+  EpochNanos,
   Double,
   Iso8601,
 };

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -39,6 +39,19 @@ std::string expand_with_env(const std::string& input)
   return expand_env(input, env_lookup);
 }
 
+// Stamps a Bridge-generated Record (File status, retention audit) with the current time,
+// split into the seconds/nanoseconds pair the ingest protocol's EventTime carries. These
+// Records have no ROS header to take a stamp from, unlike the ones forwarded from a
+// Measurement's topic. Truncating this to whole seconds was part of #308.
+void stamp_now(Record& record)
+{
+  const auto since_epoch = std::chrono::system_clock::now().time_since_epoch();
+  const auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_epoch);
+  record.timestamp_secs = static_cast<std::uint64_t>(secs.count());
+  record.timestamp_nanos =
+      static_cast<std::uint32_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(since_epoch - secs).count());
+}
+
 // Declares `name` with dynamic typing and a PARAMETER_NOT_SET default, so a value the
 // user didn't provide reads back as nullopt (rather than forcing a sentinel/default).
 std::optional<std::string> declare_optional_string(rclcpp::Node* node, const std::string& name)
@@ -419,7 +432,11 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
           {
             Record record;
             record.tag = tag;
+            // Both halves of the ROS stamp. The nanoseconds used to be dropped here,
+            // which rounded every Record to the second and left a Measurement polling
+            // faster than 1 Hz with Records indistinguishable in time (#308).
             record.timestamp_secs = static_cast<std::uint64_t>(std::max<std::int32_t>(0, msg.header.stamp.sec));
+            record.timestamp_nanos = msg.header.stamp.nanosec;
             record.payload = std::move(payload);
             try
             {
@@ -465,8 +482,7 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
   auto emit = [&forwarder](const nlohmann::json& row) {
     Record record;
     record.tag = uploader::FILE_STATUS_TAG;
-    record.timestamp_secs = static_cast<std::uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    stamp_now(record);
     record.payload = row;
     // Vector may be briefly down (restart, backpressure); keep trying for a while before
     // handing the whole Record back for an idempotent retry.
@@ -493,8 +509,7 @@ void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t for
   auto retention_emit = [&forwarder](const nlohmann::json& row) {
     Record record;
     record.tag = uploader::FILE_STATUS_TAG;
-    record.timestamp_secs = static_cast<std::uint64_t>(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+    stamp_now(record);
     record.payload = row;
     forwarder.send(record);
   };

--- a/dc_bridge/src/forwarder.cpp
+++ b/dc_bridge/src/forwarder.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
 #include <cstring>
 #include <ctime>
@@ -87,6 +88,29 @@ void pack_record_map(Packer& pk, const nlohmann::json& payload)
   }
 }
 
+// Packs a timestamp as the ingest protocol's **EventTime** extension: msgpack ext type
+// 0x00 with an 8-byte body — 4 bytes of seconds then 4 of nanoseconds, both big-endian
+// (network order), exactly as the protocol specifies.
+//
+// The alternative the protocol allows is a plain integer of whole seconds, which is what
+// DC sent until #308. That silently rounded every Record's timestamp down to the second,
+// so five Records from a 5 Hz Measurement all claimed the same instant. Seconds are
+// narrowed to 32 bits here because the extension's layout is fixed at 4 bytes; that field
+// overflows in 2106, long after the int32 ROS header stamp this is built from.
+template <typename Packer>
+void pack_event_time(Packer& pk, std::uint64_t seconds, std::uint32_t nanos)
+{
+  std::array<char, 8> body{};
+  const auto secs32 = static_cast<std::uint32_t>(seconds);
+  for (int i = 0; i < 4; ++i)
+  {
+    body[i] = static_cast<char>((secs32 >> (8 * (3 - i))) & 0xFF);
+    body[4 + i] = static_cast<char>((nanos >> (8 * (3 - i))) & 0xFF);
+  }
+  pk.pack_ext(body.size(), 0x00);
+  pk.pack_ext_body(body.data(), body.size());
+}
+
 }  // namespace
 
 Forwarder::Forwarder(ForwarderConfig config) : config_(std::move(config))
@@ -153,7 +177,7 @@ std::string Forwarder::frame(const Record& record, const std::string& chunk_id)
   pk.pack(record.tag);
   pk.pack_array(1);  // one entry
   pk.pack_array(2);  // [time, record]
-  pk.pack(record.timestamp_secs);
+  pack_event_time(pk, record.timestamp_secs, record.timestamp_nanos);
   pack_record_map(pk, record.payload);
   pk.pack_map(1);
   pk.pack(std::string("chunk"));

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -134,7 +134,14 @@ std::string render_normalize_source(const RenderConfig& config)
   for (const auto& dest : config.destinations)
   {
     out += "if " + tag_condition(destination_tags(dest)) + " {\n";
-    if (dest.time_format == TimeFormat::Double)
+    if (dest.time_format == TimeFormat::EpochNanos)
+    {
+      // Exact: an i64 of nanoseconds since the epoch, no float rounding anywhere. Good
+      // until the year 2262, and the only format here that can round-trip the full
+      // resolution the Forwarder now sends (#308).
+      out += "  ." + dest.time_key + " = to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")\n";
+    }
+    else if (dest.time_format == TimeFormat::Double)
     {
       out +=
           "  ." + dest.time_key + " = to_float(to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")) / 1000000000.0\n";
@@ -430,9 +437,13 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   }
 
   std::string time_key = optional_field(raw.time_key).value_or("date");
-  std::string tf = raw.time_format && !raw.time_format->empty() ? *raw.time_format : "double";
+  std::string tf = raw.time_format && !raw.time_format->empty() ? *raw.time_format : "epoch_nanos";
   TimeFormat time_format;
-  if (tf == "double")
+  if (tf == "epoch_nanos")
+  {
+    time_format = TimeFormat::EpochNanos;
+  }
+  else if (tf == "double")
   {
     time_format = TimeFormat::Double;
   }
@@ -442,9 +453,10 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   }
   else
   {
-    throw RenderError(
-        RenderErrorKind::InvalidTimeFormat,
-        "destination '" + name + "': time_format '" + tf + "' is invalid (expected 'double' or 'iso8601')", name, tf);
+    throw RenderError(RenderErrorKind::InvalidTimeFormat,
+                      "destination '" + name + "': time_format '" + tf +
+                          "' is invalid (expected 'epoch_nanos', 'double' or 'iso8601')",
+                      name, tf);
   }
 
   DestinationKind kind;

--- a/dc_bridge/test/forwarder_test.cpp
+++ b/dc_bridge/test/forwarder_test.cpp
@@ -25,9 +25,29 @@ using namespace dc_bridge;
 namespace
 {
 
-Record make_record(const std::string& tag, const std::string& json)
+Record make_record(const std::string& tag, const std::string& json, std::uint32_t nanos = 0)
 {
-  return Record{ tag, 1700000000ULL, nlohmann::json::parse(json) };
+  return Record{ tag, 1700000000ULL, nanos, nlohmann::json::parse(json) };
+}
+
+// The EventTime extension the frame carries the timestamp in: msgpack ext type 0x00,
+// 8-byte body of big-endian seconds then big-endian nanoseconds (#308). Built here
+// independently of the packing code so the test pins the wire bytes rather than
+// re-deriving them the same way the implementation does.
+std::string expected_event_time_bytes(std::uint32_t secs, std::uint32_t nanos)
+{
+  std::string out;
+  out.push_back(static_cast<char>(0xd7));  // fixext8
+  out.push_back(static_cast<char>(0x00));  // ext type 0 = EventTime
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((secs >> (8 * (3 - i))) & 0xFF));
+  }
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((nanos >> (8 * (3 - i))) & 0xFF));
+  }
+  return out;
 }
 
 // A mock shipper ingest protocol server: binds :0, hands back the chosen port, and runs
@@ -147,7 +167,8 @@ TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
   msgpack::object entries = top.via.array.ptr[1];
   ASSERT_EQ(entries.via.array.size, 1u);
   msgpack::object entry = entries.via.array.ptr[0];  // [time, record]
-  EXPECT_EQ(entry.via.array.ptr[0].as<std::uint64_t>(), 1700000000ULL);
+  // The time element is the EventTime extension, not a bare integer of seconds (#308).
+  EXPECT_EQ(entry.via.array.ptr[0].type, msgpack::type::EXT);
 
   msgpack::object rec = entry.via.array.ptr[1];
   ASSERT_EQ(rec.type, msgpack::type::MAP);
@@ -161,6 +182,36 @@ TEST(Forwarder, FrameIsWellFormedWithCorrectTag)
     }
   }
   EXPECT_TRUE(found);
+}
+
+// #308: sub-second resolution must survive the wire. Before this, the frame carried a
+// plain integer of whole seconds, so a Measurement polling faster than 1 Hz produced
+// Records that all claimed the same instant.
+TEST(Forwarder, FrameCarriesSubSecondPrecisionAsEventTime)
+{
+  const std::uint32_t nanos = 123456789u;
+  const std::string frame = Forwarder::frame(make_record("dc.test", R"({"n": 1})", nanos), "chunk-ns");
+  EXPECT_NE(frame.find(expected_event_time_bytes(1700000000u, nanos)), std::string::npos)
+      << "frame does not carry the EventTime extension for 1700000000.123456789";
+}
+
+// Two Records one nanosecond apart must not collapse onto the same wire timestamp —
+// the property that makes a timestamp usable as part of an identity.
+TEST(Forwarder, FramesWithinTheSameSecondAreDistinguishable)
+{
+  const std::string a = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 1u), "c1");
+  const std::string b = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 2u), "c1");
+  EXPECT_NE(a, b);
+  EXPECT_NE(a.find(expected_event_time_bytes(1700000000u, 1u)), std::string::npos);
+  EXPECT_NE(b.find(expected_event_time_bytes(1700000000u, 2u)), std::string::npos);
+}
+
+// A whole-second Record still encodes as EventTime, with a zero nanosecond half, rather
+// than falling back to the integer form.
+TEST(Forwarder, WholeSecondTimestampStillUsesEventTime)
+{
+  const std::string frame = Forwarder::frame(make_record("dc.test", R"({"n": 1})", 0u), "c0");
+  EXPECT_NE(frame.find(expected_event_time_bytes(1700000000u, 0u)), std::string::npos);
 }
 
 TEST(Forwarder, FrameCarriesTheChunkOption)
@@ -258,7 +309,7 @@ TEST(Forwarder, ReturnsBackpressureWhenPeerStalls)
 
   nlohmann::json big;
   big["blob"] = std::string(1000000, 'x');
-  Record big_record{ "dc.test", 1700000000ULL, big };
+  Record big_record{ "dc.test", 1700000000ULL, 0u, big };
 
   bool saw_backpressure = false;
   for (int i = 0; i < 20; ++i)

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -417,6 +417,33 @@ TEST(Render, DestinationFromRawRejectsInvalidTimeFormat)
   }
 }
 
+TEST(Render, DestinationFromRawAcceptsEveryTimeFormat)
+{
+  const std::vector<std::pair<std::string, TimeFormat>> cases = { { "epoch_nanos", TimeFormat::EpochNanos },
+                                                                  { "double", TimeFormat::Double },
+                                                                  { "iso8601", TimeFormat::Iso8601 } };
+  for (const auto& c : cases)
+  {
+    RawDestinationParams raw;
+    raw.time_format = c.first;
+    auto dest = destination_from_raw("debug_console", "console", "records", { "/dc/measurement/map" }, raw);
+    EXPECT_EQ(dest.time_format, c.second) << "time_format '" << c.first << "'";
+  }
+}
+
+// The normalize transform must emit the timestamp with no float arithmetic in it —
+// `to_float(...) / 1000000000.0` is precisely what loses resolution below ~1 us.
+TEST(Render, EpochNanosNormalizesWithoutFloatRounding)
+{
+  auto config =
+      config_with({ make_destination("pgsql", { "/dc/group/robot" }, TimeFormat::EpochNanos, postgres_kind()) });
+  const std::string rendered = render(config);
+  EXPECT_NE(rendered.find(".date = to_unix_timestamp!(.timestamp, unit: \"nanoseconds\")"), std::string::npos)
+      << rendered;
+  EXPECT_EQ(rendered.find("to_float("), std::string::npos)
+      << "epoch_nanos must not round through a float: " << rendered;
+}
+
 TEST(Render, PostgresFromRawRejectsMissingRequiredFields)
 {
   RawDestinationParams raw;
@@ -465,11 +492,13 @@ TEST(Render, PostgresFromRawAppliesDefaults)
   EXPECT_EQ(pg.port, 5432);
 }
 
+// #308: the default is the exact integer format, not the lossy float one. A Destination
+// that says nothing about time must not silently round its timestamps.
 TEST(Render, DestinationFromRawAppliesTimeDefaults)
 {
   auto dest = destination_from_raw("debug_console", "console", "records", { "/dc/group/robot" }, {});
   EXPECT_EQ(dest.time_key, "date");
-  EXPECT_EQ(dest.time_format, TimeFormat::Double);
+  EXPECT_EQ(dest.time_format, TimeFormat::EpochNanos);
 }
 
 TEST(Render, S3FromRawRejectsMissingBucket)

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -25,7 +25,10 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
+      # epoch_nanos (default) = exact integer nanoseconds since the epoch; iso8601 =
+      # "…T11:36:28.123456789" string; double = fractional seconds, which is a float64
+      # and rounds below ~1 us. Match the column type: bigint for epoch_nanos.
+      time_format: "epoch_nanos"
     # The other blessed destination types (add the name to `destinations` to enable):
     #
     # rustfs:                     # S3-compatible object storage (self-hosted: RustFS

--- a/dc_demos/params/qrcodes_minio_pgsql.yaml
+++ b/dc_demos/params/qrcodes_minio_pgsql.yaml
@@ -20,7 +20,6 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
     pgsql_files:
       type: postgres
       receives: records
@@ -31,7 +30,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
     rustfs:
       type: s3
       receives: files

--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -31,7 +31,6 @@ dc_bridge:
       database: "dc"
       table: "dc"
       time_key: "date"
-      time_format: "double"
     pgsql_files:
       type: postgres
       receives: records
@@ -42,7 +41,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
     rustfs:
       type: s3
       receives: files

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -71,8 +71,9 @@ The `data` string **must** be valid JSON:
 
 The timestamp is the time the Record was created. Measurements convert ROS time to a
 UTC timestamp. Each Destination normalizes it into one field before delivery, controlled
-by `time_key` (default `date`) and `time_format` (`double` for Unix epoch seconds, or
-`iso8601`).
+by `time_key` (default `date`) and `time_format` (`epoch_nanos`, the default, for exact
+integer nanoseconds since the epoch; `iso8601` for a string; `double` for fractional
+seconds, which rounds — see [Destinations](./destinations.md#time_format)).
 
 ### JSON validation
 

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -59,7 +59,7 @@ dc_bridge:
       receives: records
       inputs: ["/dc/measurement/uptime"]
       time_key: "date"                       # Field the normalized timestamp is written to
-      time_format: "iso8601"                 # "double" (Unix epoch seconds) or "iso8601"
+      time_format: "iso8601"                 # "epoch_nanos" (default) | "iso8601" | "double"
 
 measurement_server:
   ros__parameters:

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -84,8 +84,32 @@ deployments work identically: set `endpoint`, explicit credentials, and (typical
 
 Common parameters for every blessed type: `type`, `receives` (`records` | `files`, see
 the File uploads section below), `inputs` (ROS topic names), `time_key` (default
-`date`) and `time_format` (`double` | `iso8601`, default `double`) controlling the
-normalized timestamp field written into each Record before routing.
+`date`) and `time_format` (default `epoch_nanos`) controlling the normalized timestamp
+field written into each Record before routing.
+
+### `time_format`
+
+The Bridge forwards each Record's timestamp at full nanosecond resolution, taken from the
+ROS message header. `time_format` decides how that is written into the Record:
+
+| Value         | Written as                                     | Resolution kept |
+| ------------- | ---------------------------------------------- | --------------- |
+| `epoch_nanos` | integer nanoseconds since the epoch (default)  | nanosecond — exact |
+| `iso8601`     | `2026-08-09T11:36:28.123456789` string         | nanosecond |
+| `double`      | fractional seconds as a float64                | ~microsecond, rounds |
+
+`double` is lossy by construction, not by implementation: a float64 has ~15–16 significant
+digits and current epoch seconds already consume 10 of them. It remains available for
+consumers that want a fractional-seconds column, but it cannot represent the resolution
+the pipeline delivers.
+
+```admonish warning
+The destination's own column type can truncate independently of `time_format`. A
+`double precision` column rounds an `epoch_nanos` value back off; PostgreSQL's native
+`timestamptz` is microseconds internally; Elasticsearch's `date` type is milliseconds
+(use `date_nanos` for the full value). Choose the column to match — `bigint` for
+`epoch_nanos` is exact, sortable and indexable.
+```
 
 Type-specific parameters:
 

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -124,6 +124,68 @@ Invalid parameters (unknown `type`, missing required field, half a credential pa
 out-of-range port…) are rejected with a clear error at Bridge startup — before Vector
 is ever started.
 
+## Delivery is at-least-once: make the write idempotent
+
+The Shipper confirms every Record end to end, and re-sends anything it has not had
+confirmed. That is what makes the pipeline lossless — but it means a Record in flight
+when a destination goes away, or when the Bridge restarts, can be **delivered twice**.
+Measured in the E2E harness before this was handled: an outage plus a restart duplicated
+roughly a fifth of the run.
+
+A re-delivery is byte-identical to the original — the Forwarder re-sends the frame it
+serialised the first time, so the timestamp is the one the Measurement sampled at, not
+the time of the retry. With `time_format: epoch_nanos` that makes **`(tag, <time_key>)`
+an exact identity** for a Record, and the destination can collapse a re-delivery on write.
+
+For a `postgres` Destination, DC's example schemas ship this trigger (see
+`tools/e2e/sql/init.sql`):
+
+```sql
+CREATE OR REPLACE FUNCTION dc_skip_duplicate() RETURNS trigger AS $$
+DECLARE
+  already_present boolean;
+BEGIN
+  EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I WHERE tag = $1 AND date = $2)', TG_TABLE_NAME)
+    INTO already_present USING NEW.tag, NEW.date;
+  IF already_present THEN
+    RETURN NULL;  -- skip this row; the rest of the batch still commits
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE INDEX IF NOT EXISTS dc_records_identity ON dc_records (tag, date);
+
+CREATE TRIGGER dc_records_skip_duplicate BEFORE INSERT ON dc_records
+  FOR EACH ROW EXECUTE FUNCTION dc_skip_duplicate();
+```
+
+```admonish danger title="Do not use a UNIQUE constraint for this"
+It looks like the obvious answer and it will lose data. Vector's `postgres` sink has no
+conflict handling — its configuration accepts only `endpoint`, `table`, `pool_size`,
+`batch`, `request` and `acknowledgements` — and it writes a whole batch in a single
+statement. A constraint violation therefore fails the **entire statement**, which Vector
+classes as non-retriable and drops. Measured: a batch of four containing one duplicate
+lost all four, with no retry and no dead-letter. One re-delivered Record takes out every
+Record batched with it.
+
+The trigger avoids this because returning `NULL` from `BEFORE INSERT` skips one row
+without failing the statement. Keep the index non-unique: the trigger enforces identity,
+the index only makes its lookup cheap.
+```
+
+Other destination types need their own equivalent — an S3 Destination wants a
+deterministic object key, and a passthrough sink is its author's responsibility. An
+Elasticsearch sink, for instance, gets there by deriving its document `id_key` from the
+same fields, which turns a re-delivery into an overwrite of the row it duplicates.
+
+```admonish info
+Two caveats on the trigger. It costs one indexed lookup per inserted row, which is
+negligible at Measurement rates but not free. And `EXISTS` followed by `INSERT` is not
+atomic, so it assumes a single writer — Vector's default `pool_size`. Raise that and two
+concurrent batches could both pass the check.
+```
+
 ## The `dc.<tag>` routing contract (public API)
 
 The Bridge exposes one Shipper route per **Tag**. The Tag for a topic is its name with

--- a/doc/src/dc/migration.md
+++ b/doc/src/dc/migration.md
@@ -136,7 +136,7 @@ console:
   receives: records
   inputs: ["/dc/group/data"]
   time_key: "date"          # was json_date_key
-  time_format: "iso8601"    # was json_date_format; "double" | "iso8601"
+  time_format: "iso8601"    # was json_date_format; "epoch_nanos" (default) | "iso8601" | "double"
 ```
 
 `format` is gone: the `console` Destination always writes JSON.
@@ -591,9 +591,33 @@ dc_bridge:
 See [Setup](./setup.md) for the resulting install, which is now `rosdep install` +
 `colcon build`.
 
+## Timestamps: `time_format` now defaults to `epoch_nanos`
+
+Records carry their ROS header timestamp at full nanosecond resolution, and the default
+`time_format` writes it as an exact integer count of nanoseconds since the epoch rather
+than fractional seconds in a float64.
+
+```admonish warning title="Schema change"
+The column receiving `time_key` must be **`bigint`**, not `double precision`. A double
+rounds the value back off below roughly microsecond resolution — which is what stopped
+timestamps telling two Records of a fast Measurement apart in the first place.
+
+If you already have a populated `dc_records` from an earlier `jazzy` checkout:
+
+    ALTER TABLE dc_records ALTER COLUMN date TYPE bigint USING (date * 1e9)::bigint;
+
+and update any query that treated the column as seconds — `to_timestamp(date)` becomes
+`to_timestamp(date / 1e9)`.
+```
+
+Set `time_format: "double"` explicitly to keep the old fractional-seconds column. It
+remains supported, and remains lossy: a float64 has ~15-16 significant digits and current
+epoch seconds already spend 10 of them. `iso8601` is the other lossless option.
+
 ## Migration checklist
 
 - [ ] `destination_server:` renamed to `dc_bridge:`, `destination_plugins:` to `destinations:`
+- [ ] The column behind `time_key` is `bigint` (or `time_format: "double"` is set explicitly)
 - [ ] Every destination has a `type:` and a `receives:` instead of a `plugin:`
 - [ ] The `flb:` block is deleted; `shipper.data_dir` is set
 - [ ] Every `tags:` entry under `measurement_server` / `group_server` is deleted

--- a/progress.txt
+++ b/progress.txt
@@ -3015,3 +3015,25 @@ the bandwidth half. But it only helps if duplicates are born at the Bridge → V
 a sink retry re-sends a batch that has *already* passed the transform, so it would not be
 caught. Which hop dominates is still unmeasured (the local repro produced nothing to
 measure), so adding it now would be speculative. Left in #309.
+
+#### #309 follow-up - make the dedup assertion non-vacuous
+
+The "no duplicate rows" checks only fail if the run happened to produce a re-delivery,
+and the local repro above showed re-delivery is **not** deterministic — so a quiet CI run
+would have passed them without the trigger ever firing. Same vacuous-pass flaw the
+timestamp check is explicitly guarded against; it should not have shipped without the
+same guard.
+
+`check_dedup_trigger` now injects a known duplicate every run: it inserts a probe row,
+then re-inserts it in a *single statement* alongside two fresh rows (how Vector's sink
+writes a batch), and asserts exactly 3 rows survive. Uses its own `dc.e2e.dedup_probe`
+Tag that no other check reads, and deletes its rows in a `finally`.
+
+Exercised against a real Postgres loading the shipped `sql/init.sql`, four ways:
+trigger present -> PASS; trigger dropped -> FAIL naming the missing trigger; a UNIQUE
+index instead of the trigger -> FAIL with its own message; trigger restored -> PASS.
+Table left empty afterwards.
+
+Writing that fourth case found a bug in the check itself: the UNIQUE-index path made
+`psql()` raise, so the verifier crashed with a traceback instead of reporting the one
+failure mode most worth explaining. Now caught and reported as a violation.

--- a/progress.txt
+++ b/progress.txt
@@ -2904,3 +2904,68 @@ from `gh-pages`) is being retired.
 - `doc/src/dc/groups.md` gains the parameter row and a "Warnings and throttling" subsection
   with both rendered log lines (plain and `[+N more ...]`), the per-group-not-per-call-site
   guarantee, and the explicit note that Records are never throttled, only the log line.
+
+### #308 - Record timestamps were truncated to whole seconds on the wire
+
+Found while investigating #309's duplicate Records: `(tag, date, run_id)` looked like a
+free dedup key until the timestamps turned out not to be unique.
+
+- **The bug.** `bridge_node.cpp` read only `msg.header.stamp.sec` and dropped
+  `.nanosec`; the struct field was `std::uint64_t timestamp_secs`, so there was nowhere
+  to put it, and the Forwarder packed it as a plain msgpack integer. Measured before the
+  fix, a `Memory` Measurement at `polling_interval: 200`: **8 Records, 3 distinct
+  timestamps.** Everything downstream was faithful to an already-rounded number — not a
+  Vector problem.
+- **The wire already supported it.** Fluent Forward has an EventTime extension (ext type
+  `0x00`, 4 bytes seconds + 4 nanoseconds). Verified against the vendored Vector 0.57.0
+  by hand-rolling both frame shapes at its `fluent` source: integer seconds gave
+  `"timestamp":"...T11:36:28Z"`, EventTime gave `"...T11:36:28.123456789Z"`. Same source,
+  same config — only the Bridge needed to change.
+- Fix: `Record` carries seconds + nanoseconds, the Forwarder packs EventTime, all three
+  forwarding sites fill both halves (the two Bridge-generated ones via a new `stamp_now`
+  helper, since they have no ROS header to read).
+- **New `epoch_nanos` time_format, now the default.** `double` cannot carry nanoseconds:
+  a float64 has ~15-16 significant digits and current epoch seconds spend 10 of them, so
+  it tops out near microseconds. That is IEEE 754, not an implementation choice.
+  `epoch_nanos` is an exact i64 — and exactness is what makes it usable as part of the
+  identity #309 needs. `double`/`iso8601` remain available.
+- Schema follows: `date double precision` -> `bigint` in both `tools/e2e/sql/init.sql`
+  and the demos' `postgresql/init.sql`, `to_timestamp(date)` -> `to_timestamp(date / 1e9)`
+  in the Grafana dashboard, and the params files that write to those tables dropped their
+  explicit `time_format: "double"`. Console/stdout-only demos keep theirs — harmless
+  there, and it keeps the docs' example of the option honest.
+
+**Verified, not assumed:**
+- 58 unit tests pass, up from a 53-test baseline I ran on pristine `origin/jazzy` to be
+  sure the delta was mine. 5 new: EventTime bytes for a sub-second stamp, two stamps one
+  nanosecond apart producing different frames, a whole-second stamp still using EventTime,
+  every `time_format` string parsing, and `epoch_nanos` rendering with no `to_float(` in
+  the VRL at all.
+- **A trap worth recording.** Adding `timestamp_nanos` between `timestamp_secs` and
+  `payload` silently broke `Record big_record{ "dc.test", 1700000000ULL, big }` in
+  `forwarder_test.cpp` — it still *compiled*, because `nlohmann::json` has an implicit
+  conversion to `uint32_t`, then threw at runtime and took the test binary down with
+  `terminate called without an active exception` (an exception escaping past a joinable
+  `std::thread`). It looked like a crash in an unrelated backpressure test. The baseline
+  run is what proved it was mine rather than pre-existing.
+- End to end with the rebuilt Bridge, same 5 Hz Measurement as the "before" measurement:
+  `date=1786279421087842889 / ...287875768 / ...487844760 / ...` — **8 of 8 distinct**,
+  exactly 200 ms apart, all integers, all with a nanosecond remainder.
+- New `check_timestamp_resolution` in `verify_zero_loss.py` guards the regression in CI,
+  and `e2e_params.yaml`'s `memory` Measurement now polls at 5 Hz specifically so several
+  Records land inside one second — at 1 Hz a return to whole-second stamps would not
+  collide and would pass unnoticed. The check asserts a nanosecond remainder exists, that
+  some second holds 2+ Records (so it cannot pass vacuously), and that no two Records
+  share an instant. Exercised against a **real Postgres** with the new `bigint` schema
+  (`podman exec`, so no host port needed): good 5 Hz data passes; whole-second data,
+  colliding stamps, 1 Hz-only data, and an empty table all fail.
+- `pre-commit`: clang-format clean; flake8 back to the pre-existing baseline (E221x2 /
+  E231x2 / VNE001x2, all in the untouched `main()`); a JSON hook reflowed `robot.json`'s
+  long `rawSql` lines, including two I had not touched. `pycln` and the two
+  `poetry-requirements` hooks fail identically on an untouched file. `build_doc.sh` could
+  not finish its image-**tag** step (`/` is at 0 bytes free, podman's image copy needs
+  `/var/tmp`), so the two content steps were run in the cached image directly — clean,
+  linkcheck included.
+- **Not run locally**: the full `tools/e2e/scripts/run.sh`. A rootless-Docker Postgres
+  holds port 5432 on this host and the harness binds its stores on `--network host`. CI
+  gates it.

--- a/progress.txt
+++ b/progress.txt
@@ -2969,3 +2969,49 @@ free dedup key until the timestamps turned out not to be unique.
 - **Not run locally**: the full `tools/e2e/scripts/run.sh`. A rootless-Docker Postgres
   holds port 5432 on this host and the harness binds its stores on `--network host`. CI
   gates it.
+
+### #309 - collapse duplicate Records on write
+
+Depends on #308/#310: `(tag, date)` only became an exact per-Record identity once
+timestamps carried nanoseconds.
+
+- **Vector's `postgres` sink cannot do this itself.** Its config accepts only
+  `endpoint`, `table`, `pool_size`, `batch`, `request`, `acknowledgements`; `on_conflict`
+  is rejected as an unknown field. Checked against the vendored 0.57.0 binary.
+- **A UNIQUE constraint would have lost data.** The sink writes a batch in one statement,
+  so a violation fails the whole statement, which Vector classes non-retriable and drops.
+  Measured against a real Postgres: a batch of 4 containing 1 duplicate → `Events dropped
+  intentional=false count=4`, all three good Records gone, no retry, no dead-letter. That
+  is strictly worse than the duplicates it was meant to fix.
+- **What shipped**: a `BEFORE INSERT` trigger returning `NULL`, which skips the offending
+  row without failing the statement. Added to both `tools/e2e/sql/init.sql` and
+  `tools/infrastructure/docker/config/postgresql/init.sql`, with a **non-unique** index on
+  `(tag, date)` — the trigger enforces identity, the index only makes its lookup cheap.
+  Verified through the shipped file: schema loads clean, and a single-statement insert of
+  4 rows where 1 already exists returns `INSERT 0 3` with the other three committed.
+- `verify_zero_loss.py` now **hard-fails on duplicates** for `dc_records` instead of
+  reporting them as notes — re-delivery still happens, but nothing should survive the
+  trigger. `dc_files` stays a note and says why: its rows are Bridge-generated audit
+  records stamped at emit time, so `(tag, date)` is not their identity. Giving them their
+  own key is follow-up.
+- `destinations.md` gains a "Delivery is at-least-once: make the write idempotent"
+  section with the trigger, the measured danger of the UNIQUE alternative, and the two
+  honest caveats (one indexed lookup per row; `EXISTS`-then-`INSERT` assumes a single
+  writer, i.e. Vector's default `pool_size`).
+
+**The local reproduction did not duplicate, and that is worth recording.** Before writing
+any fix I tried to reproduce the CI numbers on one topic at 1 Hz with a Postgres
+Destination: steady state gave 97 rows / 97 distinct, and a 60s outage plus a mid-outage
+container restart plus a 120s drain gave **271 rows / 271 distinct, zero duplicates**. So
+duplicates are not a deterministic consequence of outage+restart, and the CI harness's 26
+per topic depend on something my single-topic workload does not exercise (20 topics, a
+30s steady-state window immediately before the outage, and far more in flight). Two
+consequences: steady state is genuinely clean, which was previously only an assumption;
+and the fix is verified by CI's own reproduction rather than a local one.
+
+**Deliberately not done**: Vector's `dedupe` transform. It would stop a re-delivery
+crossing the uplink rather than cleaning up after it, which is the better place to solve
+the bandwidth half. But it only helps if duplicates are born at the Bridge → Vector hop —
+a sink retry re-sends a batch that has *already* passed the transform, so it would not be
+caught. Which hop dominates is still unmeasured (the local repro produced nothing to
+measure), so adding it now would be speculative. Left in #309.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -78,7 +78,11 @@ not just a local tool.
    write (a `BEFORE INSERT` trigger keyed on `(tag, date)` — see `sql/init.sql`), so a
    duplicate row reaching the verifier means that dedup did not work. `dc_files` is the
    one exception and still reports duplicates as notes: its rows are timestamped at emit
-   time, so `(tag, date)` is not their identity. Nothing here is a skip-on-missing check — a table
+   time, so `(tag, date)` is not their identity. Because a re-delivery is not
+   deterministic (a quiet run may produce none), the verifier also **injects a known
+   duplicate** and asserts the trigger skips it — writing it in one statement alongside
+   two fresh rows, so a UNIQUE constraint (which would abort the whole batch) fails the
+   check with its own message rather than passing. Nothing here is a skip-on-missing check — a table
    that doesn't exist or a query that fails is a FAIL, not silence.
 7. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -73,9 +73,12 @@ not just a local tool.
    `podman exec` on the Postgres container (no host psycopg2/psql needed). The shipper is
    at-least-once (ADR-0002), so it **hard-fails on loss** — a gap in a synth topic's
    counter (checked against the *distinct* values, so a re-send can't hide a gap), or
-   zero Records for any of the 20 measurement Tags — while a boundary **duplicate** (a
-   record re-sent on recovery) is reported as a note and deduplicated on read
-   (exactly-once on read), not failed. Nothing here is a skip-on-missing check — a table
+   zero Records for any of the 20 measurement Tags. Since #309 it **also hard-fails on
+   duplicates**: re-delivery still happens, but the destination schema collapses it on
+   write (a `BEFORE INSERT` trigger keyed on `(tag, date)` — see `sql/init.sql`), so a
+   duplicate row reaching the verifier means that dedup did not work. `dc_files` is the
+   one exception and still reports duplicates as notes: its rows are timestamped at emit
+   time, so `(tag, date)` is not their identity. Nothing here is a skip-on-missing check — a table
    that doesn't exist or a query that fails is a FAIL, not silence.
 7. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.

--- a/tools/e2e/params/e2e_params.yaml
+++ b/tools/e2e/params/e2e_params.yaml
@@ -6,7 +6,11 @@ measurement_server:
 
     memory:
       plugin: "dc_measurements/Memory"
-      polling_interval: 1000
+      # 5 Hz, unlike every other Measurement here. Deliberate: it is the only topic that
+      # puts several Records inside the same wall-clock second, which is what makes the
+      # timestamp-resolution check in verify_zero_loss.py meaningful. At 1 Hz a
+      # regression to whole-second timestamps (#308) would not collide and would pass.
+      polling_interval: 200
       group_key: "memory"
 
     os:
@@ -172,7 +176,6 @@ dc_bridge:
       database: "dc"
       table: "dc_records"
       time_key: "date"
-      time_format: "double"
 
     pgsql_files:
       type: postgres
@@ -189,7 +192,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
 
     rustfs:
       type: s3

--- a/tools/e2e/params/e2e_retention_params.yaml
+++ b/tools/e2e/params/e2e_retention_params.yaml
@@ -50,7 +50,6 @@ dc_bridge:
       database: "dc"
       table: "dc_records"
       time_key: "date"
-      time_format: "double"
 
     pgsql_files:
       type: postgres
@@ -64,7 +63,6 @@ dc_bridge:
       database: "dc"
       table: "dc_files"
       time_key: "date"
-      time_format: "double"
 
     rustfs:
       type: s3

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -17,9 +17,13 @@ standard, cheap answer for an at-least-once pipeline is to dedupe on *read* — 
 exact re-sends on the natural key (a one-line DISTINCT) at query time. So:
 
   - LOSS is a hard failure: a value the pipeline accepted must come out (zero-loss).
-  - A boundary DUPLICATE is expected and reported as a note, not a failure. The checks
-    below assert the *deduplicated* data is exactly-once — every record present once
-    after collapsing exact re-sends — which is exactly-once-on-read.
+  - A DUPLICATE is now also a hard failure (#309). Re-delivery still happens — that is
+    inherent to at-least-once — but the destination schema collapses it on write: a
+    BEFORE INSERT trigger keyed on (tag, date) skips a row already present, so a
+    re-delivered Record overwrites nothing and adds nothing. `date` is exact to the
+    nanosecond (#308), so that key identifies a Record rather than a second. A duplicate
+    row surviving to here means the dedup did not work, which is what these assertions
+    are for. (dc_files is exempt — see check_files.)
 
 Checks:
 
@@ -98,11 +102,12 @@ def check_synth_topic(
             f"{name}: {expected - distinct} value(s) missing (expected {expected} distinct "
             f"values 0..{max_value}, got {distinct}) — data loss"
         )
-    # At-least-once boundary re-send (informational): collapsed by dedup-on-read.
+    # #309: the schema's dedup trigger should have collapsed any re-delivery on write.
     if total > distinct:
-        notes.append(
+        violations.append(
             f"{name}: {total - distinct} duplicate row(s) across {dup_values} value(s) "
-            "(at-least-once outage-boundary re-send; deduped on read)"
+            "survived the (tag, date) dedup trigger — re-delivered Records must not "
+            "accumulate"
         )
 
 
@@ -117,14 +122,14 @@ def check_real_tag(
     )
     details[tag] = {"total": total, "duplicate_dates": dup_count}
     # These Measurements carry no counter, so loss can't be checked by sequence; the
-    # presence + the synth topics' zero-loss result stand in. A duplicate timestamp is
-    # the expected at-least-once boundary re-send, deduped on read — a note, not a fail.
+    # presence + the synth topics' zero-loss result stand in. A repeated timestamp is a
+    # re-delivery the dedup trigger should have skipped on write (#309) — now a failure.
     if total == 0:
         violations.append(f"{tag}: zero Records landed in Postgres")
     if dup_count > 0:
-        notes.append(
-            f"{tag}: {dup_count} duplicate timestamp(s) "
-            "(at-least-once outage-boundary re-send; deduped on read)"
+        violations.append(
+            f"{tag}: {dup_count} repeated timestamp(s) survived the (tag, date) dedup "
+            "trigger — re-delivered Records must not accumulate"
         )
 
 
@@ -155,9 +160,13 @@ def check_files(pg_container: str, violations: list, notes: list, details: dict)
     if complete_count == 0:
         violations.append("files: zero group_complete markers for the camera group")
     if dup_uploaded > 0:
+        # Still a note, not a failure: dc_files carries no dedup trigger. Its rows are
+        # Bridge-generated audit records timestamped at emit time, so (tag, date) is not
+        # their identity the way it is for Measurement Records — a re-emitted status row
+        # gets a fresh timestamp. Giving dc_files its own key is follow-up work (#309).
         notes.append(
             f"files: {dup_uploaded} local_path(s) have more than one 'uploaded' status row "
-            "(at-least-once outage-boundary re-send; deduped on read)"
+            "(Uploader-level re-emit; dc_files has no dedup trigger yet)"
         )
 
 

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -161,6 +161,73 @@ def check_files(pg_container: str, violations: list, notes: list, details: dict)
         )
 
 
+# The Measurement configured above 1 Hz in params/e2e_params.yaml. It is the only topic
+# that puts several Records inside one wall-clock second, which is what gives the
+# resolution check below something to actually collide on.
+FAST_TAG = "dc.measurement.memory"
+
+
+def check_timestamp_resolution(
+    pg_container: str, tag: str, violations: list, notes: list, details: dict
+) -> None:
+    """Assert sub-second timestamps survive the pipeline (#308).
+
+    `date` is epoch_nanos, an exact integer of nanoseconds. If the Bridge went back to
+    sending whole seconds, every value would be an exact multiple of 1e9 and the Records
+    of a 5 Hz Measurement would collapse onto shared timestamps.
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        tag: Tag of the faster-than-1-Hz Measurement to check.
+        violations: hard failures, appended to in place.
+        notes: informational observations, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
+    total = scalar_int(pg_container, f"SELECT count(*) FROM dc_records WHERE tag='{tag}'")
+    distinct = scalar_int(
+        pg_container, f"SELECT count(DISTINCT date) FROM dc_records WHERE tag='{tag}'"
+    )
+    sub_second = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM dc_records WHERE tag='{tag}' AND date % 1000000000 <> 0",
+    )
+    # Seconds holding more than one Record — proves the Measurement really ran above
+    # 1 Hz, so "no two Records share a timestamp" is a real assertion, not a vacuous one.
+    shared_seconds = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM (SELECT date / 1000000000 AS sec FROM dc_records "
+        f"WHERE tag='{tag}' GROUP BY sec HAVING count(*) > 1) t",
+    )
+    details["timestamp_resolution"] = {
+        "tag": tag,
+        "total": total,
+        "distinct_timestamps": distinct,
+        "sub_second_timestamps": sub_second,
+        "seconds_holding_multiple_records": shared_seconds,
+    }
+
+    if total == 0:
+        violations.append(f"timestamps: zero Records for {tag} — cannot check resolution")
+        return
+    if sub_second == 0:
+        violations.append(
+            f"timestamps: every {tag} Record has a whole-second timestamp ({total} Records, "
+            "none with a nanosecond remainder) — sub-second resolution was lost on the "
+            "wire (#308)"
+        )
+    if shared_seconds == 0:
+        violations.append(
+            f"timestamps: no wall-clock second holds more than one {tag} Record, so this "
+            "check proves nothing — is that Measurement still polling above 1 Hz?"
+        )
+    elif distinct < total:
+        violations.append(
+            f"timestamps: {total - distinct} {tag} Record(s) share a timestamp with another "
+            f"({distinct} distinct out of {total}) — Records taken at different instants "
+            "must be distinguishable in time"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -182,6 +249,7 @@ def main() -> int:
     for tag in REAL_TAGS:
         check_real_tag(pg, tag, violations, notes, details)
     check_files(pg, violations, notes, details)
+    check_timestamp_resolution(pg, FAST_TAG, violations, notes, details)
 
     report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
     if args.report:

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -237,6 +237,72 @@ def check_timestamp_resolution(
         )
 
 
+# A Tag no other check looks at, so the probe rows below can't disturb them.
+DEDUP_PROBE_TAG = "dc.e2e.dedup_probe"
+
+
+def check_dedup_trigger(pg_container: str, violations: list, notes: list, details: dict) -> None:
+    """Prove the dedup trigger actually rejects a duplicate (#309).
+
+    The "no duplicate rows" assertions elsewhere only fail if the run happened to produce
+    a re-delivery, and re-delivery is not deterministic — a quiet run would pass them
+    without the trigger ever firing. This injects a known duplicate instead, so the
+    guarantee is exercised on every run whether or not the outage produced one.
+
+    Writes the duplicate and two fresh rows in a *single* statement, which is how Vector's
+    postgres sink writes a batch: that is what distinguishes a trigger (skips the one row)
+    from a UNIQUE constraint (fails the statement, and Vector drops the whole batch).
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        violations: hard failures, appended to in place.
+        notes: informational observations, appended to in place.
+        details: counters for the JSON report, populated in place.
+
+    Raises:
+        RuntimeError: a psql failure that isn't the expected constraint violation.
+    """
+    tag = DEDUP_PROBE_TAG
+    batch = (
+        f"INSERT INTO dc_records (date, tag) SELECT * FROM "
+        f"(VALUES (1, '{tag}'), (2, '{tag}'), (3, '{tag}')) AS v(date, tag)"
+    )
+    try:
+        psql(pg_container, f"DELETE FROM dc_records WHERE tag='{tag}'")
+        psql(pg_container, f"INSERT INTO dc_records (date, tag) VALUES (1, '{tag}')")
+        # One statement: the already-present row plus two new ones.
+        try:
+            psql(pg_container, batch)
+        except RuntimeError as exc:
+            if "unique constraint" in str(exc) or "duplicate key" in str(exc):
+                # The whole statement was rejected — with Vector this is a non-retriable
+                # error and the entire batch is dropped, so the two good rows would be
+                # lost along with the duplicate. Report it rather than crashing here.
+                violations.append(
+                    "dedup: the duplicate probe aborted the whole INSERT — a UNIQUE "
+                    "constraint is in play instead of the BEFORE INSERT trigger. Vector "
+                    "drops the entire batch on this error, so one re-delivered Record "
+                    "would take every Record batched with it (see tools/e2e/sql/init.sql)"
+                )
+                return
+            raise
+        total = scalar_int(pg_container, f"SELECT count(*) FROM dc_records WHERE tag='{tag}'")
+        distinct = scalar_int(
+            pg_container, f"SELECT count(DISTINCT date) FROM dc_records WHERE tag='{tag}'"
+        )
+    finally:
+        psql(pg_container, f"DELETE FROM dc_records WHERE tag='{tag}'")
+
+    details["dedup_trigger"] = {"rows_after_probe": total, "distinct_after_probe": distinct}
+
+    if total != 3 or distinct != 3:
+        violations.append(
+            f"dedup: expected 3 rows after re-inserting 1 of 3, got {total} row(s) / "
+            f"{distinct} distinct — the (tag, date) dedup trigger is missing or not "
+            "skipping duplicates (see tools/e2e/sql/init.sql)"
+        )
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -259,6 +325,7 @@ def main() -> int:
         check_real_tag(pg, tag, violations, notes, details)
     check_files(pg, violations, notes, details)
     check_timestamp_resolution(pg, FAST_TAG, violations, notes, details)
+    check_dedup_trigger(pg, violations, notes, details)
 
     report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
     if args.report:

--- a/tools/e2e/sql/init.sql
+++ b/tools/e2e/sql/init.sql
@@ -60,3 +60,37 @@ CREATE TABLE IF NOT EXISTS dc_files (
   complete boolean,
   updated_at double precision
 );
+
+-- Idempotent writes (#309). The Shipper is at-least-once (ADR-0002): after an outage or
+-- a restart, a Record that was in flight can be delivered a second time. It arrives
+-- byte-identical — the Forwarder re-sends the frame it serialised the first time — so
+-- (tag, date) identifies it exactly, now that `date` is nanosecond-precise (#308).
+--
+-- This is a trigger rather than a UNIQUE index on purpose. Vector's `postgres` sink has
+-- no conflict handling (its config accepts only endpoint/table/pool_size/batch/request/
+-- acknowledgements), and it writes a whole batch in one statement. A constraint violation
+-- therefore fails the entire statement, which Vector classes as non-retriable and drops:
+-- one re-delivered Record would take every Record batched with it down as well. Measured:
+-- a batch of 4 containing 1 duplicate lost all 4. A BEFORE INSERT trigger returning NULL
+-- skips just the offending row and lets the rest of the batch commit.
+--
+-- The index is deliberately NOT unique: the trigger is what enforces identity, the index
+-- only makes its lookup cheap.
+CREATE OR REPLACE FUNCTION dc_skip_duplicate() RETURNS trigger AS $$
+DECLARE
+  already_present boolean;
+BEGIN
+  EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I WHERE tag = $1 AND date = $2)', TG_TABLE_NAME)
+    INTO already_present USING NEW.tag, NEW.date;
+  IF already_present THEN
+    RETURN NULL;  -- skip this row; the statement (and the rest of the batch) continues
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE INDEX IF NOT EXISTS dc_records_identity ON dc_records (tag, date);
+
+DROP TRIGGER IF EXISTS dc_records_skip_duplicate ON dc_records;
+CREATE TRIGGER dc_records_skip_duplicate BEFORE INSERT ON dc_records
+  FOR EACH ROW EXECUTE FUNCTION dc_skip_duplicate();

--- a/tools/e2e/sql/init.sql
+++ b/tools/e2e/sql/init.sql
@@ -6,8 +6,13 @@
 -- lands here. `tag` (added to every event by Vector's fluent source) + `date` (the
 -- normalized event timestamp, per the destination's time_key/time_format) are the
 -- verification key tools/e2e/scripts/verify_zero_loss.py uses.
+--
+-- `date` is bigint, not double precision: the default time_format is epoch_nanos, an
+-- exact integer count of nanoseconds since the epoch (#308). A double would round it
+-- back off below roughly microsecond resolution, which is what made timestamps useless
+-- for telling two Records of a fast Measurement apart.
 CREATE TABLE IF NOT EXISTS dc_records (
-  date double precision,
+  date bigint,
   tag text,
   group_key text,
   -- memory
@@ -39,7 +44,7 @@ CREATE TABLE IF NOT EXISTS dc_records (
 -- column set proven against real dc_bridge behavior in
 -- dc_bridge/dc_bridge_core/tests/uploader_tests.rs and dc_bridge/tests/end_to_end.rs.
 CREATE TABLE IF NOT EXISTS dc_files (
-  date double precision,
+  date bigint,
   kind text,
   group_name text,
   robot_name text,

--- a/tools/infrastructure/docker/config/grafana/dashboards/robot.json
+++ b/tools/infrastructure/docker/config/grafana/dashboards/robot.json
@@ -62,7 +62,8 @@
           },
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(date) AS \"time\", (speed->>'computed')::double precision AS speed FROM dc WHERE name = 'robot' AND speed IS NOT NULL ORDER BY 1",
+          "rawSql":
+              "SELECT to_timestamp(date / 1e9) AS \"time\", (speed->>'computed')::double precision AS speed FROM dc WHERE name = 'robot' AND speed IS NOT NULL ORDER BY 1",
           "refId": "A"
         },
         {
@@ -72,7 +73,8 @@
           },
           "format": "time_series",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(date) AS \"time\", (cmd_vel->'linear'->>'x')::double precision AS cmd_vel_linear_x, (cmd_vel->'angular'->>'z')::double precision AS cmd_vel_angular_z FROM dc WHERE name = 'robot' AND cmd_vel IS NOT NULL ORDER BY 1",
+          "rawSql":
+              "SELECT to_timestamp(date / 1e9) AS \"time\", (cmd_vel->'linear'->>'x')::double precision AS cmd_vel_linear_x, (cmd_vel->'angular'->>'z')::double precision AS cmd_vel_angular_z FROM dc WHERE name = 'robot' AND cmd_vel IS NOT NULL ORDER BY 1",
           "refId": "B"
         }
       ],
@@ -106,7 +108,8 @@
           },
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, storage_type, remote_path, content_type, size, uploaded FROM dc_files WHERE kind = 'file_status' ORDER BY updated_at DESC LIMIT 100",
+          "rawSql":
+              "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, storage_type, remote_path, content_type, size, uploaded FROM dc_files WHERE kind = 'file_status' ORDER BY updated_at DESC LIMIT 100",
           "refId": "A"
         }
       ],
@@ -140,7 +143,8 @@
           },
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, file_count, complete FROM dc_files WHERE kind = 'group_complete' ORDER BY updated_at DESC LIMIT 20",
+          "rawSql":
+              "SELECT to_timestamp(updated_at) AS \"time\", group_name, robot_name, file_count, complete FROM dc_files WHERE kind = 'group_complete' ORDER BY updated_at DESC LIMIT 20",
           "refId": "A"
         }
       ],

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -25,7 +25,7 @@
 -- wire up a CPU panel.
 CREATE TABLE IF NOT EXISTS dc (
   -- Common (every Record)
-  date double precision,
+  date bigint,
   name text,
   robot_name text,
   id text,

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -86,3 +86,37 @@ CREATE TABLE IF NOT EXISTS dc_files (
   files jsonb,
   updated_at double precision
 );
+
+-- Idempotent writes (#309). The Shipper is at-least-once (ADR-0002): after an outage or
+-- a restart, a Record that was in flight can be delivered a second time. It arrives
+-- byte-identical — the Forwarder re-sends the frame it serialised the first time — so
+-- (tag, date) identifies it exactly, now that `date` is nanosecond-precise (#308).
+--
+-- This is a trigger rather than a UNIQUE index on purpose. Vector's `postgres` sink has
+-- no conflict handling (its config accepts only endpoint/table/pool_size/batch/request/
+-- acknowledgements), and it writes a whole batch in one statement. A constraint violation
+-- therefore fails the entire statement, which Vector classes as non-retriable and drops:
+-- one re-delivered Record would take every Record batched with it down as well. Measured:
+-- a batch of 4 containing 1 duplicate lost all 4. A BEFORE INSERT trigger returning NULL
+-- skips just the offending row and lets the rest of the batch commit.
+--
+-- The index is deliberately NOT unique: the trigger is what enforces identity, the index
+-- only makes its lookup cheap.
+CREATE OR REPLACE FUNCTION dc_skip_duplicate() RETURNS trigger AS $$
+DECLARE
+  already_present boolean;
+BEGIN
+  EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I WHERE tag = $1 AND date = $2)', TG_TABLE_NAME)
+    INTO already_present USING NEW.tag, NEW.date;
+  IF already_present THEN
+    RETURN NULL;  -- skip this row; the statement (and the rest of the batch) continues
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE INDEX IF NOT EXISTS dc_identity ON dc (tag, date);
+
+DROP TRIGGER IF EXISTS dc_skip_duplicate ON dc;
+CREATE TRIGGER dc_skip_duplicate BEFORE INSERT ON dc
+  FOR EACH ROW EXECUTE FUNCTION dc_skip_duplicate();


### PR DESCRIPTION
Closes #309

> **Stacked on #310.** This branches from `feature/308-record-timestamp-nanoseconds`, because `(tag, date)` only becomes an exact per-Record identity once timestamps carry nanoseconds. Review/merge #310 first.

The Shipper is at-least-once, so an outage or a restart can deliver a Record twice — roughly a fifth of a run in the E2E harness. Nothing collapsed them: `dc_records` had no identity and the sink plain-inserts, so extra rows accumulated forever and every query had to remember `DISTINCT`.

## Why not a UNIQUE constraint

It's the obvious answer and it loses data. Vector's `postgres` sink has no conflict handling — `on_conflict` is rejected as an unknown field, the config accepts only `endpoint`, `table`, `pool_size`, `batch`, `request`, `acknowledgements` — and it writes a whole batch in one statement. A violation fails the entire statement, which Vector classes as non-retriable and drops. Measured against a real Postgres:

```
ERROR  Non-retriable error; dropping the request.
       error=duplicate key value violates unique constraint "dc_records_key"
ERROR  component_events_dropped: Events dropped intentional=false count=4
```

One duplicate, four events dropped, three good Records lost. Strictly worse than the bug.

## What shipped

A `BEFORE INSERT` trigger returning `NULL`, which skips the offending row without failing the statement:

```sql
CREATE TRIGGER dc_records_skip_duplicate BEFORE INSERT ON dc_records
  FOR EACH ROW EXECUTE FUNCTION dc_skip_duplicate();
```

Verified through the shipped `init.sql` — a single-statement insert of four rows where one already exists returns `INSERT 0 3`, with the other three committed and no error.

The index on `(tag, date)` is deliberately **not** unique: the trigger enforces identity, the index only makes its lookup cheap. Both `tools/e2e/sql/init.sql` and the demos' `postgresql/init.sql` get it.

`verify_zero_loss.py` now **hard-fails** on duplicate Records instead of reporting them as notes. `dc_files` is exempt and says why: its rows are Bridge-generated audit records stamped at emit time, so `(tag, date)` isn't their identity.

## The local reproduction came back clean, and that matters

Before writing anything I tried to reproduce CI's numbers locally — one topic at 1 Hz into a Postgres Destination:

| | rows | distinct |
|---|---|---|
| steady state | 97 | 97 |
| after 60s outage + mid-outage container restart + 120s drain | 271 | 271 |

**Zero duplicates.** So duplication is not a deterministic consequence of outage-plus-restart, and CI's 26-per-topic depends on something a single-topic workload doesn't exercise — 20 topics, a 30s steady-state window immediately before the outage, far more in flight.

Two consequences worth stating plainly: steady state is genuinely clean (previously an assumption), and **this fix is verified by CI's reproduction rather than a local one.** If the CI run on this PR comes back with zero duplicate violations where the same harness previously reported 26 per topic, that is the verification.

## Deliberately not done

Vector's `dedupe` transform. It would stop a re-delivery crossing the uplink rather than cleaning up after it — the better place to solve the bandwidth half of this. But it only helps if duplicates are born at the Bridge → Vector hop; a sink retry re-sends a batch that has *already* passed the transform. Which hop dominates is still unmeasured (the local repro produced nothing to measure), so adding it now would be speculative. Left open on #309.

Also left open: `dc_files` needs its own key, the trigger costs one indexed lookup per row, and `EXISTS`-then-`INSERT` assumes a single writer (Vector's default `pool_size`). All three are documented in `destinations.md` rather than left for someone to discover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5JwZEZrxEtYJdQUfsZRVo
