### PR TITLE
feat(dc_bridge): collect any ROS topic with a generic-subscription mode

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -19,6 +19,11 @@ find_package(nlohmann_json REQUIRED)
 find_package(tomlplusplus REQUIRED)
 find_package(msgpack-cxx REQUIRED)
 find_package(Threads REQUIRED)
+# Runtime message introspection for raw / generic-subscription mode (#227): the same
+# type support pair `ros2 bag record -a` uses to handle types it was never built against.
+find_package(rosidl_runtime_cpp REQUIRED)
+find_package(rosidl_typesupport_introspection_cpp REQUIRED)
+find_package(rcpputils REQUIRED)
 # The AWS SDK for C++ (s3) comes from the aws_sdk_vendor package (built from source);
 # colcon puts its install prefix on CMAKE_PREFIX_PATH so this resolves.
 find_package(AWSSDK REQUIRED COMPONENTS s3)
@@ -34,6 +39,7 @@ add_library(dc_bridge_core
   src/supervisor.cpp
   src/vector_binary.cpp
   src/render.cpp
+  src/raw_config.cpp
   src/uploader/content_type.cpp
   src/uploader/group.cpp
   src/uploader/status.cpp
@@ -50,13 +56,30 @@ target_link_libraries(dc_bridge_core PUBLIC
   msgpack-cxx
   Threads::Threads)
 
+# Raw / generic-subscription mode (#227). Its own library rather than a file in the
+# executable below, so the introspection→JSON conversion can be gtested against real
+# message types (raw_json_test) without pulling in the node, Vector or the AWS SDK. Not
+# part of dc_bridge_core: this half genuinely needs rclcpp and the type support
+# libraries, which is exactly what the core is defined as not needing.
+add_library(dc_bridge_ros
+  src/raw_subscriptions.cpp)
+target_include_directories(dc_bridge_ros PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+# Plain signature (no PUBLIC/PRIVATE): ament_target_dependencies below uses the plain
+# form of target_link_libraries internally, and CMake refuses to mix the two on one
+# target.
+target_link_libraries(dc_bridge_ros dc_bridge_core)
+ament_target_dependencies(dc_bridge_ros
+  rclcpp rosidl_runtime_cpp rosidl_typesupport_introspection_cpp rcpputils)
+
 # The ROS node, plus the aws-sdk-cpp S3 ObjectStore implementation (the only Uploader
 # piece that links the SDK).
 add_executable(dc_bridge
   src/main.cpp
   src/bridge_node.cpp
   src/uploader/s3_object_store.cpp)
-target_link_libraries(dc_bridge dc_bridge_core ${AWSSDK_LINK_LIBRARIES})
+target_link_libraries(dc_bridge dc_bridge_core dc_bridge_ros ${AWSSDK_LINK_LIBRARIES})
 ament_target_dependencies(dc_bridge rclcpp dc_interfaces std_msgs std_srvs)
 
 install(TARGETS dc_bridge DESTINATION lib/${PROJECT_NAME})
@@ -64,12 +87,21 @@ install(TARGETS dc_bridge DESTINATION lib/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
-  foreach(t forwarder supervisor render misc uploader intent_queue retention)
+  foreach(t forwarder supervisor render misc uploader intent_queue retention raw_config)
     ament_add_gtest(${t}_test test/${t}_test.cpp)
     target_link_libraries(${t}_test dc_bridge_core)
     target_compile_definitions(${t}_test PRIVATE
       DC_BRIDGE_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/render")
   endforeach()
+
+  # Raw mode against real message types and a real ROS graph (#227) — the one dc_bridge
+  # test that needs both. dc_interfaces is a genuinely custom, non-std_msgs package, so
+  # the "no compile-time knowledge of the type" claim is exercised end to end: the
+  # converter is handed nothing but bytes and a type name. TIMEOUT because the firehose
+  # and discovery cases are wall-clock waits on graph events.
+  ament_add_gtest(raw_subscriptions_test test/raw_subscriptions_test.cpp TIMEOUT 180)
+  target_link_libraries(raw_subscriptions_test dc_bridge_ros)
+  ament_target_dependencies(raw_subscriptions_test rclcpp dc_interfaces std_msgs)
 endif()
 
 ament_package()

--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -35,6 +35,8 @@ install` + `colcon build` as every other `dc_*` package. See
     SIGKILL/crash.
   - `readiness` — a TCP-connect probe against Vector's ingest port + a shared ready flag.
   - `topic_config` — derives a shipper ingest protocol Tag from a ROS topic name.
+  - `raw_config` — raw-mode (#227) policy: the include/exclude filter, the
+    `dc.raw.<topic>` Tag derivation, the per-topic rate limiter and the drop counters.
   - `render` — the ADR-0003 config renderer: ROS parameters → a complete Vector TOML
     config (toml++). Pure, gold-file tested.
   - `vector_binary` — locates the vendored Vector binary on `AMENT_PREFIX_PATH`.
@@ -46,6 +48,11 @@ install` + `colcon build` as every other `dc_*` package. See
     exponential backoff, replayed on startup), and `uploader` (the verify-then-delete
     orchestration). All built on an abstract `ObjectStore` interface, so the logic is
     tested against an in-memory fake with no cloud dependency.
+- **`src/raw_subscriptions.cpp`** (`dc_bridge_ros`) — raw / generic-subscription mode's
+  rclcpp half (#227): topic discovery, `create_generic_subscription`, and the runtime
+  introspection walk that turns a message of a type the Bridge was never compiled against
+  into JSON. Its own library rather than a file in the executable, so the conversion is
+  gtested against real message types without the node, Vector or the AWS SDK.
 - **`src/uploader/s3_object_store.cpp`** — the aws-sdk-cpp implementation of
   `ObjectStore` (the only Uploader piece that links the SDK, via `aws_sdk_vendor`).
   Verified against RustFS (PutObject + multipart) before adoption.
@@ -90,6 +97,37 @@ disk buffer per persistent sink; and the blessed sinks.
 `validate_custom_config_files` collision-checks passthrough snippets, and `main.cpp` runs
 `vector validate --no-environment` over the merged config before starting Vector, so a
 bad config fails loudly at startup rather than crash-looping.
+
+## Raw / generic-subscription mode (#227)
+
+Beside the Record topics above, the Bridge can subscribe to topics it was **never
+compiled against** — `rclcpp::GenericSubscription` plus the runtime introspection type
+support, the same mechanism `ros2 bag record -a` uses — and ship every message as a
+Record under the `dc.raw.<topic>` Tag:
+
+```yaml
+    raw:
+      enabled: true
+      destination: "raw_console"   # a configured `receives: records` Destination
+      include: ["^/"]              # topic-name regexes; see doc/src/dc/raw_topics.md
+      max_rate_hz: 10.0            # per topic; raw mode sheds at the source
+```
+
+Two things about this are worth knowing at the code level:
+
+- **The whole Tag namespace shares one Vector route.** Topics are discovered while Vector
+  is already running, and a rendered config can't grow exact-Tag branches without a
+  restart — so `Destination::tag_prefixes` renders a `starts_with(.tag, "dc.raw.")`
+  branch at `dc.dc.raw` (`route_output_for_tag_prefix`). It is the only routing
+  construct in the renderer that matches something other than an exact Tag.
+- **Raw Records are dropped, never queued.** A raw Record the Forwarder refuses
+  (backpressure, dropped connection) is counted and discarded rather than kept in the
+  unacked window: a firehose topic would otherwise fill that window and push real
+  Measurement Records out of it. The counters are on `~/ready`.
+
+`ros2 launch dc_bringup dc_raw.launch.py` runs the Bridge in this mode with no collection
+nodes at all. See [doc/src/dc/raw_topics.md](../doc/src/dc/raw_topics.md) for the
+configuration reference and the volume/backpressure contract.
 
 ## Delivery guarantees (#266)
 

--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -27,6 +27,8 @@
 #include <vector>
 
 #include "dc_bridge/forwarder.hpp"
+#include "dc_bridge/raw_config.hpp"
+#include "dc_bridge/raw_subscriptions.hpp"
 #include "dc_bridge/readiness.hpp"
 #include "dc_bridge/render.hpp"
 #include "dc_bridge/supervisor.hpp"
@@ -89,6 +91,13 @@ private:
   // (the default) either way.
   uploader::RetentionConfig retention_config_;
   std::vector<Storage> files_storages_;
+
+  // Raw / generic-subscription mode (#227) — created only when `raw.enabled` is true.
+  // Its Records go out through the same Forwarder as the Measurement Records above,
+  // under the `dc.raw.<topic>` Tag namespace routed to `raw.destination`.
+  RawConfig raw_config_;
+  RawStats raw_stats_;
+  std::unique_ptr<RawSubscriptionManager> raw_manager_;
 };
 
 }  // namespace dc_bridge

--- a/dc_bridge/include/dc_bridge/raw_config.hpp
+++ b/dc_bridge/include/dc_bridge/raw_config.hpp
@@ -126,10 +126,19 @@ private:
 /// safety net for anything a future ROS naming rule allows.
 std::string raw_tag(const std::string& tag_prefix, const std::string& topic);
 
-/// Per-topic decimation: at most one message per `1/max_rate_hz` seconds, newest wins.
+/// Per-topic decimation: at most one message per `1/max_rate_hz` seconds — specifically,
+/// a message passes once that long has elapsed since the last one that passed. So each
+/// Record is the newest message at the instant it is emitted (nothing is buffered and
+/// released later); between emissions, the most recent Record is up to one window old.
+///
 /// Deliberately not a token bucket — a bucket lets a burst through all at once, which is
-/// exactly the shape of traffic this exists to flatten. Not thread-safe; the subscription
-/// manager owns the lock (raw callbacks can run on several executor threads).
+/// exactly the shape of traffic this exists to flatten. Dropping by time like this is
+/// uniform: every window is represented, so the result is an unbiased lower-resolution
+/// time series. (Contrast `max_message_size_bytes`, which drops by *content* and
+/// therefore biases what survives — see doc/src/dc/raw_topics.md.)
+///
+/// Not thread-safe; the subscription manager owns the lock (raw callbacks can run on
+/// several executor threads).
 class RawRateLimiter
 {
 public:

--- a/dc_bridge/include/dc_bridge/raw_config.hpp
+++ b/dc_bridge/include/dc_bridge/raw_config.hpp
@@ -1,0 +1,171 @@
+// Generic-subscription ("raw") mode policy (#227): which discovered topics the Bridge
+// subscribes to with no compile-time knowledge of their types, the Tag each one's
+// Records carry, and the volume controls that stop a firehose topic from outrunning the
+// Shipper.
+//
+// Deliberately ROS-free — the filter/tag/rate-limit decisions are pure functions of a
+// topic name, a type name, a serialized size and a clock, so they are unit-tested with
+// plain gtest (raw_config_test) and no ROS graph. The rclcpp side (discovery,
+// `create_generic_subscription`, introspection→JSON) lives in raw_subscriptions.hpp,
+// which is built into the node target only.
+#ifndef DC_BRIDGE__RAW_CONFIG_HPP_
+#define DC_BRIDGE__RAW_CONFIG_HPP_
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace dc_bridge
+{
+
+/// Tag namespace every raw Record is published under: `dc.raw.<sanitised topic>`. The
+/// trailing dot matters — the rendered Vector config routes the whole namespace with one
+/// `starts_with(.tag, …)` branch (see route_output_for_tag_prefix), which is what lets
+/// topics discovered *after* Vector started still reach their Destination.
+inline constexpr const char* RAW_TAG_PREFIX = "dc.raw.";
+
+/// Raw-mode configuration, as declared from the `raw.*` ROS parameters.
+struct RawConfig
+{
+  bool enabled{ false };
+  /// Name of the `receives: records` Destination raw Records are routed to. Required
+  /// when enabled — a raw Record with nowhere to go is a config error, not a default.
+  std::string destination;
+  /// Topic-name regexes (ECMAScript, `regex_search` — unanchored unless you anchor
+  /// them). A topic must match at least one to be subscribed.
+  std::vector<std::string> include;
+  /// Topic-name regexes that veto a match from `include`.
+  std::vector<std::string> exclude;
+  /// Message-*type* regexes (matched against e.g. `sensor_msgs/msg/Image`) that veto a
+  /// topic regardless of its name — the type is the robust way to keep the high-rate
+  /// sensor streams out (a camera topic is not reliably named `*image*`).
+  std::vector<std::string> exclude_types;
+  /// How often the topic graph is re-scanned so topics appearing after startup get
+  /// picked up. 0 disables re-scanning (one scan at startup).
+  double rescan_interval_secs{ 5.0 };
+  /// Depth of each generic subscription's QoS history.
+  std::size_t qos_depth{ 10 };
+  /// Per-topic ceiling on how many messages are turned into Records each second.
+  /// 0 = unlimited. This is raw mode's first line of volume defence (see
+  /// doc/src/dc/raw_topics.md "Backpressure and volume").
+  double max_rate_hz{ 10.0 };
+  /// Serialized messages larger than this are dropped, not truncated. 0 = unlimited.
+  std::uint64_t max_message_size_bytes{ 1048576 };
+  /// Tag namespace; overridable, but the rendered route follows whatever is set here.
+  std::string tag_prefix{ RAW_TAG_PREFIX };
+};
+
+/// Topic-name regexes excluded unless the operator overrides `raw.exclude`: ROS's own
+/// infrastructure topics (`/rosout` would also feed the Bridge's own warnings back into
+/// the pipeline) and DC's own Record topics, which already reach their Destinations as
+/// Measurement Records — subscribing to them raw as well would ship everything twice
+/// under two different Tags.
+std::vector<std::string> default_raw_exclude();
+
+/// Message types excluded unless the operator overrides `raw.exclude_types`: the
+/// high-rate sensor streams (#227's third open question — answered "yes, excluded by
+/// default"). One 640x480 `sensor_msgs/msg/Image` is ~900 kB of JSON numbers at 30 Hz;
+/// nothing downstream of the Bridge is sized for that, and a user who genuinely wants it
+/// can say so explicitly.
+std::vector<std::string> default_raw_exclude_types();
+
+/// Why a discovered topic was (not) subscribed. Reported once per topic at discovery
+/// time, so an operator can see what the filters actually did.
+enum class RawSkip
+{
+  Accepted,
+  NotIncluded,
+  Excluded,
+  ExcludedType,
+};
+
+const char* to_string(RawSkip skip);
+
+/// Thrown for a raw config that cannot be honoured (an uncompilable regex, an enabled
+/// mode with no destination). Surfaces as a loud Bridge startup failure, like every
+/// other config error (ADR-0003).
+class RawConfigError : public std::runtime_error
+{
+public:
+  explicit RawConfigError(const std::string& message) : std::runtime_error(message)
+  {
+  }
+};
+
+/// Compiled include/exclude policy. Construction validates every regex, so a typo in a
+/// params file fails at startup rather than silently matching nothing.
+class RawTopicFilter
+{
+public:
+  explicit RawTopicFilter(const RawConfig& config);
+
+  /// Full verdict for one discovered topic, including *why* it was skipped.
+  RawSkip evaluate(const std::string& topic, const std::string& type) const;
+
+  bool accepts(const std::string& topic, const std::string& type) const
+  {
+    return evaluate(topic, type) == RawSkip::Accepted;
+  }
+
+private:
+  std::vector<std::regex> include_;
+  std::vector<std::regex> exclude_;
+  std::vector<std::regex> exclude_types_;
+};
+
+/// The Tag a raw topic's Records carry: `<prefix><topic with the leading `/` stripped and
+/// every remaining `/` turned into `.`>`, with anything outside `[A-Za-z0-9_.]` mapped to
+/// `_`. `/dc/e2e/synth/synth00` → `dc.raw.dc.e2e.synth.synth00`. Sanitising matters
+/// because the Tag ends up in a VRL string literal and a Vector route name; ROS topic
+/// tokens are already `[A-Za-z0-9_]`, so the mapping is a no-op in practice and a
+/// safety net for anything a future ROS naming rule allows.
+std::string raw_tag(const std::string& tag_prefix, const std::string& topic);
+
+/// Per-topic decimation: at most one message per `1/max_rate_hz` seconds, newest wins.
+/// Deliberately not a token bucket — a bucket lets a burst through all at once, which is
+/// exactly the shape of traffic this exists to flatten. Not thread-safe; the subscription
+/// manager owns the lock (raw callbacks can run on several executor threads).
+class RawRateLimiter
+{
+public:
+  using Clock = std::chrono::steady_clock;
+
+  explicit RawRateLimiter(double max_rate_hz);
+
+  /// True if `topic` may emit a Record now (and records that it did).
+  bool allow(const std::string& topic, Clock::time_point now);
+
+  bool unlimited() const noexcept
+  {
+    return min_interval_ == Clock::duration::zero();
+  }
+
+private:
+  Clock::duration min_interval_;
+  std::unordered_map<std::string, Clock::time_point> last_pass_;
+};
+
+/// Raw-mode counters, surfaced through the Bridge's `~/ready` service so an operator can
+/// see whether raw mode is shedding — the drop counters are the observable half of the
+/// documented backpressure behaviour.
+struct RawStats
+{
+  std::atomic<std::uint64_t> subscribed_topics{ 0 };
+  std::atomic<std::uint64_t> forwarded{ 0 };
+  std::atomic<std::uint64_t> dropped_rate{ 0 };
+  std::atomic<std::uint64_t> dropped_oversize{ 0 };
+  std::atomic<std::uint64_t> dropped_shipper{ 0 };
+  std::atomic<std::uint64_t> dropped_undecodable{ 0 };
+
+  /// One-line human summary for logs and the readiness service.
+  std::string summary() const;
+};
+
+}  // namespace dc_bridge
+
+#endif  // DC_BRIDGE__RAW_CONFIG_HPP_

--- a/dc_bridge/include/dc_bridge/raw_subscriptions.hpp
+++ b/dc_bridge/include/dc_bridge/raw_subscriptions.hpp
@@ -1,0 +1,158 @@
+// Generic-subscription ("raw") mode, rclcpp side (#227): discovers topics on the ROS
+// graph, subscribes to them with `create_generic_subscription` — no compile-time
+// knowledge of their types, no generated headers, nothing the Bridge has to be rebuilt
+// against — turns each serialized message into JSON through the runtime introspection
+// type support, and hands the result to a sink as a Record under the `dc.raw.<topic>`
+// Tag.
+//
+// This is the same mechanism `ros2 bag record -a` and PlotJuggler use: two type support
+// libraries are loaded per message type at run time, one to deserialize
+// (`rosidl_typesupport_cpp`) and one to describe the fields
+// (`rosidl_typesupport_introspection_cpp`).
+//
+// Why an introspection walk rather than a converter dependency: `dynmsg`
+// (`dynamic_message_introspection`) is the obvious candidate, but it has no binary
+// release in the ROS 2 Jazzy distribution — adopting it means vendoring a source
+// dependency into the workspace — and it emits YAML, which would then have to be parsed
+// back into the JSON the ingest protocol actually carries. The walk below is ~200 lines
+// against a stable, core-ROS ABI, produces `nlohmann::json` directly, and keeps
+// dc_bridge's dependency list unchanged apart from type support packages every ROS
+// install already has.
+#ifndef DC_BRIDGE__RAW_SUBSCRIPTIONS_HPP_
+#define DC_BRIDGE__RAW_SUBSCRIPTIONS_HPP_
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rcpputils/shared_library.hpp>
+#include <set>
+#include <string>
+
+#include "dc_bridge/raw_config.hpp"
+
+namespace dc_bridge
+{
+
+/// Deserializes and JSON-encodes messages of one runtime-known type.
+///
+/// Field mapping: numbers become JSON numbers, `string` becomes a JSON string,
+/// `wstring` is transcoded UTF-16→UTF-8, nested messages become nested objects, and
+/// arrays/sequences (fixed, bounded or unbounded) become JSON arrays — including
+/// `uint8[]` blobs, which are *not* base64'd: raw mode's volume controls
+/// (`raw.max_message_size_bytes`, `raw.exclude_types`) exist to keep those out rather
+/// than to compress them.
+class RawMessageConverter
+{
+public:
+  /// Loads both type support libraries for `type_name` (e.g. `dc_interfaces/msg/
+  /// StringStamped`). Throws RawConfigError if the type cannot be resolved at run time —
+  /// which is what happens for a message package that isn't on this Bridge's
+  /// AMENT_PREFIX_PATH.
+  explicit RawMessageConverter(const std::string& type_name);
+  ~RawMessageConverter();
+
+  RawMessageConverter(const RawMessageConverter&) = delete;
+  RawMessageConverter& operator=(const RawMessageConverter&) = delete;
+
+  /// Deserializes `serialized` and converts it to a JSON object. Throws
+  /// std::runtime_error if deserialization fails (a truncated or mistyped payload).
+  nlohmann::json to_json(const rclcpp::SerializedMessage& serialized) const;
+
+  const std::string& type_name() const noexcept
+  {
+    return type_name_;
+  }
+
+private:
+  std::string type_name_;
+  std::shared_ptr<rcpputils::SharedLibrary> typesupport_library_;
+  std::shared_ptr<rcpputils::SharedLibrary> introspection_library_;
+  /// `rosidl_typesupport_introspection_cpp::MessageMembers*`, kept type-erased so this
+  /// header doesn't drag the introspection headers into every translation unit.
+  const void* members_{ nullptr };
+  std::unique_ptr<rclcpp::SerializationBase> serializer_;
+};
+
+/// A Record's time, split the way the ingest protocol's EventTime carries it.
+struct RawStamp
+{
+  std::uint64_t secs{ 0 };
+  std::uint32_t nanos{ 0 };
+};
+
+/// The `header.stamp` of a converted message, when it has one. Any message starting with
+/// a `std_msgs/msg/Header` — the majority of what a robot publishes — is then Recorded at
+/// the time the data was *captured* rather than the time the Bridge saw it. Messages
+/// without a header fall back to the Bridge's own clock.
+std::optional<RawStamp> stamp_from_payload(const nlohmann::json& payload);
+
+/// QoS that can actually receive what a topic's current publishers send.
+///
+/// A generic subscription is useless if it silently fails to match: a `best_effort`
+/// publisher (every sensor driver) is invisible to a `reliable` subscription, and a
+/// latched (`transient_local`) topic delivers nothing at all to a `volatile` one until
+/// it next publishes. This applies the same heuristic `ros2 bag record` uses — best
+/// effort if *any* publisher is best effort, transient local if *every* publisher is —
+/// with `depth` for history. Falls back to a plain reliable/volatile profile when the
+/// topic has no publishers yet.
+rclcpp::QoS raw_qos_for_topic(rclcpp::Node& node, const std::string& topic, std::size_t depth);
+
+/// Owns raw mode's discovery timer and its generic subscriptions.
+class RawSubscriptionManager
+{
+public:
+  /// Sink for one raw Record. Returns false if the Shipper refused it (backpressure, a
+  /// dropped connection) so the manager can count the drop; raw Records are *dropped at
+  /// the source* rather than queued, see doc/src/dc/raw_topics.md.
+  using RecordSink = std::function<bool(const std::string& tag, const RawStamp& stamp, nlohmann::json payload)>;
+
+  /// Builds the manager and validates the filter regexes (throws RawConfigError on a bad
+  /// pattern). Does not touch the graph until scan()/start() runs.
+  RawSubscriptionManager(rclcpp::Node* node, RawConfig config, RecordSink sink, RawStats* stats);
+
+  /// One discovery pass: subscribes to every newly-appeared topic that passes the filter.
+  /// Idempotent — topics already subscribed are left alone. Never throws; a type that
+  /// can't be resolved is logged once and skipped.
+  void scan();
+
+  /// Runs an immediate scan and, when `rescan_interval_secs > 0`, arms the periodic
+  /// re-scan that picks up topics appearing after startup.
+  void start();
+
+  std::size_t subscription_count() const;
+
+private:
+  void on_raw_message(const std::string& topic, std::shared_ptr<const rclcpp::SerializedMessage> message);
+
+  struct Entry
+  {
+    std::shared_ptr<rclcpp::GenericSubscription> subscription;
+    std::shared_ptr<RawMessageConverter> converter;
+    std::string tag;
+  };
+
+  rclcpp::Node* node_;
+  RawConfig config_;
+  RawTopicFilter filter_;
+  RecordSink sink_;
+  RawStats* stats_;
+
+  mutable std::mutex mutex_;
+  RawRateLimiter limiter_;
+  std::map<std::string, Entry> subscriptions_;
+  /// Topics already reported as skipped, so a 5-second rescan doesn't reprint the same
+  /// verdict for the same topic forever.
+  std::set<std::string> reported_;
+  rclcpp::TimerBase::SharedPtr rescan_timer_;
+};
+
+}  // namespace dc_bridge
+
+#endif  // DC_BRIDGE__RAW_SUBSCRIPTIONS_HPP_

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -36,6 +36,14 @@ inline constexpr std::uint64_t MIN_DISK_BUFFER_BYTES = 268435488ULL;
 /// route transform id, rest = the Tag verbatim).
 std::string route_output_for_tag(const std::string& tag);
 
+/// The public Shipper route a whole Tag *namespace* is exposed under (raw mode, #227):
+/// prefix `dc.raw.` → route `dc.dc.raw`, whose branch matches on `starts_with(.tag, …)`
+/// instead of an exact Tag. A rendered config is fixed at Bridge startup, but raw mode
+/// discovers topics — and therefore mints Tags — while Vector is already running; a
+/// prefix branch is what lets those later Tags reach a Destination without re-rendering
+/// and restarting the Shipper.
+std::string route_output_for_tag_prefix(const std::string& prefix);
+
 /// How a Destination's normalized time field is written.
 ///
 /// `EpochNanos` is the default: an exact integer count of nanoseconds since the epoch.
@@ -107,6 +115,10 @@ struct Destination
   /// Extra Tags routed here that don't come from a topic (Bridge-internal producers —
   /// today just the Uploader's dc.files Tag).
   std::vector<std::string> extra_tags;
+  /// Tag *namespaces* routed here, each matched with `starts_with` rather than equality
+  /// (raw mode's `dc.raw.`, #227) — the one way a Destination can receive Tags that did
+  /// not exist when the config was rendered.
+  std::vector<std::string> tag_prefixes;
   std::string time_key;
   TimeFormat time_format;
   DestinationKind kind;
@@ -131,6 +143,7 @@ enum class RenderErrorKind
   ReservedDestinationName,
   DuplicateDestination,
   EmptyInputs,
+  TagPrefixCollidesWithTag,
   UnsupportedType,
   InvalidReceives,
   FilesRequireObjectStorage,

--- a/dc_bridge/package.xml
+++ b/dc_bridge/package.xml
@@ -18,6 +18,13 @@
   <depend>dc_interfaces</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <!-- Runtime message introspection for raw / generic-subscription mode (#227): types
+       the Bridge was never compiled against are deserialized and walked through these,
+       the same pair `ros2 bag record -a` uses. Core ROS packages — no new rosdep source
+       needed, unlike tomlplusplus/msgpack-cxx below. -->
+  <depend>rosidl_runtime_cpp</depend>
+  <depend>rosidl_typesupport_introspection_cpp</depend>
+  <depend>rcpputils</depend>
   <depend>nlohmann-json-dev</depend>
   <!-- tomlplusplus (Vector-config render/parse) and msgpack-cxx (Fluent Forward framing)
        have no upstream rosdistro rosdep keys; rosdep/dc.yaml (registered as a local

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -215,6 +215,46 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
     }
   }
 
+  // --- raw / generic-subscription mode (#227) ---
+  // Declared before render() below, because enabling it adds a routed Tag namespace to
+  // one of the Destinations the Vector config is rendered from.
+  raw_config_.enabled = this->declare_parameter<bool>("raw.enabled", false);
+  raw_config_.destination = this->declare_parameter<std::string>("raw.destination", "");
+  raw_config_.include =
+      this->declare_parameter<std::vector<std::string>>("raw.include", std::vector<std::string>{ "^/" });
+  raw_config_.exclude = this->declare_parameter<std::vector<std::string>>("raw.exclude", default_raw_exclude());
+  raw_config_.exclude_types =
+      this->declare_parameter<std::vector<std::string>>("raw.exclude_types", default_raw_exclude_types());
+  raw_config_.rescan_interval_secs = this->declare_parameter<double>("raw.rescan_interval_secs", 5.0);
+  raw_config_.qos_depth =
+      static_cast<std::size_t>(std::max<std::int64_t>(1, this->declare_parameter<std::int64_t>("raw.qos_depth", 10)));
+  raw_config_.max_rate_hz = this->declare_parameter<double>("raw.max_rate_hz", 10.0);
+  raw_config_.max_message_size_bytes = static_cast<std::uint64_t>(
+      std::max<std::int64_t>(0, this->declare_parameter<std::int64_t>("raw.max_message_size_bytes", 1048576)));
+  raw_config_.tag_prefix = this->declare_parameter<std::string>("raw.tag_prefix", RAW_TAG_PREFIX);
+
+  if (raw_config_.enabled)
+  {
+    if (raw_config_.tag_prefix.empty())
+    {
+      // An empty prefix renders as `starts_with(.tag, "")`, which matches every Record
+      // in the pipeline — every Measurement Record would be duplicated into the raw
+      // Destination. Refuse rather than route the whole pipeline by accident.
+      throw std::runtime_error("`raw.tag_prefix` must not be empty");
+    }
+    auto target = std::find_if(records_destinations.begin(), records_destinations.end(),
+                               [this](const Destination& d) { return d.name == raw_config_.destination; });
+    if (target == records_destinations.end())
+    {
+      throw std::runtime_error("raw.destination '" + raw_config_.destination +
+                               "' does not name a configured `receives: records` destination");
+    }
+    // One routed Tag *namespace* rather than one route per topic: raw mode discovers
+    // topics while Vector is already running, and a rendered config can't grow new
+    // routes without a restart (see route_output_for_tag_prefix).
+    target->tag_prefixes.push_back(raw_config_.tag_prefix);
+  }
+
   // files.* parameters (ADR-0005).
   const bool files_delete_when_sent = this->declare_parameter<bool>("files.delete_when_sent", false);
   const std::string files_ffprobe = this->declare_parameter<std::string>("files.ffprobe_binary", "ffprobe");
@@ -452,6 +492,36 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
     subscriptions_.push_back(sub);
   }
 
+  // Raw mode's own subscriptions are created last: they discover topics from the live
+  // graph rather than from parameters, and the Forwarder they feed has to exist first.
+  if (raw_config_.enabled)
+  {
+    raw_manager_ = std::make_unique<RawSubscriptionManager>(
+        this, raw_config_,
+        [this](const std::string& tag, const RawStamp& stamp, nlohmann::json payload) {
+          Record record;
+          record.tag = tag;
+          record.timestamp_secs = stamp.secs;
+          record.timestamp_nanos = stamp.nanos;
+          record.payload = std::move(payload);
+          try
+          {
+            std::lock_guard<std::mutex> lock(forwarder_mutex_);
+            forwarder_->send(record);
+            return true;
+          }
+          catch (const ForwarderError&)
+          {
+            // Deliberately dropped, not retried or queued: raw mode can produce Records
+            // faster than the Shipper accepts them, and the only bounded answer is to
+            // shed at the source. The manager counts the drop and warns (throttled).
+            return false;
+          }
+        },
+        &raw_stats_);
+    raw_manager_->start();
+  }
+
   readiness_service_ = this->create_service<std_srvs::srv::Trigger>(
       "~/ready", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request>,
                         std::shared_ptr<std_srvs::srv::Trigger::Response> response) {
@@ -463,10 +533,23 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
           // without a separate metrics path.
           response->message += " | upload queue depth: " + std::to_string(intent_queue_->size());
         }
+        if (raw_manager_)
+        {
+          // The drop counters are the observable half of raw mode's documented
+          // backpressure behaviour — an operator asking "is raw mode shedding?" gets the
+          // answer from the same probe the readiness gate already uses.
+          response->message += " | " + raw_stats_.summary();
+        }
       });
 
   RCLCPP_INFO(this->get_logger(), "dc_bridge up: %zu subscribed topic(s), supervising %s", subscriptions_.size(),
               vector_binary.c_str());
