### PR TITLE
refactor(dc_measurements,dc_util): unify parameter declaration on dc_util helpers

### DIFF
--- a/dc_measurements/include/dc_measurements/plugins/conditions/bool_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/bool_equal.hpp
@@ -5,6 +5,7 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
 #include "nav2_util/node_utils.hpp"
 

--- a/dc_measurements/include/dc_measurements/plugins/conditions/double_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/double_equal.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/double_inferior.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/double_inferior.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/double_superior.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/double_superior.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/exist.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/exist.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/integer_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/integer_equal.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/integer_inferior.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/integer_inferior.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/integer_superior.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/integer_superior.hpp
@@ -5,8 +5,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/list_bool_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/list_bool_equal.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/list_double_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/list_double_equal.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/list_integer_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/list_integer_equal.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/list_string_equal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/list_string_equal.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/moving.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/moving.hpp
@@ -5,7 +5,7 @@
 
 #include "dc_core/condition.hpp"
 #include "dc_measurements/condition.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 
 namespace dc_conditions

--- a/dc_measurements/include/dc_measurements/plugins/conditions/same_as_previous.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/same_as_previous.hpp
@@ -9,8 +9,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/conditions/string_match.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/conditions/string_match.hpp
@@ -7,8 +7,8 @@
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/condition.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_conditions
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
@@ -15,6 +15,7 @@
 #include "dc_util/base64.hpp"
 #include "dc_util/image_utils.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/service_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/image.hpp"

--- a/dc_measurements/include/dc_measurements/plugins/measurements/cmd_vel.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/cmd_vel.hpp
@@ -5,8 +5,8 @@
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
 #include "dc_util/json_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "geometry_msgs/msg/twist.hpp"
-#include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp/serialization.hpp"
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/cpu.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/cpu.hpp
@@ -6,7 +6,7 @@
 #include "dc_measurements/measurement.hpp"
 #include "dc_measurements/system/linux_parser.hpp"
 #include "dc_measurements/system/system.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/diagnostics.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/diagnostics.hpp
@@ -6,9 +6,9 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "diagnostic_msgs/msg/diagnostic_array.hpp"
 #include "diagnostic_msgs/msg/diagnostic_status.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/distance_traveled.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/distance_traveled.hpp
@@ -3,6 +3,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "nav2_util/node_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
@@ -9,8 +9,8 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "geometry_msgs/msg/twist.hpp"
-#include "nav2_util/node_utils.hpp"
 #include "std_msgs/msg/string.hpp"
 
 namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/dummy.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/dummy.hpp
@@ -3,7 +3,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/ip_camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/ip_camera.hpp
@@ -10,8 +10,8 @@ extern "C" {
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 
 namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/map.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/map.hpp
@@ -10,8 +10,8 @@
 #include "dc_measurements/measurement.hpp"
 #include "dc_util/base64.hpp"
 #include "dc_util/filesystem_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/network.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/network.hpp
@@ -32,8 +32,8 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 #define MAXPACKETLEN 4096
 #define TIMEOUT 10

--- a/dc_measurements/include/dc_measurements/plugins/measurements/permissions.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/permissions.hpp
@@ -15,8 +15,8 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/position.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/position.hpp
@@ -4,7 +4,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "nav2_util/robot_utils.hpp"
 
 namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
@@ -7,7 +7,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/serial_interface.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/serial_interface.hpp
@@ -7,7 +7,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/speed.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/speed.hpp
@@ -4,7 +4,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 
 namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/storage.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/storage.hpp
@@ -6,8 +6,8 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
 #include "dc_util/string_utils.hpp"
-#include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/string_stamped.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/string_stamped.hpp
@@ -4,7 +4,7 @@
 #include "dc_core/measurement.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/tcp_health.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/tcp_health.hpp
@@ -6,7 +6,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
@@ -7,7 +7,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_measurements/measurement.hpp"
-#include "nav2_util/node_utils.hpp"
+#include "dc_util/node_utils.hpp"
 
 namespace dc_measurements
 {

--- a/dc_measurements/plugins/conditions/bool_equal.cpp
+++ b/dc_measurements/plugins/conditions/bool_equal.cpp
@@ -10,9 +10,13 @@ BoolEqual::BoolEqual() : dc_conditions::Condition()
 void BoolEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  // NOTE: `value_` is `double` (dc_measurements/plugins/conditions/bool_equal.hpp) despite the
+  // parameter being declared PARAMETER_BOOL -- a pre-existing type mismatch, left as its
+  // original direct nav2_util call rather than routed through dc_util::get_bool_type_param,
+  // which would change what type get_parameter() reads and so risk changing behavior. Not in
+  // scope for #178; worth its own follow-up.
   nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_BOOL);
-  node->get_parameter(condition_name_ + ".key", key_);
   node->get_parameter(condition_name_ + ".value", value_);
 }
 

--- a/dc_measurements/plugins/conditions/double_equal.cpp
+++ b/dc_measurements/plugins/conditions/double_equal.cpp
@@ -10,10 +10,8 @@ DoubleEqual::DoubleEqual() : dc_conditions::Condition()
 void DoubleEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_DOUBLE);
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_double_type_param(node, condition_name_, "value");
 }
 
 bool DoubleEqual::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/double_inferior.cpp
+++ b/dc_measurements/plugins/conditions/double_inferior.cpp
@@ -10,12 +10,9 @@ DoubleInferior::DoubleInferior() : dc_conditions::Condition()
 void DoubleInferior::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_DOUBLE);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".include_value", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".include_value", include_value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_double_type_param(node, condition_name_, "value");
+  include_value_ = dc_util::get_bool_type_param(node, condition_name_, "include_value", true);
 }
 
 bool DoubleInferior::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/double_superior.cpp
+++ b/dc_measurements/plugins/conditions/double_superior.cpp
@@ -10,12 +10,9 @@ DoubleSuperior::DoubleSuperior() : dc_conditions::Condition()
 void DoubleSuperior::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_DOUBLE);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".include_value", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".include_value", include_value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_double_type_param(node, condition_name_, "value");
+  include_value_ = dc_util::get_bool_type_param(node, condition_name_, "include_value", true);
 }
 
 bool DoubleSuperior::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/exist.cpp
+++ b/dc_measurements/plugins/conditions/exist.cpp
@@ -10,8 +10,7 @@ Exist::Exist() : dc_conditions::Condition()
 void Exist::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  node->get_parameter(condition_name_ + ".key", key_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
 }
 
 bool Exist::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/integer_equal.cpp
+++ b/dc_measurements/plugins/conditions/integer_equal.cpp
@@ -10,10 +10,8 @@ IntegerEqual::IntegerEqual() : dc_conditions::Condition()
 void IntegerEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_INTEGER);
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_int_type_param(node, condition_name_, "value");
 }
 
 bool IntegerEqual::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/integer_inferior.cpp
+++ b/dc_measurements/plugins/conditions/integer_inferior.cpp
@@ -10,12 +10,9 @@ IntegerInferior::IntegerInferior() : dc_conditions::Condition()
 void IntegerInferior::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_INTEGER);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".include_value", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".include_value", include_value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_int_type_param(node, condition_name_, "value");
+  include_value_ = dc_util::get_bool_type_param(node, condition_name_, "include_value", true);
 }
 
 bool IntegerInferior::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/integer_superior.cpp
+++ b/dc_measurements/plugins/conditions/integer_superior.cpp
@@ -10,12 +10,9 @@ IntegerSuperior::IntegerSuperior() : dc_conditions::Condition()
 void IntegerSuperior::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_INTEGER);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".include_value", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".include_value", include_value_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_int_type_param(node, condition_name_, "value");
+  include_value_ = dc_util::get_bool_type_param(node, condition_name_, "include_value", true);
 }
 
 bool IntegerSuperior::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/list_bool_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_bool_equal.cpp
@@ -10,12 +10,9 @@ ListBoolEqual::ListBoolEqual() : dc_conditions::Condition()
 void ListBoolEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_BOOL_ARRAY);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".order_matters", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".order_matters", order_matters_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_bool_array_type_param(node, condition_name_, "value");
+  order_matters_ = dc_util::get_bool_type_param(node, condition_name_, "order_matters", true);
 }
 
 bool ListBoolEqual::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/list_double_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_double_equal.cpp
@@ -10,12 +10,9 @@ ListDoubleEqual::ListDoubleEqual() : dc_conditions::Condition()
 void ListDoubleEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_DOUBLE_ARRAY);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".order_matters", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".order_matters", order_matters_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_double_array_type_param(node, condition_name_, "value");
