### PR TITLE
docs(lifecycle-manager): add mermaid diagram of managed nodes, bond, and autostart

### DIFF
--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [Custom plugin](./dc/demos/custom_stdout.md)
 - [Concepts](./dc/concepts.md)
 - [Data Pipeline](./dc/data_pipeline.md)
+- [Lifecycle Manager](./dc/lifecycle_manager.md)
 - [Measurements](./dc/measurements.md)
   - [Camera](./dc/measurements/camera.md)
   - [Command velocity](./dc/measurements/cmd_vel.md)

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -179,6 +179,10 @@ manager (ADR-0006): it must be up and its Shipper ready *before* the collection 
 are allowed to activate. See [Data Pipeline](./data_pipeline.md).
 ```
 
+See [Lifecycle Manager](./lifecycle_manager.md) for the managed-node list, the bond
+heartbeat and state-transition diagrams, and the autostart flow that ties into the
+Bridge readiness gate above.
+
 ## Buffering and data persistence
 
 The Shipper manages its own disk buffer (`shipper.data_dir` on the Bridge's parameters)

--- a/doc/src/dc/data_pipeline.md
+++ b/doc/src/dc/data_pipeline.md
@@ -24,10 +24,12 @@ Shipper-supported sink.
 
 ### Container (C2)
 
-Inside DC, only three nodes are lifecycle-managed by `dc_lifecycle_manager`:
-`measurement_server` and `group_server`. The Bridge (`dc_bridge`) and its supervised
-Shipper child are deliberately outside that boundary (ADR-0006) — the Bridge has no
-meaningful deactivated state, so its readiness comes from launch ordering
+Inside DC, `measurement_server` is the node lifecycle-managed by
+`dc_lifecycle_manager` (see [Lifecycle Manager](./lifecycle_manager.md) for the
+managed-node list and why it's just the one node today). `group_server` runs as a plain
+node alongside it, not under lifecycle management. The Bridge (`dc_bridge`) and its
+supervised Shipper child are deliberately outside that boundary too (ADR-0006) — the
+Bridge has no meaningful deactivated state, so its readiness comes from launch ordering
 (`bridge_ready_gate`) instead of a lifecycle transition. See
 [Deterministic startup ordering](#deterministic-startup-ordering) for the sequence this
 diagram's `bridge_ready_gate` → `dc_lifecycle_manager` relationship summarizes.
@@ -134,6 +136,10 @@ can be emitted before the pipeline is able to accept it:
    `lifecycle_manager_dc`, which configures and then activates the collection nodes. If
    the Bridge never becomes ready before the gate's deadline, the whole launch shuts
    down loudly instead of leaving a half-started pipeline running.
+
+See [Lifecycle Manager](./lifecycle_manager.md) for the diagrammed version of this
+sequence, plus the state transitions and bond-heartbeat recovery behavior it drives
+once activated.
 
 ## Durability and supervision
 

--- a/doc/src/dc/lifecycle_manager.md
+++ b/doc/src/dc/lifecycle_manager.md
@@ -1,0 +1,129 @@
+# Lifecycle Manager
+
+`dc_lifecycle_manager` is DC's nav2-style manager for the nodes that have a meaningful
+deactivated state. It walks each managed node through the ROS 2 [managed-node state
+machine](https://design.ros2.org/articles/node_lifecycle.html) (`configure`,
+`activate`, `deactivate`, `cleanup`, `shutdown`), watches a bond heartbeat on every node
+it has activated, and can bring the whole managed set up automatically at launch. See
+[Concepts](./concepts.md#lifecycle-nodes-and-bond) for the general nav2_util
+`LifecycleNode` background this page builds on.
+
+```admonish info
+The Bridge (`dc_bridge`) is deliberately **not** one of the managed nodes (ADR-0006): it
+has no meaningful deactivated state, so its readiness is a launch-ordering problem
+instead — see [the boundary and autostart flow](#the-boundary-and-the-autostart-flow)
+below.
+```
+
+## What it manages
+
+The set of managed nodes is the `node_names` parameter, walked in list order for
+bring-up (`configure` then `activate`, each transition applied to every node before the
+next one starts) and in reverse order for teardown. In every params file this repo
+ships — `dc_bringup.launch.py`'s inline `lifecycle_manager_params` and both E2E harness
+params files — that list is:
+
+```yaml
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]
+```
+
+`measurement_server` is the only node under lifecycle management today.
+`group_server`, when enabled, is launched as a plain `Node` alongside it — not added to
+`node_names` — so it is not lifecycle-managed. Nothing stops a future `node_names` entry
+from adding it if it ever needs a deactivated state; the manager is already list-driven
+for exactly that reason.
+
+## The boundary and the autostart flow
+
+`dc_bringup.launch.py` brings the pipeline up in a fixed order (ADR-0006) so that no
+Record can be emitted before the Bridge can accept it. The Bridge, its Vector Shipper
+child, and the `bridge_ready_gate` process that polls the Bridge's `~/ready`
+(`std_srvs/Trigger`) service all run **outside** `lifecycle_manager_dc` — only once the
+gate exits `0` does the lifecycle manager exist at all in the launch graph.
+
+```mermaid
+flowchart TB
+    subgraph outside["Outside the lifecycle manager (ADR-0006)"]
+        direction TB
+        vector["Vector<br/>(Shipper child process)"]
+        bridge["dc_bridge<br/>(plain node, launch respawn)"]
+        gate["bridge_ready_gate<br/>(polls ~/ready)"]
+        bridge -- "spawns and supervises" --> vector
+        bridge -- "~/ready (std_srvs/Trigger)" --> gate
+    end
+    subgraph managed["Managed by lifecycle_manager_dc"]
+        direction TB
+        lm["lifecycle_manager_dc<br/>(autostart=true by default)"]
+        meas["measurement_server<br/>(only entry in node_names)"]
+        lm -- "configure, then activate" --> meas
+        meas -- "bond heartbeat (10 Hz)" --> lm
+    end
+
+    gate -- "exit 0: Bridge ready" --> lm
+    gate -. "exit != 0: never ready" .-> abort["Shutdown(reason=...)<br/>whole launch aborts"]
+```
+
+1. **Bridge first.** `dc_bridge` starts as a plain node and spawns Vector as a
+   supervised child process.
+2. **Readiness gate.** `bridge_ready_gate` blocks until `~/ready` answers
+   `success=True` (Vector accepting connections on its ingest socket), or its own
+   `timeout_s` (default 120 s) expires.
+3. **Activation, only on success.** `dc_bringup.launch.py` registers an
+   `OnProcessExit` handler on the gate: exit `0` starts `lifecycle_manager_dc`; any
+   other exit code shuts the whole launch down (`Shutdown(reason=...)`) instead of
+   leaving collection nodes running against a Bridge that never came up.
+4. **Autostart.** `dc_bringup.launch.py`'s `autostart` launch argument defaults to
+   `True` and is always passed through explicitly — overriding the code's own default of
+   `false` for a manager launched some other way. With `autostart=true`,
+   `lifecycle_manager_dc` calls its own `startup()` as soon as it has constructed
+   lifecycle service clients for every managed node, with no external service call
+   needed. `autostart=false` leaves the managed set in `Unconfigured` until something
+   calls the manager's `~/manage_nodes` service (`nav2_msgs/srv/ManageLifecycleNodes`,
+   command `STARTUP`).
+
+## State transitions and bond heartbeats
+
+Each managed node moves through the same five primary states nav2 uses. The manager's
+five service-level operations (`startup`, `shutdown`, `reset`, `pause`, `resume`) are
+each just a sequence of these per-node transitions applied across every managed node —
+`pause`/`resume` reuse the same `deactivate`/`activate` edges `startup` uses, not
+separate ones.
+
+A **bond** (10 Hz heartbeat, `bond_timeout` — 10 s in `dc_bringup.launch.py`, 4 s
+default otherwise) is created for a node the moment it activates and torn down the
+moment it deactivates. The manager polls every bond every 200 ms; a missed heartbeat
+past `bond_timeout` is treated as that node having crashed.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Unconfigured
+    Unconfigured --> Inactive: configure
+    Inactive --> Active: activate / resume
+    Active --> Inactive: deactivate / pause
+    Inactive --> Unconfigured: cleanup
+    Unconfigured --> Finalized: shutdown
+    Finalized --> [*]
+
+    Active --> Unconfigured: bond heartbeat lost -> reset(hard_reset=true)
+    Unconfigured --> Active: node reachable again within\nbond_respawn_max_duration -> startup()
+```
+
+A lost heartbeat does not just deactivate the one node that crashed — `checkBondConnections`
+hard-resets **every** managed node (`deactivate` then `cleanup`, continuing past
+per-node failures since `hard_reset=true`) and clears all bonds, on the principle that a
+half-alive managed set is worse than a fully torn-down one. If
+`attempt_respawn_reconnection` (default `true`) is set, a 1 s-period timer then polls
+whether every managed node's lifecycle service is reachable again:
+
+- **Reachable within `bond_respawn_max_duration`** (default 10 s): the manager calls
+  `startup()` again — a full `configure` + `activate` pass — and resumes normal
+  operation, bonds included.
+- **Still unreachable once `bond_respawn_max_duration` elapses:** the manager gives up
+  and leaves the managed set `Unconfigured`. Recovery from there needs an explicit
+  `STARTUP` call to `~/manage_nodes` (or a relaunch).
+
+`~/is_active` (`std_srvs/srv/Trigger`) reports whether the managed set is currently
+`Active`, and a `diagnostic_updater` entry surfaces the same status on `/diagnostics`.