+  if (raw_manager_)
+  {
+    RCLCPP_INFO(this->get_logger(),
+                "raw mode on: %zu topic(s) discovered so far, Tag namespace '%s' → destination '%s'",
+                raw_manager_->subscription_count(), raw_config_.tag_prefix.c_str(), raw_config_.destination.c_str());
+  }
 }
 
 void BridgeNode::run_uploader_worker(std::string forward_host, std::uint16_t forward_port)

--- a/dc_bridge/src/raw_config.cpp
+++ b/dc_bridge/src/raw_config.cpp
@@ -1,0 +1,162 @@
+#include "dc_bridge/raw_config.hpp"
+
+#include <sstream>
+
+namespace dc_bridge
+{
+
+namespace
+{
+
+std::vector<std::regex> compile(const std::vector<std::string>& patterns, const char* what)
+{
+  std::vector<std::regex> compiled;
+  compiled.reserve(patterns.size());
+  for (const auto& pattern : patterns)
+  {
+    try
+    {
+      compiled.emplace_back(pattern, std::regex::ECMAScript | std::regex::optimize);
+    }
+    catch (const std::regex_error& e)
+    {
+      throw RawConfigError(std::string("raw.") + what + ": '" + pattern + "' is not a valid regex: " + e.what());
+    }
+  }
+  return compiled;
+}
+
+bool matches_any(const std::vector<std::regex>& patterns, const std::string& value)
+{
+  for (const auto& pattern : patterns)
+  {
+    if (std::regex_search(value, pattern))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+std::vector<std::string> default_raw_exclude()
+{
+  return { "^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/" };
+}
+
+std::vector<std::string> default_raw_exclude_types()
+{
+  return { "^sensor_msgs/msg/(Image|CompressedImage|PointCloud|PointCloud2|LaserScan)$", "^tf2_msgs/msg/TFMessage$" };
+}
+
+const char* to_string(RawSkip skip)
+{
+  switch (skip)
+  {
+    case RawSkip::Accepted:
+      return "accepted";
+    case RawSkip::NotIncluded:
+      return "no include pattern matched";
+    case RawSkip::Excluded:
+      return "excluded by raw.exclude";
+    case RawSkip::ExcludedType:
+      return "excluded by raw.exclude_types";
+  }
+  return "unknown";
+}
+
+RawTopicFilter::RawTopicFilter(const RawConfig& config)
+  : include_(compile(config.include, "include"))
+  , exclude_(compile(config.exclude, "exclude"))
+  , exclude_types_(compile(config.exclude_types, "exclude_types"))
+{
+}
+
+RawSkip RawTopicFilter::evaluate(const std::string& topic, const std::string& type) const
+{
+  // An empty include list means "nothing", not "everything": raw mode's default include
+  // is an explicit `^/` (see the parameter defaults), so an operator who deliberately
+  // empties the list gets silence rather than the whole graph.
+  if (!matches_any(include_, topic))
+  {
+    return RawSkip::NotIncluded;
+  }
+  if (matches_any(exclude_, topic))
+  {
+    return RawSkip::Excluded;
+  }
+  if (matches_any(exclude_types_, type))
+  {
+    return RawSkip::ExcludedType;
+  }
+  return RawSkip::Accepted;
+}
+
+std::string raw_tag(const std::string& tag_prefix, const std::string& topic)
+{
+  std::string out = tag_prefix;
+  std::size_t i = 0;
+  if (i < topic.size() && topic[i] == '/')
+  {
+    ++i;  // leading '/' is the namespace root, not a separator
+  }
+  for (; i < topic.size(); ++i)
+  {
+    const char c = topic[i];
+    if (c == '/')
+    {
+      out.push_back('.');
+    }
+    else if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '.')
+    {
+      out.push_back(c);
+    }
+    else
+    {
+      out.push_back('_');
+    }
+  }
+  return out;
+}
+
+RawRateLimiter::RawRateLimiter(double max_rate_hz)
+{
+  if (max_rate_hz <= 0.0)
+  {
+    min_interval_ = Clock::duration::zero();
+    return;
+  }
+  const double seconds = 1.0 / max_rate_hz;
+  min_interval_ = std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(seconds));
+}
+
+bool RawRateLimiter::allow(const std::string& topic, Clock::time_point now)
+{
+  if (unlimited())
+  {
+    return true;
+  }
+  auto [it, inserted] = last_pass_.emplace(topic, now);
+  if (inserted)
+  {
+    return true;  // first message on this topic always passes
+  }
+  if (now - it->second < min_interval_)
+  {
+    return false;
+  }
+  it->second = now;
+  return true;
+}
+
+std::string RawStats::summary() const
+{
+  std::ostringstream out;
+  out << "raw: " << subscribed_topics.load() << " topic(s), " << forwarded.load() << " forwarded, dropped "
+      << dropped_rate.load() << " rate / " << dropped_oversize.load() << " oversize / " << dropped_shipper.load()
+      << " shipper / " << dropped_undecodable.load() << " undecodable";
+  return out.str();
+}
+
+}  // namespace dc_bridge

--- a/dc_bridge/src/raw_subscriptions.cpp
+++ b/dc_bridge/src/raw_subscriptions.cpp
@@ -1,0 +1,543 @@
+#include "dc_bridge/raw_subscriptions.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <rclcpp/typesupport_helpers.hpp>
+#include <rosidl_runtime_cpp/message_initialization.hpp>
+#include <rosidl_typesupport_introspection_cpp/field_types.hpp>
+#include <rosidl_typesupport_introspection_cpp/identifier.hpp>
+#include <rosidl_typesupport_introspection_cpp/message_introspection.hpp>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace dc_bridge
+{
+
+namespace introspection = rosidl_typesupport_introspection_cpp;
+using introspection::MessageMember;
+using introspection::MessageMembers;
+using nlohmann::json;
+
+namespace
+{
+
+/// How often a repeated raw-mode warning (oversize, undecodable, shipper drop) is
+/// allowed through. A firehose topic hits these paths at the topic's own rate, so an
+/// unthrottled log line would itself become the volume problem.
+constexpr int RAW_WARN_THROTTLE_MS = 5000;
+
+std::string utf16_to_utf8(const std::u16string& input)
+{
+  std::string out;
+  for (std::size_t i = 0; i < input.size(); ++i)
+  {
+    char32_t code_point = input[i];
+    // Surrogate pair: the code point is split across two UTF-16 units.
+    if (code_point >= 0xD800 && code_point <= 0xDBFF && i + 1 < input.size() && input[i + 1] >= 0xDC00 &&
+        input[i + 1] <= 0xDFFF)
+    {
+      code_point = 0x10000 + ((code_point - 0xD800) << 10) + (input[i + 1] - 0xDC00);
+      ++i;
+    }
+    if (code_point < 0x80)
+    {
+      out.push_back(static_cast<char>(code_point));
+    }
+    else if (code_point < 0x800)
+    {
+      out.push_back(static_cast<char>(0xC0 | (code_point >> 6)));
+      out.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+    }
+    else if (code_point < 0x10000)
+    {
+      out.push_back(static_cast<char>(0xE0 | (code_point >> 12)));
+      out.push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+    }
+    else
+    {
+      out.push_back(static_cast<char>(0xF0 | (code_point >> 18)));
+      out.push_back(static_cast<char>(0x80 | ((code_point >> 12) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | ((code_point >> 6) & 0x3F)));
+      out.push_back(static_cast<char>(0x80 | (code_point & 0x3F)));
+    }
+  }
+  return out;
+}
+
+json message_to_json(const void* message, const MessageMembers* members);
+
+json scalar_to_json(const void* field, const MessageMember& member)
+{
+  switch (member.type_id_)
+  {
+    case introspection::ROS_TYPE_FLOAT:
+      return *static_cast<const float*>(field);
+    case introspection::ROS_TYPE_DOUBLE:
+      return *static_cast<const double*>(field);
+    case introspection::ROS_TYPE_LONG_DOUBLE:
+      // JSON has one number type; long double's extra range/precision has nowhere to go.
+      return static_cast<double>(*static_cast<const long double*>(field));
+    case introspection::ROS_TYPE_CHAR:
+      return static_cast<std::int64_t>(*static_cast<const unsigned char*>(field));
+    case introspection::ROS_TYPE_WCHAR:
+      return static_cast<std::int64_t>(*static_cast<const char16_t*>(field));
+    case introspection::ROS_TYPE_BOOLEAN:
+      return *static_cast<const bool*>(field);
+    case introspection::ROS_TYPE_OCTET:
+      // `std::byte` in the C++ mapping; layout-compatible with unsigned char.
+      return static_cast<std::int64_t>(*static_cast<const unsigned char*>(field));
+    case introspection::ROS_TYPE_UINT8:
+      return static_cast<std::int64_t>(*static_cast<const std::uint8_t*>(field));
+    case introspection::ROS_TYPE_INT8:
+      return static_cast<std::int64_t>(*static_cast<const std::int8_t*>(field));
+    case introspection::ROS_TYPE_UINT16:
+      return static_cast<std::int64_t>(*static_cast<const std::uint16_t*>(field));
+    case introspection::ROS_TYPE_INT16:
+      return static_cast<std::int64_t>(*static_cast<const std::int16_t*>(field));
+    case introspection::ROS_TYPE_UINT32:
+      return static_cast<std::int64_t>(*static_cast<const std::uint32_t*>(field));
+    case introspection::ROS_TYPE_INT32:
+      return static_cast<std::int64_t>(*static_cast<const std::int32_t*>(field));
+    case introspection::ROS_TYPE_UINT64:
+      return *static_cast<const std::uint64_t*>(field);
+    case introspection::ROS_TYPE_INT64:
+      return *static_cast<const std::int64_t*>(field);
+    case introspection::ROS_TYPE_STRING:
+      return *static_cast<const std::string*>(field);
+    case introspection::ROS_TYPE_WSTRING:
+      return utf16_to_utf8(*static_cast<const std::u16string*>(field));
+    case introspection::ROS_TYPE_MESSAGE:
+      return message_to_json(field, static_cast<const MessageMembers*>(member.members_->data));
+    default:
+      break;
+  }
+  throw std::runtime_error("field '" + std::string(member.name_) + "': unsupported introspection type id " +
+                           std::to_string(static_cast<int>(member.type_id_)));
+}
+
+/// In-memory size of one element, used only for the fallback path below.
+std::size_t element_size(const MessageMember& member)
+{
+  switch (member.type_id_)
+  {
+    case introspection::ROS_TYPE_FLOAT:
+      return sizeof(float);
+    case introspection::ROS_TYPE_DOUBLE:
+      return sizeof(double);
+    case introspection::ROS_TYPE_LONG_DOUBLE:
+      return sizeof(long double);
+    case introspection::ROS_TYPE_CHAR:
+    case introspection::ROS_TYPE_OCTET:
+    case introspection::ROS_TYPE_UINT8:
+    case introspection::ROS_TYPE_INT8:
+      return 1;
+    case introspection::ROS_TYPE_WCHAR:
+    case introspection::ROS_TYPE_UINT16:
+    case introspection::ROS_TYPE_INT16:
+      return 2;
+    case introspection::ROS_TYPE_BOOLEAN:
+      return sizeof(bool);
+    case introspection::ROS_TYPE_UINT32:
+    case introspection::ROS_TYPE_INT32:
+      return 4;
+    case introspection::ROS_TYPE_UINT64:
+    case introspection::ROS_TYPE_INT64:
+      return 8;
+    case introspection::ROS_TYPE_STRING:
+      return sizeof(std::string);
+    case introspection::ROS_TYPE_WSTRING:
+      return sizeof(std::u16string);
+    case introspection::ROS_TYPE_MESSAGE:
+      return static_cast<const MessageMembers*>(member.members_->data)->size_of_;
+    default:
+      break;
+  }
+  throw std::runtime_error("field '" + std::string(member.name_) + "': unsupported introspection type id " +
+                           std::to_string(static_cast<int>(member.type_id_)));
+}
+
+json array_to_json(const void* field, const MessageMember& member)
+{
+  // The generated accessors are the correct way to walk both `std::array` (fixed) and
+  // `std::vector` (bounded/unbounded sequence) members without knowing which one this
+  // is. The pointer-arithmetic fallback only applies to a fixed array whose accessors a
+  // type support generator declined to emit — contiguous storage, so the arithmetic is
+  // valid there and nowhere else.
+  const std::size_t count = member.size_function != nullptr ? member.size_function(field) : member.array_size_;
+  json array = json::array();
+  for (std::size_t i = 0; i < count; ++i)
+  {
+    const void* element =
+        member.get_const_function != nullptr ?
+            member.get_const_function(field, i) :
+            static_cast<const void*>(static_cast<const std::uint8_t*>(field) + i * element_size(member));
+    array.push_back(scalar_to_json(element, member));
+  }
+  return array;
+}
+
+json message_to_json(const void* message, const MessageMembers* members)
+{
+  json out = json::object();
+  for (std::uint32_t i = 0; i < members->member_count_; ++i)
+  {
+    const MessageMember& member = members->members_[i];
+    const void* field = static_cast<const std::uint8_t*>(message) + member.offset_;
+    out[member.name_] = member.is_array_ ? array_to_json(field, member) : scalar_to_json(field, member);
+  }
+  return out;
+}
+
+/// A default-constructed instance of a runtime-known message type. `::operator new`
+/// rather than a `std::vector<uint8_t>` because the buffer holds real C++ objects
+/// (std::string, std::vector) whose alignment requirements the introspection data does
+/// not report — operator new is guaranteed suitably aligned for any type that size.
+class MessageStorage
+{
+public:
+  explicit MessageStorage(const MessageMembers* members) : members_(members), buffer_(::operator new(members->size_of_))
+  {
+    members_->init_function(buffer_, rosidl_runtime_cpp::MessageInitialization::ALL);
+  }
+
+  ~MessageStorage()
+  {
+    members_->fini_function(buffer_);
+    ::operator delete(buffer_);
+  }
+
+  MessageStorage(const MessageStorage&) = delete;
+  MessageStorage& operator=(const MessageStorage&) = delete;
+
+  void* get() noexcept
+  {
+    return buffer_;
+  }
+
+private:
+  const MessageMembers* members_;
+  void* buffer_;
+};
+
+}  // namespace
+
+RawMessageConverter::RawMessageConverter(const std::string& type_name) : type_name_(type_name)
+{
+  try
+  {
+    // Two libraries, two jobs: `rosidl_typesupport_cpp` knows how to turn the wire bytes
+    // back into an in-memory message, `rosidl_typesupport_introspection_cpp` knows what
+    // that message's fields are called and where they live. Both must outlive every
+    // handle taken from them, hence the members.
+    typesupport_library_ = rclcpp::get_typesupport_library(type_name, "rosidl_typesupport_cpp");
+    const rosidl_message_type_support_t* type_support =
+        rclcpp::get_message_typesupport_handle(type_name, "rosidl_typesupport_cpp", *typesupport_library_);
+
+    introspection_library_ = rclcpp::get_typesupport_library(type_name, introspection::typesupport_identifier);
+    const rosidl_message_type_support_t* introspection_support = rclcpp::get_message_typesupport_handle(
+        type_name, introspection::typesupport_identifier, *introspection_library_);
+
+    members_ = introspection_support->data;
+    serializer_ = std::make_unique<rclcpp::SerializationBase>(type_support);
+  }
+  catch (const std::exception& e)
+  {
+    throw RawConfigError("cannot load type support for message type '" + type_name + "': " + e.what());
+  }
+}
+
+RawMessageConverter::~RawMessageConverter() = default;
+
+json RawMessageConverter::to_json(const rclcpp::SerializedMessage& serialized) const
+{
+  const auto* members = static_cast<const MessageMembers*>(members_);
+  MessageStorage storage(members);
+  serializer_->deserialize_message(&serialized, storage.get());
+  return message_to_json(storage.get(), members);
+}
+
+std::optional<RawStamp> stamp_from_payload(const json& payload)
+{
+  if (!payload.is_object() || !payload.contains("header"))
+  {
+    return std::nullopt;
+  }
+  const json& header = payload.at("header");
+  if (!header.is_object() || !header.contains("stamp"))
+  {
+    return std::nullopt;
+  }
+  const json& stamp = header.at("stamp");
+  if (!stamp.is_object() || !stamp.contains("sec") || !stamp.contains("nanosec"))
+  {
+    return std::nullopt;
+  }
+  if (!stamp.at("sec").is_number_integer() || !stamp.at("nanosec").is_number_integer())
+  {
+    return std::nullopt;
+  }
+  const std::int64_t secs = stamp.at("sec").get<std::int64_t>();
+  RawStamp out;
+  // A message published before its clock was initialised carries stamp 0 (or, with
+  // sim time misconfigured, a negative one) — clamp rather than wrap into 1970-adjacent
+  // nonsense on the unsigned protocol field.
+  out.secs = secs > 0 ? static_cast<std::uint64_t>(secs) : 0;
+  out.nanos = static_cast<std::uint32_t>(stamp.at("nanosec").get<std::uint64_t>() % 1000000000ULL);
+  return out;
+}
+
+rclcpp::QoS raw_qos_for_topic(rclcpp::Node& node, const std::string& topic, std::size_t depth)
+{
+  // Braces, not parentheses: `QoS qos(KeepLast(depth))` is a function declaration.
+  rclcpp::QoS qos{ rclcpp::KeepLast(depth) };
+  const auto publishers = node.get_publishers_info_by_topic(topic);
+  if (publishers.empty())
+  {
+    return qos;
+  }
+
+  bool any_best_effort = false;
+  bool all_transient_local = true;
+  for (const auto& publisher : publishers)
+  {
+    const rclcpp::QoS& profile = publisher.qos_profile();
+    if (profile.reliability() == rclcpp::ReliabilityPolicy::BestEffort)
+    {
+      any_best_effort = true;
+    }
+    if (profile.durability() != rclcpp::DurabilityPolicy::TransientLocal)
+    {
+      all_transient_local = false;
+    }
+  }
+  if (any_best_effort)
+  {
+    qos.best_effort();
+  }
+  if (all_transient_local)
+  {
+    qos.transient_local();
+  }
+  return qos;
+}
+
+RawSubscriptionManager::RawSubscriptionManager(rclcpp::Node* node, RawConfig config, RecordSink sink, RawStats* stats)
+  : node_(node)
+  , config_(std::move(config))
+  , filter_(config_)
+  , sink_(std::move(sink))
+  , stats_(stats)
+  , limiter_(config_.max_rate_hz)
+{
+  if (config_.destination.empty())
+  {
+    throw RawConfigError("raw.enabled is true but raw.destination is empty; name the `receives: records` "
+                         "destination raw Records should be routed to");
+  }
+}
+
+void RawSubscriptionManager::start()
+{
+  scan();
+  if (config_.rescan_interval_secs > 0.0)
+  {
+    const auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::duration<double>(config_.rescan_interval_secs));
+    rescan_timer_ = node_->create_wall_timer(period, [this]() { this->scan(); });
+  }
+  else
+  {
+    RCLCPP_INFO(node_->get_logger(), "raw: rescan disabled (raw.rescan_interval_secs = 0); topics appearing "
+                                     "after startup will not be picked up");
+  }
+}
+
+void RawSubscriptionManager::scan()
+{
+  for (const auto& [topic, types] : node_->get_topic_names_and_types())
+  {
+    bool already_subscribed = false;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      already_subscribed = subscriptions_.count(topic) > 0;
+    }
+    if (already_subscribed || types.empty())
+    {
+      continue;
+    }
+
+    // Every skipped topic is re-evaluated on the next scan — some reasons to skip are
+    // transient (a second publisher advertising a different type goes away; a message
+    // package's type support becomes loadable) and a permanent skip list would never
+    // notice. Only the *log line* is suppressed after the first time, so a 5-second
+    // rescan doesn't reprint the same verdict forever.
+    auto report = [this, &topic](const std::string& message, bool warn) {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (!reported_.insert(topic).second)
+      {
+        return;
+      }
+      if (warn)
+      {
+        RCLCPP_WARN(node_->get_logger(), "raw: cannot subscribe to %s: %s", topic.c_str(), message.c_str());
+      }
+      else
+      {
+        RCLCPP_INFO(node_->get_logger(), "raw: skipping %s (%s)", topic.c_str(), message.c_str());
+      }
+    };
+
+    if (types.size() > 1)
+    {
+      // Genuinely ambiguous: one generic subscription can carry exactly one type, and
+      // picking arbitrarily would silently drop the other publisher's messages.
+      report("topic advertises " + std::to_string(types.size()) + " types", false);
+      continue;
+    }
+
+    const std::string& type = types.front();
+    const RawSkip verdict = filter_.evaluate(topic, type);
+    if (verdict != RawSkip::Accepted)
+    {
+      report(to_string(verdict), false);
+      continue;
+    }
+
+    std::shared_ptr<RawMessageConverter> converter;
+    try
+    {
+      converter = std::make_shared<RawMessageConverter>(type);
+    }
+    catch (const std::exception& e)
+    {
+      // The message package isn't on this Bridge's AMENT_PREFIX_PATH. Not fatal — the
+      // rest of the graph is still collectable — but the operator has to know.
+      report(e.what(), true);
+      continue;
+    }
+
+    const std::string tag = raw_tag(config_.tag_prefix, topic);
+    std::shared_ptr<rclcpp::GenericSubscription> subscription;
+    try
+    {
+      subscription =
+          node_->create_generic_subscription(topic, type, raw_qos_for_topic(*node_, topic, config_.qos_depth),
+                                             [this, topic](std::shared_ptr<const rclcpp::SerializedMessage> message) {
+                                               this->on_raw_message(topic, std::move(message));
+                                             });
+    }
+    catch (const std::exception& e)
+    {
+      report(std::string("creating the generic subscription failed: ") + e.what(), true);
+      continue;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      subscriptions_.emplace(topic, Entry{ subscription, converter, tag });
+      if (stats_ != nullptr)
+      {
+        stats_->subscribed_topics.store(subscriptions_.size());
+      }
+    }
+    RCLCPP_INFO(node_->get_logger(), "raw: subscribed to %s [%s] under Tag '%s'", topic.c_str(), type.c_str(),
+                tag.c_str());
+  }
+}
+
+std::size_t RawSubscriptionManager::subscription_count() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return subscriptions_.size();
+}
+
+void RawSubscriptionManager::on_raw_message(const std::string& topic,
+                                            std::shared_ptr<const rclcpp::SerializedMessage> message)
+{
+  std::shared_ptr<RawMessageConverter> converter;
+  std::string tag;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = subscriptions_.find(topic);
+    if (it == subscriptions_.end())
+    {
+      return;
+    }
+    converter = it->second.converter;
+    tag = it->second.tag;
+
+    // Both volume gates run before any deserialization work: the cheapest possible drop
+    // is the point (#227's "a raw-subscribe-everything mode can outrun the Shipper").
+    if (config_.max_message_size_bytes > 0 && message->size() > config_.max_message_size_bytes)
+    {
+      if (stats_ != nullptr)
+      {
+        stats_->dropped_oversize.fetch_add(1);
+      }
+      RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), RAW_WARN_THROTTLE_MS,
+                           "raw: dropping messages on %s: %zu bytes exceeds raw.max_message_size_bytes (%lu)",
+                           topic.c_str(), message->size(), static_cast<unsigned long>(config_.max_message_size_bytes));
+      return;
+    }
+    if (!limiter_.allow(topic, RawRateLimiter::Clock::now()))
+    {
+      if (stats_ != nullptr)
+      {
+        stats_->dropped_rate.fetch_add(1);
+      }
+      return;
+    }
+  }
+
+  json payload;
+  try
+  {
+    payload = converter->to_json(*message);
+  }
+  catch (const std::exception& e)
+  {
+    if (stats_ != nullptr)
+    {
+      stats_->dropped_undecodable.fetch_add(1);
+    }
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), RAW_WARN_THROTTLE_MS,
+                         "raw: dropping a message on %s: %s", topic.c_str(), e.what());
+    return;
+  }
+
+  RawStamp stamp;
+  if (const auto header_stamp = stamp_from_payload(payload))
+  {
+    stamp = *header_stamp;
+  }
+  else
+  {
+    // No header: stamp with the node's own clock (sim time included, like every other
+    // DC timestamp).
+    const std::int64_t since_epoch = std::max<std::int64_t>(0, node_->now().nanoseconds());
+    stamp.secs = static_cast<std::uint64_t>(since_epoch / 1000000000LL);
+    stamp.nanos = static_cast<std::uint32_t>(since_epoch % 1000000000LL);
+  }
+
+  const bool forwarded = sink_(tag, stamp, std::move(payload));
+  if (stats_ == nullptr)
+  {
+    return;
+  }
+  if (forwarded)
+  {
+    stats_->forwarded.fetch_add(1);
+  }
+  else
+  {
+    stats_->dropped_shipper.fetch_add(1);
+    RCLCPP_WARN_THROTTLE(node_->get_logger(), *node_->get_clock(), RAW_WARN_THROTTLE_MS,
+                         "raw: the Shipper refused a Record on %s; raw Records are dropped rather than queued "
+                         "(see doc/src/dc/raw_topics.md)",
+                         topic.c_str());
+  }
+}
+
+}  // namespace dc_bridge

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -60,6 +60,32 @@ std::string debug_quote(const std::string& s)
   return out;
 }
 