+  order_matters_ = dc_util::get_bool_type_param(node, condition_name_, "order_matters", true);
 }
 
 bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/list_integer_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_integer_equal.cpp
@@ -10,12 +10,9 @@ ListIntegerEqual::ListIntegerEqual() : dc_conditions::Condition()
 void ListIntegerEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_INTEGER_ARRAY);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".order_matters", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".order_matters", order_matters_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_int_array_type_param(node, condition_name_, "value");
+  order_matters_ = dc_util::get_bool_type_param(node, condition_name_, "order_matters", true);
 }
 
 bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/conditions/list_string_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_string_equal.cpp
@@ -10,12 +10,9 @@ ListStringEqual::ListStringEqual() : dc_conditions::Condition()
 void ListStringEqual::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".value", rclcpp::PARAMETER_STRING_ARRAY);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".order_matters", rclcpp::ParameterValue(true));
-  node->get_parameter(condition_name_ + ".key", key_);
-  node->get_parameter(condition_name_ + ".value", value_);
-  node->get_parameter(condition_name_ + ".order_matters", order_matters_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  value_ = dc_util::get_str_array_type_param(node, condition_name_, "value");
+  order_matters_ = dc_util::get_bool_type_param(node, condition_name_, "order_matters", true);
 }
 
 bool ListStringEqual::compareFunction(const std::string& a, const std::string& b)

--- a/dc_measurements/plugins/conditions/moving.cpp
+++ b/dc_measurements/plugins/conditions/moving.cpp
@@ -11,14 +11,10 @@ void Moving::onConfigure()
 {
   auto node = getNode();
 
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".odom_topic", rclcpp::ParameterValue("/odom"));
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".speed_threshold", rclcpp::ParameterValue(0.2));
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".count_limit", rclcpp::ParameterValue(8));
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".count_hysteresis", rclcpp::ParameterValue(5));
-  node->get_parameter(condition_name_ + ".odom_topic", odom_topic_);
-  node->get_parameter(condition_name_ + ".speed_threshold", speed_threshold_);
-  node->get_parameter(condition_name_ + ".count_limit", count_limit_);
-  node->get_parameter(condition_name_ + ".count_hysteresis", count_hysteresis_);
+  odom_topic_ = dc_util::get_str_type_param(node, condition_name_, "odom_topic", "/odom");
+  speed_threshold_ = dc_util::get_double_type_param(node, condition_name_, "speed_threshold", 0.2);
+  count_limit_ = dc_util::get_int_type_param(node, condition_name_, "count_limit", 8);
+  count_hysteresis_ = dc_util::get_int_type_param(node, condition_name_, "count_hysteresis", 5);
 
   subscription_ = node->create_subscription<nav_msgs::msg::Odometry>(
       odom_topic_, 10, std::bind(&Moving::odomCb, this, std::placeholders::_1));

--- a/dc_measurements/plugins/conditions/same_as_previous.cpp
+++ b/dc_measurements/plugins/conditions/same_as_previous.cpp
@@ -10,10 +10,8 @@ SameAsPrevious::SameAsPrevious() : dc_conditions::Condition()
 void SameAsPrevious::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".keys", rclcpp::PARAMETER_STRING_ARRAY);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".exclude", rclcpp::PARAMETER_STRING_ARRAY);
-  node->get_parameter(condition_name_ + ".keys", keys_);
-  node->get_parameter(condition_name_ + ".exclude", exclude_);
+  keys_ = dc_util::get_str_array_type_param(node, condition_name_, "keys");
+  exclude_ = dc_util::get_str_array_type_param(node, condition_name_, "exclude");
 
   for (std::size_t i = 0; i < keys_.size(); ++i)
   {

--- a/dc_measurements/plugins/conditions/string_match.cpp
+++ b/dc_measurements/plugins/conditions/string_match.cpp
@@ -10,10 +10,8 @@ StringMatch::StringMatch() : dc_conditions::Condition()
 void StringMatch::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".key", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, condition_name_ + ".regex", rclcpp::PARAMETER_STRING);
-  node->get_parameter(condition_name_ + ".regex", regex_);
-  node->get_parameter(condition_name_ + ".key", key_);
+  key_ = dc_util::get_str_type_param(node, condition_name_, "key");
+  regex_ = dc_util::get_str_type_param(node, condition_name_, "regex");
 }
 
 bool StringMatch::getState(dc_interfaces::msg::StringStamped msg)

--- a/dc_measurements/plugins/measurements/camera.cpp
+++ b/dc_measurements/plugins/measurements/camera.cpp
@@ -12,51 +12,26 @@ Camera::~Camera() = default;
 void Camera::onConfigure()
 {
   auto node = getNode();
-  // Declare parameters
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".cam_name", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".cam_topic", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".draw_det_barcodes",
-                                               rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".rotation_angle", rclcpp::ParameterValue(0));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_raw_img", rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_rotated_img",
-                                               rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_detections_img",
-                                               rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_raw_path",
-                                               rclcpp::ParameterValue("camera/raw/%Y-%m-%dT%H:%M:%S"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_raw_base64",
-                                               rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_rotated_path",
-                                               rclcpp::ParameterValue("camera/rotated/%Y-%m-%dT%H:%M:%S"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_rotated_base64",
-                                               rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_inspected_path",
-                                               rclcpp::ParameterValue("camera/inspected/%Y-%m-%dT%H:%M:%S"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_inspected_base64",
-                                               rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".detection_modules",
-                                               rclcpp::ParameterValue(std::vector<std::string>()));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".destinations.minio.bucket",
-                                               rclcpp::ParameterValue(std::string("")));
-
-  // Get parameters
-  node->get_parameter(measurement_name_ + ".cam_name", cam_name_);
-  node->get_parameter(measurement_name_ + ".draw_det_barcodes", draw_det_barcodes_);
-  node->get_parameter(measurement_name_ + ".rotation_angle", rotation_angle_);
-  node->get_parameter(measurement_name_ + ".cam_topic", cam_topic_);
-  node->get_parameter(measurement_name_ + ".save_raw_img", save_raw_img_);
-  node->get_parameter(measurement_name_ + ".save_rotated_img", save_rotated_img_);
-  node->get_parameter(measurement_name_ + ".save_detections_img", save_detections_img_);
-  node->get_parameter(measurement_name_ + ".save_raw_path", save_raw_path_);
-  node->get_parameter(measurement_name_ + ".save_raw_base64", save_raw_base64_);
-  node->get_parameter(measurement_name_ + ".save_rotated_path", save_rotated_path_);
-  node->get_parameter(measurement_name_ + ".save_rotated_base64", save_rotated_base64_);
-  node->get_parameter(measurement_name_ + ".save_inspected_path", save_inspected_path_);
-  node->get_parameter(measurement_name_ + ".save_inspected_base64", save_inspected_base64_);
-  node->get_parameter(measurement_name_ + ".detection_modules", detection_modules_);
+  cam_name_ = dc_util::get_str_type_param(node, measurement_name_, "cam_name");
+  cam_topic_ = dc_util::get_str_type_param(node, measurement_name_, "cam_topic");
+  draw_det_barcodes_ = dc_util::get_bool_type_param(node, measurement_name_, "draw_det_barcodes", true);
+  rotation_angle_ = dc_util::get_int_type_param(node, measurement_name_, "rotation_angle", 0);
+  save_raw_img_ = dc_util::get_bool_type_param(node, measurement_name_, "save_raw_img", false);
+  save_rotated_img_ = dc_util::get_bool_type_param(node, measurement_name_, "save_rotated_img", false);
+  save_detections_img_ = dc_util::get_bool_type_param(node, measurement_name_, "save_detections_img", true);
+  save_raw_path_ =
+      dc_util::get_str_type_param(node, measurement_name_, "save_raw_path", "camera/raw/%Y-%m-%dT%H:%M:%S");
+  save_raw_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_raw_base64", false);
+  save_rotated_path_ =
+      dc_util::get_str_type_param(node, measurement_name_, "save_rotated_path", "camera/rotated/%Y-%m-%dT%H:%M:%S");
+  save_rotated_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_rotated_base64", false);
+  save_inspected_path_ =
+      dc_util::get_str_type_param(node, measurement_name_, "save_inspected_path", "camera/inspected/%Y-%m-%dT%H:%M:%S");
+  save_inspected_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_inspected_base64", false);
+  detection_modules_ =
+      dc_util::get_str_array_type_param(node, measurement_name_, "detection_modules", std::vector<std::string>());
   // FIXME Not used, wrong parameter too, should be without measurement_name_
-  node->get_parameter(measurement_name_ + ".destinations.minio.bucket", minio_bucket_);
+  minio_bucket_ = dc_util::get_str_type_param(node, measurement_name_, "destinations.minio.bucket", "");
 
   client_cb_group_ = node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
 

--- a/dc_measurements/plugins/measurements/cmd_vel.cpp
+++ b/dc_measurements/plugins/measurements/cmd_vel.cpp
@@ -26,9 +26,7 @@ void CmdVel::cmdVelCb(const geometry_msgs::msg::Twist& msg)
 void CmdVel::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".topic", rclcpp::ParameterValue("/cmd_vel"));
