### PR TITLE
feat(doc): surface the docs preview artifact in the PR job summary

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -1,5 +1,5 @@
 # DC 2.0 (Jazzy) documentation build (#252). Builds the mdbook site and the strictdoc
-# requirements export as a CI gate; does not publish anywhere. GitHub Pages for this repo
+# requirements export as a CI gate; does not deploy anywhere. GitHub Pages for this repo
 # has been taken down (gh-pages branch deleted) and this job no longer deploys to it.
 #
 # Like ci.yaml, this runs the same script a developer runs locally
@@ -22,6 +22,15 @@
 # same-repo events — GitHub forces GITHUB_TOKEN to read-only on `pull_request` from a
 # fork regardless of what's requested here. That just means a fork PR pushes no cache and
 # builds cold, same as before this change; it does not fail the build.
+#
+# PR preview (#135): the built site is uploaded as a workflow artifact on every run,
+# including PRs — deliberately artifact-only rather than a hosted deploy, since this repo
+# has no preview host configured (#184 closed without one) and reaching one from a fork PR
+# would need `pull_request_target` plus a deploy token, i.e. secrets exposed to untrusted
+# PR code. `pull_request` (not `pull_request_target`) keeps this safe for fork PRs — the
+# default `GITHUB_TOKEN` is read-only there, which is all an artifact upload needs. The
+# job summary step below turns that artifact into a one-click link from the PR's Checks
+# tab instead of leaving reviewers to dig through the run's Artifacts section.
 
 name: Documentation
 
@@ -84,7 +93,23 @@ jobs:
         run: ./tools/ci/pre-commit/build_doc.sh
 
       - name: Upload the built site
+        id: upload-doc-site
         uses: actions/upload-artifact@v4
         with:
           name: doc-site
           path: doc/book/html
+
+      - name: Link the preview from the job summary
+        if: github.event_name == 'pull_request'
+        env:
+          ARTIFACT_URL: ${{ steps.upload-doc-site.outputs.artifact-url }}
+        run: |
+          {
+            echo "### 📖 Documentation preview"
+            echo
+            echo "[Download the built site](${ARTIFACT_URL}) (\`doc-site\`)."
+            echo
+            echo "This is a workflow artifact, not a hosted deploy — unzip it and open"
+            echo "\`index.html\`. Downloading requires a GitHub login with read access to"
+            echo "this repo, same as any other Actions artifact."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/progress.txt
+++ b/progress.txt
@@ -3213,3 +3213,35 @@ run --files .github/workflows/doc.yaml tools/ci/pre-commit/build_doc.sh` — `ch
 `shellcheck`, and the `build-doc` hook (a real `strictdoc export` + `mdbook build`) all
 pass; only the pre-existing `poetry-requirements` env failure reproduces (same as every
 prior entry above — not this diff).
+
+### #135 - Publish a documentation preview from PR builds
+
+`doc.yaml` (#252) already uploaded the built book as a workflow artifact
+(`actions/upload-artifact`, name `doc-site`) on every run including PRs — that step has no
+`if:` restricting it to push, so the "build the docs on PRs" half of #135 was already
+done before this issue was filed. What was actually missing was *discoverability*: the
+artifact only surfaced at the bottom of the run's Artifacts section, several clicks past
+where a reviewer lands from the PR's Checks tab.
+
+**Fix**: gave the upload step an `id`, and added a step (`if:
+github.event_name == 'pull_request'`) that reads its `artifact-url` output (available
+since upload-artifact v4, no waiting for run completion) into an env var and writes a
+Markdown link to `$GITHUB_STEP_SUMMARY` — the summary is exactly what "Details" on a PR
+check opens, so the download link is now one click away instead of buried.
+
+**Stayed artifact-only, deliberately**, matching the option the issue itself flagged as
+the one needing no tradeoff: this repo has no preview host configured (#184 closed
+without one), and a hosted preview reachable from fork PRs would need
+`pull_request_target` plus a deploy token — secrets handed to untrusted PR code. Kept
+`pull_request` (not `_target`); its default `GITHUB_TOKEN` is read-only, which is all an
+artifact upload needs, so fork PRs get the same preview as same-repo PRs with zero secret
+exposure. All three acceptance criteria are satisfied by the artifact-only path: reachable
+from Checks (job summary), works for fork PRs, no secrets.
+
+**Verified**: `pre-commit run --files .github/workflows/doc.yaml` — `check-yaml` and the
+`build-doc` hook (a real `strictdoc export` + `mdbook build`, unaffected by this change)
+both pass; only the pre-existing `poetry-requirements` env failure reproduces (progress.txt
+entries above; not this diff). Did not verify the summary rendering end-to-end against a
+live GitHub Actions run (would need a pushed branch + opened PR) — the `artifact-url`
+output and `$GITHUB_STEP_SUMMARY` mechanism are both documented, stable GitHub Actions
+features, not something this repo's tooling can dry-run locally.


### PR DESCRIPTION
## Summary

`doc.yaml` (#252) already uploaded the built mdbook site as a workflow artifact (`doc-site`) on every run, including PRs — nothing restricted that step to `push`. What #135 actually needed was discoverability: the artifact was buried in the run's Artifacts section, several clicks past where a reviewer lands from the PR's Checks tab.

- Give the `Upload the built site` step an `id` and, on `pull_request` runs, read its `artifact-url` output (available immediately post-upload since upload-artifact v4) into an env var and write a Markdown download link to `$GITHUB_STEP_SUMMARY` — the same page "Details" on a PR check opens.
- Stayed artifact-only rather than a hosted deploy: this repo has no preview host configured (#184 closed without one), and reaching fork PRs with a hosted preview would need `pull_request_target` plus a deploy token — secrets exposed to untrusted PR code. `pull_request` keeps this safe; its default `GITHUB_TOKEN` is read-only, which is all an artifact upload needs, so fork PRs get the same preview link as same-repo PRs.
- Updated the workflow's header comment to document the new behavior and the reasoning for staying artifact-only.

## Acceptance criteria (from #135)

- [x] Preview (artifact download at minimum) reachable from the PR checks — one-click link in the job summary
- [x] Works for fork PRs, or degrades gracefully with the limitation documented — `pull_request` trigger, no secrets, documented in the workflow header
- [x] No secrets exposed to untrusted PR code — no secrets used at all

## Test plan

- [x] `pre-commit run --files .github/workflows/doc.yaml` — `check-yaml` passes; the `build-doc` hook (real `strictdoc export` + `mdbook build`) passes unaffected
- [ ] Not verified end-to-end against a live Actions run (would need this PR's own CI to actually execute the new step) — `artifact-url` output and `$GITHUB_STEP_SUMMARY` are documented, stable GitHub Actions features

Closes #135

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01BxvjR5XyyaEPBBpwGfUK9W