+// The `route` transform branch key a Tag namespace is exposed under: the prefix with its
+// trailing separator dot(s) dropped, so `dc.raw.` → branch `dc.raw` → public route
+// `dc.dc.raw` (route_output_for_tag_prefix), reading exactly like an exact-Tag branch.
+std::string route_branch_for_tag_prefix(const std::string& prefix)
+{
+  std::string branch = prefix;
+  while (!branch.empty() && branch.back() == '.')
+  {
+    branch.pop_back();
+  }
+  return branch;
+}
+
+// The VRL predicate matching every Tag in a namespace.
+//
+// `to_string(.tag) ?? ""` rather than a bare `.tag`: VRL types an event field as `any`,
+// and `starts_with` demands an exact string — Vector rejects the whole config at
+// `validate` time otherwise ("this expression resolves to any", E110). The `??` fallback
+// keeps the predicate infallible, so a Record that somehow arrives with a non-string tag
+// simply doesn't match instead of aborting the transform. `includes()` (the exact-Tag
+// half) has no such requirement, which is why only this side needs the coercion.
+std::string tag_prefix_predicate(const std::string& prefix)
+{
+  return "starts_with(to_string(.tag) ?? \"\", " + debug_quote(prefix) + ")";
+}
+
 bool is_valid_destination_name(const std::string& name)
 {
   if (name.empty())
@@ -112,20 +138,48 @@ std::set<std::string> destination_tags(const Destination& dest)
   return tags;
 }
 