-
-  node->get_parameter(measurement_name_ + ".topic", cmd_vel_topic_);
+  cmd_vel_topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic", "/cmd_vel");
 
   subscription_ = node->create_subscription<geometry_msgs::msg::Twist>(
       cmd_vel_topic_, 10, std::bind(&CmdVel::cmdVelCb, this, std::placeholders::_1));

--- a/dc_measurements/plugins/measurements/cpu.cpp
+++ b/dc_measurements/plugins/measurements/cpu.cpp
@@ -13,10 +13,8 @@ Cpu::~Cpu() = default;
 void Cpu::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".max_processes", rclcpp::ParameterValue(5));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".cpu_min", rclcpp::ParameterValue(5.0));
-  node->get_parameter(measurement_name_ + ".max_processes", max_processes_);
-  node->get_parameter(measurement_name_ + ".cpu_min", cpu_min_);
+  max_processes_ = dc_util::get_int_type_param(node, measurement_name_, "max_processes", 5);
+  cpu_min_ = dc_util::get_double_type_param(node, measurement_name_, "cpu_min", 5.0);
 }
 
 void Cpu::setValidationSchema()

--- a/dc_measurements/plugins/measurements/diagnostics.cpp
+++ b/dc_measurements/plugins/measurements/diagnostics.cpp
@@ -37,16 +37,9 @@ uint8_t Diagnostics::levelThresholdFromString(const std::string& level_threshold
 void Diagnostics::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".topic",
-                                               rclcpp::ParameterValue("/diagnostics"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".level_threshold",
-                                               rclcpp::ParameterValue("OK"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".names",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-
-  node->get_parameter(measurement_name_ + ".topic", topic_);
-  node->get_parameter(measurement_name_ + ".level_threshold", level_threshold_str_);
-  node->get_parameter(measurement_name_ + ".names", names_);
+  topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic", "/diagnostics");
+  level_threshold_str_ = dc_util::get_str_type_param(node, measurement_name_, "level_threshold", "OK");
+  names_ = dc_util::get_str_array_type_param(node, measurement_name_, "names", std::vector<std::string>{});
 
   level_threshold_ = levelThresholdFromString(level_threshold_str_);
 

--- a/dc_measurements/plugins/measurements/distance_traveled.cpp
+++ b/dc_measurements/plugins/measurements/distance_traveled.cpp
@@ -12,13 +12,15 @@ DistanceTraveled::~DistanceTraveled() = default;
 void DistanceTraveled::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".global_frame", rclcpp::ParameterValue("map"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".robot_base_frame",
-                                               rclcpp::ParameterValue("base_link"));
+  global_frame_ = dc_util::get_str_type_param(node, measurement_name_, "global_frame", "map");
+  robot_base_frame_ = dc_util::get_str_type_param(node, measurement_name_, "robot_base_frame", "base_link");
+  // NOTE: pre-existing bug -- this declares "transform_tolerance" but reads back
+  // "transform_timeout" (an undeclared name); the documented/YAML-configured parameter is
+  // never actually applied to transform_timeout_. Left as its original direct nav2_util call
+  // rather than routed through dc_util, to avoid silently changing this behavior. Not in scope
+  // for #178; worth its own follow-up.
   nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".transform_tolerance",
                                                rclcpp::ParameterValue(static_cast<float>(0.1)));
-  node->get_parameter(measurement_name_ + ".global_frame", global_frame_);
-  node->get_parameter(measurement_name_ + ".robot_base_frame", robot_base_frame_);
   node->get_parameter(measurement_name_ + ".transform_timeout", transform_timeout_);
 }
 

--- a/dc_measurements/plugins/measurements/driving_type.cpp
+++ b/dc_measurements/plugins/measurements/driving_type.cpp
@@ -23,25 +23,16 @@ DrivingType::~DrivingType() = default;
 void DrivingType::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".mode_topic",
-                                               rclcpp::ParameterValue(std::string("")));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".value_mapping_from",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".value_mapping_to",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_topics",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_modes",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".velocity_timeout_s",
-                                               rclcpp::ParameterValue(1.0));
-
-  node->get_parameter(measurement_name_ + ".mode_topic", mode_topic_);
-  node->get_parameter(measurement_name_ + ".value_mapping_from", value_mapping_from_);
-  node->get_parameter(measurement_name_ + ".value_mapping_to", value_mapping_to_);
-  node->get_parameter(measurement_name_ + ".velocity_topics", velocity_topics_);
-  node->get_parameter(measurement_name_ + ".velocity_modes", velocity_modes_);
-  node->get_parameter(measurement_name_ + ".velocity_timeout_s", velocity_timeout_s_);
+  mode_topic_ = dc_util::get_str_type_param(node, measurement_name_, "mode_topic", "");
+  value_mapping_from_ =
+      dc_util::get_str_array_type_param(node, measurement_name_, "value_mapping_from", std::vector<std::string>{});
+  value_mapping_to_ =
+      dc_util::get_str_array_type_param(node, measurement_name_, "value_mapping_to", std::vector<std::string>{});
+  velocity_topics_ =
+      dc_util::get_str_array_type_param(node, measurement_name_, "velocity_topics", std::vector<std::string>{});
+  velocity_modes_ =
+      dc_util::get_str_array_type_param(node, measurement_name_, "velocity_modes", std::vector<std::string>{});
+  velocity_timeout_s_ = dc_util::get_double_type_param(node, measurement_name_, "velocity_timeout_s", 1.0);
 
   // No mode has been observed yet: emit "unknown" rather than suppressing the Record, so
   // downstream consumers can tell "not yet known" apart from "no data collected at all".

--- a/dc_measurements/plugins/measurements/dummy.cpp
+++ b/dc_measurements/plugins/measurements/dummy.cpp
@@ -20,10 +20,7 @@ void Dummy::setValidationSchema()
 void Dummy::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".record",
-                                               rclcpp::ParameterValue("{\"message\":\"Hello from ROS 2 DC\"}"));
-
-  node->get_parameter(measurement_name_ + ".record", record_);
+  record_ = dc_util::get_str_type_param(node, measurement_name_, "record", "{\"message\":\"Hello from ROS 2 DC\"}");
 }
 
 dc_interfaces::msg::StringStamped Dummy::collect()

