### PR TITLE
fix(e2e): verify zero-loss against a ledger, not against max(value)+1

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -2904,3 +2904,50 @@ from `gh-pages`) is being retired.
 - `doc/src/dc/groups.md` gains the parameter row and a "Warnings and throttling" subsection
   with both rendered log lines (plain and `[+N more ...]`), the per-group-not-per-call-site
   guarantee, and the explicit note that Records are never throttled, only the log line.
+
+### #312 - the E2E zero-loss check could pass while Records were missing
+
+Found by running the full harness to test something else (#309's dedup), which is the
+only reason it surfaced at all.
+
+- **The defect**, in `jazzy` since the harness landed and gating every PR:
+  `verify_zero_loss.py` computed `expected = max(value) + 1` from the table it was
+  verifying. It cannot notice that the largest value received is smaller than the largest
+  value *sent*. Demonstrated: deliver a contiguous 0..84 having lost 85..96 and the old
+  check reports `expected = 85, distinct = 85` -> **PASS with 12 Records gone**. The tail
+  is exactly what is at risk, being what is in flight when the outage hits.
+- **Second defect, same file**: `workload_generator.py` reset every counter to 0 in
+  `__init__`, and the harness restarts that container mid-run by design. So the counter
+  repeated, which (a) let a republished low value fill the hole left by a lost one, and
+  (b) made every post-restart Record look like a duplicate. Measured before the fix:
+  `synth00` finished with 96 rows, 96 *distinct timestamps*, max value 64.
+- **That second point retracts #309.** The "~20% duplication" was this artifact — those
+  rows have distinct timestamps and are distinct Records, and the counts track the
+  post-restart window exactly (CI's 30s drain -> 26; a 40s drain -> 31). The real
+  Measurement Tags showed zero duplicates and zero gaps throughout. My earlier local repro
+  (271 rows / 271 distinct on `uptime.time`, which does not reset) was right, and I
+  discounted it because CI disagreed.
+- **Fix**: the generator appends every published `source,value` to a ledger on the
+  `dc_e2e_data` volume, resumes its counters from it instead of resetting, and writes a
+  `#boundary,<source>,<value>` marker where it was killed. The verifier diffs the ledger
+  against Postgres one-to-one. Ledger entries are written *after* publish returns, so it
+  can never claim a Record that was never handed to the middleware; the reverse leaves a
+  delivered Record unrecorded, which is reported rather than counted as loss.
+- **Kill-point tolerance, deliberately bounded.** The generator publishes from inside the
+  container the harness restarts, so the tick in flight when it dies is genuinely
+  unrecoverable — nothing persists it. Rather than excuse it vaguely, the marker makes the
+  kill points explicit and only `MAX_KILL_GAP` (3) Records adjacent to one may vanish;
+  anything else fails. The real run loses exactly 1 there (value 65) plus 2 at shutdown.
+
+**Verified with the full harness, run locally for the first time.** The port-5432 conflict
+that blocked earlier attempts was worked around without touching the host's database: an
+"anchor" container owns a private netns and the others join it with
+`--network container:`, so `127.0.0.1` works between them and nothing binds on the host.
+(Tried a podman pod first; it needs to build a pause image and `/` is at 0 bytes.) That
+patch was local-only and is not committed.
+
+- Healthy run: **PASSED, 0 violations**, with the three kill-point losses reported as
+  notes (65 at the restart, 95-96 at shutdown).
+- Interior Record deleted -> **FAIL**, naming the value.
+- Contiguous tail 85..96 deleted, no interior gap -> **old check PASSES, new check FAILS**.
+  That is the whole point of the issue, shown side by side.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -71,11 +71,20 @@ not just a local tool.
    queue would have forgotten it).
 6. **Verification** (`tools/e2e/scripts/verify_zero_loss.py`): queries Postgres via
    `podman exec` on the Postgres container (no host psycopg2/psql needed). The shipper is
-   at-least-once (ADR-0002), so it **hard-fails on loss** — a gap in a synth topic's
-   counter (checked against the *distinct* values, so a re-send can't hide a gap), or
-   zero Records for any of the 20 measurement Tags — while a boundary **duplicate** (a
-   record re-sent on recovery) is reported as a note and deduplicated on read
-   (exactly-once on read), not failed. Nothing here is a skip-on-missing check — a table
+   at-least-once (ADR-0002), so it **hard-fails on loss**. Loss is found by diffing what
+   arrived against `params/../workload_ledger.txt` — the generator's own record of every
+   value it published, written to the `dc_e2e_data` volume so it survives the restart.
+   That comparison is one-to-one against an independent source. It replaced
+   `expected = max(value) + 1`, which read its expectation out of the table it was
+   checking and so could not see a missing tail: deliver a clean 0..84 having lost 85..96
+   and `max` drops to 84, the bar drops with it, and the check passed with 12 Records gone
+   (#312). A **duplicate** is reported as a note and deduplicated on read.
+
+   Two gaps are tolerated rather than failed, both bounded by `MAX_KILL_GAP` and both
+   reported: the tick in flight when the harness restarts the DC container, and the last
+   Records at shutdown. The workload generator runs *inside* that container, so a message
+   it published as the process died was never handed to `measurement_server` and no buffer
+   could have held it. A gap anywhere other than a kill point is loss and fails. Nothing here is a skip-on-missing check — a table
    that doesn't exist or a query that fails is a FAIL, not silence.
 7. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -232,10 +232,19 @@ fi
 log "PASS: upload intent queue empty (0 orphaned intents)"
 
 # --- verify -------------------------------------------------------------------------
-log "verifying zero-loss (duplicates from the at-least-once boundary are deduped on read)"
+# The generator's ledger of what it published (#312) — the independent side of the
+# comparison. It lives on the dc_e2e_data volume so it survives the restart above; read it
+# back the same way the intent-queue check does, via a one-off container on that volume.
+log "extracting the workload ledger (what the generator published)"
+podman run --rm --entrypoint bash \
+  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
+  -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger.txt"
+
+log "verifying zero-loss against the published ledger"
 python3 "$SCRIPT_DIR/verify_zero_loss.py" \
   --postgres-container "$PG_C" \
   --num-synth-topics 14 \
+  --ledger-file "$RUN_DIR/workload_ledger.txt" \
   --report "$RUN_DIR/verification_report.json"
 
 log "PASS: zero-loss E2E harness"

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -23,9 +23,13 @@ exact re-sends on the natural key (a one-line DISTINCT) at query time. So:
 
 Checks:
 
-1. Per synth topic (tools/e2e/scripts/workload_generator.py's strictly-incrementing
-   `value` counter): the distinct values are exactly 0..max with no gap (loss) — a check
-   independent of timestamp precision. Repeated values are counted and reported as notes.
+1. Per synth topic: every value the generator recorded in its ledger
+   (tools/e2e/scripts/workload_generator.py, on the dc_e2e_data volume) is present in
+   Postgres. The ledger is written independently of the pipeline, so this compares what
+   was *sent* against what *arrived*, one to one. It replaces `expected = max(value) + 1`,
+   which read its expectation out of the very table it was checking and therefore could
+   not notice a missing tail: lose the last 40 of 100 and `max` drops to 59, the bar drops
+   with it, and the check passed (#312).
 2. Per real-measurement Tag (memory/os/storage/uptime/tcp_health/dummy): at least one
    Record landed; duplicate (tag, date) rows are reported as notes.
 3. File pipeline (ADR-0005): at least one verified file_status row and one
@@ -35,8 +39,16 @@ Checks:
 """
 import argparse
 import json
+import os
 import subprocess
 import sys
+
+# Records lost at a point where the harness kills the workload generator — the mid-run
+# container restart, and the stop that ends the run. The generator publishes from inside
+# that container, so a tick in flight when it dies was never handed to measurement_server
+# and no buffer could have held it. Bounded and reported, never a blanket excuse: a gap
+# anywhere other than a kill point is loss and fails.
+MAX_KILL_GAP = 3
 
 REAL_TAGS = [
     "dc.measurement.memory",
@@ -65,44 +77,127 @@ def scalar_int(pg_container: str, query: str) -> int:
     return int(out) if out else 0
 
 
+def read_ledger(path: str) -> dict:
+    """Load the generator's published-Record ledger as {source: set(values)}.
+
+    Args:
+        path: newline-delimited "source,value" file extracted from the dc_e2e_data volume.
+
+    Returns:
+        dict: per-source set of published counter values.
+
+    Raises:
+        RuntimeError: the ledger is missing or empty — the generator never wrote it, so
+            there is nothing to verify against and silence would look like success.
+    """
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        raise RuntimeError(
+            f"workload ledger missing or empty at {path} — without it there is no "
+            "independent record of what was published, so loss cannot be checked"
+        )
+    published: dict = {}
+    with open(path) as ledger:
+        for line in ledger:
+            source, _, value = line.strip().partition(",")
+            if source and value.isdigit():
+                published.setdefault(source, set()).add(int(value))
+    return published
+
+
+def read_boundaries(path: str) -> dict:
+    """Load the kill-point markers the generator wrote when it resumed after a restart.
+
+    Args:
+        path: the same ledger file read by read_ledger.
+
+    Returns:
+        dict: {source: set(resume values)} — a gap just below one of these is the
+            generator having been killed mid-tick, not the pipeline losing a Record.
+    """
+    boundaries: dict = {}
+    with open(path) as ledger:
+        for line in ledger:
+            if not line.startswith("#boundary,"):
+                continue
+            _, _, rest = line.strip().partition(",")
+            source, _, value = rest.partition(",")
+            if source and value.isdigit():
+                boundaries.setdefault(source, set()).add(int(value))
+    return boundaries
+
+
 def check_synth_topic(
-    pg_container: str, name: str, violations: list, notes: list, details: dict
+    pg_container: str,
+    name: str,
+    published: set,
+    boundaries: set,
+    violations: list,
+    notes: list,
+    details: dict,
 ) -> None:
+    """Compare what the generator published against what reached Postgres, one to one.
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        name: synth topic name.
+        published: values the generator recorded as published for this topic.
+        boundaries: counter values the generator resumed at after being killed.
+        violations: hard failures, appended to in place.
+        notes: informational observations, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
     total = scalar_int(pg_container, f"SELECT count(*) FROM dc_records WHERE source='{name}'")
-    distinct = scalar_int(
-        pg_container, f"SELECT count(DISTINCT value) FROM dc_records WHERE source='{name}'"
-    )
-    dup_values = scalar_int(
-        pg_container,
-        f"SELECT count(*) FROM (SELECT value FROM dc_records "
-        f"WHERE source='{name}' GROUP BY value HAVING count(*) > 1) t",
-    )
-    max_out = psql(pg_container, f"SELECT max(value) FROM dc_records WHERE source='{name}'")
-    max_value = int(max_out) if max_out else None
+    rows = psql(pg_container, f"SELECT DISTINCT value FROM dc_records WHERE source='{name}'")
+    arrived = {int(v) for v in rows.split() if v.strip().isdigit()}
+
+    missing = published - arrived
+    unexpected = arrived - published
+
+    # Every point at which the generator was killed: each restart it resumed from, plus
+    # the end of the run (the stop that ends the harness). Only the few Records
+    # immediately below such a point may go missing without it being pipeline loss.
+    kill_points = set(boundaries) | {max(published) + 1 if published else 0}
+    tolerated = {
+        value
+        for value in missing
+        if any(0 < point - value <= MAX_KILL_GAP for point in kill_points)
+    }
+    lost = missing - tolerated
 
     details[name] = {
-        "total": total,
-        "distinct": distinct,
-        "max_value": max_value,
-        "duplicate_values": dup_values,
+        "published": len(published),
+        "arrived": len(arrived),
+        "rows": total,
+        "lost": len(lost),
+        "tolerated_at_kill_points": len(tolerated),
+        "unexpected": len(unexpected),
     }
 
-    if max_value is None or total == 0:
-        violations.append(f"{name}: zero Records landed in Postgres")
+    if not published:
+        violations.append(f"{name}: the ledger recorded nothing published")
         return
-    # Zero-loss (hard): every value 0..max must be present after dedup. A gap here is a
-    # value the pipeline accepted but never delivered — real loss.
-    expected = max_value + 1
-    if distinct < expected:
+    if lost:
         violations.append(
-            f"{name}: {expected - distinct} value(s) missing (expected {expected} distinct "
-            f"values 0..{max_value}, got {distinct}) — data loss"
+            f"{name}: {len(lost)} published Record(s) never arrived, away from any kill "
+            f"point — first missing: {sorted(lost)[:10]} — data loss"
         )
-    # At-least-once boundary re-send (informational): collapsed by dedup-on-read.
-    if total > distinct:
+    if tolerated:
         notes.append(
-            f"{name}: {total - distinct} duplicate row(s) across {dup_values} value(s) "
-            "(at-least-once outage-boundary re-send; deduped on read)"
+            f"{name}: {len(tolerated)} Record(s) lost in flight where the generator was "
+            f"killed ({sorted(tolerated)}) — the workload runs inside the restarted "
+            "container, so nothing could persist them"
+        )
+    if unexpected:
+        notes.append(
+            f"{name}: {len(unexpected)} row(s) in Postgres with no ledger entry "
+            "(generator killed between publish and ledger write)"
+        )
+    # A value now identifies exactly one Record for the whole run, so a repeat is a
+    # genuine double delivery rather than the counter having restarted (#312).
+    if total > len(arrived):
+        notes.append(
+            f"{name}: {total - len(arrived)} duplicate row(s) "
+            "(at-least-once re-delivery; deduplicated on read)"
         )
 
 
@@ -169,6 +264,11 @@ def main() -> int:
         help="name of the running Postgres container to query via podman exec",
     )
     parser.add_argument("--num-synth-topics", type=int, default=14)
+    parser.add_argument(
+        "--ledger-file",
+        required=True,
+        help="workload ledger extracted from the dc_e2e_data volume (what was published)",
+    )
     parser.add_argument("--report", default=None, help="write a JSON report to this path")
     args = parser.parse_args()
 
@@ -177,8 +277,19 @@ def main() -> int:
     notes: list = []
     details: dict = {}
 
+    published = read_ledger(args.ledger_file)
+    boundaries = read_boundaries(args.ledger_file)
     for i in range(args.num_synth_topics):
-        check_synth_topic(pg, f"synth{i:02d}", violations, notes, details)
+        name = f"synth{i:02d}"
+        check_synth_topic(
+            pg,
+            name,
+            published.get(name, set()),
+            boundaries.get(name, set()),
+            violations,
+            notes,
+            details,
+        )
     for tag in REAL_TAGS:
         check_real_tag(pg, tag, violations, notes, details)
     check_files(pg, violations, notes, details)

--- a/tools/e2e/scripts/workload_generator.py
+++ b/tools/e2e/scripts/workload_generator.py
@@ -12,6 +12,7 @@ data loss) and "no duplicates" (a repeated value is a double-delivery) independe
 timestamp precision.
 """
 import json
+import os
 
 import rclpy
 from rclpy.duration import Duration
@@ -30,6 +31,19 @@ SYNTH_TOPIC_PREFIX = "/dc/e2e/synth/synth"
 CAMERA_TOPIC = "/dc/e2e/camera/image_raw"
 CAMERA_WIDTH = 64
 CAMERA_HEIGHT = 64
+
+# Ledger of every synth Record this generator has published, on the dc_e2e_data volume so
+# it survives the harness's mid-run container restart (#312). Two jobs:
+#
+#  1. It is the *independent* record of what should have arrived. Without it the verifier
+#     had to infer the expectation from the data it was checking (`expected = max(value) +
+#     1`), which cannot notice that the largest value received is smaller than the largest
+#     value sent — lose the tail and the bar lowers itself.
+#  2. Counters resume from it instead of resetting to 0 on restart, so a value identifies
+#     exactly one Record for the whole run. A counter that repeats is not an identity: a
+#     republished value can fill the hole left by a lost one, and it also made the old
+#     duplicate check report every post-restart Record as a double delivery.
+LEDGER_PATH = os.environ.get("DC_E2E_LEDGER", "/root/.dc/e2e/data/workload_ledger.txt")
 
 
 def _solid_bgr8_image(width: int, height: int, value: int) -> Image:
@@ -61,11 +75,47 @@ class WorkloadGenerator(Node):
             name: self.create_publisher(StringStamped, f"{SYNTH_TOPIC_PREFIX}{i:02d}", 10)
             for i, name in enumerate(self._names)
         }
-        self._counters = {name: 0 for name in self._names}
+        self._counters = self._resume_counters()
+        # Line-buffered append: one short line per Record at 20/s is nothing, and the
+        # entry must be on disk before the restart that this whole mechanism exists to
+        # survive. Opened for the process lifetime rather than per write.
+        os.makedirs(os.path.dirname(LEDGER_PATH), exist_ok=True)
+        self._ledger = open(LEDGER_PATH, "a", buffering=1)
         self._camera_pub = self.create_publisher(Image, CAMERA_TOPIC, 10)
         self._camera_tick = 0
         self._rate_hz = rate_hz
         self._camera_period_s = camera_period_s
+
+    def _resume_counters(self) -> dict:
+        """Continue each topic's counter from the ledger, so values never repeat.
+
+        A fresh run starts at 0. After the harness restarts this container mid-run, the
+        ledger is already on the volume and each counter picks up past its highest
+        recorded value.
+
+        Returns:
+            dict: per-topic next counter value.
+        """
+        counters = {name: 0 for name in self._names}
+        if not os.path.exists(LEDGER_PATH):
+            return counters
+        with open(LEDGER_PATH) as ledger:
+            for line in ledger:
+                source, _, value = line.strip().partition(",")
+                if source in counters and value.isdigit():
+                    counters[source] = max(counters[source], int(value) + 1)
+        resumed = {k: v for k, v in counters.items() if v}
+        if resumed:
+            # Mark where this process was killed. The generator runs *inside* the
+            # container the harness restarts, so the tick published as the kill landed
+            # was never picked up by measurement_server and nothing could have persisted
+            # it. That is a property of the test rig, not of the pipeline — the verifier
+            # tolerates a bounded gap adjacent to a marker and fails on any gap elsewhere.
+            with open(LEDGER_PATH, "a", buffering=1) as ledger:
+                for source, value in resumed.items():
+                    ledger.write(",".join(("#boundary", source, str(value))) + "\n")
+            self.get_logger().info(f"resumed workload counters from the ledger: {resumed}")
+        return counters
 
     def wait_for_pipeline(self, timeout_s: float = PIPELINE_READY_TIMEOUT_S) -> None:
         """Block until the DC pipeline has subscribed to every topic we publish.
@@ -106,8 +156,14 @@ class WorkloadGenerator(Node):
             msg = StringStamped()
             msg.header.stamp = now.to_msg()
             msg.group_key = name
-            msg.data = json.dumps({"value": self._counters[name], "source": name})
+            value = self._counters[name]
+            msg.data = json.dumps({"value": value, "source": name})
             pub.publish(msg)
+            # Recorded *after* publish returns, so the ledger can never claim a Record
+            # that was never handed to the middleware. The reverse (killed between the
+            # publish and this write) leaves a delivered Record absent from the ledger,
+            # which the verifier reports rather than treating as loss.
+            self._ledger.write(",".join((name, str(value))) + "\n")
             self._counters[name] += 1
 
     def _tick_camera(self) -> None:


### PR DESCRIPTION
Closes #312

Found while running the full harness to test something else — which is the only reason it surfaced.

## The defect

`verify_zero_loss.py` read its expectation out of the table it was verifying:

```python
max_out = psql(pg_container, f"SELECT max(value) FROM dc_records WHERE source='{name}'")
expected = max_value + 1
if distinct < expected:  # -> "data loss"
```

It cannot notice that the largest value *received* is smaller than the largest value *sent*. Demonstrated side by side, on the ledger from a real run:

```
delivered 0..84 contiguous; 85..96 lost (12 Records)

OLD check: expected = max(value)+1 = 85, distinct = 85  ->  PASS   <- 12 Records lost, unnoticed
NEW check: FAIL — 9 published Record(s) never arrived, away from any kill point
```

The tail is exactly what is at risk, being what is in flight when the outage hits. This is on `jazzy` and gates every PR.

## Second defect, same harness

`workload_generator.py:64` reset every counter to `0` in `__init__`, and the harness restarts that container mid-run *by design*. So a value stopped identifying a Record: a republished low value could fill the hole left by a lost one, and every post-restart Record looked like a duplicate. Measured before the fix — `synth00` finished with **96 rows, 96 distinct timestamps, max value 64**.

**This retracts the premise of #309.** The "~20% duplication" reported there was this artifact: those rows have distinct timestamps and are distinct Records, and the counts track the post-restart window exactly (CI's 30s drain → 26; a 40s drain → 31). The real Measurement Tags showed zero duplicates and zero gaps throughout. I'll close #309 and #311 separately.

## The fix

The generator appends every published `source,value` to a ledger on the `dc_e2e_data` volume, resumes its counters from it instead of resetting, and writes a `#boundary,<source>,<value>` marker where it was killed. The verifier diffs ledger against table, one to one.

Ledger entries are written *after* `publish()` returns, so the ledger can never claim a Record that was never handed to the middleware. The reverse — killed between publish and write — leaves a delivered Record unrecorded, which is reported as a note rather than counted as loss.

**Kill points are tolerated but bounded.** The generator publishes from inside the container the harness restarts, so the tick in flight when it dies was never handed to `measurement_server` and no buffer could have held it. Rather than excuse that vaguely, the markers make the kill points explicit and only `MAX_KILL_GAP` (3) Records adjacent to one may vanish. A gap anywhere else fails. A real run loses exactly one there, plus two at shutdown.

## Testing

Ran the **full harness locally**, which had not been possible before — a rootless-Docker Postgres holds port 5432 and the harness binds its stores on `--network host`. Worked around without touching your database: an anchor container owns a private netns and the others join it with `--network container:`, so `127.0.0.1` works between them and nothing binds on the host. (A podman pod was the first idea; it needs to build a pause image and `/` is at 0 bytes.) That patch was local-only and is not in this PR.

| scenario | result |
|---|---|
| healthy pipeline, outage + restart | **PASS**, 0 violations; 3 kill-point losses reported as notes |
| one interior Record deleted | **FAIL**, naming the value |
| contiguous tail 85..96 deleted, no interior gap | **FAIL** — where the old check **passes** |

flake8 matches the `origin/jazzy` baseline for both files exactly (C420×1, DAR101×1, E221×2, E231×4, E702×1, VNE001×2 — all pre-existing). Three E231s I did add were flake8 mis-tokenising commas inside f-strings; restructured with `join` rather than silenced with `noqa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5JwZEZrxEtYJdQUfsZRVo