-std::string tag_condition(const std::set<std::string>& tags)
+// The Tag namespaces routed to a Destination with `starts_with` rather than equality
+// (raw mode, #227) — sorted+unique for the same determinism reason as destination_tags.
+std::set<std::string> destination_tag_prefixes(const Destination& dest)
 {
-  std::string joined;
-  bool first = true;
-  for (const auto& t : tags)
+  return std::set<std::string>(dest.tag_prefixes.begin(), dest.tag_prefixes.end());
+}
+
+// The VRL condition selecting a Destination's events: exact Tags via `includes(...)`,
+// plus one `starts_with` per routed Tag namespace. Either half may be empty (a
+// raw-only Destination has no exact Tags at all), never both — validate() rejects that.
+std::string tag_condition(const std::set<std::string>& tags, const std::set<std::string>& prefixes)
+{
+  std::vector<std::string> terms;
+  if (!tags.empty())
   {
-    if (!first)
+    std::string joined;
+    bool first = true;
+    for (const auto& t : tags)
     {
-      joined += ", ";
+      if (!first)
+      {
+        joined += ", ";
+      }
+      joined += debug_quote(t);
+      first = false;
     }
-    joined += debug_quote(t);
-    first = false;
+    terms.push_back("includes([" + joined + "], .tag)");
   }
-  return "includes([" + joined + "], .tag)";
+  for (const auto& prefix : prefixes)
+  {
+    terms.push_back(tag_prefix_predicate(prefix));
+  }
+  std::string out;
+  for (std::size_t i = 0; i < terms.size(); ++i)
+  {
+    if (i > 0)
+    {
+      out += " || ";
+    }
+    out += terms[i];
+  }
+  return out;
 }
 
 std::string render_normalize_source(const RenderConfig& config)
@@ -133,7 +187,7 @@ std::string render_normalize_source(const RenderConfig& config)
   std::string out;
   for (const auto& dest : config.destinations)
   {
-    out += "if " + tag_condition(destination_tags(dest)) + " {\n";
+    out += "if " + tag_condition(destination_tags(dest), destination_tag_prefixes(dest)) + " {\n";
     if (dest.time_format == TimeFormat::EpochNanos)
     {
       // Exact: an i64 of nanoseconds since the epoch, no float rounding anywhere. Good
@@ -185,6 +239,10 @@ toml::array sink_inputs(const Destination& dest)
   for (const auto& tag : destination_tags(dest))
   {
     inputs.push_back(route_output_for_tag(tag));
+  }
+  for (const auto& prefix : destination_tag_prefixes(dest))
+  {
+    inputs.push_back(route_output_for_tag_prefix(prefix));
   }
   return inputs;
 }
@@ -312,7 +370,7 @@ void validate(const RenderConfig& config)
       throw RenderError(RenderErrorKind::DuplicateDestination, "duplicate destination name '" + dest.name + "'",
                         dest.name);
     }
-    if (dest.inputs.empty() && dest.extra_tags.empty())
+    if (dest.inputs.empty() && dest.extra_tags.empty() && dest.tag_prefixes.empty())
     {
       throw RenderError(RenderErrorKind::EmptyInputs, "destination '" + dest.name + "': `inputs` must not be empty",
                         dest.name);
@@ -323,6 +381,36 @@ void validate(const RenderConfig& config)
                         "internal error: `receives: files` destination '" + dest.name +
                             "' reached the shipper config renderer",
                         dest.name);
+    }
+  }
+
+  // A prefix branch and an exact-Tag branch are both keys in the same `route` table, so
+  // a Tag equal to a prefix's branch id (Tag `dc.raw` against prefix `dc.raw.`) would
+  // have one silently overwrite the other and send that Destination's data to the wrong
+  // sink. Vanishingly unlikely — it takes a topic literally named `/dc/raw` — but a
+  // silent mis-route is exactly the failure that must not be possible, so it's a loud
+  // config error instead.
+  std::set<std::string> prefix_branches;
+  std::set<std::string> exact_tags;
+  for (const auto& dest : config.destinations)
+  {
+    for (const auto& prefix : dest.tag_prefixes)
+    {
+      prefix_branches.insert(route_branch_for_tag_prefix(prefix));
+    }
+    for (const auto& tag : destination_tags(dest))
+    {
+      exact_tags.insert(tag);
+    }
+  }
+  for (const auto& tag : exact_tags)
+  {
+    if (prefix_branches.count(tag))
+    {
+      throw RenderError(RenderErrorKind::TagPrefixCollidesWithTag,
+                        "Tag '" + tag + "' collides with the routed Tag namespace '" + tag +
+                            ".'; rename the topic or the raw tag_prefix",
+                        tag);
     }
   }
 }
@@ -342,6 +430,11 @@ std::set<std::string> rendered_component_ids(const RenderConfig& config)
 std::string route_output_for_tag(const std::string& tag)
 {
   return std::string(ROUTE_TRANSFORM_ID) + "." + tag;
+}
+
+std::string route_output_for_tag_prefix(const std::string& prefix)
+{
+  return std::string(ROUTE_TRANSFORM_ID) + "." + route_branch_for_tag_prefix(prefix);
 }
 
 PostgresParams postgres_from_raw(const std::string& name, const RawDestinationParams& raw)
@@ -642,11 +735,16 @@ std::string render(const RenderConfig& config)
   normalize.insert("source", render_normalize_source(config));
 
   std::set<std::string> all_tags;
+  std::set<std::string> all_tag_prefixes;
   for (const auto& dest : config.destinations)
   {
     for (const auto& tag : destination_tags(dest))
     {
       all_tags.insert(tag);
+    }
+    for (const auto& prefix : destination_tag_prefixes(dest))
+    {
+      all_tag_prefixes.insert(prefix);
     }
   }
   toml::table route_branches;
@@ -656,6 +754,13 @@ std::string render(const RenderConfig& config)
     branch.insert("type", "vrl");
     branch.insert("source", ".tag == " + debug_quote(tag));
     route_branches.insert(tag, std::move(branch));
+  }
+  for (const auto& prefix : all_tag_prefixes)
+  {
+    toml::table branch;
+    branch.insert("type", "vrl");
+    branch.insert("source", tag_prefix_predicate(prefix));
+    route_branches.insert(route_branch_for_tag_prefix(prefix), std::move(branch));
   }
   toml::table route;
   route.insert("type", "route");

--- a/dc_bridge/test/local/CMakeLists.txt
+++ b/dc_bridge/test/local/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(dc_bridge_core
   ${CORE_ROOT}/src/supervisor.cpp
   ${CORE_ROOT}/src/vector_binary.cpp
   ${CORE_ROOT}/src/render.cpp
+  ${CORE_ROOT}/src/raw_config.cpp
   ${CORE_ROOT}/src/uploader/content_type.cpp
   ${CORE_ROOT}/src/uploader/group.cpp
   ${CORE_ROOT}/src/uploader/status.cpp
@@ -38,7 +39,7 @@ if(TARGET msgpack-cxx)
 endif()
 
 enable_testing()
-foreach(t forwarder supervisor render misc uploader intent_queue retention)
+foreach(t forwarder supervisor render misc uploader intent_queue retention raw_config)
   add_executable(${t}_test ${CORE_ROOT}/test/${t}_test.cpp)
   target_link_libraries(${t}_test dc_bridge_core GTest::gtest GTest::gtest_main Threads::Threads)
   target_compile_definitions(${t}_test PRIVATE

--- a/dc_bridge/test/raw_config_test.cpp
+++ b/dc_bridge/test/raw_config_test.cpp
@@ -1,0 +1,180 @@
+// Raw / generic-subscription mode policy (#227): the filter, the Tag derivation and the
+// per-topic rate limit that is raw mode's first line of defence against a firehose
+// topic. All ROS-free — these are the decisions the manager makes before it ever touches
+// a message.
+#include "dc_bridge/raw_config.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace dc_bridge;
+
+namespace
+{
+
+RawConfig default_config()
+{
+  RawConfig config;
+  config.enabled = true;
+  config.destination = "records";
+  config.include = { "^/" };
+  config.exclude = default_raw_exclude();
+  config.exclude_types = default_raw_exclude_types();
+  return config;
+}
+
+}  // namespace
+
+TEST(RawFilter, AcceptsEveryTopicByDefault)
+{
+  RawTopicFilter filter(default_config());
+  EXPECT_TRUE(filter.accepts("/robot/state", "my_robot_msgs/msg/State"));
+  EXPECT_TRUE(filter.accepts("/deeply/nested/topic", "std_msgs/msg/String"));
+}
+
+TEST(RawFilter, IncludePatternsAreTheAllowlist)
+{
+  RawConfig config = default_config();
+  config.include = { "^/robot/", "^/diagnostics$" };
+  RawTopicFilter filter(config);
+
+  EXPECT_TRUE(filter.accepts("/robot/state", "std_msgs/msg/String"));
+  EXPECT_TRUE(filter.accepts("/diagnostics", "std_msgs/msg/String"));
+  EXPECT_EQ(filter.evaluate("/other/topic", "std_msgs/msg/String"), RawSkip::NotIncluded);
+}
+
+TEST(RawFilter, ExcludeVetoesAnInclude)
+{
+  RawConfig config = default_config();
+  config.include = { "^/robot/" };
+  config.exclude = { "/secret" };
+  RawTopicFilter filter(config);
+
+  EXPECT_TRUE(filter.accepts("/robot/state", "std_msgs/msg/String"));
+  EXPECT_EQ(filter.evaluate("/robot/secret/key", "std_msgs/msg/String"), RawSkip::Excluded);
+}
+
+TEST(RawFilter, DefaultsKeepRosInfrastructureAndDcRecordTopicsOut)
+{
+  RawTopicFilter filter(default_config());
+
+  // /rosout would feed the Bridge's own warnings back into the pipeline it warns about.
+  EXPECT_EQ(filter.evaluate("/rosout", "rcl_interfaces/msg/Log"), RawSkip::Excluded);
+  EXPECT_EQ(filter.evaluate("/parameter_events", "rcl_interfaces/msg/ParameterEvent"), RawSkip::Excluded);
+  // Already shipped as Measurement/Group Records — raw would double every one of them.
+  EXPECT_EQ(filter.evaluate("/dc/measurement/uptime", "dc_interfaces/msg/StringStamped"), RawSkip::Excluded);
+  EXPECT_EQ(filter.evaluate("/dc/group/robot", "dc_interfaces/msg/StringStamped"), RawSkip::Excluded);
+  // A non-Record topic under /dc is fair game.
+  EXPECT_TRUE(filter.accepts("/dc/e2e/synth/synth00", "dc_interfaces/msg/StringStamped"));
+}
+
+TEST(RawFilter, DefaultsKeepHighRateSensorTypesOut)
+{
+  RawTopicFilter filter(default_config());
+
+  // #227's third open question, answered by the defaults: yes, excluded — and by *type*,
+  // because a camera topic is not reliably named anything in particular.
+  EXPECT_EQ(filter.evaluate("/front/rgb", "sensor_msgs/msg/Image"), RawSkip::ExcludedType);
+  EXPECT_EQ(filter.evaluate("/anything", "sensor_msgs/msg/CompressedImage"), RawSkip::ExcludedType);
+  EXPECT_EQ(filter.evaluate("/lidar/points", "sensor_msgs/msg/PointCloud2"), RawSkip::ExcludedType);
+  EXPECT_EQ(filter.evaluate("/tf", "tf2_msgs/msg/TFMessage"), RawSkip::ExcludedType);
+  // Small, low-rate sensor messages stay in.
+  EXPECT_TRUE(filter.accepts("/imu", "sensor_msgs/msg/Imu"));
+  EXPECT_TRUE(filter.accepts("/battery", "sensor_msgs/msg/BatteryState"));
+}
+
+TEST(RawFilter, EmptyIncludeListMatchesNothing)
+{
+  RawConfig config = default_config();
+  config.include.clear();
+  RawTopicFilter filter(config);
+  EXPECT_EQ(filter.evaluate("/robot/state", "std_msgs/msg/String"), RawSkip::NotIncluded);
+}
+
+TEST(RawFilter, RejectsAnUncompilableRegexAtConstruction)
+{
+  RawConfig config = default_config();
+  config.include = { "^/robot/[" };
+  EXPECT_THROW(RawTopicFilter{ config }, RawConfigError);
+}
+
+TEST(RawTag, DerivesFromTheTopicUnderTheRawNamespace)
+{
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/dc/e2e/synth/synth00"), "dc.raw.dc.e2e.synth.synth00");
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/imu"), "dc.raw.imu");
+  // No leading slash (never produced by the ROS graph, but the derivation shouldn't care).
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "imu"), "dc.raw.imu");
+  EXPECT_EQ(raw_tag("raw.", "/robot/state"), "raw.robot.state");
+}
+
+TEST(RawTag, SanitisesAnythingOutsideTheTagAlphabet)
+{
+  // A Tag ends up in a VRL string literal and a Vector route name; nothing outside
+  // [A-Za-z0-9_.] survives the derivation.
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/robot state"), "dc.raw.robot_state");
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/robot\"state"), "dc.raw.robot_state");
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/a-b"), "dc.raw.a_b");
+  EXPECT_EQ(raw_tag(RAW_TAG_PREFIX, "/ok_1/ok_2"), "dc.raw.ok_1.ok_2");
+}
+
+TEST(RawRateLimiter, DecimatesAFirehoseToTheConfiguredRate)
+{
+  // The firehose case (#227's second open question): 1000 messages arriving over one
+  // simulated second on a 10 Hz limit must not produce 1000 Records.
+  RawRateLimiter limiter(10.0);
+  const auto start = RawRateLimiter::Clock::now();
+  std::size_t passed = 0;
+  for (int i = 0; i < 1000; ++i)
+  {
+    if (limiter.allow("/firehose", start + std::chrono::milliseconds(i)))
+    {
+      ++passed;
+    }
+  }
+  // One per 100 ms across a 1 s window, plus the first message.
+  EXPECT_GE(passed, 9u);
+  EXPECT_LE(passed, 11u);
+}
+
+TEST(RawRateLimiter, LimitsAreIndependentPerTopic)
+{
+  RawRateLimiter limiter(10.0);
+  const auto now = RawRateLimiter::Clock::now();
+  EXPECT_TRUE(limiter.allow("/a", now));
+  EXPECT_TRUE(limiter.allow("/b", now));
+  EXPECT_FALSE(limiter.allow("/a", now + std::chrono::milliseconds(1)));
+  EXPECT_FALSE(limiter.allow("/b", now + std::chrono::milliseconds(1)));
+  EXPECT_TRUE(limiter.allow("/a", now + std::chrono::milliseconds(200)));
+}
+
+TEST(RawRateLimiter, ZeroOrNegativeRateMeansUnlimited)
+{
+  RawRateLimiter limiter(0.0);
+  EXPECT_TRUE(limiter.unlimited());
+  const auto now = RawRateLimiter::Clock::now();
+  for (int i = 0; i < 100; ++i)
+  {
+    EXPECT_TRUE(limiter.allow("/firehose", now));
+  }
+  EXPECT_TRUE(RawRateLimiter(-1.0).unlimited());
+}
+
+TEST(RawStatsTest, SummaryReportsEveryDropReason)
+{
+  RawStats stats;
+  stats.subscribed_topics.store(3);
+  stats.forwarded.store(10);
+  stats.dropped_rate.store(4);
+  stats.dropped_oversize.store(2);
+  stats.dropped_shipper.store(1);
+  stats.dropped_undecodable.store(5);
+
+  const std::string summary = stats.summary();
+  EXPECT_NE(summary.find("3 topic(s)"), std::string::npos);
+  EXPECT_NE(summary.find("10 forwarded"), std::string::npos);
+  EXPECT_NE(summary.find("4 rate"), std::string::npos);
+  EXPECT_NE(summary.find("2 oversize"), std::string::npos);
+  EXPECT_NE(summary.find("1 shipper"), std::string::npos);
+  EXPECT_NE(summary.find("5 undecodable"), std::string::npos);
+}