--- a/progress.txt
+++ b/progress.txt
@@ -3957,3 +3957,40 @@ earlier entries), `pycln` (a broken hook virtualenv), and `flake8` on
 `verify_zero_loss.py`, whose six findings are all in `main()`'s pre-existing print loops:
 verified identical by running the same hook against `git show HEAD:` of that file, so
 they surface only because the file is now in the changed set.
+
+## #234: Lifecycle manager documentation (mermaid diagram)
+
+**Read**: `dc_lifecycle_manager`'s header/source (`lifecycle_manager.hpp`/`.cpp`),
+`dc_bringup/launch/dc_bringup.launch.py`, ADR-0006, and `concepts.md`'s existing
+"Lifecycle Nodes and Bond" prose section to ground the diagram in the real code rather
+than the general nav2 lifecycle-node story that section already tells.
+
+**Found**: `node_names` is `["measurement_server"]` in every params file that sets it
+(`dc_bringup.launch.py`'s inline `lifecycle_manager_params`, both E2E harness params
+files) — `group_server` launches as a plain `Node`, never added to `node_names`, so it
+is not lifecycle-managed today. `data_pipeline.md`'s C2 section claimed otherwise
+("only three nodes are lifecycle-managed... measurement_server and group_server" — a
+stale claim, inconsistent even with itself on the count), so that sentence was
+corrected alongside the new page rather than left contradicting it.
+
+**Added**: `doc/src/dc/lifecycle_manager.md` — two mermaid diagrams: a flowchart
+showing the ADR-0006 boundary (Vector/Bridge/`bridge_ready_gate` outside the manager)
+feeding into the manager's autostart, and a `stateDiagram-v2` for the five-state
+transition machine plus the bond-loss → hard-reset → respawn-reconnect-or-give-up path
+(`checkBondConnections`/`checkBondRespawnConnection` in `lifecycle_manager.cpp`).
+Covers the acceptance criteria's four elements — managed nodes, bond heartbeats, state
+transitions, autostart flow — and makes the ADR-0006 boundary and the readiness gate
+visible in a diagram, not just prose. Linked from `SUMMARY.md` (between Data Pipeline
+and Measurements), `concepts.md`'s "Lifecycle Nodes and Bond" admonish block, and
+`data_pipeline.md`'s "Deterministic startup ordering" section.
+
+**Verified**: `mdbook build` locally (with linkcheck) — no errors or warnings touching
+the new page or its links; the two pre-existing linkcheck warnings on
+`measurements/diagnostics.md` and `measurements/serial_interface.md` (unrelated
+`list[str]`-as-markdown-link false positives) are untouched by this change. Also ran
+the full `build-doc` pre-commit hook (the real Podman/mdbook toolchain, the hard gate
+per `CLAUDE.md`) against the changed files — passed. `poetry-requirements` failed for
+the same pre-existing reason as earlier entries (no local `poetry` binary); `black`
+reformatted an unrelated file (`tools/e2e/scripts/verify_zero_loss.py`) as a side
+effect of the hook run against the whole repo — reverted before committing since it's
+outside this issue's scope.


### PR DESCRIPTION
## Summary
- Adds `doc/src/dc/lifecycle_manager.md`: a mermaid flowchart of the ADR-0006 boundary/autostart flow (Vector → `dc_bridge` → `bridge_ready_gate` → `lifecycle_manager_dc`) and a `stateDiagram-v2` of the managed-node state transitions plus bond-heartbeat loss/recovery, sourced from `dc_lifecycle_manager`'s actual code (`node_names`, `checkBondConnections`/`checkBondRespawnConnection`).
- Links the new page from `SUMMARY.md`, `concepts.md`'s "Lifecycle Nodes and Bond" section, and `data_pipeline.md`'s "Deterministic startup ordering" section.
- Corrects `data_pipeline.md`'s C2 text, which claimed `group_server` is lifecycle-managed — `node_names` is `["measurement_server"]` everywhere in the repo, and `group_server` launches as a plain node.

Closes #234

## Test plan
- [x] `mdbook build` (with linkcheck) locally — no errors/warnings on the new page or its links
- [x] `tools/ci/pre-commit/build_doc.sh` (the real Podman/mdbook toolchain, `build-doc` pre-commit hook) passed against the changed files