--- a/dc_measurements/plugins/measurements/ip_camera.cpp
+++ b/dc_measurements/plugins/measurements/ip_camera.cpp
@@ -24,30 +24,16 @@ std::string IpCamera::getAbsolutePath(const std::string& param_reference)
 void IpCamera::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".input", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".video", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".audio", rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".bitrate_video", rclcpp::ParameterValue("2M"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".bitrate_audio",
-                                               rclcpp::ParameterValue("192k"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".segment", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".segment_time", rclcpp::ParameterValue(10));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".ffmpeg_log_level",
-                                               rclcpp::ParameterValue("info"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".ffmpeg_banner", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_path",
-                                               rclcpp::ParameterValue("ffmpeg_%Y-%m-%dT%H:%M:%S"));
-
-  node->get_parameter(measurement_name_ + ".input", input_);
-  node->get_parameter(measurement_name_ + ".video", video_);
-  node->get_parameter(measurement_name_ + ".audio", audio_);
-  node->get_parameter(measurement_name_ + ".bitrate_video", bitrate_video_);
-  node->get_parameter(measurement_name_ + ".bitrate_audio", bitrate_audio_);
-  node->get_parameter(measurement_name_ + ".segment", segment_);
-  node->get_parameter(measurement_name_ + ".segment_time", segment_time_);
-  node->get_parameter(measurement_name_ + ".ffmpeg_log_level", ffmpeg_log_level_);
-  node->get_parameter(measurement_name_ + ".ffmpeg_banner", ffmpeg_banner_);
-  node->get_parameter(measurement_name_ + ".save_path", save_path_);
+  input_ = dc_util::get_str_type_param(node, measurement_name_, "input");
+  video_ = dc_util::get_bool_type_param(node, measurement_name_, "video", true);
+  audio_ = dc_util::get_bool_type_param(node, measurement_name_, "audio", false);
+  bitrate_video_ = dc_util::get_str_type_param(node, measurement_name_, "bitrate_video", "2M");
+  bitrate_audio_ = dc_util::get_str_type_param(node, measurement_name_, "bitrate_audio", "192k");
+  segment_ = dc_util::get_bool_type_param(node, measurement_name_, "segment", true);
+  segment_time_ = dc_util::get_int_type_param(node, measurement_name_, "segment_time", 10);
+  ffmpeg_log_level_ = dc_util::get_str_type_param(node, measurement_name_, "ffmpeg_log_level", "info");
+  ffmpeg_banner_ = dc_util::get_bool_type_param(node, measurement_name_, "ffmpeg_banner", true);
+  save_path_ = dc_util::get_str_type_param(node, measurement_name_, "save_path", "ffmpeg_%Y-%m-%dT%H:%M:%S");
 
   // Validate parameters
   if (dc_util::stringMatchesRegex(save_path_, "^(?!%).+"))

--- a/dc_measurements/plugins/measurements/map.cpp
+++ b/dc_measurements/plugins/measurements/map.cpp
@@ -12,19 +12,11 @@ Map::~Map() = default;
 void Map::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".topic", rclcpp::ParameterValue("/map"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_path",
-                                               rclcpp::ParameterValue("map/%Y-%m-%dT%H:%M:%S"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_map_timeout",
-                                               rclcpp::ParameterValue(3.0));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".quiet", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".save_base64", rclcpp::ParameterValue(false));
-
-  node->get_parameter(measurement_name_ + ".topic", map_topic_);
-  node->get_parameter(measurement_name_ + ".save_path", save_path_);
-  node->get_parameter(measurement_name_ + ".save_map_timeout", save_map_timeout_);
-  node->get_parameter(measurement_name_ + ".quiet", quiet_);
-  node->get_parameter(measurement_name_ + ".save_base64", save_base64_);
+  map_topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic", "/map");
+  save_path_ = dc_util::get_str_type_param(node, measurement_name_, "save_path", "map/%Y-%m-%dT%H:%M:%S");
+  save_map_timeout_ = dc_util::get_double_type_param(node, measurement_name_, "save_map_timeout", 3.0);
+  quiet_ = dc_util::get_bool_type_param(node, measurement_name_, "quiet", true);
+  save_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_base64", false);
 }
 
 void Map::setValidationSchema()

--- a/dc_measurements/plugins/measurements/network.cpp
+++ b/dc_measurements/plugins/measurements/network.cpp
@@ -10,11 +10,8 @@ Network::Network() : dc_measurements::Measurement()
 void Network::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".ping_address",
-                                               rclcpp::ParameterValue("8.8.8.8"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".ping_timeout", rclcpp::ParameterValue(200));
-  node->get_parameter(measurement_name_ + ".ping_address", ping_address_);
-  node->get_parameter(measurement_name_ + ".ping_timeout", ping_timeout_ms_);
+  ping_address_ = dc_util::get_str_type_param(node, measurement_name_, "ping_address", "8.8.8.8");
+  ping_timeout_ms_ = dc_util::get_int_type_param(node, measurement_name_, "ping_timeout", 200);
 
   // Validate parameters
   // https://stackoverflow.com/questions/5284147/validating-ipv4-addresses-with-regexp

--- a/dc_measurements/plugins/measurements/permissions.cpp
+++ b/dc_measurements/plugins/measurements/permissions.cpp
@@ -12,10 +12,8 @@ Permissions::~Permissions() = default;
 void Permissions::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".path", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".format", rclcpp::ParameterValue("int"));
-  node->get_parameter(measurement_name_ + ".path", path_);
-  node->get_parameter(measurement_name_ + ".format", permission_format_);
+  path_ = dc_util::get_str_type_param(node, measurement_name_, "path");
+  permission_format_ = dc_util::get_str_type_param(node, measurement_name_, "format", "int");
 
   full_path_ = dc_util::expand_env(path_);
 

--- a/dc_measurements/plugins/measurements/position.cpp
+++ b/dc_measurements/plugins/measurements/position.cpp
@@ -12,14 +12,9 @@ Position::~Position() = default;
 void Position::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".global_frame", rclcpp::ParameterValue("map"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".robot_base_frame",
-                                               rclcpp::ParameterValue("base_link"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".transform_timeout",
-                                               rclcpp::ParameterValue(static_cast<float>(0.1)));
-  node->get_parameter(measurement_name_ + ".global_frame", global_frame_);
-  node->get_parameter(measurement_name_ + ".robot_base_frame", robot_base_frame_);
-  node->get_parameter(measurement_name_ + ".transform_timeout", transform_timeout_);
+  global_frame_ = dc_util::get_str_type_param(node, measurement_name_, "global_frame", "map");
+  robot_base_frame_ = dc_util::get_str_type_param(node, measurement_name_, "robot_base_frame", "base_link");
+  transform_timeout_ = dc_util::get_double_type_param(node, measurement_name_, "transform_timeout", 0.1);
 }
 
 void Position::setValidationSchema()

--- a/dc_measurements/plugins/measurements/random.cpp
+++ b/dc_measurements/plugins/measurements/random.cpp
@@ -20,16 +20,10 @@ void Random::setValidationSchema()
 void Random::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".type",
-                                               rclcpp::ParameterValue(std::string("integer")));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".min", rclcpp::ParameterValue(0.0));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".max", rclcpp::ParameterValue(100.0));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".seed", rclcpp::ParameterValue(-1));
-
-  node->get_parameter(measurement_name_ + ".type", value_type_);
-  node->get_parameter(measurement_name_ + ".min", min_);
-  node->get_parameter(measurement_name_ + ".max", max_);
-  node->get_parameter(measurement_name_ + ".seed", seed_);
+  value_type_ = dc_util::get_str_type_param(node, measurement_name_, "type", "integer");
+  min_ = dc_util::get_double_type_param(node, measurement_name_, "min", 0.0);
+  max_ = dc_util::get_double_type_param(node, measurement_name_, "max", 100.0);
+  seed_ = dc_util::get_int_type_param(node, measurement_name_, "seed", -1);
 
   if (value_type_ != "integer" && value_type_ != "double")
   {

--- a/dc_measurements/plugins/measurements/serial_interface.cpp
+++ b/dc_measurements/plugins/measurements/serial_interface.cpp
@@ -51,23 +51,13 @@ int SerialInterface::baudToSpeed(int baud_rate)
 void SerialInterface::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".port", rclcpp::ParameterValue(""));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".baud_rate", rclcpp::ParameterValue(9600));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".framing", rclcpp::ParameterValue("line"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".parsing_type",
-                                               rclcpp::ParameterValue("delimiter"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".delimiter", rclcpp::ParameterValue(","));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".regex", rclcpp::ParameterValue(""));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".fields",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-
-  node->get_parameter(measurement_name_ + ".port", port_);
-  node->get_parameter(measurement_name_ + ".baud_rate", baud_rate_);
-  node->get_parameter(measurement_name_ + ".framing", framing_);
-  node->get_parameter(measurement_name_ + ".parsing_type", parsing_type_);
-  node->get_parameter(measurement_name_ + ".delimiter", delimiter_);
-  node->get_parameter(measurement_name_ + ".regex", regex_pattern_);
-  node->get_parameter(measurement_name_ + ".fields", fields_);
+  port_ = dc_util::get_str_type_param(node, measurement_name_, "port", "");
+  baud_rate_ = dc_util::get_int_type_param(node, measurement_name_, "baud_rate", 9600);
+  framing_ = dc_util::get_str_type_param(node, measurement_name_, "framing", "line");
+  parsing_type_ = dc_util::get_str_type_param(node, measurement_name_, "parsing_type", "delimiter");
+  delimiter_ = dc_util::get_str_type_param(node, measurement_name_, "delimiter", ",");
+  regex_pattern_ = dc_util::get_str_type_param(node, measurement_name_, "regex", "");
+  fields_ = dc_util::get_str_array_type_param(node, measurement_name_, "fields", std::vector<std::string>{});
 
   if (framing_ != "line")
   {

--- a/dc_measurements/plugins/measurements/speed.cpp
+++ b/dc_measurements/plugins/measurements/speed.cpp
@@ -32,9 +32,7 @@ void Speed::odomCb(const nav_msgs::msg::Odometry& msg)
 void Speed::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".odom_topic", rclcpp::ParameterValue("/odom"));