--- a/dc_bridge/test/raw_subscriptions_test.cpp
+++ b/dc_bridge/test/raw_subscriptions_test.cpp
@@ -1,0 +1,319 @@
+// Raw / generic-subscription mode against real message types (#227).
+//
+// The point of every test here is that the Bridge is handed *bytes and a type name* and
+// nothing else: `dc_interfaces/msg/StringStamped` is a custom, non-std_msgs type, and
+// the converter resolves it through the runtime type support libraries exactly as it
+// would for a message package it has never seen. The manager tests additionally run a
+// real ROS graph — publisher, discovery, generic subscription — and cover the firehose
+// behaviour (#227's "a raw-subscribe-everything mode can outrun the Shipper").
+#include "dc_bridge/raw_subscriptions.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/serialization.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
+#include <string>
+#include <vector>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+
+using namespace dc_bridge;
+using namespace std::chrono_literals;
+
+namespace
+{
+
+/// Serializes a message the ordinary typed way, so the converter's input is the same
+/// CDR the middleware would hand a generic subscription.
+template <typename MessageT>
+rclcpp::SerializedMessage serialize(const MessageT& message)
+{
+  rclcpp::Serialization<MessageT> serializer;
+  rclcpp::SerializedMessage serialized;
+  serializer.serialize_message(&message, &serialized);
+  return serialized;
+}
+
+dc_interfaces::msg::StringStamped make_string_stamped()
+{
+  dc_interfaces::msg::StringStamped message;
+  message.header.stamp.sec = 1750000000;
+  message.header.stamp.nanosec = 123456789;
+  message.header.frame_id = "base_link";
+  message.data = R"({"value": 42})";
+  message.group_key = "synth00";
+  return message;
+}
+
+RawConfig test_config(std::vector<std::string> include)
+{
+  RawConfig config;
+  config.enabled = true;
+  config.destination = "records";
+  config.include = std::move(include);
+  config.exclude = {};
+  config.exclude_types = {};
+  config.rescan_interval_secs = 0.2;
+  config.max_rate_hz = 0.0;
+  config.max_message_size_bytes = 0;
+  return config;
+}
+
+/// Spins `node` until `predicate` holds or the deadline passes. Returns whether it held.
+template <typename Predicate>
+bool spin_until(const rclcpp::Node::SharedPtr& node, Predicate predicate, std::chrono::seconds timeout = 10s)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline)
+  {
+    if (predicate())
+    {
+      return true;
+    }
+    rclcpp::spin_some(node);
+    std::this_thread::sleep_for(10ms);
+  }
+  return predicate();
+}
+
+}  // namespace
+
+// --- introspection → JSON -----------------------------------------------------------
+
+TEST(RawMessageConverterTest, ConvertsACustomNonStdMsgsType)
+{
+  RawMessageConverter converter("dc_interfaces/msg/StringStamped");
+  const nlohmann::json payload = converter.to_json(serialize(make_string_stamped()));
+
+  EXPECT_EQ(payload["data"], R"({"value": 42})");
+  EXPECT_EQ(payload["group_key"], "synth00");
+  EXPECT_EQ(payload["header"]["frame_id"], "base_link");
+  EXPECT_EQ(payload["header"]["stamp"]["sec"], 1750000000);
+  EXPECT_EQ(payload["header"]["stamp"]["nanosec"], 123456789);
+}
+
+TEST(RawMessageConverterTest, ConvertsNestedMessagesAndSequences)
+{
+  std_msgs::msg::Float64MultiArray message;
+  message.data = { 1.5, -2.25, 0.0 };
+  message.layout.data_offset = 7;
+  std_msgs::msg::MultiArrayDimension dimension;
+  dimension.label = "rows";
+  dimension.size = 3;
+  dimension.stride = 1;
+  message.layout.dim.push_back(dimension);
+
+  RawMessageConverter converter("std_msgs/msg/Float64MultiArray");
+  const nlohmann::json payload = converter.to_json(serialize(message));
+
+  EXPECT_EQ(payload["data"], (nlohmann::json{ 1.5, -2.25, 0.0 }));
+  EXPECT_EQ(payload["layout"]["data_offset"], 7);
+  ASSERT_EQ(payload["layout"]["dim"].size(), 1u);
+  EXPECT_EQ(payload["layout"]["dim"][0]["label"], "rows");
+  EXPECT_EQ(payload["layout"]["dim"][0]["size"], 3);
+}
+
+TEST(RawMessageConverterTest, RejectsAnUnknownType)
+{
+  EXPECT_THROW(RawMessageConverter("no_such_pkg/msg/NoSuchMessage"), RawConfigError);
+}
+
+TEST(RawStampTest, PrefersTheMessageHeaderStamp)
+{
+  RawMessageConverter converter("dc_interfaces/msg/StringStamped");
+  const auto stamp = stamp_from_payload(converter.to_json(serialize(make_string_stamped())));
+  ASSERT_TRUE(stamp.has_value());
+  EXPECT_EQ(stamp->secs, 1750000000u);
+  EXPECT_EQ(stamp->nanos, 123456789u);
+}
+
+TEST(RawStampTest, ReportsNoStampForAHeaderlessMessage)
+{
+  RawMessageConverter converter("std_msgs/msg/Float64MultiArray");
+  EXPECT_FALSE(stamp_from_payload(converter.to_json(serialize(std_msgs::msg::Float64MultiArray()))).has_value());
+  // Not a message at all, and messages whose `header` isn't a Header.
+  EXPECT_FALSE(stamp_from_payload(nlohmann::json{ { "header", 3 } }).has_value());
+  EXPECT_FALSE(stamp_from_payload(nlohmann::json{ { "header", { { "stamp", "now" } } } }).has_value());
+}
+
+// --- discovery + generic subscription on a live graph --------------------------------
+
+TEST(RawSubscriptionManagerTest, DiscoversAndForwardsACustomTypeTopic)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_discovery_test");
+  auto publisher = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test/custom", 10);
+
+  std::mutex mutex;
+  std::vector<std::pair<std::string, nlohmann::json>> received;
+  RawStats stats;
+  RawSubscriptionManager manager(
+      node.get(), test_config({ "^/raw_test/" }),
+      [&](const std::string& tag, const RawStamp&, nlohmann::json payload) {
+        std::lock_guard<std::mutex> lock(mutex);
+        received.emplace_back(tag, std::move(payload));
+        return true;
+      },
+      &stats);
+  manager.start();
+
+  ASSERT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }))
+      << "the manager never discovered /raw_test/custom";
+
+  ASSERT_TRUE(spin_until(node, [&] {
+    publisher->publish(make_string_stamped());
+    std::lock_guard<std::mutex> lock(mutex);
+    return !received.empty();
+  })) << "no raw Record reached the sink";
+
+  std::lock_guard<std::mutex> lock(mutex);
+  EXPECT_EQ(received.front().first, "dc.raw.raw_test.custom");
+  EXPECT_EQ(received.front().second["group_key"], "synth00");
+  EXPECT_GT(stats.forwarded.load(), 0u);
+}
+
+TEST(RawSubscriptionManagerTest, PicksUpATopicThatAppearsAfterStartup)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_rescan_test");
+  RawStats stats;
+  RawSubscriptionManager manager(
+      node.get(), test_config({ "^/raw_test_late/" }),
+      [](const std::string&, const RawStamp&, nlohmann::json) { return true; }, &stats);
+  manager.start();
+  EXPECT_EQ(manager.subscription_count(), 0u);
+
+  // The publisher only exists now — the whole point of the periodic rescan.
+  auto publisher = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_late/appeared", 10);
+  EXPECT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }));
+}
+
+TEST(RawSubscriptionManagerTest, RespectsTheFilterOnDiscoveredTopics)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_filter_test");
+  auto kept = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_filter/kept", 10);
+  auto dropped = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_filter/dropped", 10);
+
+  RawConfig config = test_config({ "^/raw_test_filter/" });
+  config.exclude = { "dropped$" };
+  RawStats stats;
+  RawSubscriptionManager manager(
+      node.get(), config, [](const std::string&, const RawStamp&, nlohmann::json) { return true; }, &stats);
+  manager.start();
+
+  ASSERT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }));
+  // Give a second rescan a chance to (wrongly) pick the excluded topic up.
+  spin_until(
+      node, [&] { return manager.subscription_count() > 1; }, 2s);
+  EXPECT_EQ(manager.subscription_count(), 1u);
+}
+
+// --- firehose / backpressure ---------------------------------------------------------
+
+TEST(RawSubscriptionManagerTest, RateLimitDecimatesAFirehoseTopic)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_firehose_test");
+  auto publisher = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_fire/hose", 500);
+
+  RawConfig config = test_config({ "^/raw_test_fire/" });
+  config.max_rate_hz = 2.0;  // at most one Record every 500 ms
+  // Deep enough that the burst below is actually delivered to the callback rather than
+  // being discarded by the middleware's own history depth first — the point of this test
+  // is the Bridge's decimation, not the DDS queue's. (With the default depth of 10 the
+  // subscription only ever sees the last 10 of the 200, which is itself worth knowing:
+  // `raw.qos_depth` bounds how much a momentarily busy Bridge can buffer per topic.)
+  config.qos_depth = 500;
+  RawStats stats;
+  std::atomic<std::size_t> forwarded{ 0 };
+  RawSubscriptionManager manager(
+      node.get(), config,
+      [&](const std::string&, const RawStamp&, nlohmann::json) {
+        ++forwarded;
+        return true;
+      },
+      &stats);
+  manager.start();
+  ASSERT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }));
+
+  // A burst far faster than the limit: everything must still arrive at the subscription
+  // (so the drops are the Bridge's deliberate decision, not lost messages) and almost
+  // all of it must be shed before it reaches the Shipper.
+  for (int i = 0; i < 200; ++i)
+  {
+    publisher->publish(make_string_stamped());
+  }
+  spin_until(
+      node, [&] { return stats.dropped_rate.load() >= 150; }, 5s);
+
+  EXPECT_GT(stats.dropped_rate.load(), 100u) << "the firehose was not decimated";
+  EXPECT_LE(forwarded.load(), 5u) << "far more Records were forwarded than the 2 Hz limit allows";
+}
+
+TEST(RawSubscriptionManagerTest, DropsRatherThanQueuesWhenTheShipperRefuses)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_backpressure_test");
+  auto publisher = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_bp/hose", 200);
+
+  RawStats stats;
+  // The sink stands in for a Forwarder that is refusing everything (Vector unreachable,
+  // or its socket blocked past write_timeout). The documented behaviour is that raw
+  // Records are dropped and counted — never buffered inside the Bridge, which is what
+  // would turn a firehose into unbounded memory growth.
+  RawSubscriptionManager manager(
+      node.get(), test_config({ "^/raw_test_bp/" }),
+      [](const std::string&, const RawStamp&, nlohmann::json) { return false; }, &stats);
+  manager.start();
+  ASSERT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }));
+
+  for (int i = 0; i < 50; ++i)
+  {
+    publisher->publish(make_string_stamped());
+  }
+  ASSERT_TRUE(spin_until(
+      node, [&] { return stats.dropped_shipper.load() >= 10; }, 5s));
+  EXPECT_EQ(stats.forwarded.load(), 0u);
+}
+
+TEST(RawSubscriptionManagerTest, DropsMessagesOverTheSizeLimitBeforeDeserializing)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_oversize_test");
+  auto publisher = node->create_publisher<dc_interfaces::msg::StringStamped>("/raw_test_size/big", 10);
+
+  RawConfig config = test_config({ "^/raw_test_size/" });
+  config.max_message_size_bytes = 64;
+  RawStats stats;
+  RawSubscriptionManager manager(
+      node.get(), config, [](const std::string&, const RawStamp&, nlohmann::json) { return true; }, &stats);
+  manager.start();
+  ASSERT_TRUE(spin_until(node, [&] { return manager.subscription_count() == 1; }));
+
+  auto big = make_string_stamped();
+  big.data = std::string(4096, 'x');
+  ASSERT_TRUE(spin_until(node, [&] {
+    publisher->publish(big);
+    return stats.dropped_oversize.load() > 0;
+  }));
+  EXPECT_EQ(stats.forwarded.load(), 0u);
+}
+
+TEST(RawSubscriptionManagerTest, RejectsAnEnabledModeWithNoDestination)
+{
+  auto node = std::make_shared<rclcpp::Node>("raw_no_destination_test");
+  RawConfig config = test_config({ "^/" });
+  config.destination.clear();
+  EXPECT_THROW(RawSubscriptionManager(
+                   node.get(), config, [](const std::string&, const RawStamp&, nlohmann::json) { return true; },
+                   nullptr),
+               RawConfigError);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -379,6 +379,72 @@ TEST(Render, ExtraTagsAreRoutedNormalizedAndConsumed)
   EXPECT_NE(normalize->find("includes([\"dc.files\", \"dc.group.robot\"], .tag)"), std::string::npos);
 }
 
