### PR TITLE
test(dc_lifecycle_manager): gtest coverage for startup ordering, bond timeout and respawn

### DIFF
--- a/dc_lifecycle_manager/CMakeLists.txt
+++ b/dc_lifecycle_manager/CMakeLists.txt
@@ -68,6 +68,31 @@ install(TARGETS
 
 install(DIRECTORY include/ DESTINATION include/)
 
+set(tests
+  test_lifecycle_manager_startup
+  test_lifecycle_manager_bond
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  foreach(test ${tests})
+    # Bond timeouts and the respawn retry window are wall-clock waits; the default
+    # 60 s gtest timeout is not enough for them.
+    ament_add_gtest(${PROJECT_NAME}_${test} test/${test}.cpp TIMEOUT 300)
+    target_include_directories(${PROJECT_NAME}_${test} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/test>
+      $<INSTALL_INTERFACE:include>
+    )
+    ament_target_dependencies(${PROJECT_NAME}_${test}
+      ${dependencies}
+    )
+    target_link_libraries(${PROJECT_NAME}_${test}
+      ${library_name}
+    )
+  endforeach()
+endif()
+
 ament_export_include_directories(include)
 ament_export_libraries(${library_name})
 ament_export_dependencies(${dependencies})

--- a/dc_lifecycle_manager/test/managed_node_harness.hpp
+++ b/dc_lifecycle_manager/test/managed_node_harness.hpp
@@ -1,0 +1,230 @@
+// Shared harness for the dc_lifecycle_manager gtest suites.
+//
+// Everything here runs in-process: the manager under test, the lifecycle nodes it
+// manages, and the recorder both write to. Per ADR-0006 the Bridge is deliberately
+// outside the lifecycle manager, so these doubles stand in for the C++ collection
+// nodes `lifecycle_manager_dc` actually manages — nothing here models the Bridge.
+#ifndef MANAGED_NODE_HARNESS_HPP_
+#define MANAGED_NODE_HARNESS_HPP_
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "dc_lifecycle_manager/lifecycle_manager.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "nav2_util/node_thread.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace dc_lifecycle_manager_test
+{
+
+/**
+ * @brief Ordered log of every lifecycle transition every managed node went through.
+ *
+ * Entries are "<node name>:<transition>". The manager transitions nodes one at a time
+ * with blocking service calls, so the recorded order is the order the manager drove
+ * them in, and can be compared against exactly.
+ */
+class TransitionRecorder
+{
+public:
+  void record(const std::string& entry)
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    entries_.push_back(entry);
+  }
+
+  std::vector<std::string> entries() const
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return entries_;
+  }
+
+  /**
+   * @brief Block until the recorded entries satisfy `predicate`, or `timeout` elapses.
+   * @return Whether the predicate held.
+   */
+  bool waitFor(const std::function<bool(const std::vector<std::string>&)>& predicate,
+               std::chrono::milliseconds timeout) const
+  {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      if (predicate(entries()))
+      {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    return predicate(entries());
+  }
+
+  /**
+   * @brief Block until at least `count` transitions have been recorded.
+   */
+  bool waitForCount(std::size_t count, std::chrono::milliseconds timeout) const
+  {
+    return waitFor([count](const std::vector<std::string>& entries) { return entries.size() >= count; }, timeout);
+  }
+
+private:
+  mutable std::mutex mutex_;
+  std::vector<std::string> entries_;
+};
+
+/**
+ * @brief A lifecycle node standing in for one of the nodes the manager brings up.
+ *
+ * Records each transition it is driven through, and — when bonds are in play — keeps a
+ * bond with the manager exactly like the real collection nodes do (created on activate,
+ * destroyed on deactivate). Spinning is under the test's control so a test can simulate
+ * a node that stops answering heartbeats without killing the process it lives in.
+ */
+class DummyManagedNode : public nav2_util::LifecycleNode
+{
+public:
+  DummyManagedNode(const std::string& name, std::shared_ptr<TransitionRecorder> recorder, bool use_bond)
+    : nav2_util::LifecycleNode(name), recorder_(std::move(recorder)), use_bond_(use_bond)
+  {
+  }
+
+  ~DummyManagedNode() override
+  {
+    stopSpinning();
+  }
+
+  /// Start processing callbacks (heartbeats, lifecycle service calls) in a background thread.
+  void startSpinning()
+  {
+    if (!spin_thread_)
+    {
+      spin_thread_ = std::make_unique<nav2_util::NodeThread>(get_node_base_interface());
+    }
+  }
+
+  /// Stop processing callbacks: the node stays discoverable but answers nothing.
+  void stopSpinning()
+  {
+    spin_thread_.reset();
+  }
+
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State& /*state*/) override
+  {
+    recorder_->record(std::string(get_name()) + ":configure");
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State& /*state*/) override
+  {
+    if (use_bond_)
+    {
+      createBond();
+    }
+    recorder_->record(std::string(get_name()) + ":activate");
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& /*state*/) override
+  {
+    if (use_bond_)
+    {
+      destroyBond();
+    }
+    recorder_->record(std::string(get_name()) + ":deactivate");
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State& /*state*/) override
+  {
+    recorder_->record(std::string(get_name()) + ":cleanup");
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+  nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State& /*state*/) override
+  {
+    recorder_->record(std::string(get_name()) + ":shutdown");
+    return nav2_util::CallbackReturn::SUCCESS;
+  }
+
+private:
+  std::shared_ptr<TransitionRecorder> recorder_;
+  bool use_bond_;
+  std::unique_ptr<nav2_util::NodeThread> spin_thread_;
+};
+
+/**
+ * @brief The manager under test, with the internals a test needs to drive or observe.
+ *
+ * Only the bond-respawn give-up path uses the exposed internals; every other test drives
+ * the manager through its `manage_nodes` / `is_active` services like a real caller does.
+ */
+class TestableLifecycleManager : public dc_lifecycle_manager::LifecycleManager
+{
+public:
+  explicit TestableLifecycleManager(const rclcpp::NodeOptions& options) : LifecycleManager(options)
+  {
+  }
+
+  using LifecycleManager::checkBondRespawnConnection;
+  using LifecycleManager::createLifecycleServiceClients;
+
+  rclcpp::Time bondRespawnStartTime() const
+  {
+    return bond_respawn_start_time_;
+  }
+
+  void setBondRespawnMaxDuration(double seconds)
+  {
+    bond_respawn_max_duration_ = rclcpp::Duration::from_seconds(seconds);
+  }
+};
+
+/**
+ * @brief Build the NodeOptions a `LifecycleManager` reads its configuration from.
+ *
+ * `manager_name` renames the node (and with it its `manage_nodes` / `is_active`
+ * services). Every test needs its own: the manager holds service clients built from its
+ * own `shared_from_this()`, a reference cycle that keeps the node alive past the end of
+ * the test that created it, so a manager left over from an earlier test would otherwise
+ * still be answering on the name the next test's client connects to.
+ */
+inline rclcpp::NodeOptions managerOptions(const std::string& manager_name, const std::vector<std::string>& node_names,
+                                          const std::vector<std::string>& transitions, bool autostart,
+                                          double bond_timeout, bool attempt_respawn_reconnection = true,
+                                          double bond_respawn_max_duration = 10.0)
+{
+  rclcpp::NodeOptions options;
+  options.arguments({ "--ros-args", "-r", "__node:=" + manager_name });
+  options.parameter_overrides({
+      rclcpp::Parameter("node_names", node_names),
+      rclcpp::Parameter("transitions", transitions),
+      rclcpp::Parameter("autostart", autostart),
+      rclcpp::Parameter("bond_timeout", bond_timeout),
+      rclcpp::Parameter("attempt_respawn_reconnection", attempt_respawn_reconnection),
+      rclcpp::Parameter("bond_respawn_max_duration", bond_respawn_max_duration),
+  });
+  return options;
+}
+
+/// Whether `entries` contains `entry`.
+inline bool contains(const std::vector<std::string>& entries, const std::string& entry)
+{
+  return std::find(entries.begin(), entries.end(), entry) != entries.end();
+}
+
+/// How many times `entry` appears in `entries`.
+inline std::size_t countOf(const std::vector<std::string>& entries, const std::string& entry)
+{
+  return static_cast<std::size_t>(std::count(entries.begin(), entries.end(), entry));
+}
+
+}  // namespace dc_lifecycle_manager_test
+
+#endif  // MANAGED_NODE_HARNESS_HPP_