-
-  node->get_parameter(measurement_name_ + ".odom_topic", odom_topic_);
+  odom_topic_ = dc_util::get_str_type_param(node, measurement_name_, "odom_topic", "/odom");
 
   subscription_ = node->create_subscription<nav_msgs::msg::Odometry>(
       odom_topic_, 10, std::bind(&Speed::odomCb, this, std::placeholders::_1));

--- a/dc_measurements/plugins/measurements/storage.cpp
+++ b/dc_measurements/plugins/measurements/storage.cpp
@@ -10,8 +10,7 @@ Storage::Storage() : dc_measurements::Measurement()
 void Storage::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".path", rclcpp::PARAMETER_STRING);
-  node->get_parameter(measurement_name_ + ".path", path_);
+  path_ = dc_util::get_str_type_param(node, measurement_name_, "path");
 
   full_path_ = dc_util::expand_env(path_);
 

--- a/dc_measurements/plugins/measurements/string_stamped.cpp
+++ b/dc_measurements/plugins/measurements/string_stamped.cpp
@@ -12,10 +12,8 @@ StringStamped::~StringStamped() = default;
 void StringStamped::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".topic", rclcpp::PARAMETER_STRING);
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".timer_based", rclcpp::ParameterValue(true));
-  node->get_parameter(measurement_name_ + ".topic", topic_);
-  node->get_parameter(measurement_name_ + ".timer_based", timer_based_);
+  topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic");
+  timer_based_ = dc_util::get_bool_type_param(node, measurement_name_, "timer_based", true);
 
   subscription_ = node->create_subscription<dc_interfaces::msg::StringStamped>(
       topic_, 10, std::bind(&StringStamped::dataCb, this, std::placeholders::_1));

--- a/dc_measurements/plugins/measurements/tcp_health.cpp
+++ b/dc_measurements/plugins/measurements/tcp_health.cpp
@@ -12,12 +12,9 @@ TCPHealth::~TCPHealth() = default;
 void TCPHealth::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".host", rclcpp::ParameterValue("127.0.0.1"));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".port", rclcpp::ParameterValue(80));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".name", rclcpp::PARAMETER_STRING);
-  node->get_parameter(measurement_name_ + ".host", host_);
-  node->get_parameter(measurement_name_ + ".port", port_);
-  node->get_parameter(measurement_name_ + ".name", name_);
+  host_ = dc_util::get_str_type_param(node, measurement_name_, "host", "127.0.0.1");
+  port_ = dc_util::get_int_type_param(node, measurement_name_, "port", 80);
+  name_ = dc_util::get_str_type_param(node, measurement_name_, "name");
 }
 
 void TCPHealth::setValidationSchema()

--- a/dc_measurements/plugins/measurements/thermal.cpp
+++ b/dc_measurements/plugins/measurements/thermal.cpp
@@ -44,12 +44,8 @@ Thermal::~Thermal() = default;
 void Thermal::onConfigure()
 {
   auto node = getNode();
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".base_path",
-                                               rclcpp::ParameterValue(std::string("/sys/class/thermal")));
-  nav2_util::declare_parameter_if_not_declared(node, measurement_name_ + ".zones",
-                                               rclcpp::ParameterValue(std::vector<std::string>{}));
-  node->get_parameter(measurement_name_ + ".base_path", base_path_);
-  node->get_parameter(measurement_name_ + ".zones", zones_);
+  base_path_ = dc_util::get_str_type_param(node, measurement_name_, "base_path", "/sys/class/thermal");
+  zones_ = dc_util::get_str_array_type_param(node, measurement_name_, "zones", std::vector<std::string>{});
 
   // Deliberately don't touch the filesystem (or throw) here: a missing/unreadable
   // /sys/class/thermal (e.g. a container without the host's thermal sysfs mounted, or a

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -11,18 +11,14 @@ MeasurementServer::MeasurementServer(const rclcpp::NodeOptions& options,
   , measurement_plugin_loader_("dc_core", "dc_core::Measurement")
   , condition_plugin_loader_("dc_core", "dc_core::Condition")
 {
-  declare_parameter("measurement_plugins", measurement_plugins);
-  get_parameter("measurement_plugins", measurement_ids_);
-  declare_parameter("condition_plugins", std::vector<std::string>());
-  get_parameter("condition_plugins", condition_ids_);
+  measurement_ids_ = dc_util::get_str_array_param(this, "measurement_plugins", measurement_plugins);
+  condition_ids_ = dc_util::get_str_array_param(this, "condition_plugins", std::vector<std::string>());
 }
 
 void MeasurementServer::setBaseSavePath()
 {
-  declare_parameter("save_local_base_path", "$HOME/ros2/data/%Y/%M/%D/%H");
-  get_parameter("save_local_base_path", save_local_base_path_);
-  declare_parameter("all_base_path", "");
-  get_parameter("all_base_path", all_base_path_);
+  save_local_base_path_ = dc_util::get_str_param(this, "save_local_base_path", "$HOME/ros2/data/%Y/%M/%D/%H");
+  all_base_path_ = dc_util::get_str_param(this, "all_base_path", "");
 
   save_local_base_path_expanded_ = dc_util::expand_env(save_local_base_path_);
   save_local_base_path_expanded_ = dc_util::expand_values(save_local_base_path_expanded_, this);
@@ -34,16 +30,15 @@ void MeasurementServer::setBaseSavePath()
 
 void MeasurementServer::setCustomParameters()
 {
-  nav2_util::declare_parameter_if_not_declared(this, "custom_str_params.force_override", rclcpp::ParameterValue(false));
-  nav2_util::declare_parameter_if_not_declared(this, "custom_str_params_list",
-                                               rclcpp::ParameterValue(std::vector<std::string>()));
-  custom_str_params_list_ = this->get_parameter("custom_str_params_list").as_string_array();
+  // Declared for override parity with the per-parameter custom_str_params.<name>.force_override
+  // below; not consumed here (each custom param's own force_override is what's actually read).
+  dc_util::get_bool_type_param(this, "custom_str_params", "force_override", false);
+  custom_str_params_list_ = dc_util::get_str_array_param(this, "custom_str_params_list", std::vector<std::string>());
 
   for (auto param = std::begin(measurement_custom_str_params_); param != std::end(measurement_custom_str_params_);
        ++param)
   {
-    declare_parameter(*param, "");
-    get_parameter(*param, custom_str_params_map_[*param]);
+    custom_str_params_map_[*param] = dc_util::get_str_param(this, *param, "");
   }
 
   custom_params_.resize(custom_str_params_list_.size());
@@ -51,19 +46,11 @@ void MeasurementServer::setCustomParameters()
   for (size_t i = 0; i < custom_str_params_list_.size(); i++)
   {
     auto custom_param = custom_str_params_list_[i];
-    nav2_util::declare_parameter_if_not_declared(this, "custom_str_params." + custom_param + ".name",
-                                                 rclcpp::ParameterValue(""));
-    nav2_util::declare_parameter_if_not_declared(this, "custom_str_params." + custom_param + ".value",
-                                                 rclcpp::ParameterValue(""));
-    nav2_util::declare_parameter_if_not_declared(this, "custom_str_params." + custom_param + ".value_from_file",
-                                                 rclcpp::ParameterValue(""));
-    nav2_util::declare_parameter_if_not_declared(this, "custom_str_params." + custom_param + ".force_override",
-                                                 rclcpp::ParameterValue(false));
-    std::string key = this->get_parameter("custom_str_params." + custom_param + ".name").as_string();
-    std::string value = this->get_parameter("custom_str_params." + custom_param + ".value").as_string();
-    std::string value_from_file =
-        this->get_parameter("custom_str_params." + custom_param + ".value_from_file").as_string();
-    bool force_override = this->get_parameter("custom_str_params." + custom_param + ".force_override").as_bool();
+    std::string custom_param_ns = "custom_str_params." + custom_param;
+    std::string key = dc_util::get_str_type_param(this, custom_param_ns, "name", "");
+    std::string value = dc_util::get_str_type_param(this, custom_param_ns, "value", "");
+    std::string value_from_file = dc_util::get_str_type_param(this, custom_param_ns, "value_from_file", "");
+    bool force_override = dc_util::get_bool_type_param(this, custom_param_ns, "force_override", false);
 
     custom_params_[i]["key"] = key;
     custom_params_[i]["override"] = force_override;
@@ -81,15 +68,11 @@ void MeasurementServer::setCustomParameters()
 void MeasurementServer::setRunId()
 {
   auto node = shared_from_this();
-  nav2_util::declare_parameter_if_not_declared(node, "run_id.enabled", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, "run_id.counter", rclcpp::ParameterValue(true));
-  nav2_util::declare_parameter_if_not_declared(node, "run_id.counter_path", rclcpp::ParameterValue("$HOME/run_id"));
-  nav2_util::declare_parameter_if_not_declared(node, "run_id.uuid", rclcpp::ParameterValue(false));
-
-  run_id_enabled_ = this->get_parameter("run_id.enabled").as_bool();
-  run_id_counter_ = this->get_parameter("run_id.counter").as_bool();
-  run_id_counter_path_ = dc_util::expand_env(this->get_parameter("run_id.counter_path").as_string());
-  run_id_uuid_ = this->get_parameter("run_id.uuid").as_bool();
+  run_id_enabled_ = dc_util::get_bool_type_param(node, "run_id", "enabled", true);
+  run_id_counter_ = dc_util::get_bool_type_param(node, "run_id", "counter", true);
+  run_id_counter_path_ =
+      dc_util::expand_env(dc_util::get_str_type_param(node, "run_id", "counter_path", "$HOME/run_id"));
+  run_id_uuid_ = dc_util::get_bool_type_param(node, "run_id", "uuid", false);
 
   if (run_id_enabled_)
   {

--- a/dc_util/include/dc_util/node_utils.hpp
+++ b/dc_util/include/dc_util/node_utils.hpp
@@ -3,7 +3,9 @@
 #define DC_UTIL__NODE_UTILS_HPP_
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
+#include <vector>
 
 #include "nav2_util/node_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
@@ -30,27 +32,76 @@ std::vector<T> flatten(std::vector<std::vector<T>> const& vec)
   return flattened;
 }
 
-template <typename NodeT>
-std::vector<std::string> get_str_array_type_param(NodeT node, const std::string& plugin_name,
-                                                  const std::string& param_name)
+namespace detail
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_STRING_ARRAY);
-  std::vector<std::string> str_arr_param;
+
+// Shared implementation behind every dc_util::get_*_type_param()/get_*_param() helper below:
+// declare `full_name` via nav2_util's idempotent declare-if-not-declared, then read it back,
+// logging and exiting fatally if the value can't be retrieved. This is the single place in
+// dc_util (and, by convention, in dc_measurements/dc_group) that talks to nav2_util directly —
+// see docs/adr/0008-dc-util-owns-parameter-declaration.md.
+template <typename T, typename NodeT>
+T get_param_or_fatal(NodeT node, const std::string& full_name)
+{
+  T value{};
   try
   {
-    if (!node->get_parameter(plugin_name + "." + param_name, str_arr_param))
+    if (!node->get_parameter(full_name, value))
     {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
+      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value", full_name.c_str());
       exit(-1);
     }
   }
   catch (rclcpp::exceptions::ParameterUninitializedException& ex)
   {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
+    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined", full_name.c_str());
     exit(-1);
   }
 
-  return str_arr_param;
+  return value;
+}
+
+template <typename T, typename NodeT>
+T declare_and_get(NodeT node, const std::string& full_name, const rclcpp::ParameterType& param_type)
+{
+  nav2_util::declare_parameter_if_not_declared(node, full_name, param_type);
+  return get_param_or_fatal<T>(node, full_name);
+}
+
+template <typename T, typename NodeT>
+T declare_and_get(NodeT node, const std::string& full_name, const T& default_value)
+{
+  nav2_util::declare_parameter_if_not_declared(node, full_name, rclcpp::ParameterValue(default_value));
+  return get_param_or_fatal<T>(node, full_name);
+}
+
+}  // namespace detail
+
+// ---------------------------------------------------------------------------------------------
+// Plugin-scoped helpers: declare and read "<plugin_name>.<param_name>". This is the sanctioned
+// way for a Measurement/Condition plugin to declare its own parameters — see
+// doc/src/dc/contributing.md "Declaring plugin parameters".
+// ---------------------------------------------------------------------------------------------
+
+template <typename NodeT>
+std::string get_str_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
+{
+  return detail::declare_and_get<std::string>(node, plugin_name + "." + param_name, rclcpp::PARAMETER_STRING);
+}
+
+template <typename NodeT>
+std::string get_str_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
+                               const std::string& default_value)
+{
+  return detail::declare_and_get<std::string>(node, plugin_name + "." + param_name, default_value);
+}
+
+template <typename NodeT>
+std::vector<std::string> get_str_array_type_param(NodeT node, const std::string& plugin_name,
+                                                  const std::string& param_name)
+{
+  return detail::declare_and_get<std::vector<std::string>>(node, plugin_name + "." + param_name,
+                                                           rclcpp::PARAMETER_STRING_ARRAY);
 }
 
 template <typename NodeT>
@@ -58,208 +109,88 @@ std::vector<std::string> get_str_array_type_param(NodeT node, const std::string&
                                                   const std::string& param_name,
                                                   const std::vector<std::string>& default_value)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
-                                               rclcpp::ParameterValue(default_value));
-  std::vector<std::string> str_arr_param;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, str_arr_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return str_arr_param;
-}
-
-template <typename NodeT>
-std::string get_str_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
-{
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_STRING);
-  std::string str_param;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, str_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return str_param;
-}
-
-template <typename NodeT>
-std::string get_str_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
-                               const std::string& default_value)
-{
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
-                                               rclcpp::ParameterValue(default_value));
-  std::string str_param;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, str_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return str_param;
+  return detail::declare_and_get<std::vector<std::string>>(node, plugin_name + "." + param_name, default_value);
 }
 
 template <typename NodeT>
 bool get_bool_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_BOOL);