+TEST(Render, TagPrefixesRouteAWholeNamespaceWithStartsWith)
+{
+  // Raw mode (#227): the Tags don't exist yet when this config is rendered — topics are
+  // discovered while Vector is already running — so the branch matches the namespace.
+  auto config = basic_config(TimeFormat::Double);
+  config.destinations[0].tag_prefixes.push_back("dc.raw.");
+  toml::table parsed = toml::parse(render(config));
+
+  auto* route = parsed["transforms"]["dc"]["route"].as_table();
+  ASSERT_TRUE(route->contains("dc.raw"));
+  EXPECT_EQ((*route)["dc.raw"]["source"].value<std::string>(), "starts_with(to_string(.tag) ?? \"\", \"dc.raw.\")");
+  // The exact-Tag branches are untouched.
+  EXPECT_TRUE(route->contains("dc.group.robot"));
+
+  auto inputs = parsed["sinks"]["pgsql"]["inputs"].as_array();
+  ASSERT_EQ(inputs->size(), 2u);
+  EXPECT_EQ((*inputs)[0].value<std::string>(), "dc.dc.group.robot");
+  EXPECT_EQ((*inputs)[1].value<std::string>(), "dc.dc.raw");
+
+  // The timestamp normalization has to cover the namespace too, or raw Records would
+  // reach the sink with no `date` column.
+  auto normalize = parsed["transforms"]["dc_bridge_normalize"]["source"].value<std::string>();
+  EXPECT_NE(normalize->find("includes([\"dc.group.robot\"], .tag) || "
+                            "starts_with(to_string(.tag) ?? \"\", \"dc.raw.\")"),
+            std::string::npos);
+}
+
+TEST(Render, DestinationWithOnlyATagPrefixNeedsNoInputs)
+{
+  // The raw-only Destination a `dc_raw.launch.py` bringup produces: no Measurement
+  // topics at all, everything arrives under the namespace.
+  auto config = basic_config(TimeFormat::Double);
+  config.destinations[0].inputs.clear();
+  config.destinations[0].tag_prefixes.push_back("dc.raw.");
+  ASSERT_NO_THROW(render(config));
+
+  toml::table parsed = toml::parse(render(config));
+  auto normalize = parsed["transforms"]["dc_bridge_normalize"]["source"].value<std::string>();
+  EXPECT_NE(normalize->find("if starts_with(to_string(.tag) ?? \"\", \"dc.raw.\") {"), std::string::npos);
+  EXPECT_EQ(normalize->find("includes("), std::string::npos);
+}
+
+TEST(Render, RouteOutputForTagPrefixDropsTheTrailingSeparator)
+{
+  EXPECT_EQ(route_output_for_tag_prefix("dc.raw."), "dc.dc.raw");
+  EXPECT_EQ(route_output_for_tag_prefix("dc.raw"), "dc.dc.raw");
+}
+
+TEST(Render, RejectsATagThatCollidesWithARoutedNamespace)
+{
+  // Topic `/dc/raw` derives Tag `dc.raw`, which is also the branch id the `dc.raw.`
+  // namespace claims — one would silently overwrite the other in the route table.
+  auto config = config_with({ make_destination("pgsql", { "/dc/raw" }, TimeFormat::Double, postgres_kind()) });
+  config.destinations[0].tag_prefixes.push_back("dc.raw.");
+  try
+  {
+    render(config);
+    FAIL() << "expected a RenderError";
+  }
+  catch (const RenderError& e)
+  {
+    EXPECT_EQ(e.kind(), RenderErrorKind::TagPrefixCollidesWithTag);
+    EXPECT_EQ(e.arg0(), "dc.raw");
+  }
+}
+
 TEST(Render, DestinationWithOnlyExtraTagsNeedsNoInputs)
 {
   auto config = basic_config(TimeFormat::Double);

--- a/dc_bringup/launch/dc_raw.launch.py
+++ b/dc_bringup/launch/dc_raw.launch.py
@@ -1,0 +1,71 @@
+"""Raw-topic bringup (#227): `dc_bridge` alone, collecting the ROS graph itself.
+
+The DC 2.0 equivalent of the original "only start the destination server" idea. Nothing
+here declares a Measurement, so none of the collection stack is launched: no
+`measurement_server`, no `group_server`, no `lifecycle_manager_dc`, and no readiness
+gate — the gate exists to hold *collection nodes* back until the Bridge can accept their
+Records (ADR-0006), and with no collection nodes there is nothing to hold back. The
+Bridge subscribes to whatever the `raw:` block in the params file matches, whenever it
+appears on the graph.
+
+    ros2 launch dc_bringup dc_raw.launch.py
+
+Point it at your own file with `dc_params_file:=/path/to/params.yaml`; the default
+(`params/dc_raw_params.yaml`) dumps everything but the ROS infrastructure topics to
+stdout. See doc/src/dc/raw_topics.md.
+
+This is a *complement* to the normal bringup, not a replacement: raw mode ships whatever
+a topic happens to contain, with no validation, no Conditions, no Groups and no File
+uploads. Use `dc_bringup.launch.py` (which can also enable `raw:` alongside real
+Measurements) when you want any of that.
+"""
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetEnvironmentVariable
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from nav2_common.launch import RewrittenYaml
+
+
+def generate_launch_description():
+    bringup_dir = get_package_share_directory("dc_bringup")
+
+    namespace = LaunchConfiguration("namespace")
+    dc_params_file = LaunchConfiguration("dc_params_file")
+    log_level = LaunchConfiguration("log_level")
+
+    configured_params = RewrittenYaml(
+        source_file=dc_params_file,
+        root_key=namespace,
+        param_rewrites={},
+        convert_types=True,
+    )
+
+    return LaunchDescription(
+        [
+            SetEnvironmentVariable("RCUTILS_LOGGING_BUFFERED_STREAM", "1"),
+            DeclareLaunchArgument("namespace", default_value="", description="Top-level namespace"),
+            DeclareLaunchArgument(
+                "dc_params_file",
+                default_value=os.path.join(bringup_dir, "params", "dc_raw_params.yaml"),
+                description="Full path to the ROS 2 parameters file to use for dc_bridge",
+            ),
+            DeclareLaunchArgument("log_level", default_value="info", description="log level"),
+            # Same node, same respawn policy as in dc_bringup.launch.py: dc_bridge
+            # spawns and supervises the Vector shipper, and stays outside the lifecycle
+            # manager (ADR-0006).
+            Node(
+                package="dc_bridge",
+                executable="dc_bridge",
+                name="dc_bridge",
+                output={"stdout": "screen", "stderr": "screen"},
+                respawn=True,
+                respawn_delay=2.0,
+                parameters=[configured_params],
+                arguments=["--ros-args", "--log-level", log_level],
+            ),
+        ]
+    )

--- a/dc_bringup/params/dc_params.yaml
+++ b/dc_bringup/params/dc_params.yaml
@@ -85,6 +85,23 @@ dc_bridge:
     #     max_bytes: 10737418240  # 10 GiB cap on the un-uploaded Files pool
     #     max_age_days: 30        # optional; whichever limit is hit first
     #
+    # Raw topic collection (#227): subscribe to topics dc_bridge was never compiled
+    # against (rclcpp::GenericSubscription + runtime introspection, as `ros2 bag record
+    # -a` does), convert each message to JSON, and ship it under the Tag
+    # `dc.raw.<topic>` to one Destination. Works next to the Measurements above, or on
+    # its own via `ros2 launch dc_bringup dc_raw.launch.py` (params/dc_raw_params.yaml).
+    # Read doc/src/dc/raw_topics.md — especially "Backpressure and volume" — first.
+    #
+    # raw:
+    #   enabled: true
+    #   destination: "pgsql"        # a configured `receives: records` destination
+    #   include: ["^/"]             # topic-name regexes (unanchored regex_search)
+    #   exclude: ["^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/"]
+    #   exclude_types: ["^sensor_msgs/msg/(Image|CompressedImage|PointCloud2)$"]
+    #   rescan_interval_secs: 5.0   # pick up topics that appear later; 0 = scan once
+    #   max_rate_hz: 10.0           # per topic, newest-wins decimation; 0 = unlimited
+    #   max_message_size_bytes: 1048576   # drop bigger messages whole; 0 = unlimited
+    #
     # Any other Vector sink type via the ADR-0003 passthrough: raw Vector config
     # snippets consuming the public per-Tag `dc.<tag>` routes (see
     # doc/src/dc/destinations.md for the routing contract).

--- a/dc_bringup/params/dc_raw_params.yaml
+++ b/dc_bringup/params/dc_raw_params.yaml
@@ -55,10 +55,15 @@ dc_bridge:
 
       # --- volume --------------------------------------------------------------------
       # Per-topic ceiling on Records per second; extra messages are dropped at the
-      # source, newest-wins. 0 = unlimited (only do this if you know the topic's rate).
+      # source. Dropping by time is uniform — every window is still represented — so the
+      # result is an honest lower-resolution time series. 0 = unlimited (only do this if
+      # you know the topic's rate).
       max_rate_hz: 10.0
-      # Serialized messages larger than this are dropped whole, before deserialization.
-      # 0 = unlimited.
+      # Circuit breaker, not a volume knob: serialized messages larger than this are
+      # dropped whole, before deserialization. Keep it high enough that it essentially
+      # never fires. Lowering it to shed a big topic drops *by content*, which keeps the
+      # small messages and silently biases the data — exclude the topic or its type
+      # instead. 0 = unlimited.
       max_message_size_bytes: 1048576
 
       # Tag namespace. Every raw Record's Tag is this + the sanitised topic name, and

--- a/dc_bringup/params/dc_raw_params.yaml
+++ b/dc_bringup/params/dc_raw_params.yaml
@@ -1,0 +1,69 @@
+# Raw-topic collection (#227) — the params file `dc_raw.launch.py` uses by default.
+#
+# `dc_bridge` subscribes to topics it was never compiled against
+# (rclcpp::GenericSubscription + runtime message introspection, the same mechanism
+# `ros2 bag record -a` uses), turns each message into JSON, and ships it under the Tag
+# `dc.raw.<topic>` to the Destination named by `raw.destination`. No Measurement, no
+# lifecycle node and no plugin is involved.
+#
+# See doc/src/dc/raw_topics.md — especially "Backpressure and volume" — before pointing
+# this at a real robot: raw mode ships whatever a topic contains, at whatever rate the
+# limits below allow.
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+
+    destinations: ["raw_console"]
+    raw_console:
+      type: console         # JSON on the Bridge's stdout; swap for postgres/s3/file
+      receives: records
+      # No `inputs` key on purpose: this Destination takes no *topic* subscriptions.
+      # Raw mode routes to it by Tag namespace instead (`raw.destination` below), which
+      # is what lets topics discovered after startup reach it without re-rendering the
+      # Shipper config. (`inputs: []` cannot be written here — rclcpp can't load an
+      # empty YAML array — so the key is omitted.)
+      time_key: "date"
+      time_format: "iso8601"
+
+    raw:
+      enabled: true
+      destination: "raw_console"
+
+      # --- what gets collected -------------------------------------------------------
+      # ECMAScript regexes matched (unanchored `regex_search`) against the topic name.
+      # A topic must match one `include` and no `exclude` to be subscribed.
+      include: ["^/"]
+      # Defaults, spelled out. `/rosout` would feed the Bridge's own log messages back
+      # into the pipeline; `/dc/measurement/*` and `/dc/group/*` are already shipped as
+      # Records by the collection stack, so raw would double them under a second Tag.
+      exclude: ["^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/"]
+      # Excluded by *type*, not by name — a camera topic is not reliably called
+      # anything in particular, and one 640x480 Image is ~900 kB of JSON numbers.
+      # Replace this list (not with an empty one — rclcpp can't load `[]`; use a
+      # pattern that matches nothing, e.g. ["^$"]) to collect them anyway.
+      exclude_types:
+        - "^sensor_msgs/msg/(Image|CompressedImage|PointCloud|PointCloud2|LaserScan)$"
+        - "^tf2_msgs/msg/TFMessage$"
+
+      # --- discovery -----------------------------------------------------------------
+      # How often the graph is re-scanned for topics that appeared after startup. A
+      # topic is therefore collected within ~this long of first being advertised;
+      # messages published before that are not captured. 0 = scan once at startup.
+      rescan_interval_secs: 5.0
+      qos_depth: 10          # per-subscription history depth (also bounds in-flight buffering)
+
+      # --- volume --------------------------------------------------------------------
+      # Per-topic ceiling on Records per second; extra messages are dropped at the
+      # source, newest-wins. 0 = unlimited (only do this if you know the topic's rate).
+      max_rate_hz: 10.0
+      # Serialized messages larger than this are dropped whole, before deserialization.
+      # 0 = unlimited.
+      max_message_size_bytes: 1048576
+
+      # Tag namespace. Every raw Record's Tag is this + the sanitised topic name, and
+      # the rendered Vector config routes the whole namespace with one branch.
+      tag_prefix: "dc.raw."
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -59,6 +59,7 @@
   - [String match](./dc/conditions/string_match.md)
 - [Data validation](./dc/data_validation.md)
 - [Groups](./dc/groups.md)
+- [Raw topic collection](./dc/raw_topics.md)
 - [Destinations](./dc/destinations.md)
 - [Configuration examples](./dc/configuration_examples.md)
 - [Infrastructure setup](./dc/infrastructure_setup.md)

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -142,6 +142,12 @@ Tag verbatim (so `/dc/measurement/uptime`'s Records are consumable as
 wired to them internally, and custom snippets consume them the same way. A route
 exists for every topic listed in any configured Destination's `inputs`.
 
+One route is not per-Tag: **`dc.dc.raw`** carries the whole `dc.raw.` Tag namespace when
+[raw topic collection](./raw_topics.md) is enabled. Raw mode discovers topics — and so
+mints Tags — while the Shipper is already running, which no fixed set of exact-Tag
+branches can cover, so that branch matches on the Tag *prefix* instead. It is consumable
+from a snippet exactly like the others; each event still carries its own `tag` field.
+
 ## Passthrough: `custom_config_files`
 
 Any Vector sink type ships Records with zero DC code by consuming `dc.<tag>` routes

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -1,0 +1,192 @@
+# Raw topic collection
+
+Sometimes the point is not to measure three specific things well, but to capture
+*everything on the ROS graph* and put it somewhere — a bring-up session, a field
+incident, a robot whose interesting topics you don't know yet.
+
+For that, `dc_bridge` has a **generic-subscription mode**. It subscribes to topics it
+was never compiled against, converts each message to JSON, and ships it to a Destination
+like any other Record. No Measurement plugin, no `.msg` header, no rebuild of DC when
+the robot's message packages change.
+
+```yaml
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/buffer"
+    destinations: ["raw_console"]
+    raw_console:
+      type: console          # any blessed type works: postgres | s3 | file | console
+      receives: records
+      time_key: "date"
+    raw:
+      enabled: true
+      destination: "raw_console"
+```
+
+```bash
+ros2 launch dc_bringup dc_raw.launch.py
+```
+
+`dc_raw.launch.py` starts the Bridge **alone** — no `measurement_server`, no
+`group_server`, no lifecycle manager, no readiness gate (there are no collection nodes to
+gate). The default params file is
+[`dc_bringup/params/dc_raw_params.yaml`](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_bringup/params/dc_raw_params.yaml);
+point the launch file at your own with `dc_params_file:=…`. The same `raw:` block also
+works inside a normal `dc_bringup.launch.py` params file, next to your Measurements.
+
+## How it works
+
+DC uses exactly what ROS 2 offers for this — the same mechanism `ros2 bag record -a` and
+PlotJuggler use:
+
+1. `get_topic_names_and_types()` lists the graph. Topics are filtered by the
+   include/exclude patterns below.
+2. `rclcpp::GenericSubscription` subscribes to a topic given only its *name* and *type
+   string*, receiving raw serialized bytes.
+3. The type's two type support libraries are loaded at run time —
+   `rosidl_typesupport_cpp` to deserialize, `rosidl_typesupport_introspection_cpp` to
+   describe the fields — and the message is walked into JSON.
+4. The Record is Tagged `dc.raw.<topic>` and routed to `raw.destination`.
+
+The only requirement is that the message package is on the Bridge's
+`AMENT_PREFIX_PATH` — the same requirement `ros2 topic echo` has. A type that can't be
+resolved is logged once and skipped; the rest of the graph is still collected.
+
+### Tags and routing
+
+A raw Record's Tag is the topic name with the leading `/` dropped and the rest turned
+into dots, under the `dc.raw.` namespace:
+
+| Topic | Tag | Shipper route |
+|---|---|---|
+| `/imu` | `dc.raw.imu` | `dc.dc.raw` |
+| `/robot/battery_state` | `dc.raw.robot.battery_state` | `dc.dc.raw` |
+
+Unlike a Measurement's Tag, the *whole namespace* shares one Vector route
+(`dc.dc.raw`), matched with `starts_with` rather than an exact comparison. That is what
+makes discovery possible at all: a rendered Shipper config is fixed when the Bridge
+starts, but raw mode mints new Tags whenever a topic appears, and those Records still
+have to reach a sink without restarting Vector. A [passthrough
+sink](./destinations.md) can consume `dc.dc.raw` like any other route.
+
+The Tag is carried on the event itself, so a single dump file or table stays
+topic-attributable — check the `tag` field.
+
+### What a Record looks like
+
+The JSON mirrors the message structure, field for field: nested messages become nested
+objects, arrays and sequences become arrays, `string` stays a string. A
+`dc_interfaces/msg/StringStamped` on `/demo/custom` arrives as:
+
+```json
+{
+  "tag": "dc.raw.demo.custom",
+  "date": "2026-08-12T09:51:33.114777089",
+  "header": {"frame_id": "base_link", "stamp": {"sec": 1786528293, "nanosec": 114777089}},
+  "data": "{\"value\": 2}",
+  "group_key": "demo"
+}
+```
+
+Messages that start with a `std_msgs/msg/Header` are timestamped from
+`header.stamp` — the moment the data was *captured*. Everything else is stamped with the
+Bridge's own clock on arrival.
+
+## Choosing what to collect
+
+```yaml
+    raw:
+      include: ["^/"]                       # topic-name regexes: the allowlist
+      exclude: ["^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/"]
+      exclude_types:                        # message-type regexes
+        - "^sensor_msgs/msg/(Image|CompressedImage|PointCloud|PointCloud2|LaserScan)$"
+        - "^tf2_msgs/msg/TFMessage$"
+      rescan_interval_secs: 5.0
+```
+
+A topic is collected when it matches at least one `include` pattern, no `exclude`
+pattern, and its type matches no `exclude_types` pattern. All three are ECMAScript
+regexes matched with `regex_search`, so they are **unanchored** unless you anchor them:
+`camera` matches `/front/camera/info`, `^/front/` matches only that namespace.
+
+The values above are the defaults, and they matter:
+
+- **`/rosout` is excluded** — it carries the Bridge's own log messages, including the
+  warnings raw mode emits about volume.
+- **`/dc/measurement/*` and `/dc/group/*` are excluded** — those topics already reach
+  their Destinations as Measurement and Group Records. Collecting them raw as well ships
+  everything twice, under two different Tags.
+- **High-rate sensor types are excluded**, by type rather than by name (a camera topic is
+  not reliably called anything in particular). One 640×480 `sensor_msgs/msg/Image` is
+  roughly 900 kB of JSON numbers; at 30 Hz nothing downstream is sized for it. Override
+  the list deliberately if you want them — DC will not stop you, but read the next
+  section first.
+
+To replace a list, write the replacement; note that an *empty* YAML list (`[]`) cannot be
+loaded by rclcpp (it has no inferable element type), so use a pattern that matches
+nothing, e.g. `["^$"]`, to disable a default.
+
+`rescan_interval_secs` re-scans the graph so topics that appear after startup are picked
+up — a driver started later, a node that respawned. The cost is that a topic is collected
+only from ~one interval after it is first advertised: messages published before that are
+not captured. Set it to `0` to scan once at startup and never again.
+
+Topics advertising more than one type are skipped and logged: one subscription carries
+one type, and picking arbitrarily would silently drop the other publisher's messages.
+
+QoS is matched to the topic's current publishers, the same way `ros2 bag record` does
+it — best effort if any publisher is best effort, transient local if all of them are.
+Without that, a generic subscription silently receives nothing from a sensor driver.
+
+## Backpressure and volume
+
+Collecting everything can outrun the Shipper trivially. Raw mode's contract is that it
+**sheds at the source rather than buffering inside the Bridge** — an unbounded in-process
+queue would just move a data problem into a memory problem. Four bounds, in the order a
+message meets them:
+
+1. **`qos_depth`** (default 10) — the subscription's own history. If the Bridge is
+   momentarily busy, the middleware drops the oldest messages beyond this depth before DC
+   ever sees them.
+2. **`max_message_size_bytes`** (default 1 MiB, 0 = unlimited) — a serialized message
+   above this is dropped whole, *before* deserialization, so an unexpected point cloud
+   costs nothing but a throttled warning.
+3. **`max_rate_hz`** (default 10, per topic, 0 = unlimited) — at most one Record per
+   `1/rate` seconds per topic, newest wins. A 200 Hz topic at the default becomes 10 Hz of
+   Records. This is deliberately decimation, not a token bucket: a bucket lets a burst
+   through all at once, which is the exact traffic shape this exists to flatten.
+4. **The Shipper refusing the Record** — if Vector is unreachable or its socket is blocked
+   past the Forwarder's write timeout, the raw Record is dropped and counted. Measurement
+   Records are kept in the Forwarder's unacked window for resend; raw Records are not,
+   because a firehose fills that window and pushes real Records out of it.
+
+Everything past those bounds behaves like any other Record: Vector's disk buffer
+(`shipper.buffer_max_bytes`) absorbs a Destination outage, and delivery to the Shipper is
+acknowledged (see [Destinations](./destinations.md#delivery-guarantees)).
+
+Every drop is counted, and the counters are on the Bridge's readiness service — the
+fastest way to answer "is raw mode shedding?":
+
+```console
+$ ros2 service call /dc_bridge/ready std_srvs/srv/Trigger
+response: success=True, message='vector is accepting connections | raw: 12 topic(s),
+  3480 forwarded, dropped 51200 rate / 0 oversize / 0 shipper / 0 undecodable'
+```
+
+`dropped rate` climbing is normal and healthy (it is the limiter doing its job).
+`dropped shipper` climbing means the pipeline is genuinely behind: raise
+`shipper.buffer_max_bytes`, lower `max_rate_hz`, or narrow `include`.
+
+## When *not* to use it
+
+Raw mode ships whatever a topic happens to contain. It has no
+[Conditions](./conditions.md), no [data validation](./data_validation.md), no
+[Groups](./groups.md), and no File uploads — a Measurement is still the right tool for
+data you know you want, in a shape you control, joined with other data. Raw mode is for
+the case where you don't know yet, or where "all of it" *is* the requirement.
+
+It is also not a rosbag replacement: JSON in Postgres is not a replayable recording. If
+you want replay, point a [passthrough sink](./demos/mcap_recording.md) at the
+`dc.dc.raw` route and let `dc_mcap_writer` record it, or run `ros2 bag record` alongside
+DC.

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -179,11 +179,14 @@ message meets them:
    ever sees them.
 2. **`max_message_size_bytes`** (default 1 MiB, 0 = unlimited) — a serialized message
    above this is dropped whole, *before* deserialization, so an unexpected point cloud
-   costs nothing but a throttled warning.
+   costs nothing but a throttled warning. Treat this as a **circuit breaker, not a volume
+   knob** — see the warning below.
 3. **`max_rate_hz`** (default 10, per topic, 0 = unlimited) — at most one Record per
-   `1/rate` seconds per topic, newest wins. A 200 Hz topic at the default becomes 10 Hz of
-   Records. This is deliberately decimation, not a token bucket: a bucket lets a burst
-   through all at once, which is the exact traffic shape this exists to flatten.
+   `1/rate` seconds per topic: a message passes once that long has elapsed since the last
+   one that passed, so each Record is the newest message at the moment it is emitted and
+   nothing is held back. A 200 Hz topic at the default becomes 10 Hz of Records. This is
+   deliberately decimation, not a token bucket: a bucket lets a burst through all at once,
+   which is the exact traffic shape this exists to flatten.
 4. **The Shipper refusing the Record** — if Vector is unreachable or its socket is blocked
    past the Forwarder's write timeout, the raw Record is dropped and counted. Measurement
    Records are kept in the Forwarder's unacked window for resend; raw Records are not,
@@ -222,13 +225,28 @@ The last row is the whole argument for the default type exclusions: one VGA fram
 as much as ~3 000 odometry Records, and JSON roughly **doubles** a byte array (every
 pixel byte becomes `"0,"`).
 
-**The size cap will not save you from a camera.** That same 640×480 frame is 921 600
-bytes on the wire — *under* the default `max_message_size_bytes` of 1 MiB — so it passes
-the size gate and lands as 1.8 MB of JSON. The two guards are not redundant: it is
-`exclude_types` that keeps images out, and removing it removes the protection entirely.
-If you deliberately collect image-shaped topics, lower `max_message_size_bytes` to
-something well under one frame (e.g. 262144) so the size gate becomes a real backstop
-rather than a formality.
+**The size cap will not save you from a camera** — and it should not be asked to. That
+same 640×480 frame is 921 600 bytes on the wire, *under* the default
+`max_message_size_bytes` of 1 MiB, so it passes the size gate and lands as 1.8 MB of
+JSON. It is `exclude_types` that keeps images out, and removing that list removes the
+protection entirely.
+
+The tempting fix — lower the size cap until frames stop fitting — is a bad trade, because
+**the two limits fail differently**:
+
+- `max_rate_hz` drops *by time*, uniformly. Every window is still represented, so you get
+  an honest lower-resolution time series.
+- `max_message_size_bytes` drops *by content*. On any topic whose messages vary in size —
+  a compressed image, a point cloud that grows with scene complexity, a diagnostics array,
+  a string payload — it removes precisely the large ones and keeps the small ones. The
+  result looks complete and is silently biased toward the least interesting data, with
+  nothing in the stored Records to say what went missing.
+
+So set the size cap high enough that it essentially never fires, and treat it as a circuit
+breaker against the pathological and unanticipated (the topic you did not know carried
+100 MB). To *not* collect something, exclude it by type or topic: all-or-nothing, visible
+in the startup log, and no biased sample. The only case for a low size cap is when you
+genuinely want "this topic, except its outliers" — which is rarely what anyone means.
 
 Every drop is counted, and the counters are on the Bridge's readiness service — the
 fastest way to answer "is raw mode shedding?":

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -193,6 +193,43 @@ Everything past those bounds behaves like any other Record: Vector's disk buffer
 (`shipper.buffer_max_bytes`) absorbs a Destination outage, and delivery to the Shipper is
 acknowledged (see [Destinations](./destinations.md#delivery-guarantees)).
 
+### How much data is this?
+
+Measured against a TurtleBot3-Waffle-shaped workload — the topic mix
+`dc_simulation`'s warehouse world bridges out, at the rates those sensors actually run
+(IMU 100 Hz, odom/tf/joint_states 50 Hz, camera 30 Hz, cmd_vel 20 Hz, lidar 10 Hz,
+battery 1 Hz) — collected into a `file` Destination:
+
+| Configuration | Stored |
+|---|---|
+| **Defaults** (10 Hz cap, sensor types excluded) | 19 kB/s — **67 MB/hour, 1.6 GB/day** |
+| …plus `scan` and `tf` re-enabled | ≈ 4.3 GB/day |
+| …plus the 640×480 camera re-enabled | ≈ **1.6 TB/day** |
+
+Per-Record cost, which is what to multiply by your own topics' rates:
+
+| Message | Bytes per Record |
+|---|---|
+| `geometry_msgs/msg/Twist` | 202 |
+| `sensor_msgs/msg/JointState` (2 joints) | 326 |
+| `sensor_msgs/msg/Imu` | 488 |
+| `nav_msgs/msg/Odometry` | 605 |
+| `tf2_msgs/msg/TFMessage` (2 transforms) | 547 |
+| `sensor_msgs/msg/LaserScan` (360 ranges + intensities) | 2 585 |
+| `sensor_msgs/msg/Image` (640×480 `rgb8`) | **1 843 521** |
+
+The last row is the whole argument for the default type exclusions: one VGA frame costs
+as much as ~3 000 odometry Records, and JSON roughly **doubles** a byte array (every
+pixel byte becomes `"0,"`).
+
+**The size cap will not save you from a camera.** That same 640×480 frame is 921 600
+bytes on the wire — *under* the default `max_message_size_bytes` of 1 MiB — so it passes
+the size gate and lands as 1.8 MB of JSON. The two guards are not redundant: it is
+`exclude_types` that keeps images out, and removing it removes the protection entirely.
+If you deliberately collect image-shaped topics, lower `max_message_size_bytes` to
+something well under one frame (e.g. 262144) so the size gate becomes a real backstop
+rather than a formality.
+
 Every drop is counted, and the counters are on the Bridge's readiness service — the
 fastest way to answer "is raw mode shedding?":
 

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -93,6 +93,34 @@ Messages that start with a `std_msgs/msg/Header` are timestamped from
 `header.stamp` — the moment the data was *captured*. Everything else is stamped with the
 Bridge's own clock on arrival.
 
+### Type mapping
+
+| ROS field | JSON |
+|---|---|
+| `bool` | boolean |
+| `int8`…`int64`, `uint8`…`uint64`, `byte`, `char` | number |
+| `float32`, `float64` | number |
+| `string` | string |
+| `wstring` | string (transcoded UTF-16 → UTF-8) |
+| a nested message | object |
+| any array or sequence (fixed, bounded, unbounded) | array |
+
+Two things about numbers are worth knowing before you point a query at the result:
+
+- **`NaN` and `Infinity` both become `null`.** JSON has neither, so there is nowhere else
+  for them to go — but it means `+Inf`, `-Inf`, `NaN` and "the producer sent nothing" are
+  indistinguishable downstream. This is not a corner case: ROS messages routinely use
+  `NaN` as a sentinel (`sensor_msgs/msg/BatteryState.temperature` is `NaN` when the
+  battery has no temperature sensor), so expect nulls in fields whose message definition
+  documents one.
+- **`float32` is widened to double**, so a value written as `4.05` reads back as
+  `4.050000190734863` — the exact binary32 value, not a rounding error introduced here.
+  Round at the query, not in the pipeline, if the extra digits bother a dashboard.
+
+A `uint8[]` is an array of numbers, not base64 — DC does not compress raw payloads on the
+way out. That is one more reason the size and type limits below exist: the answer to a
+megabyte of image bytes is to not collect it, rather than to encode it more cleverly.
+
 ## Choosing what to collect
 
 ```yaml

--- a/progress.txt
+++ b/progress.txt
@@ -3934,6 +3934,22 @@ replacement). `destinations.md` documents `dc.dc.raw` as the one route that isn'
 per-Tag; `dc_bridge/README.md` covers the two code-level surprises; `dc_params.yaml`
 carries a commented block and `dc_raw_params.yaml` is the fully-annotated standalone one.
 
+**Type-mapping caveats found by a live mixed-type check** (a `sensor_msgs/msg/
+BatteryState` — float32 scalars and sequences, `uint8` enums, `bool`, `string`s, nested
+`Header` — published through the real Bridge into a `file` Destination, alongside a
+`diagnostic_msgs/msg/DiagnosticArray` used to confirm `raw.exclude` vetoes a topic).
+Everything converted correctly, and two number behaviours are worth documenting rather
+than fixing, now written up under "Type mapping" in `raw_topics.md`:
+
+- **`NaN` and `Infinity` both serialize as `null`**, since JSON has neither. That makes
+  `+Inf`, `NaN` and "absent" indistinguishable downstream — and it is not exotic, because
+  ROS messages use `NaN` as a documented sentinel (`BatteryState.temperature` is `NaN`
+  with no sensor fitted). `null` is still the right rendering: the alternatives are a
+  non-standard bare `NaN` token that most JSON parsers reject, or a `"NaN"` string that
+  would break the numeric typing of the column for every other row.
+- **`float32` widens to double**, so `4.05` reads back as `4.050000190734863` — the exact
+  binary32 value, not a rounding error introduced by the walk.
+
 **pre-commit**: clean on the changed files (including the mdbook `build-doc` hook, which
 link-checks the new page and its `SUMMARY.md` entry) apart from three environment
 failures that touch nothing here — `poetry-requirements` (no local `poetry`, as in

--- a/progress.txt
+++ b/progress.txt
@@ -3809,7 +3809,7 @@ ready, ADR-0006; with none launched there is nothing to hold).
 - **Volume control: shed at the source, in four bounds.** In the order a message meets
   them: `qos_depth` (the middleware's own history — it drops before DC ever sees the
   message), `max_message_size_bytes` (dropped whole *before* deserialization, so an
-  unexpected point cloud costs nothing), `max_rate_hz` (per-topic newest-wins decimation,
+  unexpected point cloud costs nothing), `max_rate_hz` (per-topic decimation by time,
   default 10 Hz), and finally the Shipper refusing the Record. That last one is the
   deliberate difference from a Measurement Record: a raw Record the Forwarder rejects is
   **dropped and counted, never kept in the unacked window**, because a firehose topic

--- a/progress.txt
+++ b/progress.txt
@@ -3902,9 +3902,29 @@ the namespace, and have no gaps *inside the window raw mode was subscribed for*.
 last qualifier is the honest one: unlike a Measurement, a raw subscription does not exist
 until the topic is discovered, and the harness restarts the container mid-run, so values
 published before a (re-)discovery were never offered to the pipeline at all — a gap
-anywhere else is loss and fails. A local run of the full harness (short outage/drain
-overrides) was still in flight when this was committed; CI runs the same script on the
-PR, and any fix it turns up lands on this branch.
+anywhere else is loss and fails.
+
+**The harness run itself** (locally, with compressed windows —
+`DC_E2E_STARTUP_TIMEOUT_SECONDS=30 DC_E2E_OUTAGE_SECONDS=20 DC_E2E_STEADY_STATE_SECONDS=20
+DC_E2E_DRAIN_SECONDS=30`): `check_raw()` passes outright — 61 events, every one under the
+`dc.raw.dc.e2e.synth.synth00` Tag, every one fully decoded, counter values 0..60 with **no
+gaps at all**, the mid-run container restart included. (Value 0 survives because raw mode
+subscribing to `synth00` is itself what satisfies the generator's
+`get_subscription_count() > 0` wait.) The synth, passthrough, MCAP and intent-queue
+checks all pass too.
+
+Two *other* gates fail on this machine, and both were confirmed pre-existing by re-running
+the identical command against a `dc-e2e` image built before this change:
+
+- **The <10 s launch-to-first-Record gate**: 11.24 s on this branch, **13.08 s** on the
+  pre-change baseline. This machine is slower than the PRD's budget; the change is, if
+  anything, marginally faster. Worth knowing for anyone running the harness locally — it
+  aborts at this gate before reaching any of the checks above, which is why the run has to
+  be given `DC_E2E_STARTUP_TIMEOUT_SECONDS` to exercise the rest.
+- **The camera `file_status` / `group_complete` checks**: identical failure on the
+  baseline image with the same overrides. A 15-second-interval camera Measurement's File
+  cannot complete an upload inside a 20 s outage + 30 s drain; CI's own longer windows
+  cover it.
 
 **Docs**: `doc/src/dc/raw_topics.md` (new, in `SUMMARY.md` between Groups and
 Destinations) is the reference — how it works, the filter semantics, the Tag/route

--- a/progress.txt
+++ b/progress.txt
@@ -3775,3 +3775,149 @@ respawns, starting back up" → both nodes configured and activated again. `pre-
 --files` on the new/changed files is clean apart from the `poetry-requirements` hook,
 which fails on this machine for a missing local `poetry` install and touches none of
 them.
+
+### #227 - Collect all ROS topics: generic-subscription mode in dc_bridge
+
+The original ask (Lulav Space) was "collect *everything* on the graph into one
+Destination instead of declaring a Measurement per data source". The DC 1.x plan in the
+issue — a universal subscriber inside the Fluent Bit plugin — describes nothing that
+still exists (#250 removed Fluent Bit, #244/ADR-0002 retired the destination server), but
+the need fits DC 2.0 better than it fitted the old architecture: `dc_bridge` is already
+the single process every Record leaves the robot through, so raw collection is a second
+*source* feeding the pipeline that is already there, not a second pipeline.
+
+**What was built**: `raw.enabled: true` makes the Bridge discover topics on the graph,
+subscribe to them with `rclcpp::GenericSubscription` (no compile-time knowledge of the
+type), convert each message to JSON through the runtime introspection type support, and
+ship it as a Record under the Tag `dc.raw.<sanitised topic>` to one configured
+Destination. `ros2 launch dc_bringup dc_raw.launch.py` runs that mode with no collection
+stack at all — no `measurement_server`, no `group_server`, no lifecycle manager, and no
+readiness gate (the gate exists to hold *collection nodes* back until the Bridge is
+ready, ADR-0006; with none launched there is nothing to hold).
+
+**The three open questions in the issue, settled:**
+
+- **Message → JSON: an own introspection walk, not `dynmsg`.** `dynmsg`
+  (`dynamic_message_introspection`) is the obvious candidate and was rejected on two
+  counts: it has no binary release in the Jazzy rosdistro (adopting it means vendoring a
+  source dependency into a workspace that currently builds entirely from rosdep +
+  colcon), and it emits YAML, which would then have to be parsed back into the JSON the
+  ingest protocol actually carries. `raw_subscriptions.cpp`'s walk is ~200 lines against
+  `rosidl_typesupport_introspection_cpp` — a stable core-ROS ABI, the same one
+  `ros2 bag record -a` and PlotJuggler use — produces `nlohmann::json` directly, and adds
+  only type support packages every ROS install already has.
+- **Volume control: shed at the source, in four bounds.** In the order a message meets
+  them: `qos_depth` (the middleware's own history — it drops before DC ever sees the
+  message), `max_message_size_bytes` (dropped whole *before* deserialization, so an
+  unexpected point cloud costs nothing), `max_rate_hz` (per-topic newest-wins decimation,
+  default 10 Hz), and finally the Shipper refusing the Record. That last one is the
+  deliberate difference from a Measurement Record: a raw Record the Forwarder rejects is
+  **dropped and counted, never kept in the unacked window**, because a firehose topic
+  would otherwise fill that window (#266's 10 000 records / 16 MiB) and push real
+  Measurement Records out of it. Every drop reason has its own counter, and the counters
+  are appended to the `~/ready` service message — the operator-facing answer to "is raw
+  mode shedding?".
+- **High-rate sensor topics: excluded by default**, and by *type* rather than by name (a
+  camera topic is not reliably called anything in particular): `sensor_msgs/msg/Image`,
+  `CompressedImage`, `PointCloud`, `PointCloud2`, `LaserScan` and `tf2_msgs/msg/TFMessage`.
+  One 640×480 Image is ~900 kB of JSON numbers at 30 Hz. `/rosout`, `/parameter_events`
+  and DC's own `/dc/measurement/*`, `/dc/group/*` are excluded for different reasons —
+  `/rosout` would feed the Bridge's own volume warnings back into the pipeline, and the
+  Record topics are already shipped as Measurement Records, so raw would double them
+  under a second Tag.
+
+**The one thing that needed a new construct in the renderer.** A rendered Vector config
+is fixed when the Bridge starts, but raw mode mints a Tag whenever a topic appears — so
+the per-Tag route branches (ADR-0003's `dc.<tag>` contract) cannot cover it: the Tag does
+not exist yet at render time. `Destination::tag_prefixes` adds one branch matching a Tag
+*namespace* (`starts_with`, at the public route `dc.dc.raw`), which is the only routing
+construct in `render.cpp` that matches something other than an exact Tag. Three details
+that fell out of it:
+
+- **VRL types an event field as `any`.** `starts_with(.tag, "dc.raw.")` is rejected by
+  `vector validate` outright (E110, "this expression resolves to any but the parameter
+  expects the exact type string") — found by running the real pinned binary, not by
+  reading docs. The rendered predicate is `starts_with(to_string(.tag) ?? "", …)`, which
+  is also infallible, so a Record arriving with a non-string tag fails to match instead
+  of aborting the whole transform. `includes()` (the exact-Tag half) has no such
+  requirement, which is why only this side needs the coercion.
+- **The prefix branch is keyed on the prefix minus its trailing dot** (`dc.raw.` →
+  branch `dc.raw` → route `dc.dc.raw`), so it reads like every other branch. That makes a
+  collision possible in principle — a topic literally named `/dc/raw` derives Tag
+  `dc.raw` — and the two branches would silently overwrite each other in the route table.
+  Vanishingly unlikely, but a silent mis-route is the wrong failure mode, so
+  `RenderErrorKind::TagPrefixCollidesWithTag` makes it a loud startup error.
+- **A raw-only Destination has no `inputs` at all**, which the renderer previously
+  treated as a config error. `EmptyInputs` now also accepts `tag_prefixes`, the same way
+  it already accepted the Uploader's `extra_tags`.
+
+**Two things that make generic subscription actually work in practice**, both learned
+from how `ros2 bag record` does it:
+
+- **QoS is matched to the topic's current publishers** — best effort if *any* publisher
+  is best effort, transient local if *all* are. A plain reliable/volatile subscription is
+  invisible to every sensor driver on the robot; without this, raw mode would silently
+  collect nothing from exactly the topics people expect it to.
+- **Topics advertising more than one type are skipped**, not guessed at: one subscription
+  carries one type, and picking arbitrarily would silently drop the other publisher's
+  messages. Skips are re-evaluated on every rescan (the condition can go away) but logged
+  only once, so a 5-second rescan doesn't reprint the same verdict forever.
+
+**Tests** (`colcon test --packages-select dc_bridge`: 138 tests, 0 failures — was 113):
+
+- `raw_config_test` (13, ROS-free, also in the standalone `test/local` CMake project) —
+  the filter's include/exclude/exclude-types precedence and its defaults, Tag derivation
+  and sanitisation, and the rate limiter (1000 messages across a simulated second at
+  10 Hz → 10 pass).
+- `raw_subscriptions_test` (12, needs a real ROS graph) — the introspection walk against
+  `dc_interfaces/msg/StringStamped` (a genuinely custom, non-`std_msgs` type: the test
+  hands the converter nothing but bytes and a type name) and `std_msgs/msg/
+  Float64MultiArray` (nested message + sequence of nested messages), header-stamp
+  extraction, discovery of a topic that only appears *after* startup, and the two
+  firehose cases: a 200-message burst at a 2 Hz limit sheds >100 and forwards ≤5, and a
+  sink that refuses everything produces `dropped_shipper` with `forwarded == 0` and no
+  in-Bridge queue growth.
+- `render_test` gained 4 cases for the namespace routing (branch shape, raw-only
+  Destination, the route-name derivation, the collision rejection).
+
+The `bringup` path was checked the same way: `ros2 launch dc_bringup dc_raw.launch.py`
+against the default params file starts exactly one process (`dc_bridge-1` — no
+measurement server, no lifecycle manager, no gate), discovers a `/demo/custom` publisher
+started 15 s later, and prints its Records on the `console` Destination.
+
+**Verified end to end** against the real pinned Vector binary and a
+`file` Destination: a `dc_interfaces/msg/StringStamped` published on `/demo/custom` was
+discovered, converted, Tagged `dc.raw.demo.custom`, routed through the namespace branch
+and written out with its `date` normalized from the message's own `header.stamp` —
+8 of the 10 published messages, the first two having been published in the ~1 s before
+the rescan discovered the topic (raw mode's documented discovery-latency behaviour, not
+loss).
+
+**Made permanent as a leg of the zero-loss E2E harness**: `e2e_params.yaml` now
+subscribes generically to `/dc/e2e/synth/synth00` — the workload generator's own source
+topic, a custom type — beside the Measurement path that same topic already feeds, and
+`verify_zero_loss.py`'s new `check_raw()` asserts the Records arrived, decoded
+field-for-field (both strings plus the nested `Header`/`Time`), carry no Tag from outside
+the namespace, and have no gaps *inside the window raw mode was subscribed for*. That
+last qualifier is the honest one: unlike a Measurement, a raw subscription does not exist
+until the topic is discovered, and the harness restarts the container mid-run, so values
+published before a (re-)discovery were never offered to the pipeline at all — a gap
+anywhere else is loss and fails. A local run of the full harness (short outage/drain
+overrides) was still in flight when this was committed; CI runs the same script on the
+PR, and any fix it turns up lands on this branch.
+
+**Docs**: `doc/src/dc/raw_topics.md` (new, in `SUMMARY.md` between Groups and
+Destinations) is the reference — how it works, the filter semantics, the Tag/route
+contract, "Backpressure and volume", and a "when *not* to use it" section (raw mode has
+no Conditions, no validation, no Groups, no File uploads, and is not a rosbag
+replacement). `destinations.md` documents `dc.dc.raw` as the one route that isn't
+per-Tag; `dc_bridge/README.md` covers the two code-level surprises; `dc_params.yaml`
+carries a commented block and `dc_raw_params.yaml` is the fully-annotated standalone one.
+
+**pre-commit**: clean on the changed files (including the mdbook `build-doc` hook, which
+link-checks the new page and its `SUMMARY.md` entry) apart from three environment
+failures that touch nothing here — `poetry-requirements` (no local `poetry`, as in
+earlier entries), `pycln` (a broken hook virtualenv), and `flake8` on
+`verify_zero_loss.py`, whose six findings are all in `main()`'s pre-existing print loops:
+verified identical by running the same hook against `git show HEAD:` of that file, so
+they surface only because the file is now in the changed set.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -86,7 +86,19 @@ not just a local tool.
    zero-loss/only-subscribed-Tags standard as the NDJSON passthrough, via a JSON summary
    of the capture (`scripts/mcap_summary.py`, which needs the `mcap` library the DC image
    installs — not this script's own host runner).
-8. **Verification** (`tools/e2e/scripts/verify_zero_loss.py`): queries Postgres via
+8. **Raw / generic-subscription coverage** (#227, the `raw:` block in
+   `params/e2e_params.yaml`): `dc_bridge` also subscribes *generically* to
+   `/dc/e2e/synth/synth00` — the workload generator's own source topic, carrying
+   `dc_interfaces/msg/StringStamped`, a custom non-`std_msgs` type the Bridge has no
+   compile-time knowledge of — and ships it to its own `file` Destination under the
+   `dc.raw.` Tag namespace, beside the Measurement path that same topic already feeds.
+   `check_raw()` asserts the Records arrived, decoded field-for-field (both strings plus
+   the nested `Header`/`Time`, proving the runtime introspection walk is complete),
+   carry no Tag from outside the namespace (the prefix route branch discriminates), and
+   have no gaps *inside the window raw mode was subscribed for* — unlike a Measurement, a
+   raw subscription doesn't exist until the topic is discovered, so values published
+   before the first discovery were never offered to the pipeline at all.
+9. **Verification** (`tools/e2e/scripts/verify_zero_loss.py`): queries Postgres via
    `podman exec` on the Postgres container (no host psycopg2/psql needed). The shipper is
    at-least-once (ADR-0002), so it **hard-fails on loss**. Loss is found by diffing what
    arrived against `params/../workload_ledger.txt` — the generator's own record of every
@@ -109,7 +121,7 @@ not just a local tool.
    have reached it, it must have received *only* the Tags it subscribed to (proving the
    per-Tag route branches discriminate rather than fanning everything out), and a missing
    or empty output file is a FAIL, never a skip.
-9. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
+10. **Resource usage** (`tools/e2e/scripts/measure_resources.sh`): samples the `dc`
    container's CPU/RSS throughout the run into `tools/e2e/.run/resource_usage.csv`.
    Informational only, per the PRD — it does not gate the run.
 
@@ -156,8 +168,9 @@ below.
   hold across a restart, not just a live process.
 - `params/e2e_params.yaml` — the reference workload's ROS parameters (measurement
   plugins, `dc_bridge` destinations: `pgsql_records`, `pgsql_files` for the Uploader's
-  metadata Records, `rustfs` for the actual File bytes), plus the `custom_config_files`
-  entry that loads the passthrough snippet below.
+  metadata Records, `rustfs` for the actual File bytes, `raw_file` for raw mode's own
+  output), plus the `raw:` block (#227) and the `custom_config_files` entry that loads the
+  passthrough snippet below.
 - `params/e2e_passthrough_sink.toml` — the ADR-0003 passthrough snippet: a raw Vector
   `file` sink on the `dc.<tag>` routes for `synth00`/`synth01`, written to the
   `dc_e2e_data` volume so it survives the mid-run restart. Note its `inputs` name topics

--- a/tools/e2e/params/e2e_params.yaml
+++ b/tools/e2e/params/e2e_params.yaml
@@ -164,7 +164,7 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/e2e/buffer"
-    destinations: ["pgsql_records", "pgsql_files", "rustfs"]
+    destinations: ["pgsql_records", "pgsql_files", "rustfs", "raw_file"]
     pgsql_records:
       type: postgres
       receives: records
@@ -203,6 +203,36 @@ dc_bridge:
       access_key_id: "rustfsadmin"
       secret_access_key: "rustfsadmin"
       force_path_style: true
+
+    # Raw / generic-subscription mode (#227). Subscribes to the generator's *source*
+    # topic — `/dc/e2e/synth/synth00` carries `dc_interfaces/msg/StringStamped`, a
+    # custom non-std_msgs type dc_bridge has no compile-time knowledge of — and ships it
+    # under the `dc.raw.` Tag namespace to its own `file` Destination, entirely beside
+    # the Measurement path that same topic already feeds. verify_zero_loss.py's
+    # check_raw() asserts the Records arrived, decoded field-for-field, and have no gaps
+    # inside the window raw mode was subscribed for.
+    raw_file:
+      type: file
+      receives: records
+      # No `inputs`: raw mode routes to this Destination by Tag namespace, not by topic.
+      path: "/root/.dc/e2e/data/raw/records.ndjson"
+      time_key: "date"
+
+    raw:
+      enabled: true
+      destination: "raw_file"
+      include: ["^/dc/e2e/synth/synth00$"]
+      # The default excludes would veto nothing here, but spell out that the Record
+      # topics stay out: without this raw mode would re-ship every Measurement Record
+      # under a second Tag.
+      exclude: ["^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/"]
+      exclude_types: ["^sensor_msgs/msg/(Image|CompressedImage|PointCloud2)$"]
+      # 1 s below the generator's own 1 Hz, so discovery is quick without the rescan
+      # itself becoming the thing under test.
+      rescan_interval_secs: 1.0
+      # Comfortably above the generator's 1 Hz: the limiter is exercised but must not
+      # drop anything, so a gap in the output is real loss rather than decimation.
+      max_rate_hz: 10.0
 
     files:
       delete_when_sent: false

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -243,6 +243,16 @@ podman run --rm --entrypoint bash \
   -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
   -c 'cat /vol/passthrough/records.ndjson 2>/dev/null || true' > "$RUN_DIR/passthrough.ndjson"
 
+# --- extract raw / generic-subscription mode's output (#227) -------------------------
+# Same extraction shape as the passthrough above: raw mode's Destination is a `file`
+# sink on the dc_e2e_data volume. Deliberately not `|| true` on the container run itself
+# for the same reason — a failed extraction must not be mistakable for an empty result;
+# verify_zero_loss.py's check_raw() hard-fails on a missing or empty file.
+log "extracting raw mode's Destination output"
+podman run --rm --entrypoint bash \
+  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
+  -c 'cat /vol/raw/records.ndjson 2>/dev/null || true' > "$RUN_DIR/raw.ndjson"
+
 # --- summarize the MCAP passthrough writer's output (ADR-0009, #210) -----------------
 # scripts/mcap_summary.py needs the `mcap` library, which is only installed in the DC
 # image (tools/e2e/Containerfile) — run it inside a one-off container on the same
@@ -269,6 +279,7 @@ python3 "$SCRIPT_DIR/verify_zero_loss.py" \
   --ledger-file "$RUN_DIR/workload_ledger.txt" \
   --passthrough-file "$RUN_DIR/passthrough.ndjson" \
   --mcap-summary-file "$RUN_DIR/mcap_summary.json" \
+  --raw-file "$RUN_DIR/raw.ndjson" \
   --report "$RUN_DIR/verification_report.json"
 
 log "PASS: zero-loss E2E harness"

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -56,6 +56,7 @@ Checks:
    image via run.sh, not on the CI host runner).
 """
 import argparse
+import datetime
 import json
 import os
 import subprocess
@@ -526,6 +527,12 @@ def check_raw(
     total_lines = 0
     namespace_events = 0
     decoded_fields = 0
+    # Stored volume (#227): the bytes a raw Record actually costs in a Destination, and
+    # the wall-clock span they arrived over, so every run reports what "collect this
+    # topic raw" is worth in MB/day rather than leaving operators to guess. Reported,
+    # never gated: throughput on a CI runner is not a property worth failing a build on.
+    total_bytes = 0
+    event_times: list = []
 
     with open(path) as f:
         for line in f:
@@ -533,6 +540,7 @@ def check_raw(
             if not line:
                 continue
             total_lines += 1
+            total_bytes += len(line) + 1  # the newline the sink wrote
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
@@ -542,6 +550,14 @@ def check_raw(
                 unexpected_tags.add(event.get("tag"))
                 continue
             namespace_events += 1
+            stored_at = event.get("timestamp")
+            if isinstance(stored_at, str):
+                try:
+                    event_times.append(
+                        datetime.datetime.fromisoformat(stored_at.replace("Z", "+00:00"))
+                    )
+                except ValueError:
+                    pass
             # The introspection walk has to have produced every field of the message:
             # the two `string`s, and the nested Header with its nested builtin Time.
             stamp = (event.get("header") or {}).get("stamp") or {}
@@ -567,7 +583,18 @@ def check_raw(
         "distinct_values": len(arrived),
         "first_value": min(arrived) if arrived else None,
         "last_value": max(arrived) if arrived else None,
+        "stored_bytes": total_bytes,
+        "bytes_per_record": total_bytes // total_lines if total_lines else None,
     }
+    # Only meaningful with two timestamps far enough apart to divide by.
+    if len(event_times) >= 2:
+        span = (max(event_times) - min(event_times)).total_seconds()
+        if span >= 1.0:
+            details["raw"]["span_seconds"] = round(span, 1)
+            details["raw"]["bytes_per_second"] = round(total_bytes / span, 1)
+            details["raw"]["projected_mb_per_day"] = round(
+                total_bytes / span * 86400 / 1e6, 1
+            )
 
     if total_lines == 0:
         violations.append(

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -41,7 +41,14 @@ Checks:
    public `dc.<tag>` routes — received the same synth counters with no gaps, and received
    *only* the Tags it subscribed to (proving the per-Tag route branches actually
    discriminate rather than fanning everything out).
-5. MCAP passthrough (ADR-0009, #210): a second, differently-shaped passthrough — a
+5. Raw / generic-subscription mode (#227): `/dc/e2e/synth/synth00` carries
+   `dc_interfaces/msg/StringStamped`, a custom non-std_msgs type dc_bridge was never
+   compiled against — the `raw:` block subscribes to it generically and ships it to its
+   own `file` Destination under the `dc.raw.` Tag namespace. Asserts the Records
+   arrived, decoded field-for-field (both strings plus the nested Header/Time), carry no
+   Tag from outside the namespace, and have no gaps inside the window raw mode was
+   subscribed for.
+6. MCAP passthrough (ADR-0009, #210): a second, differently-shaped passthrough — a
    Vector `socket` sink (params/e2e_mcap_sink.toml) streaming synth02/synth03 to the
    standalone `dc_mcap_writer` process — held to the same zero-loss/only-subscribed-Tags
    standard as the NDJSON passthrough above, via a JSON summary of its `.mcap` capture
@@ -79,6 +86,11 @@ PASSTHROUGH_TAGS = {f"dc.measurement.{s}" for s in PASSTHROUGH_SOURCES}
 # topics from the NDJSON passthrough above, so the two checks stay independent.
 MCAP_SOURCES = ["synth02", "synth03"]
 MCAP_TAGS = {f"dc.measurement.{s}" for s in MCAP_SOURCES}
+
+# Raw / generic-subscription mode (#227): the `raw:` block in params/e2e_params.yaml
+# subscribes to the generator's own source topic and ships it under this Tag.
+RAW_SOURCE = "synth00"
+RAW_TAG = "dc.raw.dc.e2e.synth.synth00"
 
 
 def psql(pg_container: str, query: str) -> str:
@@ -472,6 +484,143 @@ def check_passthrough(
             )
 
 
+def check_raw(
+    path: str,
+    boundaries: dict,
+    violations: list,
+    notes: list,
+    details: dict,
+) -> None:
+    """Assert raw / generic-subscription mode reached a real Destination (#227).
+
+    This is the end-to-end proof for a message type dc_bridge has no compile-time
+    knowledge of: `/dc/e2e/synth/synth00` carries `dc_interfaces/msg/StringStamped` (a
+    custom, non-std_msgs type), and every event here was produced by loading that type's
+    introspection type support at run time, walking its fields, and shipping the result
+    through the `dc.raw.` Tag namespace to a `file` Destination.
+
+    Loss is judged only *inside* the window raw mode was actually subscribed for. Unlike
+    a Measurement, a raw subscription does not exist until the topic is discovered
+    (`raw.rescan_interval_secs`), and the harness restarts the whole container mid-run —
+    so values published before the first discovery, or during a re-discovery, were never
+    offered to the pipeline at all. Between the first and last value that did arrive, a
+    gap is real loss and fails.
+
+    Args:
+        path: newline-delimited JSON run.sh extracted from the raw `file` Destination.
+        boundaries: per-source counter values the generator resumed at after a kill.
+        violations: hard failures, appended to in place.
+        notes: informational at-least-once observations, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
+    if not os.path.exists(path):
+        violations.append(
+            f"raw: no output at {path} — the raw Destination produced nothing, or run.sh "
+            "could not extract it from the dc_e2e_data volume"
+        )
+        return
+
+    values: list = []
+    unexpected_tags: set = set()
+    malformed = 0
+    total_lines = 0
+    namespace_events = 0
+    decoded_fields = 0
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            total_lines += 1
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                malformed += 1
+                continue
+            if event.get("tag") != RAW_TAG:
+                unexpected_tags.add(event.get("tag"))
+                continue
+            namespace_events += 1
+            # The introspection walk has to have produced every field of the message:
+            # the two `string`s, and the nested Header with its nested builtin Time.
+            stamp = (event.get("header") or {}).get("stamp") or {}
+            if (
+                event.get("group_key") == RAW_SOURCE
+                and isinstance(stamp.get("sec"), int)
+                and isinstance(stamp.get("nanosec"), int)
+                and stamp["sec"] > 0
+            ):
+                decoded_fields += 1
+            try:
+                values.append(int(json.loads(event["data"])["value"]))
+            except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+                malformed += 1
+
+    arrived = set(values)
+    details["raw"] = {
+        "total_events": total_lines,
+        "namespace_events": namespace_events,
+        "malformed_events": malformed,
+        "fully_decoded_events": decoded_fields,
+        "unexpected_tags": sorted(t for t in unexpected_tags if t is not None),
+        "distinct_values": len(arrived),
+        "first_value": min(arrived) if arrived else None,
+        "last_value": max(arrived) if arrived else None,
+    }
+
+    if total_lines == 0:
+        violations.append(
+            f"raw: {path} is empty — no generic-subscription Record reached the Destination"
+        )
+        return
+    if malformed:
+        violations.append(
+            f"raw: {malformed} event(s) did not carry a decodable StringStamped payload "
+            "— the introspection walk produced something the message does not contain"
+        )
+    if decoded_fields != namespace_events:
+        violations.append(
+            f"raw: only {decoded_fields} of {namespace_events} event(s) carried the full "
+            "decoded message (group_key + nested header.stamp) — field-by-field "
+            "conversion of the custom type is incomplete"
+        )
+    # Same reasoning as the passthrough's Tag check: the namespace route branch must
+    # still discriminate, or every Measurement Record would land here too.
+    if unexpected_tags:
+        violations.append(
+            f"raw: received Tag(s) outside the raw namespace: "
+            f"{sorted(t for t in unexpected_tags if t is not None)} — the dc.raw. route "
+            "branch is not discriminating"
+        )
+    if not arrived:
+        violations.append("raw: no event carried a usable counter value")
+        return
+
+    kill_points = set(boundaries.get(RAW_SOURCE, set()))
+    gaps = set(range(min(arrived), max(arrived) + 1)) - arrived
+    tolerated = {
+        value for value in gaps if any(0 < point - value <= MAX_KILL_GAP for point in kill_points)
+    }
+    lost = gaps - tolerated
+    if lost:
+        violations.append(
+            f"raw: {len(lost)} Record(s) missing between the first and last raw value "
+            f"received, away from any kill point — first missing: {sorted(lost)[:10]} — "
+            "data loss through raw mode"
+        )
+    if tolerated:
+        notes.append(
+            f"raw: {len(tolerated)} Record(s) lost in flight where the generator was "
+            "killed (tolerated)"
+        )
+    if len(values) > len(arrived):
+        notes.append(
+            f"raw: {len(values) - len(arrived)} duplicate value(s) (at-least-once "
+            "re-delivery; deduplicated on read)"
+        )
+
+
 def check_mcap_passthrough(
     path: str,
     published: dict,
@@ -616,6 +765,11 @@ def main() -> int:
         help="JSON summary (scripts/mcap_summary.py output) of the ADR-0009 MCAP "
         "passthrough writer's .mcap capture",
     )
+    parser.add_argument(
+        "--raw-file",
+        required=True,
+        help="newline-delimited JSON extracted from the raw (#227) `file` Destination",
+    )
     parser.add_argument("--report", default=None, help="write a JSON report to this path")
     args = parser.parse_args()
 
@@ -645,6 +799,7 @@ def main() -> int:
     check_mcap_passthrough(
         args.mcap_summary_file, published, boundaries, violations, notes, details
     )
+    check_raw(args.raw_file, boundaries, violations, notes, details)
 
     report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
     if args.report:


### PR DESCRIPTION
Original ask (Lulav Space): collect *everything* on the ROS graph into one Destination, instead of declaring a Measurement per data source. The plan in the issue described the old architecture (a universal subscriber inside the Fluent Bit plugin, removed in #250; the destination server, retired in #244/ADR-0002), but the need fits DC 2.0 better than it fitted DC 1.x — `dc_bridge` is already the single process every Record leaves the robot through, so raw collection is a second *source* into the pipeline that already exists.

## What this adds

```yaml
dc_bridge:
  ros__parameters:
    destinations: ["raw_console"]
    raw_console: {type: console, receives: records, time_key: "date"}
    raw:
      enabled: true
      destination: "raw_console"
```

```bash
ros2 launch dc_bringup dc_raw.launch.py
```

The Bridge discovers topics with `get_topic_names_and_types()`, subscribes with `rclcpp::GenericSubscription` (name + type string only — no generated headers, no rebuild when the robot's message packages change), converts each message to JSON through the runtime introspection type support, and ships it under the Tag `dc.raw.<sanitised topic>`. `dc_raw.launch.py` starts the Bridge **alone** — no `measurement_server`, no `group_server`, no lifecycle manager, and no readiness gate (the gate holds *collection nodes* back until the Bridge is ready, ADR-0006; with none launched there is nothing to hold).

## The issue's three open questions, settled

- **Message → JSON: an own introspection walk, not `dynmsg`.** `dynmsg` has no binary release in the Jazzy rosdistro (adopting it means vendoring a source dependency into a workspace that builds entirely from rosdep + colcon) and emits YAML, which would then have to be parsed back into the JSON the ingest protocol carries. The walk in `raw_subscriptions.cpp` is ~200 lines against `rosidl_typesupport_introspection_cpp` — the stable core-ROS ABI `ros2 bag record -a` and PlotJuggler use — produces `nlohmann::json` directly, and adds only type support packages every ROS install already has.
- **Volume: shed at the source, in four bounds.** In the order a message meets them: `qos_depth` (the middleware drops before DC sees it), `max_message_size_bytes` (dropped whole *before* deserialization), `max_rate_hz` (per-topic newest-wins decimation, default 10 Hz), and the Shipper refusing the Record. That last one is the deliberate difference from a Measurement Record: a raw Record the Forwarder rejects is **dropped and counted, never kept in the unacked window** — a firehose would otherwise fill that window (#266's 10 000 records / 16 MiB) and push real Measurement Records out of it. Every drop reason has a counter, appended to the `~/ready` service message.
- **High-rate sensor topics: excluded by default**, and by *type* rather than name (a camera topic is not reliably called anything in particular): `Image`, `CompressedImage`, `PointCloud`, `PointCloud2`, `LaserScan`, `TFMessage`. `/rosout` is excluded too (it would feed the Bridge's own volume warnings back into the pipeline), as are `/dc/measurement/*` and `/dc/group/*` (already shipped as Records — raw would double them under a second Tag).

## The one new construct in the renderer

A rendered Vector config is fixed when the Bridge starts, but raw mode mints a Tag whenever a topic appears — so ADR-0003's per-Tag `dc.<tag>` branches cannot cover it. `Destination::tag_prefixes` adds one branch matching a Tag *namespace* (`starts_with`, at the public route `dc.dc.raw`), the only routing construct in `render.cpp` that matches something other than an exact Tag. Details that fell out:

- **VRL types an event field as `any`**, so `starts_with(.tag, "dc.raw.")` is rejected by `vector validate` outright (E110) — found by running the real pinned binary. The rendered predicate is `starts_with(to_string(.tag) ?? "", …)`, which is also infallible.
- The branch is keyed on the prefix minus its trailing dot, making a collision possible in principle (a topic named `/dc/raw` derives Tag `dc.raw`); `RenderErrorKind::TagPrefixCollidesWithTag` makes that a loud startup error instead of a silent mis-route.
- A raw-only Destination has no `inputs` at all, which `EmptyInputs` now accepts alongside the Uploader's `extra_tags`.

Two things borrowed from how `ros2 bag record` works, without which generic subscription silently collects nothing: QoS is matched to the topic's current publishers (best effort if any is, transient local if all are), and topics advertising more than one type are skipped rather than guessed at.

## Verification

- `colcon test --packages-select dc_bridge`: **138 tests, 0 failures** (was 113). `raw_config_test` (13, ROS-free) covers filter precedence, defaults, Tag sanitisation and the rate limiter; `raw_subscriptions_test` (12, live graph) covers the introspection walk against `dc_interfaces/msg/StringStamped` — a genuinely custom non-`std_msgs` type, handed to the converter as nothing but bytes and a type name — plus nested messages/sequences, discovery of a topic appearing *after* startup, and both firehose cases (a 200-message burst at a 2 Hz limit sheds >100 and forwards ≤5; a sink refusing everything produces `dropped_shipper` with `forwarded == 0`). `render_test` gained 4 namespace-routing cases.
- **End to end against the real Vector binary**: a `StringStamped` on `/demo/custom` discovered, converted, Tagged `dc.raw.demo.custom`, routed through the namespace branch and written to a `file` Destination with `date` normalized from the message's own `header.stamp`.
- **`ros2 launch dc_bringup dc_raw.launch.py`** starts exactly one process and prints raw Records on a `console` Destination.
- **Made permanent in the zero-loss E2E harness**: `e2e_params.yaml` subscribes generically to `/dc/e2e/synth/synth00` (the generator's own source topic, a custom type) beside the Measurement path it already feeds, and `check_raw()` asserts the Records arrived, decoded field-for-field, carry no Tag from outside the namespace, and have no gaps inside the window raw mode was subscribed for.

## Docs

New `doc/src/dc/raw_topics.md` (in `SUMMARY.md` between Groups and Destinations) is the reference: how it works, filter semantics, the Tag/route contract, "Backpressure and volume", and a "when *not* to use it" section — raw mode has no Conditions, no validation, no Groups, no File uploads, and is not a rosbag replacement. `destinations.md` documents `dc.dc.raw` as the one route that isn't per-Tag; `dc_bridge/README.md` covers the two code-level surprises; `dc_params.yaml` carries a commented block and `dc_raw_params.yaml` is the annotated standalone one.

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BaCqaHeFP6EbtG1i2VVxMb