### PR TITLE
feat(ci): cache the docs image build through ghcr.io

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -13,6 +13,15 @@
 # internal link, and book.toml sets `create-missing = false` so a SUMMARY.md entry
 # pointing at a missing page fails too. External links are not followed — see the comment
 # on `follow-web-links` in doc/book.toml.
+#
+# Build cache (#315): each run is a fresh runner, so podman's build cache is otherwise
+# local-only and never survives between runs — this image (Rust toolchain + five `cargo
+# install`s) was rebuilding from scratch every time. Mirrors ci.yaml's `build-workspace`
+# job: log into ghcr.io, compute a stable `dc-doc-cache` ref, and pass it to
+# build_doc.sh's `--cache-from`/`--cache-to`. `packages: write` only actually lands for
+# same-repo events — GitHub forces GITHUB_TOKEN to read-only on `pull_request` from a
+# fork regardless of what's requested here. That just means a fork PR pushes no cache and
+# builds cold, same as before this change; it does not fail the build.
 
 name: Documentation
 
@@ -39,6 +48,7 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,9 +63,24 @@ jobs:
       - name: Verify podman
         run: podman --version
 
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # ghcr image names must be lowercase and GitHub expressions have no lowercase
+      # function, so the ref is computed here rather than inline (same as ci.yaml).
+      - name: Compute the cache ref
+        id: refs
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          IMAGE="ghcr.io/$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
+          echo "cache_ref=$IMAGE/dc-doc-cache" >> "$GITHUB_OUTPUT"
+
       - name: Build the documentation
         env:
           IMAGE_TAG: dc-doc:${{ github.sha }}
+          CACHE_REF: ${{ steps.refs.outputs.cache_ref }}
         run: ./tools/ci/pre-commit/build_doc.sh
 
       - name: Upload the built site

--- a/progress.txt
+++ b/progress.txt
@@ -3170,3 +3170,46 @@ path). The `dc-doc` image was a full cache hit, so the script's two content step
 (`strictdoc export`, `mdbook build`) were run in it directly — both clean, linkcheck
 included, with only the two pre-existing `list[str]` warnings in unrelated measurement
 pages. The disk is a host problem, not a repo one, and worth clearing before the next run.