-  bool bool_param = false;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, bool_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return bool_param;
+  return detail::declare_and_get<bool>(node, plugin_name + "." + param_name, rclcpp::PARAMETER_BOOL);
 }
 
 template <typename NodeT>
 bool get_bool_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
                          const bool& default_value)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
-                                               rclcpp::ParameterValue(default_value));
-  bool bool_param = false;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, bool_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
+  return detail::declare_and_get<bool>(node, plugin_name + "." + param_name, default_value);
+}
 
-  return bool_param;
+template <typename NodeT>
+std::vector<bool> get_bool_array_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
+{
+  return detail::declare_and_get<std::vector<bool>>(node, plugin_name + "." + param_name, rclcpp::PARAMETER_BOOL_ARRAY);
 }
 
 template <typename NodeT>
 int get_int_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_INTEGER);
-  int int_param = 0;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, int_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return int_param;
+  return detail::declare_and_get<int>(node, plugin_name + "." + param_name, rclcpp::PARAMETER_INTEGER);
 }
 
 template <typename NodeT>
 int get_int_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
                        const int& default_value)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
-                                               rclcpp::ParameterValue(default_value));
-  int int_param = 0;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, int_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return int_param;
+  return detail::declare_and_get<int>(node, plugin_name + "." + param_name, default_value);
 }
 
 template <typename NodeT>
-int get_float_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
+std::vector<int64_t> get_int_array_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name, rclcpp::PARAMETER_DOUBLE);
-  float float_param = 0.0F;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, float_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
-
-  return float_param;
+  return detail::declare_and_get<std::vector<int64_t>>(node, plugin_name + "." + param_name,
+                                                       rclcpp::PARAMETER_INTEGER_ARRAY);
 }
 
 template <typename NodeT>
-int get_float_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
-                         const float& default_value)
+double get_double_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name)
 {
-  nav2_util::declare_parameter_if_not_declared(node, plugin_name + "." + param_name,
-                                               rclcpp::ParameterValue(default_value));
-  float float_param = 0.0F;
-  try
-  {
-    if (!node->get_parameter(plugin_name + "." + param_name, float_param))
-    {
-      RCLCPP_FATAL(node->get_logger(), "Can not get '%s' param value for %s", param_name.c_str(), plugin_name.c_str());
-      exit(-1);
-    }
-  }
-  catch (rclcpp::exceptions::ParameterUninitializedException& ex)
-  {
-    RCLCPP_FATAL(node->get_logger(), "'%s' param not defined for %s", param_name.c_str(), plugin_name.c_str());
-    exit(-1);
-  }
+  return detail::declare_and_get<double>(node, plugin_name + "." + param_name, rclcpp::PARAMETER_DOUBLE);
+}
 