--- a/dc_lifecycle_manager/test/test_lifecycle_manager_bond.cpp
+++ b/dc_lifecycle_manager/test/test_lifecycle_manager_bond.cpp
@@ -1,0 +1,201 @@
+// Bond timeout handling and respawn behaviour of `lifecycle_manager_dc`.
+//
+// A managed node is made to look dead by stopping its executor: it stays discoverable,
+// but stops answering heartbeats, which is what the manager's bond actually watches.
+// Spinning is restored afterwards so the manager can drive the node through the hard
+// reset it triggers — a permanently dead node would block the manager's own (untimed)
+// change_state call rather than exercise the recovery path.
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "dc_lifecycle_manager/lifecycle_manager_client.hpp"
+#include "managed_node_harness.hpp"
+
+using dc_lifecycle_manager::SystemStatus;
+using dc_lifecycle_manager_test::contains;
+using dc_lifecycle_manager_test::countOf;
+using dc_lifecycle_manager_test::DummyManagedNode;
+using dc_lifecycle_manager_test::managerOptions;
+using dc_lifecycle_manager_test::TestableLifecycleManager;
+using dc_lifecycle_manager_test::TransitionRecorder;
+using namespace std::chrono_literals;  // NOLINT
+
+namespace
+{
+/// Heartbeat timeout the manager is configured with in these tests. Also the DC
+/// default: the manager gives a bond half of it to form, which a shorter value can
+/// lose the race against.
+constexpr double kBondTimeout = 4.0;
+/// How long to let a fresh bond beat before silencing the node behind it. bondcpp arms
+/// its heartbeat-timeout timer from the *second* heartbeat it receives (the first only
+/// moves the bond out of "waiting for sister"), so a node silenced the instant its bond
+/// forms is never declared dead at all.
+constexpr auto kBondSettleDuration = 2s;
+/// How long a node is silenced for: past kBondTimeout plus the bond's own disconnect
+/// timeout, so the manager's side of the bond is conclusively dead before the node
+/// starts answering again.
+constexpr auto kSilenceDuration = 8s;
+}  // namespace
+
+class LifecycleManagerBondTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    recorder_ = std::make_shared<TransitionRecorder>();
+  }
+
+  void TearDown() override
+  {
+    client_.reset();
+    client_node_.reset();
+    manager_thread_.reset();
+    manager_.reset();
+    nodes_.clear();
+  }
+
+  void spawnManagedNodes(const std::vector<std::string>& names)
+  {
+    for (const auto& name : names)
+    {
+      auto node = std::make_shared<DummyManagedNode>(name, recorder_, true);
+      node->startSpinning();
+      nodes_.push_back(node);
+    }
+  }
+
+  /// Start a manager named after the running test, and a client wired to it.
+  void startManager(const std::vector<std::string>& node_names, bool attempt_respawn_reconnection)
+  {
+    const std::string manager_name = managerName();
+    manager_ = std::make_shared<dc_lifecycle_manager::LifecycleManager>(managerOptions(
+        manager_name, node_names, { "configure", "activate" }, true, kBondTimeout, attempt_respawn_reconnection, 60.0));
+    manager_thread_ = std::make_unique<nav2_util::NodeThread>(manager_->get_node_base_interface());
+    client_node_ = std::make_shared<rclcpp::Node>(manager_name + "_client");
+    client_ = std::make_unique<dc_lifecycle_manager::LifecycleManagerClient>(manager_name, client_node_);
+  }
+
+  /// A manager node name unique to the running test.
+  static std::string managerName()
+  {
+    return std::string("lifecycle_manager_") + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  }
+
+  /// Stop a managed node's heartbeats for long enough that the manager's bond times out.
+  void silenceManagedNode(std::size_t index)
+  {
+    std::this_thread::sleep_for(kBondSettleDuration);
+    nodes_[index]->stopSpinning();
+    std::this_thread::sleep_for(kSilenceDuration);
+    nodes_[index]->startSpinning();
+  }
+
+  std::shared_ptr<TransitionRecorder> recorder_;
+  std::vector<std::shared_ptr<DummyManagedNode>> nodes_;
+  std::shared_ptr<dc_lifecycle_manager::LifecycleManager> manager_;
+  std::unique_ptr<nav2_util::NodeThread> manager_thread_;
+  rclcpp::Node::SharedPtr client_node_;
+  std::unique_ptr<dc_lifecycle_manager::LifecycleManagerClient> client_;
+};
+
+// One managed node losing its bond takes the whole managed set down; with respawn
+// reconnection enabled the manager then brings the set back up on its own.
+TEST_F(LifecycleManagerBondTest, BondTimeoutTakesSystemDownAndRespawnBringsItBack)
+{
+  const std::vector<std::string> names{ "bond_node_a", "bond_node_b" };
+  spawnManagedNodes(names);
+  startManager(names, true);
+
+  ASSERT_TRUE(recorder_->waitForCount(4, 30s)) << "managed nodes were never brought up";
+  ASSERT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+
+  silenceManagedNode(1);
+
+  ASSERT_TRUE(recorder_->waitFor(
+      [](const std::vector<std::string>& entries) {
+        return contains(entries, "bond_node_a:cleanup") && contains(entries, "bond_node_b:cleanup");
+      },
+      60s))
+      << "a broken bond did not take the managed nodes down";
+
+  ASSERT_TRUE(recorder_->waitFor(
+      [](const std::vector<std::string>& entries) {
+        return countOf(entries, "bond_node_a:activate") == 2 && countOf(entries, "bond_node_b:activate") == 2;
+      },
+      60s))
+      << "the managed nodes were never brought back up after respawn";
+
+  const auto entries = recorder_->entries();
+  EXPECT_EQ(countOf(entries, "bond_node_a:configure"), 2u)
+      << "respawn should re-run the full bring-up, not just activate";
+  EXPECT_EQ(countOf(entries, "bond_node_b:configure"), 2u);
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+}
+
+// With attempt_respawn_reconnection off, the same broken bond takes the system down and
+// leaves it down — recovery is the operator's (or the process supervisor's) call.
+TEST_F(LifecycleManagerBondTest, BondTimeoutLeavesSystemDownWhenRespawnIsDisabled)
+{
+  const std::vector<std::string> names{ "bond_norespawn_node_a", "bond_norespawn_node_b" };
+  spawnManagedNodes(names);
+  startManager(names, false);
+
+  ASSERT_TRUE(recorder_->waitForCount(4, 30s)) << "managed nodes were never brought up";
+  ASSERT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+
+  silenceManagedNode(1);
+
+  ASSERT_TRUE(recorder_->waitFor(
+      [](const std::vector<std::string>& entries) {
+        return contains(entries, "bond_norespawn_node_a:cleanup") && contains(entries, "bond_norespawn_node_b:cleanup");
+      },
+      60s))
+      << "a broken bond did not take the managed nodes down";
+
+  // Give a respawn attempt (a 1 s timer) every chance to happen before ruling it out.
+  std::this_thread::sleep_for(5s);
+  const auto entries = recorder_->entries();
+  EXPECT_EQ(countOf(entries, "bond_norespawn_node_a:activate"), 1u) << "nodes were re-activated despite respawn "
+                                                                       "reconnection being disabled";
+  EXPECT_EQ(countOf(entries, "bond_norespawn_node_b:activate"), 1u);
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::INACTIVE);
+}
+
+// A managed node that never comes back is retried until bond_respawn_max_duration is
+// up, then given up on. The node here is deliberately never spun: its services are
+// advertised, so the manager's state query reaches it and times out, exactly as it
+// would against a server that came back up but is not answering.
+TEST_F(LifecycleManagerBondTest, RespawnStopsRetryingAfterMaxDuration)
+{
+  const std::vector<std::string> names{ "bond_unresponsive_node" };
+  auto unresponsive = std::make_shared<DummyManagedNode>(names.front(), recorder_, false);
+
+  auto manager = std::make_shared<TestableLifecycleManager>(
+      managerOptions(managerName(), names, { "configure", "activate" }, false, kBondTimeout, true, 60.0));
+  manager->createLifecycleServiceClients();
+
+  ASSERT_EQ(manager->bondRespawnStartTime().nanoseconds(), 0);
+
+  manager->checkBondRespawnConnection();
+  EXPECT_NE(manager->bondRespawnStartTime().nanoseconds(), 0) << "the first respawn check should open the retry window";
+
+  manager->setBondRespawnMaxDuration(0.0);
+  manager->checkBondRespawnConnection();
+  EXPECT_EQ(manager->bondRespawnStartTime().nanoseconds(), 0) << "the retry window should close once the maximum "
+                                                                 "duration has elapsed";
+  EXPECT_TRUE(recorder_->entries().empty()) << "an unresponsive node must not be transitioned";
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/dc_lifecycle_manager/test/test_lifecycle_manager_startup.cpp
+++ b/dc_lifecycle_manager/test/test_lifecycle_manager_startup.cpp
@@ -1,0 +1,172 @@
+// Startup/teardown ordering of the nodes `lifecycle_manager_dc` manages.
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dc_lifecycle_manager/lifecycle_manager_client.hpp"
+#include "managed_node_harness.hpp"
+
+using dc_lifecycle_manager::SystemStatus;
+using dc_lifecycle_manager_test::DummyManagedNode;
+using dc_lifecycle_manager_test::managerOptions;
+using dc_lifecycle_manager_test::TransitionRecorder;
+using namespace std::chrono_literals;  // NOLINT
+
+namespace
+{
+/// The entries recorded from `from` onwards, so a phase can be compared on its own.
+std::vector<std::string> tail(const std::vector<std::string>& entries, std::size_t from)
+{
+  if (from >= entries.size())
+  {
+    return {};
+  }
+  return std::vector<std::string>(entries.begin() + static_cast<std::ptrdiff_t>(from), entries.end());
+}
+}  // namespace
+
+class LifecycleManagerStartupTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    recorder_ = std::make_shared<TransitionRecorder>();
+  }
+
+  void TearDown() override
+  {
+    client_.reset();
+    client_node_.reset();
+    manager_thread_.reset();
+    manager_.reset();
+    nodes_.clear();
+  }
+
+  void spawnManagedNodes(const std::vector<std::string>& names)
+  {
+    for (const auto& name : names)
+    {
+      // Bonds are covered by test_lifecycle_manager_bond; these tests run with
+      // bond_timeout 0.0, which is the manager's own "no bonds" configuration.
+      auto node = std::make_shared<DummyManagedNode>(name, recorder_, false);
+      node->startSpinning();
+      nodes_.push_back(node);
+    }
+  }
+
+  /// Start a manager named after the running test, and a client wired to it.
+  void startManager(const std::vector<std::string>& node_names, bool autostart)
+  {
+    const std::string manager_name = managerName();
+    manager_ = std::make_shared<dc_lifecycle_manager::LifecycleManager>(
+        managerOptions(manager_name, node_names, { "configure", "activate" }, autostart, 0.0));
+    manager_thread_ = std::make_unique<nav2_util::NodeThread>(manager_->get_node_base_interface());
+    client_node_ = std::make_shared<rclcpp::Node>(manager_name + "_client");
+    client_ = std::make_unique<dc_lifecycle_manager::LifecycleManagerClient>(manager_name, client_node_);
+  }
+
+  /// A manager node name unique to the running test.
+  static std::string managerName()
+  {
+    return std::string("lifecycle_manager_") + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+  }
+
+  std::shared_ptr<TransitionRecorder> recorder_;
+  std::vector<std::shared_ptr<DummyManagedNode>> nodes_;
+  std::shared_ptr<dc_lifecycle_manager::LifecycleManager> manager_;
+  std::unique_ptr<nav2_util::NodeThread> manager_thread_;
+  rclcpp::Node::SharedPtr client_node_;
+  std::unique_ptr<dc_lifecycle_manager::LifecycleManagerClient> client_;
+};
+
+// Every managed node is configured before any is activated, and within each transition
+// the nodes are driven in the order `node_names` declares them.
+TEST_F(LifecycleManagerStartupTest, ConfiguresThenActivatesEveryNodeInDeclaredOrder)
+{
+  const std::vector<std::string> names{ "startup_node_a", "startup_node_b", "startup_node_c" };
+  spawnManagedNodes(names);
+  startManager(names, true);
+
+  ASSERT_TRUE(recorder_->waitForCount(6, 30s)) << "managed nodes were never brought up";
+  EXPECT_EQ(recorder_->entries(), (std::vector<std::string>{ "startup_node_a:configure", "startup_node_b:configure",
+                                                             "startup_node_c:configure", "startup_node_a:activate",
+                                                             "startup_node_b:activate", "startup_node_c:activate" }));
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+}
+
+// Regression: every declared transition is applied to every managed node. Pairing the
+// two lists index-wise silently dropped each transition past the node count, leaving a
+// single managed node configured but never activated.
+TEST_F(LifecycleManagerStartupTest, AppliesEveryTransitionToASingleManagedNode)
+{
+  const std::vector<std::string> names{ "startup_solo_node" };
+  spawnManagedNodes(names);
+  startManager(names, true);
+
+  ASSERT_TRUE(recorder_->waitForCount(2, 30s)) << "single managed node was not fully brought up";
+  EXPECT_EQ(recorder_->entries(),
+            (std::vector<std::string>{ "startup_solo_node:configure", "startup_solo_node:activate" }));
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+}
+
+// With autostart off nothing moves until a STARTUP request arrives on `manage_nodes`.
+TEST_F(LifecycleManagerStartupTest, StartupServiceBringsUpNodesWhenAutostartIsDisabled)
+{
+  const std::vector<std::string> names{ "startup_manual_node_a", "startup_manual_node_b" };
+  spawnManagedNodes(names);
+  startManager(names, false);
+
+  ASSERT_EQ(client_->is_active(5s), SystemStatus::INACTIVE);
+  EXPECT_TRUE(recorder_->entries().empty()) << "nodes transitioned without a startup request";
+
+  ASSERT_TRUE(client_->startup(30s));
+  EXPECT_EQ(recorder_->entries(),
+            (std::vector<std::string>{ "startup_manual_node_a:configure", "startup_manual_node_b:configure",
+                                       "startup_manual_node_a:activate", "startup_manual_node_b:activate" }));
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::ACTIVE);
+}
+
+// Teardown runs in the reverse of the bring-up order, so a node is never left running
+// while something it came up before it is already gone.
+TEST_F(LifecycleManagerStartupTest, ResetTransitionsNodesInReverseOrder)
+{
+  const std::vector<std::string> names{ "startup_reset_node_a", "startup_reset_node_b", "startup_reset_node_c" };
+  spawnManagedNodes(names);
+  startManager(names, true);
+  ASSERT_TRUE(recorder_->waitForCount(6, 30s)) << "managed nodes were never brought up";
+
+  ASSERT_TRUE(client_->reset(30s));
+  EXPECT_EQ(tail(recorder_->entries(), 6),
+            (std::vector<std::string>{ "startup_reset_node_c:deactivate", "startup_reset_node_b:deactivate",
+                                       "startup_reset_node_a:deactivate", "startup_reset_node_c:cleanup",
+                                       "startup_reset_node_b:cleanup", "startup_reset_node_a:cleanup" }));
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::INACTIVE);
+}
+
+// Shutdown deactivates, cleans up and finalizes — each phase in reverse order.
+TEST_F(LifecycleManagerStartupTest, ShutdownTransitionsNodesInReverseOrder)
+{
+  const std::vector<std::string> names{ "startup_shutdown_node_a", "startup_shutdown_node_b" };
+  spawnManagedNodes(names);
+  startManager(names, true);
+  ASSERT_TRUE(recorder_->waitForCount(4, 30s)) << "managed nodes were never brought up";
+
+  ASSERT_TRUE(client_->shutdown(30s));
+  EXPECT_EQ(tail(recorder_->entries(), 4),
+            (std::vector<std::string>{ "startup_shutdown_node_b:deactivate", "startup_shutdown_node_a:deactivate",
+                                       "startup_shutdown_node_b:cleanup", "startup_shutdown_node_a:cleanup",
+                                       "startup_shutdown_node_b:shutdown", "startup_shutdown_node_a:shutdown" }));
+  EXPECT_EQ(client_->is_active(5s), SystemStatus::INACTIVE);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -3702,3 +3702,76 @@ root-level markdown like `README.md`. Checked that `jazzy` is not branch-protect
 (`gh api .../branches/jazzy/protection` → 404), so a skipped run leaves no required status
 check pending forever — the usual trap with path-filtered workflows, noted in a comment
 above the trigger block for whoever turns branch protection on later.
+
+### #224 - Write tests for dc_lifecycle_manager
+
+`dc_lifecycle_manager` had no `test/` directory at all — the only DC C++ package
+managing other nodes' lifecycles was the one with no coverage of that behaviour. Added a
+gtest suite covering the three things the issue asked for (startup ordering, bond timeout
+handling, respawn) plus the teardown ordering that falls out of the same code path.
+
+**Shape of the suite** (`dc_lifecycle_manager/test/`, wired into `colcon test` from
+`CMakeLists.txt` with the `set(tests …)` + `foreach`/`ament_add_gtest` pattern
+`dc_measurements` already uses, `TIMEOUT 300` since bond timeouts are wall-clock waits):
+
+- **`managed_node_harness.hpp`** — shared doubles. `DummyManagedNode` is a
+  `nav2_util::LifecycleNode` that records every transition it is driven through into a
+  mutex-guarded `TransitionRecorder`, keeps a bond with the manager exactly like the real
+  collection nodes do (`createBond()` on activate, `destroyBond()` on deactivate), and —
+  the key affordance for the bond tests — puts *spinning* under the test's control, so a
+  node can be made to stop answering heartbeats without killing the process it shares
+  with the manager. Per ADR-0006 nothing here models the Bridge: it is deliberately
+  outside the manager, and its startup ordering is the `dc_bringup` readiness gate's job.
+- **`test_lifecycle_manager_startup.cpp`** (5 tests) — every node configured before any
+  is activated and each phase driven in `node_names` order; a **regression test for the
+  single-managed-node case** (pairing `transitions` with `node_names` index-wise used to
+  drop every transition past the node count, leaving one node configured but never
+  activated); `autostart: false` moving nothing until a STARTUP request arrives; RESET
+  and SHUTDOWN transitioning nodes in *reverse* order. Driven through
+  `LifecycleManagerClient` over the real `manage_nodes` / `is_active` services, which
+  gives that class coverage too.
+- **`test_lifecycle_manager_bond.cpp`** (3 tests) — a silenced node's bond timing out
+  takes the whole managed set down and respawn reconnection brings it back
+  (configure+activate re-run, `is_active` ACTIVE again); the same failure with
+  `attempt_respawn_reconnection: false` leaves it down; and the respawn retry window
+  closing after `bond_respawn_max_duration`.
+
+**Three non-obvious things the tests ran into**, all documented in the files themselves:
+
+- **A manager outlives the test that created it.** `createLifecycleServiceClients()`
+  builds `nav2_util::LifecycleServiceClient`s from the manager's own `shared_from_this()`
+  and stores them on the manager — a reference cycle, so `manager_.reset()` does not
+  destroy the node, and its service thread keeps answering. The first run had a test
+  asserting INACTIVE get ACTIVE from the *previous* test's manager. Fixed by giving each
+  test its own manager node name (`__node:=` remap through `NodeOptions::arguments`), so
+  every test's client talks only to its own. Left the cycle alone: in production the
+  manager is a process-lifetime singleton and `shutdown()`'s
+  `destroyLifecycleServiceClients()` breaks it, so it is a test-isolation problem rather
+  than a leak worth changing production code for.
+- **`bond_timeout` doubles as the bond *formation* deadline.** `createBondConnection()`
+  gives `waitUntilFormed()` half of `bond_timeout`; at 1.5 s the second managed node's
+  bond lost that race (~110 ms formation, but only after the first bond's traffic was
+  already flowing) and startup failed outright. The tests use 4.0 — the DC/nav2 default —
+  and the constant says why.
+- **A bond only becomes detectable after its *second* heartbeat.** Probing bondcpp
+  directly (a scratch test, since the manager's logs show nothing either way): its
+  heartbeat-timeout timer is armed from `BondSM::Heartbeat()`, which the first status
+  message does not reach — that one only moves the state machine out of
+  `WaitingForSister`. A peer silenced the instant its bond forms is therefore *never*
+  declared dead, no matter how long you wait (verified: 15 s with `isBroken()` staying
+  false). The tests let a fresh bond beat for 2 s before silencing a node, and the
+  silence lasts 8 s — past the 4 s heartbeat timeout plus the bond's own disconnect
+  timeout — so the manager's side is conclusively dead before the node starts answering
+  again. Spinning is restored afterwards on purpose: the manager's recovery path calls
+  `change_state` with no timeout, so a permanently dead node would block the manager
+  instead of exercising the reset+respawn it triggers.
+
+**Verified** against the workspace image (podman, this worktree bind-mounted over
+`/root/ws/src/ros2_data_collection`, the same `colcon test` path CI runs): 10 tests, 0
+failures, ~32 s for the package. The bond suite's logs show the real sequence end to end
+— "CRITICAL FAILURE: SERVER bond_node_b IS DOWN after not receiving a heartbeat for 4000
+ms" → hard reset in reverse order → "Successfully re-established connections from server
+respawns, starting back up" → both nodes configured and activated again. `pre-commit run
+--files` on the new/changed files is clean apart from the `poetry-requirements` hook,
+which fails on this machine for a missing local `poetry` install and touches none of
+them.


### PR DESCRIPTION
Closes #224

`dc_lifecycle_manager` had **no test directory at all**. This adds one, covering the three
behaviours the issue asked for plus the teardown ordering that falls out of the same code path.

## What's covered

`test_lifecycle_manager_startup.cpp` (5 tests), driven through `LifecycleManagerClient` over the
real `manage_nodes` / `is_active` services — so that class gets coverage too:

- every managed node is configured before any is activated, each phase in `node_names` order
- **regression**: a single managed node gets *every* declared transition (pairing `transitions`
  with `node_names` index-wise used to drop everything past the node count, leaving one node
  configured but never activated)
- `autostart: false` moves nothing until a STARTUP request arrives
- RESET and SHUTDOWN transition nodes in reverse order

`test_lifecycle_manager_bond.cpp` (3 tests):

- a silenced node's bond times out → the whole managed set comes down → respawn reconnection
  brings it back (full configure+activate re-run, `is_active` ACTIVE again)
- the same failure with `attempt_respawn_reconnection: false` leaves the system down
- the respawn retry window closes after `bond_respawn_max_duration`

The managed nodes are `nav2_util::LifecycleNode` doubles that record every transition they're
driven through and keep real bonds with the manager; **spinning is under the test's control**, so
a node can stop answering heartbeats without leaving the process. Per ADR-0006 the Bridge is
deliberately outside the manager, so nothing here models it as a managed node.

Wired into `colcon test` with the same `set(tests …)` + `ament_add_gtest` pattern
`dc_measurements` uses, at `TIMEOUT 300` — bond timeouts are wall-clock waits.

## Three things worth knowing (documented in the files)

- **A manager outlives the test that created it.** `createLifecycleServiceClients()` builds its
  clients from the manager's own `shared_from_this()` and stores them on the manager — a reference
  cycle, so `reset()`ing the last test-held pointer doesn't destroy the node and its service thread
  keeps answering. Fixed by giving each test its own manager node name (`__node:=` remap). The
  cycle itself is left alone: in production the manager is a process-lifetime singleton and
  `shutdown()` breaks it, so it's a test-isolation problem, not a leak worth changing prod code for.
- **`bond_timeout` doubles as the bond *formation* deadline** (`waitUntilFormed` gets half of it).
  At 1.5 s the second node's bond lost that race and startup failed outright; the tests use 4.0,
  the DC/nav2 default.
- **A bond only becomes detectable after its second heartbeat.** bondcpp arms its heartbeat-timeout
  timer from `BondSM::Heartbeat()`, which the first status message never reaches — so a peer
  silenced the instant its bond forms is *never* declared dead (verified with a scratch probe: 15 s
  with `isBroken()` staying false). The tests let a fresh bond beat for 2 s first, then silence the
  node for 8 s — past the 4 s heartbeat timeout plus the bond's own disconnect timeout.

## Verification

`colcon test` against the workspace image (podman, this worktree bind-mounted — the same path CI
runs): **10 tests, 0 failures**, ~32 s for the package. The bond suite's logs show the real
sequence end to end: `CRITICAL FAILURE: SERVER bond_node_b IS DOWN after not receiving a heartbeat
for 4000 ms` → hard reset in reverse order → `Successfully re-established connections from server
respawns, starting back up` → both nodes configured and activated again.

`pre-commit run --files` is clean on the new/changed files apart from the `poetry-requirements`
hook, which fails locally for a missing `poetry` install and touches none of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MfdQCnEQHAnZh6hbEhnZxu