### PR TITLE
test(measurements): add gtest coverage for the camera plugin

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -268,6 +268,7 @@ install(DIRECTORY plugins/measurements/json
 )
 
 set(tests
+  test_measurement_camera
   test_measurement_diagnostics
   test_measurement_driving_type
   test_measurement_dummy

--- a/dc_measurements/test/test_measurement_camera.cpp
+++ b/dc_measurements/test/test_measurement_camera.cpp
@@ -1,0 +1,191 @@
+#include <gtest/gtest.h>
+
+#include <opencv2/imgcodecs.hpp>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/base64.hpp"
+#include "dc_util/json_utils.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+class MeasurementCameraTest : public ::testing::Test
+{
+protected:
+  MeasurementCameraTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementCameraTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "camera" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/camera", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementCameraTest::cameraDataCallback, this, std::placeholders::_1));
+    image_pub_ = ms_node_->create_publisher<sensor_msgs::msg::Image>("/camera/image_raw", rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void cameraDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  // BGR8, filled with a mid-grey so the encoded JPEG is never empty.
+  static sensor_msgs::msg::Image makeImage(uint32_t height, uint32_t width)
+  {
+    sensor_msgs::msg::Image msg;
+    msg.height = height;
+    msg.width = width;
+    msg.encoding = "bgr8";
+    msg.is_bigendian = false;
+    msg.step = width * 3;
+    msg.data.assign(static_cast<size_t>(msg.step) * height, 128);
+    return msg;
+  }
+
+  static cv::Mat decodeBase64Image(const nlohmann::json& base64_str)
+  {
+    std::string decoded = base64_decode(base64_str.get<std::string>());
+    std::vector<uchar> buf(decoded.begin(), decoded.end());
+    return cv::imdecode(buf, cv::IMREAD_COLOR);
+  }
+
+  void declareCommonParams()
+  {
+    ms_node_->declare_parameter("camera.plugin", std::string("dc_measurements/Camera"));
+    ms_node_->declare_parameter("camera.group_key", std::string("camera"));
+    ms_node_->declare_parameter("camera.topic_output", std::string("/dc/measurement/camera"));
+    ms_node_->declare_parameter("camera.cam_name", std::string("front"));
+    ms_node_->declare_parameter("camera.cam_topic", std::string("/camera/image_raw"));
+    // Avoids blocking onConfigure() on the /dc/service/draw_image service, which this test
+    // does not stand up.
+    ms_node_->declare_parameter("camera.draw_det_barcodes", false);
+    // Collect() fires on activate() by default; disabled so no Record is published before a
+    // test publishes its synthetic image.
+    ms_node_->declare_parameter("camera.init_collect", false);
+  }
+
+  void waitForImageSubscriber()
+  {
+    while (ms_node_->count_subscribers("/camera/image_raw") == 0)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr image_pub_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementCameraTest, PublishesBase64EncodedRawImage)
+{
+  declareCommonParams();
+  ms_node_->declare_parameter("camera.save_raw_base64", true);
+
+  startLifecycleNode();
+  waitForImageSubscriber();
+
+  auto image = makeImage(4, 4);
+  while (!callback_active_)
+  {
+    image_pub_->publish(image);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_EQ(data_json_["camera_name"], "front");
+  ASSERT_TRUE(data_json_.contains("base64"));
+  ASSERT_TRUE(data_json_["base64"].contains("raw"));
+
+  cv::Mat decoded_image = decodeBase64Image(data_json_["base64"]["raw"]);
+  ASSERT_FALSE(decoded_image.empty());
+  EXPECT_EQ(decoded_image.rows, 4);
+  EXPECT_EQ(decoded_image.cols, 4);
+}
+
+TEST_F(MeasurementCameraTest, RotatesImageBeforeEncoding)
+{
+  declareCommonParams();
+  ms_node_->declare_parameter("camera.rotation_angle", 90);
+  ms_node_->declare_parameter("camera.save_rotated_base64", true);
+
+  startLifecycleNode();
+  waitForImageSubscriber();
+
+  // Non-square so a 90-degree rotation is observable in the output dimensions.
+  auto image = makeImage(4, 8);
+  while (!callback_active_)
+  {
+    image_pub_->publish(image);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  ASSERT_TRUE(data_json_.contains("base64"));
+  ASSERT_TRUE(data_json_["base64"].contains("rotated"));
+
+  cv::Mat decoded_image = decodeBase64Image(data_json_["base64"]["rotated"]);
+  ASSERT_FALSE(decoded_image.empty());
+  EXPECT_EQ(decoded_image.rows, 8);
+  EXPECT_EQ(decoded_image.cols, 4);
+}
+
+TEST_F(MeasurementCameraTest, NoPublishBeforeFirstImageReceived)
+{
+  int polling_interval = 50;
+  declareCommonParams();
+  ms_node_->declare_parameter("camera.save_raw_base64", true);
+  ms_node_->declare_parameter("camera.polling_interval", polling_interval);
+
+  startLifecycleNode();
+
+  std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+  // Poll through several collect() cycles with no image published; the plugin must not
+  // publish a Record while last_data_ is still unset.
+  while ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+         polling_interval * 3)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(callback_active_);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -3994,3 +3994,61 @@ the same pre-existing reason as earlier entries (no local `poetry` binary); `bla
 reformatted an unrelated file (`tools/e2e/scripts/verify_zero_loss.py`) as a side
 effect of the hook run against the whole repo — reverted before committing since it's
 outside this issue's scope.
+
+## #254: Test coverage epic (measurement plugins) — camera plugin
+
+**Read**: Issue #254 consolidates the individually-closed #146–#157 ("Consolidated
+into the measurement test epic #254... the per-plugin checklist lives there" — each
+sub-issue's closing comment) into one 12-item checklist (camera, cmd_vel,
+distance_traveled, ip_camera, memory, map, network, permissions, position, speed,
+storage, tcp_health); none had tests yet (`dc_measurements/test/` only covers
+diagnostics, driving_type, dummy, gate_condition, os, parameters, random,
+serial_interface, thermal, uptime). Since each checkbox is described as a
+self-contained, good-first-issue-sized contribution, and per `CLAUDE.md`'s "one task
+per run" convention, this session does one item — `camera`, the first in the list —
+and leaves the rest for future runs.
+
+**Added**: `dc_measurements/test/test_measurement_camera.cpp`, registered in
+`CMakeLists.txt`'s `tests` list. Follows `test_measurement_diagnostics.cpp`'s pattern
+(a helper node publishes synthetic input on the subscribed topic, `count_subscribers`
+gates against a race where the publish happens before the plugin's subscription
+exists, then the output topic is asserted against) rather than `test_measurement_os.cpp`'s
+simpler no-input pattern, since `Camera::collect()` reads `last_data_` set by a
+`sensor_msgs/msg/Image` subscription on `cam_topic`. Three tests:
+- `PublishesBase64EncodedRawImage`: publishes a synthetic 4x4 BGR8 image,
+  `save_raw_base64=true`, asserts `camera_name` and `base64.raw` are present and that
+  base64-decoding + `cv::imdecode`ing the JPEG round-trips to a 4x4 image — tests the
+  Record JSON's actual image payload, not just that some string is present.
+- `RotatesImageBeforeEncoding`: `rotation_angle=90`, `save_rotated_base64=true`, a
+  non-square 4x8 source image so the 90° rotation is observable as a dimension swap
+  (8x4) in the decoded output — exercises `Camera::rotateImage()` externally via the
+  published Record rather than as a white-box unit test.
+- `NoPublishBeforeFirstImageReceived`: polls through several `collect()` cycles with
+  no image ever published; `Camera::collect()` returns an empty `StringStamped` when
+  `last_data_.data` is empty, and `Measurement::publish()` drops empty messages, so no
+  callback should fire.
+
+**Found**: `camera.draw_det_barcodes` defaults to `true`, and `Camera::onConfigure()`
+creates a `/dc/service/draw_image` client and blocks (`wait_for_service`, retried every
+second) until that service appears — regardless of whether `detection_modules`
+actually includes `"barcode"`. Every test here explicitly sets
+`camera.draw_det_barcodes=false` to avoid hanging on a service this test suite doesn't
+stand up (barcode detection itself, and the `dc_services draw_image` service dependency
+it pulls in, are out of scope for this checklist item — `draw_det_barcodes` only
+gates the *drawing* of detection boxes onto the saved/base64 image, not detection
+itself, so this doesn't skip anything the acceptance criteria asks for).
+
+**Not done / left for follow-up**: no local `colcon`/ROS install in this sandbox (same
+constraint as #242/#243 — disk space), so `colcon test` could not be run directly;
+CI (`tools/e2e/scripts/test.sh`) is the real gate. Verified via `pre-commit`
+(`clang-format` — no changes needed; the `build-doc`, `poetry-requirements` hooks are
+unrelated to C++ test files) and a manual read-through of `camera.cpp`/`camera.hpp`
+and the base `Measurement`/`MeasurementServer` classes to confirm parameter defaults,
+lifecycle-configure ordering, and the `publish()` empty-message-drop path referenced
+above. `black` reformatted an unrelated file
+(`tools/e2e/scripts/verify_zero_loss.py`) as a side effect of running pre-commit
+against the whole repo — reverted before committing, same as prior entries. The
+remaining 11 checklist items (cmd_vel, distance_traveled, ip_camera, memory, map,
+network, permissions, position, speed, storage, tcp_health) are untouched; the PR for
+this session uses "Contributes to #254" rather than "Closes #254" so the epic stays
+open for them.


### PR DESCRIPTION
## Summary
- Adds gtest coverage for the `camera` measurement plugin — the first item in the #254 test-coverage epic's checklist (camera, cmd_vel, distance_traveled, ip_camera, memory, map, network, permissions, position, speed, storage, tcp_health), none of which had tests yet.
- Follows the lifecycle-node pattern from `test_measurement_diagnostics.cpp`: a synthetic `sensor_msgs/msg/Image` is published on `cam_topic`, and the Record JSON published on the output topic is asserted against — testing external behaviour (the published Record), not plugin internals.
- Three tests: base64-encoded raw image round-trips through `cv::imdecode`, a 90° rotation is observable as a dimension swap in the output, and no Record is published before the first image arrives.
- `camera.draw_det_barcodes` is explicitly disabled in every test, since `Camera::onConfigure()` otherwise blocks waiting for the `/dc/service/draw_image` service regardless of whether barcode detection is actually enabled — out of scope for this checklist item.

This only covers 1 of the epic's 12 items, so the PR does **not** close #254 — it stays open for the remaining 11 plugins.

Contributes to #254

## Test plan
- [ ] CI (`colcon test` via `tools/e2e/scripts/test.sh`) passes on `dc_measurements_test_measurement_camera`
- [x] `pre-commit` (`clang-format`) clean on the changed files
- [x] Manual read-through of `camera.cpp`/`camera.hpp` and the base `Measurement`/`MeasurementServer` classes to confirm parameter defaults and the empty-message-drop path the third test relies on

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3oDsbM2XY4hPgcSm86o2L