-  return float_param;
+template <typename NodeT>
+double get_double_type_param(NodeT node, const std::string& plugin_name, const std::string& param_name,
+                             const double& default_value)
+{
+  return detail::declare_and_get<double>(node, plugin_name + "." + param_name, default_value);
+}
+
+template <typename NodeT>
+std::vector<double> get_double_array_type_param(NodeT node, const std::string& plugin_name,
+                                                const std::string& param_name)
+{
+  return detail::declare_and_get<std::vector<double>>(node, plugin_name + "." + param_name,
+                                                      rclcpp::PARAMETER_DOUBLE_ARRAY);
+}
+
+// ---------------------------------------------------------------------------------------------
+// Node-level helpers: declare and read a top-level, unprefixed parameter name (e.g.
+// "measurement_plugins", not "<something>.measurement_plugins"). Distinct names from the
+// plugin-scoped helpers above, rather than overloads, since a 3-argument
+// (node, plugin_name, param_name) call and a 3-argument (node, param_name, default_value) call
+// are otherwise indistinguishable when both a plugin_name and a default happen to be strings.
+// ---------------------------------------------------------------------------------------------
+
+template <typename NodeT>
+std::string get_str_param(NodeT node, const std::string& param_name, const std::string& default_value)
+{
+  return detail::declare_and_get<std::string>(node, param_name, default_value);
+}
+
+template <typename NodeT>
+std::vector<std::string> get_str_array_param(NodeT node, const std::string& param_name,
+                                             const std::vector<std::string>& default_value)
+{
+  return detail::declare_and_get<std::vector<std::string>>(node, param_name, default_value);
 }
 
 }  // namespace dc_util