+
+### #315 - Wire registry-backed podman build cache into the docs image build
+
+Raised live: a user rebuilding the docs image twice in CI saw no cache hit on the second
+run. Root cause was `tools/ci/pre-commit/build_doc.sh` never wiring up a registry cache at
+all — unlike `tools/e2e/scripts/build.sh` (the E2E workspace image builder), which already
+accepts a `CACHE_REF` env var and passes `--cache-from`/`--cache-to` to `podman build`,
+populated by `ci.yaml`'s `build-workspace` job via a `ghcr.io/<repo>/dc-workspace-cache`
+ref. `doc.yaml` never logged into `ghcr.io` or computed a cache ref, so every run rebuilt
+the Rust toolchain + five `cargo install`s from scratch, first run or hundredth — every
+GitHub Actions run is a fresh VM, so podman's build cache is otherwise local-only and
+doesn't survive between runs.
+
+**Fix**: added the identical `CACHE_REF` mechanism to `build_doc.sh` (an array-built
+`podman build --layers ...`, conditionally appending `--cache-from`/`--cache-to` when
+`CACHE_REF` is set — mirrors `build.sh`'s pattern exactly), and wired `doc.yaml` to log
+into `ghcr.io`, compute a stable `dc-doc-cache` ref (mirroring `ci.yaml`'s
+`build-workspace` job's `cache_ref` computation, including the lowercasing dance since
+ghcr image names must be lowercase and GitHub Actions expressions have no lowercase
+function), and pass it through.
+
+**Scoped down, deliberately**: `ci.yaml`'s `build-e2e-image` job also runs a bare `podman
+build` (for `tools/e2e/Containerfile.e2e`) with no cache flags — left untouched. Its
+`FROM` is the just-built, SHA-tagged workspace image, which is a different ref on every
+run; a cache keyed on the prior layer's digest can never hit there regardless of what ref
+it's pointed at. The layer itself is also just 3 `COPY`s + a `chmod` — sub-second, nothing
+worth caching. Wiring the same mechanism onto it would be inert cargo-culting, not a fix.
+
+**Fork PRs**: `packages: write` was added to `doc.yaml`'s permissions, but GitHub forces
+`GITHUB_TOKEN` to read-only on `pull_request` events from a fork regardless of what a
+workflow requests — documented inline. A fork PR simply builds cold (same as before this
+change); it does not fail the build, since `--cache-to`'s push is a secondary effect of a
+`podman build` that has already produced the tagged image locally.
+
+**Verified locally**: `IMAGE_TAG=dc-doc:cachetest ./tools/ci/pre-commit/build_doc.sh` run
+twice back-to-back (no `CACHE_REF` — the local-build path is unchanged) — clean build both
+times, and the second run's log shows `--> Using cache <digest>` on every one of the 12
+`STEP`s, confirming `--layers` didn't regress local caching. Did not verify the ghcr.io
+round-trip itself (would need real repo credentials against a live Actions run). `pre-commit
+run --files .github/workflows/doc.yaml tools/ci/pre-commit/build_doc.sh` — `check-yaml`,
+`shellcheck`, and the `build-doc` hook (a real `strictdoc export` + `mdbook build`) all
+pass; only the pre-existing `poetry-requirements` env failure reproduces (same as every
+prior entry above — not this diff).

--- a/tools/ci/pre-commit/build_doc.sh
+++ b/tools/ci/pre-commit/build_doc.sh
@@ -16,14 +16,24 @@ set -euo pipefail
 # Environment:
 #   IMAGE_TAG   Tag for the builder image (default dc-doc:local; CI passes dc-doc:<sha>)
 #   ENGINE      Container engine (default podman)
+#   CACHE_REF   a registry ref (e.g. ghcr.io/<repo>/dc-doc-cache) to use as a podman
+#               --cache-from/--cache-to target. podman's build cache is otherwise
+#               local-only and doesn't survive a fresh machine/runner — CI sets this so a
+#               cold GitHub-hosted runner still gets warm layers for the rarely-changing
+#               rust toolchain + cargo-installed mdbook/strictdoc RUN steps. Omit for a
+#               plain local build with no registry round-trip (the default).
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 IMAGE_TAG="${IMAGE_TAG:-dc-doc:local}"
 ENGINE="${ENGINE:-podman}"
 
 echo "==> Building the docs toolchain image ${IMAGE_TAG}"
-"${ENGINE}" build -t "${IMAGE_TAG}" -f "${REPO_ROOT}/containers/doc/Containerfile" \
-    "${REPO_ROOT}/containers/doc"
+BUILD_ARGS=(build --layers -t "${IMAGE_TAG}" -f "${REPO_ROOT}/containers/doc/Containerfile")
+if [ -n "${CACHE_REF:-}" ]; then
+    BUILD_ARGS+=(--cache-from "${CACHE_REF}" --cache-to "${CACHE_REF}")
+fi
+BUILD_ARGS+=("${REPO_ROOT}/containers/doc")
+"${ENGINE}" "${BUILD_ARGS[@]}"
 
 run_in_image() {
     "${ENGINE}" run --rm \


### PR DESCRIPTION
## Summary

- `tools/ci/pre-commit/build_doc.sh` never wired up a registry build cache — unlike `tools/e2e/scripts/build.sh`, which already accepts `CACHE_REF` and passes `--cache-from`/`--cache-to` to `podman build`. Every GitHub Actions run is a fresh VM, so podman's local build cache never survives between runs; `doc.yaml`'s image (a Rust toolchain + five `cargo install`s) was rebuilding from scratch on every single run.
- Added the same `CACHE_REF` mechanism to `build_doc.sh`, mirroring `build.sh`'s pattern.
- Wired `doc.yaml` to log into `ghcr.io`, compute a stable `dc-doc-cache` ref, and pass it through — mirroring `ci.yaml`'s `build-workspace` job (including the lowercasing dance, since ghcr image names must be lowercase).
- `packages: write` was added to `doc.yaml`'s permissions, but note: GitHub forces `GITHUB_TOKEN` to read-only on `pull_request` from a fork regardless of what's requested — documented inline. A fork PR just builds cold, same as before this change; the build does not fail.

## Deliberately out of scope

`ci.yaml`'s `build-e2e-image` job also runs a bare `podman build` (`tools/e2e/Containerfile.e2e`) with no cache flags. Its `FROM` is the just-built, SHA-tagged workspace image — a different ref every run — so a cache keyed on the prior layer's digest can never hit there. The layer itself is also just 3 `COPY`s + a `chmod` (sub-second). Wiring the same mechanism onto it would be cargo-culting with no effect, so it's left as-is.

## Test plan

- [x] `IMAGE_TAG=dc-doc:cachetest ./tools/ci/pre-commit/build_doc.sh` run twice back-to-back locally (no `CACHE_REF`) — clean build both times, second run shows `Using cache <digest>` on all 12 `STEP`s, confirming `--layers` doesn't regress local caching
- [x] `pre-commit run --files .github/workflows/doc.yaml tools/ci/pre-commit/build_doc.sh` — `check-yaml`, `shellcheck`, and the `build-doc` hook (real `strictdoc export` + `mdbook build`) pass
- [ ] Not verified: the actual ghcr.io cache round-trip on a live Actions run (needs this PR's own CI to exercise the new steps)

Closes #315

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01BxvjR5XyyaEPBBpwGfUK9W