--- a/doc/src/dc/contributing.md
+++ b/doc/src/dc/contributing.md
@@ -71,5 +71,37 @@ And open [localhost:8000](http://localhost:8000)
 Now that you open see the documentation locally, open the doc folder of the repository and edit the Markdown files you need. More about mdbook can be found [here](https://rust-lang.github.io/mdBook/guide/installation.html)
 
 
+### Declaring plugin parameters
+
+Measurement and Condition plugins (`dc_measurements/plugins/{measurements,conditions}/`)
+declare their own parameters in `onConfigure()`. Always do this through
+`dc_util::get_*_type_param()` (`dc_util/include/dc_util/node_utils.hpp`) — never call
+`declare_parameter` or `nav2_util::declare_parameter_if_not_declared` directly. One call
+both declares and reads the value, and exits with a clear `RCLCPP_FATAL` if it can't be
+retrieved, instead of a hand-rolled declare/get/try-catch block per parameter:
+
+```cpp
+// Mandatory (no default; fatal if not overridden):
+cam_name_ = dc_util::get_str_type_param(node, measurement_name_, "cam_name");
+
+// Optional, with a default:
+polling_interval_ = dc_util::get_int_type_param(node, measurement_name_, "polling_interval", 1000);
+```
+
+`plugin_name`/`measurement_name_`/`condition_name_` is the namespace prefix — the helper
+declares and reads `"<plugin_name>.<param_name>"`. Available types: `str`, `str_array`,
+`bool`, `bool_array` (mandatory only), `int`, `int_array` (mandatory only), `double`,
+`double_array` (mandatory only). `measurement_server.cpp`/`group_server.py`-level
+parameters that have no plugin namespace use the equivalent `dc_util::get_str_param()` /
+`get_str_array_param()` (no `plugin_name` argument).
+
+This is a single-source-of-truth convention deliberately, not just a style preference: see
+[ADR-0008](https://github.com/Minipada/ros2_data_collection/blob/jazzy/docs/adr/0008-dc-util-owns-parameter-declaration.md)
+for why `nav2_util` stays a dependency and `dc_util` wraps it rather than replacing it.
+
+`dc_group` (Python) has no plugins and no equivalent wrapper — `group_server.py` declares
+each of its parameters exactly once via plain `self.declare_parameter(...)`, which is
+sufficient there (see the ADR).
+
 ### Tests
 TODO...

--- a/docs/adr/0008-dc-util-owns-parameter-declaration.md
+++ b/docs/adr/0008-dc-util-owns-parameter-declaration.md
@@ -1,0 +1,53 @@
+# `dc_util` owns parameter declaration; `nav2_util` stays a dependency
+
+Before this decision, parameter declaration in `dc_measurements`/`dc_group` was three
+patterns at once: most Measurement/Condition plugins called
+`nav2_util::declare_parameter_if_not_declared` directly, duplicating the same
+declare-then-`get_parameter`-then-fatal-on-failure boilerplate in each `onConfigure()`;
+`measurement_server.cpp` mixed that with a handful of raw `declare_parameter` calls for
+its own node-level parameters (which throw on redeclaration instead of being idempotent);
+and a `dc_util::get_*_type_param()` helper family existed but was only used in ~20 of the
+roughly 90 plugin-parameter call sites, wrapping `nav2_util::declare_parameter_if_not_declared`
+for the rest without most callers going through it.
+
+## Decision
+
+- **`nav2_util` stays a dependency.** `MeasurementServer` already inherits
+  `nav2_util::LifecycleNode` for the bond/lifecycle machinery `dc_lifecycle_manager`
+  orchestrates — dropping `nav2_util` isn't on the table regardless of how parameter
+  declaration is handled, so re-implementing `declare_parameter_if_not_declared`'s
+  idempotent-declare logic inside `dc_util` would only add a second implementation of
+  the same thing for no dependency-removal benefit.
+- **`dc_util::get_*_type_param()` / `get_*_param()` become the single sanctioned way to
+  declare a parameter in `dc_measurements`/`dc_group` C++ code.** Plugin authors call
+  these, never `declare_parameter` or `nav2_util::declare_parameter_if_not_declared`
+  directly (documented in `doc/src/dc/contributing.md`). Internally these helpers still
+  call `nav2_util::declare_parameter_if_not_declared` — `dc_util/include/dc_util/node_utils.hpp`
+  is now the *only* file in `dc_measurements`/`dc_group` allowed to reference `nav2_util`
+  for parameter declaration — so the dependency is kept, but callers no longer see it or
+  hand-roll its error handling.
+- The helper family was extended to cover every parameter type actually declared across
+  the plugins (`double`, and mandatory `vector<bool>`/`vector<int64_t>`/`vector<double>`
+  were missing) plus a node-level (unprefixed) variant for `MeasurementServer`'s own
+  parameters, so the raw `declare_parameter` calls in its constructor could move to the
+  same idempotent pattern as everything else.
+- **`dc_group` (Python/rclpy) keeps its existing plain `self.declare_parameter(...)`
+  calls.** There is no Python equivalent of `nav2_util::declare_parameter_if_not_declared`
+  in this codebase, and none is needed: every `GroupServer` parameter is declared exactly
+  once, in `init_parameters()`, never re-entered — the idempotent-declare problem the C++
+  helpers solve (multiple plugins/onConfigure() calls potentially racing to declare a
+  shared namespace) doesn't exist on the group-server side. Introducing a
+  declare-if-not-declared wrapper there would be solving a problem this file doesn't have.
+
+## Consequences
+
+- A new plugin parameter is one `dc_util::get_*_type_param()` call, not a
+  declare-if-not-declared pair plus a manual fatal-on-missing check.
+- Two pre-existing bugs surfaced while converting call sites — `bool_equal.cpp`'s `value_`
+  field is `double` despite the parameter being declared `PARAMETER_BOOL`, and
+  `distance_traveled.cpp` declares `transform_tolerance` but reads back the different,
+  undeclared name `transform_timeout` — were deliberately left as direct
+  `nav2_util::declare_parameter_if_not_declared`/`get_parameter` calls rather than folded
+  into the new helpers, so as not to silently change behavior while unifying the
+  declaration *pattern*. Both are noted inline and are follow-up work, not part of this
+  change.

--- a/progress.txt
+++ b/progress.txt
@@ -3245,3 +3245,87 @@ entries above; not this diff). Did not verify the summary rendering end-to-end a
 live GitHub Actions run (would need a pushed branch + opened PR) — the `artifact-url`
 output and `$GITHUB_STEP_SUMMARY` mechanism are both documented, stable GitHub Actions
 features, not something this repo's tooling can dry-run locally.
+
+### #178 - Unify parameter declaration across the measurement and group servers
+
+Before this change, parameter declaration in `dc_measurements`/`dc_group` was three
+patterns at once: ~34 Measurement/Condition plugin files called
+`nav2_util::declare_parameter_if_not_declared` directly in `onConfigure()`, hand-rolling
+the same declare-then-`get_parameter`-then-fatal-on-failure boilerplate every time;
+`measurement_server.cpp` mixed that with 5 raw `declare_parameter` calls for its own
+node-level parameters (which throw on redeclaration instead of being idempotent); and a
+`dc_util::get_*_type_param()` helper family existed but was only reached by ~20 of the
+roughly 90 plugin-parameter call sites.
+
+- **Decision recorded in `docs/adr/0008-dc-util-owns-parameter-declaration.md`**:
+  `nav2_util` stays a dependency (`MeasurementServer` already inherits
+  `nav2_util::LifecycleNode`, so dropping it isn't on the table regardless), and
+  `dc_util::get_*_type_param()`/`get_*_param()` becomes the single sanctioned way to
+  declare a parameter in `dc_measurements`/`dc_group` C++ code — plugin authors call
+  these, never `declare_parameter`/`nav2_util::declare_parameter_if_not_declared`
+  directly. `dc_util/include/dc_util/node_utils.hpp` is now the only file allowed to
+  reference `nav2_util` for parameter declaration.
+- **`dc_util/include/dc_util/node_utils.hpp` rewritten**: the 14 near-identical
+  declare/get/try-catch-fatal helper bodies collapsed into one shared
+  `detail::declare_and_get<T>()` core (same behavior, log messages simplified from
+  "...for %s"-with-plugin-name to a single full parameter name — not part of the public
+  parameter contract, so not a "no behaviour change" violation). Added the type coverage
+  the plugins actually needed but didn't have: `get_double_type_param`,
+  `get_bool_array_type_param`/`get_int_array_type_param`/`get_double_array_type_param`
+  (mandatory-only, matching their only call sites), plus node-level (unprefixed)
+  `get_str_param`/`get_str_array_param` for `measurement_server.cpp`'s own parameters.
+  These are separately-named functions rather than new overloads of the existing
+  `(node, plugin_name, param_name[, default])` helpers, since a 3-argument
+  `(node, plugin_name, param_name)` call and a 3-argument `(node, param_name, default)`
+  call are indistinguishable by signature when both a plugin_name and a default happen to
+  be strings. The broken, unused `get_float_type_param` (declared `PARAMETER_DOUBLE`,
+  returned `int`, zero call sites anywhere) was deleted rather than fixed in place.
+- **`measurement_server.cpp`**: all 5 raw `declare_parameter` calls (constructor's
+  `measurement_plugins`/`condition_plugins`, `setBaseSavePath`'s
+  `save_local_base_path`/`all_base_path`, the custom-string-param loop) and its 3 direct
+  `nav2_util::declare_parameter_if_not_declared` call sites (`custom_str_params.*`,
+  `run_id.*`) converted to `dc_util` helpers.
+- **All 34 Measurement/Condition plugin `.cpp` files** (`dc_measurements/plugins/{measurements,conditions}/`)
+  converted from direct `nav2_util::declare_parameter_if_not_declared` + `get_parameter`
+  pairs to the matching `dc_util::get_*_type_param()` call, including the mandatory
+  (no-default) forms and the previously-unsupported `double`/array-of-scalar types.
+  Corresponding header includes swapped from `nav2_util/node_utils.hpp` to
+  `dc_util/node_utils.hpp` (or the latter added, where a plugin's parameters came in
+  transitively) everywhere the file no longer calls `nav2_util` directly.
+- **Two pre-existing, unrelated bugs surfaced while cross-checking every declared-vs-read
+  parameter name and type across all 34 files, and were deliberately left untouched**
+  (each flagged inline with a `NOTE:` comment, not fixed, to honor "no behaviour change"):
+  - `bool_equal.cpp`'s `value_` field is `double`
+    (`dc_measurements/plugins/conditions/bool_equal.hpp`) despite the parameter being
+    declared `PARAMETER_BOOL` — a copy-paste leftover from `double_equal`, apparently
+    never exercised (no test, no demo config references `bool_equal`).
+  - `distance_traveled.cpp` declares `<measurement_name>.transform_tolerance` but reads
+    back the different, undeclared name `<measurement_name>.transform_timeout` — several
+    shipped demo YAMLs (`dc_demos/params/tb3_simulation_*.yaml`,
+    `qrcodes_minio_pgsql.yaml`) set `transform_timeout` under this exact measurement,
+    meaning the configured value has never actually reached `transform_timeout_`.
+    `position.cpp` has the analogous parameter and does not have this bug (declared and
+    read name match there).
+  Both remain direct `nav2_util::declare_parameter_if_not_declared`/`get_parameter` calls
+  with an explanatory comment; worth their own follow-up issues.
+- **`dc_group`/Python**: reviewed, not changed. `group_server.py` already declares every
+  parameter exactly once via plain `self.declare_parameter(...)` — the
+  declare-if-not-declared problem the C++ helpers solve (plugins/`onConfigure()` calls
+  potentially re-entering a shared namespace) doesn't exist there, so it's already a
+  single, internally-consistent pattern; recorded as such in the ADR rather than adding
+  an unneeded wrapper.
+- **`doc/src/dc/contributing.md`** gained a "Declaring plugin parameters" section: the
+  `dc_util` convention with a short code example, the available types, and a pointer to
+  ADR-0008 for the "why".
+- **Verified in the real ROS 2 Jazzy environment** (the `dc-workspace` Podman image built
+  in earlier #249-line sessions, this worktree bind-mounted fresh): `colcon build
+  --packages-select dc_util dc_core dc_measurements dc_interfaces dc_common dc_group` —
+  clean, 6/6 packages, zero errors/warnings. `colcon test --packages-select dc_util
+  dc_measurements dc_group` — 46 tests, 0 errors, 0 failures, 0 skipped (10 dc_measurements
+  gtest suites + 12 dc_group pytest cases), including `MeasurementOSTest`,
+  `MeasurementThermalTest`, `MeasurementUptimeTest`, and the full
+  `test_group_sync_timeout.py` suite exercising the exact parameters this change touched.
+- **Not done / left for follow-up**: the two bugs noted above; `dc_util` itself has no
+  dedicated unit test target (its helpers are exercised indirectly through every
+  dc_measurements plugin test instead — no new gap introduced by this change, but a
+  direct `dc_util` test target would be worth its own issue).


### PR DESCRIPTION
## Summary

- Unifies parameter declaration across `dc_measurements`/`dc_group` onto `dc_util::get_*_type_param()`/`get_*_param()`: all 34 Measurement/Condition plugin `.cpp` files and `measurement_server.cpp`'s own 5 raw `declare_parameter` + 3 direct `nav2_util::declare_parameter_if_not_declared` call sites now go through `dc_util`, instead of ~90 call sites split across three inconsistent patterns.
- `dc_util/include/dc_util/node_utils.hpp` rewritten: the 14 near-identical helper bodies collapse onto one shared `detail::declare_and_get<T>()` core, extended with the type coverage plugins actually needed (`double`, mandatory `vector<bool>`/`vector<int64_t>`/`vector<double>`) and a node-level (unprefixed) variant. The broken, unused `get_float_type_param` (declared `PARAMETER_DOUBLE`, returned `int`, zero call sites) was deleted.
- Decision recorded in `docs/adr/0008-dc-util-owns-parameter-declaration.md`: `nav2_util` stays a dependency (`MeasurementServer` already inherits `nav2_util::LifecycleNode`), `dc_util` becomes the single sanctioned wrapper around it, and `dc_group`'s existing plain Python `declare_parameter` calls are left as-is (no equivalent idempotency problem exists there).
- Convention documented for plugin authors in `doc/src/dc/contributing.md`.
- Two pre-existing, unrelated bugs surfaced while cross-checking every declared-vs-read parameter name/type and were deliberately left untouched (flagged inline, not fixed, per "no behaviour change"): `bool_equal.cpp`'s `value_` field is `double` despite a `PARAMETER_BOOL` declaration; `distance_traveled.cpp` declares `transform_tolerance` but reads back the different, undeclared `transform_timeout`.

Closes #178

## Test plan

- [x] `colcon build --packages-select dc_util dc_core dc_measurements dc_interfaces dc_common dc_group` — clean, 6/6 packages, zero errors/warnings (real ROS 2 Jazzy Podman environment)
- [x] `colcon test --packages-select dc_util dc_measurements dc_group` — 46 tests, 0 errors, 0 failures, 0 skipped
- [x] `pre-commit run` on all changed files — clean (clang-format, black, codespell, XML/package metadata checks); only the pre-existing, environment-only `poetry-requirements` failure reproduces, unrelated to this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L56mFyxLcigqQxzZ7BzNgs