### PR TITLE
test(measurements): add gtest coverage for the remaining 11 measurement plugins

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -35,6 +35,23 @@ pkg_search_module(UUID REQUIRED uuid)
 # the shared `dependencies` list/foreach below and linked directly to dc_camera_measurement.
 find_package(ZXing REQUIRED)
 
+# yaml_cpp_vendor (already in `dependencies` above) only guarantees a system yaml-cpp is
+# installed via rosdep; it doesn't itself re-export a linkable CMake target, so anything that
+# calls into yaml-cpp's `.as<T>()` conversions (which can throw YAML::BadConversion) needs the
+# real `yaml-cpp` package found separately for its `yaml-cpp::yaml-cpp` target -- discovered via
+# #254's test suite dlopen-ing cmd_vel/map for the first time and hitting `undefined symbol:
+# typeinfo for YAML::BadConversion` at pluginlib load time (nlohmann_json/nlohmann_json_schema_validator
+# below hit the same class of gap previously, hence their own redundant target_link_libraries).
+find_package(yaml-cpp REQUIRED)
+
+# ffmpeg (already a package.xml <depend>, providing headers for ip_camera.cpp's libavformat
+# calls) has no ament package/CMake config of its own -- discovered the same way as yaml-cpp
+# above, via #254's test suite dlopen-ing ip_camera for the first time and hitting
+# `undefined symbol: av_log_set_level` (from libavutil, pulled in transitively by libavformat)
+# at pluginlib load time.
+pkg_search_module(AVFORMAT REQUIRED libavformat)
+pkg_search_module(AVUTIL REQUIRED libavutil)
+
 dc_package()
 
 set(library_name measurement_server_core)
@@ -190,11 +207,15 @@ foreach(measurement_plugin ${dc_measurement_plugin_libs})
     ${measurement_plugin}
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator
+    yaml-cpp::yaml-cpp
     ${UUID_LIBRARIES}
   )
   target_compile_definitions(${measurement_plugin} PRIVATE BT_PLUGIN_EXPORT)
 endforeach()
 target_link_libraries(dc_camera_measurement ZXing::ZXing)
+target_include_directories(dc_ip_camera_measurement PRIVATE ${AVFORMAT_INCLUDE_DIRS} ${AVUTIL_INCLUDE_DIRS})
+target_link_directories(dc_ip_camera_measurement PRIVATE ${AVFORMAT_LIBRARY_DIRS} ${AVUTIL_LIBRARY_DIRS})
+target_link_libraries(dc_ip_camera_measurement ${AVFORMAT_LIBRARIES} ${AVUTIL_LIBRARIES})
 foreach(condition_plugin ${dc_condition_plugin_libs})
   ament_target_dependencies(${condition_plugin} ${dependencies})
   target_compile_definitions(${condition_plugin} PRIVATE BT_PLUGIN_EXPORT)

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -270,7 +270,9 @@ install(DIRECTORY plugins/measurements/json
 set(tests
   test_measurement_bool_equal
   test_measurement_camera
+  test_measurement_cmd_vel
   test_measurement_diagnostics
+  test_measurement_distance_traveled
   test_measurement_double_equal
   test_measurement_double_inferior
   test_measurement_double_superior
@@ -281,17 +283,26 @@ set(tests
   test_measurement_integer_equal
   test_measurement_integer_inferior
   test_measurement_integer_superior
+  test_measurement_ip_camera
   test_measurement_list_bool_equal
   test_measurement_list_double_equal
   test_measurement_list_integer_equal
   test_measurement_list_string_equal
+  test_measurement_map
+  test_measurement_memory
   test_measurement_moving
+  test_measurement_network
   test_measurement_os
   test_measurement_parameters
+  test_measurement_permissions
+  test_measurement_position
   test_measurement_random
   test_measurement_same_as_previous
   test_measurement_serial_interface
+  test_measurement_speed
+  test_measurement_storage
   test_measurement_string_match
+  test_measurement_tcp_health
   test_measurement_thermal
   test_measurement_uptime
 )

--- a/dc_measurements/test/test_measurement_cmd_vel.cpp
+++ b/dc_measurements/test/test_measurement_cmd_vel.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "geometry_msgs/msg/twist.hpp"
+
+class MeasurementCmdVelTest : public ::testing::Test
+{
+protected:
+  MeasurementCmdVelTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementCmdVelTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "cmd_vel" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/cmd_vel", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementCmdVelTest::cmdVelDataCallback, this, std::placeholders::_1));
+    cmd_vel_pub_ = ms_node_->create_publisher<geometry_msgs::msg::Twist>("/test/cmd_vel", rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void cmdVelDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_pub_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementCmdVelTest, PublishesTwistWithComputedSpeed)
+{
+  ms_node_->declare_parameter("cmd_vel.plugin", std::string("dc_measurements/CmdVel"));
+  ms_node_->declare_parameter("cmd_vel.group_key", std::string("cmd_vel"));
+  ms_node_->declare_parameter("cmd_vel.topic_output", std::string("/dc/measurement/cmd_vel"));
+  ms_node_->declare_parameter("cmd_vel.topic", std::string("/test/cmd_vel"));
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/test/cmd_vel") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  geometry_msgs::msg::Twist twist;
+  twist.linear.x = 3.0;
+  twist.linear.y = 4.0;
+  twist.angular.z = 1.5;
+  while (!callback_active_)
+  {
+    cmd_vel_pub_->publish(twist);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_DOUBLE_EQ(data_json_["linear"]["x"].get<double>(), 3.0);
+  EXPECT_DOUBLE_EQ(data_json_["linear"]["y"].get<double>(), 4.0);
+  EXPECT_DOUBLE_EQ(data_json_["angular"]["z"].get<double>(), 1.5);
+  // sqrt(3^2 + 4^2) -- the plugin only factors linear x/y into "computed".
+  EXPECT_NEAR(data_json_["computed"].get<double>(), 5.0, 1e-9);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_distance_traveled.cpp
+++ b/dc_measurements/test/test_measurement_distance_traveled.cpp
@@ -116,17 +116,22 @@ TEST_F(MeasurementDistanceTraveledTest, PublishesDistanceFromOriginOnFirstFix)
   EXPECT_NEAR(data_json_["distance_traveled"].get<double>(), 5.0, 1e-2);
 }
 
-TEST_F(MeasurementDistanceTraveledTest, NoTransformYieldsEmptyRecord)
+TEST_F(MeasurementDistanceTraveledTest, NoTransformProducesNoPublish)
 {
   startLifecycleNode();
 
-  while (!callback_active_)
+  // With no transform ever broadcast, every collect() cycle returns an empty StringStamped, and
+  // Measurement::publish() (measurement.hpp) drops empty messages outright (logs a WARN, never
+  // calls data_pub_->publish()) rather than publishing "{}" -- so the callback can never fire.
+  // Poll through several collect() cycles (polling_interval=50) and assert it stays that way,
+  // same pattern as test_measurement_ip_camera.cpp's NoSegmentsYetProducesNoPublish.
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+  while (std::chrono::steady_clock::now() < deadline)
   {
     rclcpp::spin_some(ms_node_->get_node_base_interface());
   }
 
-  EXPECT_FALSE(data_json_.contains("distance_traveled"));
-  EXPECT_TRUE(data_json_.empty());
+  EXPECT_FALSE(callback_active_);
 }
 
 int main(int argc, char** argv)

--- a/dc_measurements/test/test_measurement_distance_traveled.cpp
+++ b/dc_measurements/test/test_measurement_distance_traveled.cpp
@@ -1,0 +1,133 @@
+#include <gtest/gtest.h>
+#include <tf2_ros/transform_broadcaster.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+class MeasurementDistanceTraveledTest : public ::testing::Test
+{
+protected:
+  MeasurementDistanceTraveledTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementDistanceTraveledTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "distance_traveled" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/distance_traveled", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementDistanceTraveledTest::distanceDataCallback, this, std::placeholders::_1));
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(ms_node_);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->declare_parameter("distance_traveled.plugin", std::string("dc_measurements/DistanceTraveled"));
+    ms_node_->declare_parameter("distance_traveled.group_key", std::string("distance_traveled"));
+    ms_node_->declare_parameter("distance_traveled.topic_output", std::string("/dc/measurement/distance_traveled"));
+    ms_node_->declare_parameter("distance_traveled.polling_interval", 50);
+    // DistanceTraveled::onConfigure() reads "transform_timeout" via the non-throwing
+    // get_parameter(name, out) overload without ever declaring it (a known pre-existing bug,
+    // documented in distance_traveled.cpp) -- if left undeclared, transform_timeout_ keeps
+    // whatever garbage value happened to be on the stack. Declared explicitly here so this test
+    // exercises real, defined behaviour instead of UB.
+    ms_node_->declare_parameter("distance_traveled.transform_timeout", 0.5);
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void distanceDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  void broadcastMapToBaseLink(double x, double y)
+  {
+    geometry_msgs::msg::TransformStamped tf_msg;
+    tf_msg.header.stamp = ms_node_->get_clock()->now();
+    tf_msg.header.frame_id = "map";
+    tf_msg.child_frame_id = "base_link";
+    tf_msg.transform.translation.x = x;
+    tf_msg.transform.translation.y = y;
+    tf_msg.transform.rotation.w = 1.0;
+    tf_broadcaster_->sendTransform(tf_msg);
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementDistanceTraveledTest, PublishesDistanceFromOriginOnFirstFix)
+{
+  startLifecycleNode();
+
+  // last_x_/last_y_ start at (0, 0), so the first successful transform lookup reports the
+  // straight-line distance from the origin. Keep re-broadcasting and resetting until a Record
+  // carrying "distance_traveled" shows up (earlier collect() cycles may fire before the
+  // transform is in the tf buffer, publishing an empty "{}" Record instead).
+  bool got_distance = false;
+  while (!got_distance)
+  {
+    broadcastMapToBaseLink(3.0, 4.0);
+    callback_active_ = false;
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    if (callback_active_ && data_json_.contains("distance_traveled"))
+    {
+      got_distance = true;
+    }
+  }
+
+  // sqrt(3^2 + 4^2)
+  EXPECT_NEAR(data_json_["distance_traveled"].get<double>(), 5.0, 1e-2);
+}
+
+TEST_F(MeasurementDistanceTraveledTest, NoTransformYieldsEmptyRecord)
+{
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(data_json_.contains("distance_traveled"));
+  EXPECT_TRUE(data_json_.empty());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_distance_traveled.cpp
+++ b/dc_measurements/test/test_measurement_distance_traveled.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 #include <tf2_ros/transform_broadcaster.h>
 
+#include <chrono>
+#include <thread>
+
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
@@ -87,13 +90,22 @@ TEST_F(MeasurementDistanceTraveledTest, PublishesDistanceFromOriginOnFirstFix)
   // last_x_/last_y_ start at (0, 0), so the first successful transform lookup reports the
   // straight-line distance from the origin. Keep re-broadcasting and resetting until a Record
   // carrying "distance_traveled" shows up (earlier collect() cycles may fire before the
-  // transform is in the tf buffer, publishing an empty "{}" Record instead).
+  // transform is in the tf buffer, publishing an empty "{}" Record instead). tf2_ros::
+  // TransformListener spins on its own background thread (MeasurementServer never passed it an
+  // explicit node/executor, so it defaults to one); a short sleep between spins here gives that
+  // thread real scheduling opportunities instead of this loop busy-spinning a core out from
+  // under it.
   bool got_distance = false;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
   while (!got_distance)
   {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "never observed a Record with \"distance_traveled\" -- tf broadcast likely never "
+           "reached the buffer";
     broadcastMapToBaseLink(3.0, 4.0);
     callback_active_ = false;
     rclcpp::spin_some(ms_node_->get_node_base_interface());
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
     if (callback_active_ && data_json_.contains("distance_traveled"))
     {
       got_distance = true;

--- a/dc_measurements/test/test_measurement_ip_camera.cpp
+++ b/dc_measurements/test/test_measurement_ip_camera.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// IpCamera::onConfigure() spawns a detached background ffmpeg process reading from "input" and
+// segmenting to disk; collect() then picks up completed segment files from that directory. A
+// real happy-path test would need a live video source and a working ffmpeg pipeline, neither of
+// which this sandbox can provide deterministically. This suite instead points "input" at a path
+// that doesn't exist, so ffmpeg fails immediately (no hang, no real video needed) and no segment
+// ever appears -- covering that the plugin doesn't crash or publish garbage while idle.
+class MeasurementIpCameraTest : public ::testing::Test
+{
+protected:
+  MeasurementIpCameraTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementIpCameraTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "ip_camera" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/ip_camera", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementIpCameraTest::ipCameraDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void ipCameraDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementIpCameraTest, NoSegmentsYetProducesNoPublish)
+{
+  // Keep saves under the test's scratch dir rather than the real $HOME default.
+  ms_node_->declare_parameter("save_local_base_path", std::string("/tmp/dc_measurement_ip_camera_test"));
+  ms_node_->declare_parameter("ip_camera.plugin", std::string("dc_measurements/IpCamera"));
+  ms_node_->declare_parameter("ip_camera.group_key", std::string("ip_camera"));
+  ms_node_->declare_parameter("ip_camera.topic_output", std::string("/dc/measurement/ip_camera"));
+  ms_node_->declare_parameter("ip_camera.input", std::string("/nonexistent/dc_ip_camera_test_input.mp4"));
+  // The default "save_path" ("ffmpeg_%Y-%m-%dT%H:%M:%S") fails onConfigure()'s own validation
+  // regex, which requires the value to *start* with '%' -- a pre-existing bug that would make
+  // onConfigure() throw (and the measurement silently disable) before ever reaching the ffmpeg
+  // spawn below. Overridden here so this test exercises the "ffmpeg never produces a segment"
+  // path it's actually meant to cover, not that unrelated bug.
+  ms_node_->declare_parameter("ip_camera.save_path", std::string("%Y-%m-%dT%H:%M:%S"));
+  ms_node_->declare_parameter("ip_camera.polling_interval", 50);
+
+  startLifecycleNode();
+
+  std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+  // Poll through several collect() cycles; since ffmpeg never produces a segment, the storage
+  // directory stays empty and collect() should never publish a Record (default StringStamped's
+  // data field is left empty, which the base publish() drops).
+  while ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+         300)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(callback_active_);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_map.cpp
+++ b/dc_measurements/test/test_measurement_map.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <thread>
+
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
@@ -60,7 +63,7 @@ public:
   bool callback_active_{ false };
 };
 
-TEST_F(MeasurementMapTest, NoMapDataYieldsEmptyRecordWithoutCrashing)
+TEST_F(MeasurementMapTest, NoMapDataProducesNoPublish)
 {
   // Keep saves under the test's scratch dir rather than the real $HOME default, and keep
   // map_saver_cli's own wait for /map short in case it is actually installed.
@@ -73,12 +76,20 @@ TEST_F(MeasurementMapTest, NoMapDataYieldsEmptyRecordWithoutCrashing)
 
   startLifecycleNode();
 
-  while (!callback_active_)
+  // With no /map data ever published, every collect() cycle returns an empty StringStamped, and
+  // Measurement::publish() (measurement.hpp) drops empty messages outright (logs a WARN, never
+  // calls data_pub_->publish()) rather than publishing "{}" -- so the callback can never fire.
+  // Each real collect() cycle here costs ~1.3s (the map_saver_cli subprocess spawn + its 1s
+  // save_map_timeout), so the poll window is longer than the other plugins' 300ms to actually
+  // exercise a couple of cycles rather than trivially passing before the first one completes.
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(4);
+  while (std::chrono::steady_clock::now() < deadline)
   {
     rclcpp::spin_some(ms_node_->get_node_base_interface());
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
 
-  EXPECT_TRUE(data_json_.empty());
+  EXPECT_FALSE(callback_active_);
 }
 
 int main(int argc, char** argv)

--- a/dc_measurements/test/test_measurement_map.cpp
+++ b/dc_measurements/test/test_measurement_map.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Map::collect() shells out to `ros2 run nav2_map_server map_saver_cli`, which is not a
+// dependency of this package and is not guaranteed to be installed, and even if it is, it needs
+// a live /map topic to save from. This suite only exercises the deterministic, environment-
+// independent path: no /map data means map_saver_cli (if present) times out or (if absent) the
+// shell command fails immediately, either way collect() falls through to an empty Record --
+// covering that the plugin degrades gracefully rather than crashing or hanging the node.
+class MeasurementMapTest : public ::testing::Test
+{
+protected:
+  MeasurementMapTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementMapTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "map" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/map", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMapTest::mapDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void mapDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementMapTest, NoMapDataYieldsEmptyRecordWithoutCrashing)
+{
+  // Keep saves under the test's scratch dir rather than the real $HOME default, and keep
+  // map_saver_cli's own wait for /map short in case it is actually installed.
+  ms_node_->declare_parameter("save_local_base_path", std::string("/tmp/dc_measurement_map_test"));
+  ms_node_->declare_parameter("map.plugin", std::string("dc_measurements/Map"));
+  ms_node_->declare_parameter("map.group_key", std::string("map"));
+  ms_node_->declare_parameter("map.topic_output", std::string("/dc/measurement/map"));
+  ms_node_->declare_parameter("map.topic", std::string("/test/map"));
+  ms_node_->declare_parameter("map.save_map_timeout", 1.0);
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_TRUE(data_json_.empty());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_memory.cpp
+++ b/dc_measurements/test/test_measurement_memory.cpp
@@ -1,0 +1,88 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementMemoryTest : public ::testing::Test
+{
+protected:
+  MeasurementMemoryTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementMemoryTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "memory" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/memory", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMemoryTest::memoryDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void memoryDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    nlohmann::json data_json = nlohmann::json::parse(data_str);
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    used_ = data_json["used"];
+    memory_callback_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  float used_;
+
+public:
+  bool memory_callback_{ false };
+};
+
+TEST_F(MeasurementMemoryTest, MemoryUsedIsAPercentage)
+{
+  ms_node_->declare_parameter("memory.plugin", std::string("dc_measurements/Memory"));
+  ms_node_->declare_parameter("memory.group_key", std::string("memory"));
+  ms_node_->declare_parameter("memory.topic_output", std::string("/dc/measurement/memory"));
+
+  startLifecycleNode();
+
+  while (!memory_callback_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_GE(used_, 0.0);
+  EXPECT_LE(used_, 100.0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_network.cpp
+++ b/dc_measurements/test/test_measurement_network.cpp
@@ -1,0 +1,118 @@
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementNetworkTest : public ::testing::Test
+{
+protected:
+  MeasurementNetworkTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementNetworkTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "network" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/network", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementNetworkTest::networkDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void networkDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+// Whether the ICMP ping itself succeeds depends on raw-socket (CAP_NET_RAW/root) privileges and
+// real network access, both of which vary by CI/sandbox environment -- so this only asserts on
+// the parts of the Record that are deterministic on any host: the network interface list (every
+// Linux host has at least loopback) and the shape/types of the ping fields, not their values.
+TEST_F(MeasurementNetworkTest, ReportsLocalInterfacesAndPingShape)
+{
+  ms_node_->declare_parameter("network.plugin", std::string("dc_measurements/Network"));
+  ms_node_->declare_parameter("network.group_key", std::string("network"));
+  ms_node_->declare_parameter("network.topic_output", std::string("/dc/measurement/network"));
+  // 127.0.0.1 rather than the 8.8.8.8 default so this doesn't depend on outbound internet access.
+  ms_node_->declare_parameter("network.ping_address", std::string("127.0.0.1"));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  ASSERT_TRUE(data_json_["interfaces"].is_array());
+  EXPECT_NE(std::find(data_json_["interfaces"].begin(), data_json_["interfaces"].end(), "lo"),
+            data_json_["interfaces"].end());
+  ASSERT_TRUE(data_json_["ping"].is_number_integer());
+  ASSERT_TRUE(data_json_["online"].is_boolean());
+}
+
+TEST_F(MeasurementNetworkTest, InvalidPingAddressDisablesTheMeasurement)
+{
+  ms_node_->declare_parameter("network.plugin", std::string("dc_measurements/Network"));
+  ms_node_->declare_parameter("network.group_key", std::string("network"));
+  ms_node_->declare_parameter("network.topic_output", std::string("/dc/measurement/network"));
+  ms_node_->declare_parameter("network.ping_address", std::string("not-an-ip-address"));
+  ms_node_->declare_parameter("network.polling_interval", 50);
+
+  startLifecycleNode();
+
+  std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+  while ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+         150)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(callback_active_);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_permissions.cpp
+++ b/dc_measurements/test/test_measurement_permissions.cpp
@@ -1,0 +1,129 @@
+#include <grp.h>
+#include <gtest/gtest.h>
+#include <pwd.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementPermissionsTest : public ::testing::Test
+{
+protected:
+  MeasurementPermissionsTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementPermissionsTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "permissions" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/permissions", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementPermissionsTest::permissionsDataCallback, this, std::placeholders::_1));
+
+    test_file_ = (std::filesystem::temp_directory_path() / "dc_measurement_permissions_test_file").u8string();
+    std::ofstream(test_file_) << "test";
+    chmod(test_file_.c_str(), 0644);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+    std::filesystem::remove(test_file_);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void permissionsDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+  std::string test_file_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementPermissionsTest, ReportsOwnerAndPermissionsAsInt)
+{
+  ms_node_->declare_parameter("permissions.plugin", std::string("dc_measurements/Permissions"));
+  ms_node_->declare_parameter("permissions.group_key", std::string("permissions"));
+  ms_node_->declare_parameter("permissions.topic_output", std::string("/dc/measurement/permissions"));
+  ms_node_->declare_parameter("permissions.path", test_file_);
+  ms_node_->declare_parameter("permissions.format", std::string("int"));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_TRUE(data_json_["exists"].get<bool>());
+  EXPECT_EQ(data_json_["permissions"].get<std::string>(), "644");
+  EXPECT_EQ(data_json_["uid"].get<uid_t>(), getuid());
+  EXPECT_EQ(data_json_["gid"].get<gid_t>(), getgid());
+
+  struct passwd* pw = getpwuid(getuid());
+  if (pw != nullptr)
+  {
+    EXPECT_EQ(data_json_["user"].get<std::string>(), pw->pw_name);
+  }
+}
+
+TEST_F(MeasurementPermissionsTest, ReportsPermissionsAsRwxString)
+{
+  ms_node_->declare_parameter("permissions.plugin", std::string("dc_measurements/Permissions"));
+  ms_node_->declare_parameter("permissions.group_key", std::string("permissions"));
+  ms_node_->declare_parameter("permissions.topic_output", std::string("/dc/measurement/permissions"));
+  ms_node_->declare_parameter("permissions.path", test_file_);
+  ms_node_->declare_parameter("permissions.format", std::string("rwx"));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  // 0644 = rw-r--r--
+  EXPECT_EQ(data_json_["permissions"].get<std::string>(), "rw-r--r--");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_position.cpp
+++ b/dc_measurements/test/test_measurement_position.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2_ros/transform_broadcaster.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "geometry_msgs/msg/transform_stamped.hpp"
+
+class MeasurementPositionTest : public ::testing::Test
+{
+protected:
+  MeasurementPositionTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementPositionTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "position" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/position", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementPositionTest::positionDataCallback, this, std::placeholders::_1));
+    tf_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>(ms_node_);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->declare_parameter("position.plugin", std::string("dc_measurements/Position"));
+    ms_node_->declare_parameter("position.group_key", std::string("position"));
+    ms_node_->declare_parameter("position.topic_output", std::string("/dc/measurement/position"));
+    ms_node_->declare_parameter("position.polling_interval", 50);
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void positionDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  void broadcastMapToBaseLink(double x, double y, double yaw)
+  {
+    geometry_msgs::msg::TransformStamped tf_msg;
+    tf_msg.header.stamp = ms_node_->get_clock()->now();
+    tf_msg.header.frame_id = "map";
+    tf_msg.child_frame_id = "base_link";
+    tf_msg.transform.translation.x = x;
+    tf_msg.transform.translation.y = y;
+    tf2::Quaternion q;
+    q.setRPY(0, 0, yaw);
+    tf_msg.transform.rotation.x = q.x();
+    tf_msg.transform.rotation.y = q.y();
+    tf_msg.transform.rotation.z = q.z();
+    tf_msg.transform.rotation.w = q.w();
+    tf_broadcaster_->sendTransform(tf_msg);
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementPositionTest, PublishesPoseFromTransform)
+{
+  startLifecycleNode();
+
+  // The very first collect() cycles may fire before the transform below is in the tf buffer,
+  // yielding an empty Record ("{}"), which still gets published; keep broadcasting and
+  // resetting until a Record carrying "x" actually shows up.
+  const double yaw = 1.5707963267948966;  // pi / 2
+  bool got_position = false;
+  while (!got_position)
+  {
+    broadcastMapToBaseLink(2.0, 3.0, yaw);
+    callback_active_ = false;
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    if (callback_active_ && data_json_.contains("x"))
+    {
+      got_position = true;
+    }
+  }
+
+  EXPECT_NEAR(data_json_["x"].get<double>(), 2.0, 1e-3);
+  EXPECT_NEAR(data_json_["y"].get<double>(), 3.0, 1e-3);
+  EXPECT_NEAR(data_json_["yaw"].get<double>(), yaw, 1e-3);
+}
+
+TEST_F(MeasurementPositionTest, NoTransformYieldsEmptyRecord)
+{
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(data_json_.contains("x"));
+  EXPECT_TRUE(data_json_.empty());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_position.cpp
+++ b/dc_measurements/test/test_measurement_position.cpp
@@ -2,6 +2,9 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2_ros/transform_broadcaster.h>
 
+#include <chrono>
+#include <thread>
+
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
@@ -86,14 +89,21 @@ TEST_F(MeasurementPositionTest, PublishesPoseFromTransform)
 
   // The very first collect() cycles may fire before the transform below is in the tf buffer,
   // yielding an empty Record ("{}"), which still gets published; keep broadcasting and
-  // resetting until a Record carrying "x" actually shows up.
+  // resetting until a Record carrying "x" actually shows up. tf2_ros::TransformListener spins
+  // on its own background thread (MeasurementServer never passed it an explicit node/executor,
+  // so it defaults to one); a short sleep between spins here gives that thread real scheduling
+  // opportunities instead of this loop busy-spinning a core out from under it.
   const double yaw = 1.5707963267948966;  // pi / 2
   bool got_position = false;
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
   while (!got_position)
   {
+    ASSERT_LT(std::chrono::steady_clock::now(), deadline)
+        << "never observed a Record with \"x\" -- tf broadcast likely never reached the buffer";
     broadcastMapToBaseLink(2.0, 3.0, yaw);
     callback_active_ = false;
     rclcpp::spin_some(ms_node_->get_node_base_interface());
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
     if (callback_active_ && data_json_.contains("x"))
     {
       got_position = true;

--- a/dc_measurements/test/test_measurement_position.cpp
+++ b/dc_measurements/test/test_measurement_position.cpp
@@ -115,17 +115,22 @@ TEST_F(MeasurementPositionTest, PublishesPoseFromTransform)
   EXPECT_NEAR(data_json_["yaw"].get<double>(), yaw, 1e-3);
 }
 
-TEST_F(MeasurementPositionTest, NoTransformYieldsEmptyRecord)
+TEST_F(MeasurementPositionTest, NoTransformProducesNoPublish)
 {
   startLifecycleNode();
 
-  while (!callback_active_)
+  // With no transform ever broadcast, every collect() cycle returns an empty StringStamped, and
+  // Measurement::publish() (measurement.hpp) drops empty messages outright (logs a WARN, never
+  // calls data_pub_->publish()) rather than publishing "{}" -- so the callback can never fire.
+  // Poll through several collect() cycles (polling_interval=50) and assert it stays that way,
+  // same pattern as test_measurement_ip_camera.cpp's NoSegmentsYetProducesNoPublish.
+  auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+  while (std::chrono::steady_clock::now() < deadline)
   {
     rclcpp::spin_some(ms_node_->get_node_base_interface());
   }
 
-  EXPECT_FALSE(data_json_.contains("x"));
-  EXPECT_TRUE(data_json_.empty());
+  EXPECT_FALSE(callback_active_);
 }
 
 int main(int argc, char** argv)

--- a/dc_measurements/test/test_measurement_speed.cpp
+++ b/dc_measurements/test/test_measurement_speed.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+class MeasurementSpeedTest : public ::testing::Test
+{
+protected:
+  MeasurementSpeedTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementSpeedTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "speed" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/speed", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementSpeedTest::speedDataCallback, this, std::placeholders::_1));
+    odom_pub_ = ms_node_->create_publisher<nav_msgs::msg::Odometry>("/test/odom", rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void speedDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementSpeedTest, PublishesTwistWithComputedSpeed)
+{
+  ms_node_->declare_parameter("speed.plugin", std::string("dc_measurements/Speed"));
+  ms_node_->declare_parameter("speed.group_key", std::string("speed"));
+  ms_node_->declare_parameter("speed.topic_output", std::string("/dc/measurement/speed"));
+  ms_node_->declare_parameter("speed.odom_topic", std::string("/test/odom"));
+
+  startLifecycleNode();
+
+  while (ms_node_->count_subscribers("/test/odom") == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  nav_msgs::msg::Odometry odom;
+  odom.twist.twist.linear.x = 3.0;
+  odom.twist.twist.linear.y = 4.0;
+  odom.twist.twist.angular.z = 0.5;
+  while (!callback_active_)
+  {
+    odom_pub_->publish(odom);
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_DOUBLE_EQ(data_json_["linear"]["x"].get<double>(), 3.0);
+  EXPECT_DOUBLE_EQ(data_json_["linear"]["y"].get<double>(), 4.0);
+  EXPECT_DOUBLE_EQ(data_json_["angular"]["z"].get<double>(), 0.5);
+  // sqrt(3^2 + 4^2) -- the plugin only factors linear x/y into "computed".
+  EXPECT_NEAR(data_json_["computed"].get<double>(), 5.0, 1e-9);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_storage.cpp
+++ b/dc_measurements/test/test_measurement_storage.cpp
@@ -1,0 +1,122 @@
+#include <gtest/gtest.h>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementStorageTest : public ::testing::Test
+{
+protected:
+  MeasurementStorageTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementStorageTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "storage" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/storage", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementStorageTest::storageDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void storageDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementStorageTest, PublishesFreeAndCapacityForConfiguredPath)
+{
+  ms_node_->declare_parameter("storage.plugin", std::string("dc_measurements/Storage"));
+  ms_node_->declare_parameter("storage.group_key", std::string("storage"));
+  ms_node_->declare_parameter("storage.topic_output", std::string("/dc/measurement/storage"));
+  ms_node_->declare_parameter("storage.path", std::string("/tmp"));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  ASSERT_TRUE(data_json_.contains("capacity"));
+  ASSERT_TRUE(data_json_.contains("free"));
+  ASSERT_TRUE(data_json_.contains("free_percent"));
+
+  auto capacity = data_json_["capacity"].get<int64_t>();
+  auto free = data_json_["free"].get<int64_t>();
+  auto free_percent = data_json_["free_percent"].get<double>();
+
+  EXPECT_GT(capacity, 0);
+  EXPECT_GE(free, 0);
+  EXPECT_LE(free, capacity);
+  EXPECT_GE(free_percent, 0.0);
+  EXPECT_LE(free_percent, 100.0);
+}
+
+TEST_F(MeasurementStorageTest, MissingMandatoryPathDisablesTheMeasurement)
+{
+  // "storage.path" has no default and is mandatory (dc_util::get_str_type_param without a
+  // default value); onConfigure() throws when it's unset, which the base Measurement class
+  // catches and disables the measurement rather than propagating -- so no Record should ever
+  // be published, and the node must not crash.
+  ms_node_->declare_parameter("storage.plugin", std::string("dc_measurements/Storage"));
+  ms_node_->declare_parameter("storage.group_key", std::string("storage"));
+  ms_node_->declare_parameter("storage.topic_output", std::string("/dc/measurement/storage"));
+  ms_node_->declare_parameter("storage.polling_interval", 50);
+
+  startLifecycleNode();
+
+  std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+  while ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+         150)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(callback_active_);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_storage.cpp
+++ b/dc_measurements/test/test_measurement_storage.cpp
@@ -83,28 +83,11 @@ TEST_F(MeasurementStorageTest, PublishesFreeAndCapacityForConfiguredPath)
   EXPECT_LE(free_percent, 100.0);
 }
 
-TEST_F(MeasurementStorageTest, MissingMandatoryPathDisablesTheMeasurement)
-{
-  // "storage.path" has no default and is mandatory (dc_util::get_str_type_param without a
-  // default value); onConfigure() throws when it's unset, which the base Measurement class
-  // catches and disables the measurement rather than propagating -- so no Record should ever
-  // be published, and the node must not crash.
-  ms_node_->declare_parameter("storage.plugin", std::string("dc_measurements/Storage"));
-  ms_node_->declare_parameter("storage.group_key", std::string("storage"));
-  ms_node_->declare_parameter("storage.topic_output", std::string("/dc/measurement/storage"));
-  ms_node_->declare_parameter("storage.polling_interval", 50);
-
-  startLifecycleNode();
-
-  std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
-  while ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
-         150)
-  {
-    rclcpp::spin_some(ms_node_->get_node_base_interface());
-  }
-
-  EXPECT_FALSE(callback_active_);
-}
+// A missing mandatory parameter (e.g. "storage.path", which has no default) is not something
+// this suite can safely test: dc_util::get_param_or_fatal() calls exit(-1) directly rather than
+// throwing a catchable exception, so it takes the whole test binary down -- including whatever
+// other TEST_F cases share the process -- rather than just failing one assertion. Left untested
+// here; a real regression test for that path would need a gtest death test in a suite of its own.
 
 int main(int argc, char** argv)
 {

--- a/dc_measurements/test/test_measurement_tcp_health.cpp
+++ b/dc_measurements/test/test_measurement_tcp_health.cpp
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+class MeasurementTCPHealthTest : public ::testing::Test
+{
+protected:
+  MeasurementTCPHealthTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementTCPHealthTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "tcp_health" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/tcp_health", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementTCPHealthTest::tcpHealthDataCallback, this, std::placeholders::_1));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void tcpHealthDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    RCLCPP_INFO_STREAM(ms_node_->get_logger(), "Value: " << data_str);
+    data_json_ = nlohmann::json::parse(data_str);
+    callback_active_ = true;
+  }
+
+  // Asks the OS for a free ephemeral port by binding to port 0.
+  static unsigned short reserveFreePort()
+  {
+    boost::asio::io_service svc;
+    boost::asio::ip::tcp::acceptor acceptor(svc);
+    acceptor.open(boost::asio::ip::tcp::v4());
+    acceptor.bind({ boost::asio::ip::tcp::v4(), 0 });
+    return acceptor.local_endpoint().port();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  nlohmann::json data_json_;
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementTCPHealthTest, ActiveWhenPortIsListening)
+{
+  boost::asio::io_service svc;
+  boost::asio::ip::tcp::acceptor acceptor(svc);
+  acceptor.open(boost::asio::ip::tcp::v4());
+  acceptor.bind({ boost::asio::ip::tcp::v4(), 0 });
+  acceptor.listen();
+  unsigned short port = acceptor.local_endpoint().port();
+
+  ms_node_->declare_parameter("tcp_health.plugin", std::string("dc_measurements/TCPHealth"));
+  ms_node_->declare_parameter("tcp_health.group_key", std::string("tcp_health"));
+  ms_node_->declare_parameter("tcp_health.topic_output", std::string("/dc/measurement/tcp_health"));
+  ms_node_->declare_parameter("tcp_health.name", std::string("test-service"));
+  ms_node_->declare_parameter("tcp_health.port", static_cast<int>(port));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_EQ(data_json_["port"].get<int>(), port);
+  EXPECT_EQ(data_json_["server_name"].get<std::string>(), "test-service");
+  EXPECT_TRUE(data_json_["active"].get<bool>());
+}
+
+TEST_F(MeasurementTCPHealthTest, InactiveWhenPortIsFree)
+{
+  unsigned short port = reserveFreePort();
+
+  ms_node_->declare_parameter("tcp_health.plugin", std::string("dc_measurements/TCPHealth"));
+  ms_node_->declare_parameter("tcp_health.group_key", std::string("tcp_health"));
+  ms_node_->declare_parameter("tcp_health.topic_output", std::string("/dc/measurement/tcp_health"));
+  ms_node_->declare_parameter("tcp_health.name", std::string("test-service"));
+  ms_node_->declare_parameter("tcp_health.port", static_cast<int>(port));
+
+  startLifecycleNode();
+
+  while (!callback_active_)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(data_json_["active"].get<bool>());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -4284,6 +4284,74 @@ pushing (same sandbox constraint as every entry in this file) — the fix commit
 informed reasoning from reading the CI log carefully, not verified execution.
 Watching the next CI run on PR #329 to confirm.
 
+### #254 follow-up 2: real CI run on PR #329 (run 31687959072) — same 3 tests still hanging
+
+The previous fix (5ms sleep + 10s deadline) was only applied to the *happy-path* test
+in each of `test_measurement_distance_traveled.cpp`, `test_measurement_position.cpp`,
+and `test_measurement_map.cpp`. Confirmed via `gh run view --log` on this run
+(`colcon-test`): all three still ended as `missing_result` errors at the colcon-test
+level *and* CTest-level failures for the same three test binaries — i.e. the process
+was killed mid-run before writing its gtest XML, not a clean assertion failure.
+
+Root cause: each of these three files' *second* test —
+`NoTransformYieldsEmptyRecord` (distance_traveled, position) and
+`NoMapDataYieldsEmptyRecordWithoutCrashing` (map, the file's only test) — still had
+the exact anti-pattern the first fix targeted: a tight `while (!callback_active_) {
+rclcpp::spin_some(...); }` loop with no sleep and no deadline. The `map` CI log is the
+clearest evidence: `collect()` visibly ran to completion and logged "Message empty
+from measurement map" (i.e. published) roughly 40 times over the run before the job
+was killed, yet `callback_active_` was never observed true by the busy loop — the
+callback almost certainly is being starved of CPU by the test's own tight spin, same
+mechanism already diagnosed for the happy-path loops.
+
+**Fixed**: added the same 5ms `sleep_for` + 10-second `ASSERT_LT` deadline to all
+three straggler loops, so a real regression now fails cleanly with a clear message
+instead of hanging the whole CI job. `map.cpp` also needed `<chrono>`/`<thread>`
+added to its includes (the file's only test didn't need them before).
+
+**Not done**: same sandbox constraint — no local `colcon`/ROS to re-run `colcon test`;
+verified via `clang-format` only. Watching the next CI run on PR #329 to confirm this
+closes out the hang.
+
+### #254 follow-up 3: real CI run on PR #329 (merge commit cf6f658) — the hang is gone, but the "CPU starvation" theory was wrong
+
+The follow-up 2 fix worked as a *symptom* fix: `colcon-test` went from 3 `missing_result`
+errors to 0 — the process no longer hangs and gets killed mid-run. But all three tests
+still failed, now as clean, fast (~10s) `ASSERT_LT` timeouts instead of a multi-minute
+hang. That ruled out the "tight spin_some() loop starves a background publishing
+thread" hypothesis from follow-up 2: a real CPU-starvation fix would have let the
+callback through eventually; instead it never fires even once in 10 real seconds,
+despite the plugin's `collect()` cycle visibly running and logging "Message empty
+from measurement <x>" repeatedly the whole time.
+
+**Root cause (the actual one)**: `Measurement::publish()` (`dc_measurements/include/
+dc_measurements/measurement.hpp`) checks `if (!msg.data.empty() && msg.data !=
+"null")` before ever calling `data_pub_->publish(msg)` — when the condition is false
+it just logs `RCLCPP_WARN_STREAM("Message empty from measurement " << ...)` and
+returns. An empty Record is never published to the topic at all. So
+`NoTransformYieldsEmptyRecord` (distance_traveled, position) and
+`NoMapDataYieldsEmptyRecordWithoutCrashing` (map) were built on a false premise from
+the start — waiting for a subscriber callback that the framework guarantees will never
+fire for an empty Record. This was a pre-existing test-design bug in the original
+follow-up-1 session's tests, not something introduced by the busy-spin fix; the busy
+loop just hid it behind an indefinite hang instead of a fast, legible failure.
+
+The correct assertion, already established by `test_measurement_ip_camera.cpp`'s
+`NoSegmentsYetProducesNoPublish` (same "no data yet" class of test, written in the
+sibling camera PR/branch): poll through a bounded number of `collect()` cycles and
+assert the callback *never* fires, rather than waiting for one that structurally can't.
+
+**Fixed**: renamed and rewrote all three tests to that pattern —
+`NoTransformProducesNoPublish` (distance_traveled, position, 300ms window matching
+`polling_interval=50`) and `NoMapDataProducesNoPublish` (map, 4s window since each
+real `collect()` cycle there costs ~1.3s — `map_saver_cli` subprocess spawn plus its
+1s `save_map_timeout` — so a short window would trivially pass without exercising the
+path at all). Each just asserts `EXPECT_FALSE(callback_active_)` after the window,
+same as the camera-suite sibling.
+
+**Not done**: same sandbox constraint as every entry — no local `colcon`/ROS; verified
+via `clang-format` only. Watching the next CI run on PR #329 to confirm.
+
 ## #255: Test coverage epic (condition plugins) — remaining 13 plugins + list_string_equal
 
 **Context**: The `double_equal` item landed separately (see the entry above) and merged to

--- a/progress.txt
+++ b/progress.txt
@@ -4227,6 +4227,63 @@ either would need the E2E harness (`tools/e2e/`) rather than a `colcon test` gte
 All 12 items of the #254 checklist (camera on the sibling branch/PR, these 11 here)
 are now covered; combined, both PRs should close #254 once merged.
 
+### #254 follow-up: real CI run on PR #329 (run 31653852372) — 6 failures, fixed
+
+The prediction above ("no local colcon, CI is the real gate") paid off: the first
+real CI run of these 11 tests found 6 failures the sandbox-only pre-commit pass
+couldn't have caught, since nothing loaded these plugin `.so`s before. Fixed in a
+follow-up commit on the same branch/PR (not a new PR, since the tests themselves
+were correct — the bugs were in the plugin build/CMakeLists and in one test's wrong
+assumption about a framework internal):
+
+- **cmd_vel and map dlopen-failed**: `undefined symbol: typeinfo for
+  YAML::BadConversion`. Neither plugin's `.so` actually linked yaml-cpp —
+  `yaml_cpp_vendor` (already in the shared `dependencies` list) only guarantees the
+  system package is installed via rosdep, it doesn't itself re-export a linkable
+  CMake target for `ament_target_dependencies` to pick up. Fixed with a separate
+  `find_package(yaml-cpp REQUIRED)` and `target_link_libraries(...,
+  yaml-cpp::yaml-cpp)` added to every measurement plugin (matching the existing
+  `nlohmann_json::nlohmann_json` / `nlohmann_json_schema_validator` explicit
+  `target_link_libraries` calls already in this file, which — in hindsight — were
+  working around the exact same class of gap, just for a different vendor
+  dependency, before this session ever touched the file).
+- **ip_camera dlopen-failed**: `undefined symbol: av_log_set_level` (libavutil, via
+  libavformat). `ffmpeg` is a `package.xml` `<depend>` but the CMakeLists never
+  actually linked it — headers happened to resolve at compile time (probably via
+  some other package's transitive include path), but the `.so` itself never got
+  `libavformat`/`libavutil` on its own `DT_NEEDED` list, so it built "successfully"
+  (shared libraries permit unresolved symbols at link time) and only failed at
+  dlopen. Fixed with `pkg_search_module(AVFORMAT REQUIRED libavformat)` /
+  `pkg_search_module(AVUTIL REQUIRED libavutil)`, linked into
+  `dc_ip_camera_measurement` specifically.
+- **storage's `MissingMandatoryPathDisablesTheMeasurement` test crashed the whole
+  binary** (exit code 255, `[FATAL] Can not get 'storage.path' param value"`):
+  wrong assumption carried over from the camera/network findings. Not every
+  onConfigure() failure is a catchable `std::runtime_error` — a genuinely missing
+  *mandatory* parameter goes through `dc_util::get_param_or_fatal()`, which calls
+  `exit(-1)` directly rather than throwing, so it takes the whole process down
+  (including the sibling test case that had already passed and reported `[ OK ]`
+  moments earlier in the same run). Removed the test; a real regression test for
+  that path would need a gtest death test in a suite of its own, out of scope here.
+- **position and distance_traveled's tf-broadcast happy-path tests hung** —
+  `canTransform`'s "frame does not exist" error repeated continuously for 250+
+  seconds in the CI log before the job presumably hit some outer timeout. Likely
+  cause: `tf2_ros::TransformListener` here spins on its *own* background thread
+  (`MeasurementServer`'s `on_configure()` constructs it from just a `Buffer&`, with
+  no explicit node/executor, so it defaults to spinning itself), and the tests'
+  retry loop was a tight `while(...) { broadcast(); spin_some(); }` with no yield —
+  plausible CPU starvation of that background thread on a constrained CI runner,
+  though unconfirmed without being able to attach a debugger to a real run. Added a
+  5ms `sleep_for` between iterations and, regardless of whether that fully fixes
+  the root cause, a 10-second deadline that fails the assertion with a clear
+  message (`ASSERT_LT` against a `steady_clock` deadline) instead of hanging the
+  whole CI job again if it doesn't.
+
+**Not done**: could not re-run `colcon test` locally to confirm these fixes before
+pushing (same sandbox constraint as every entry in this file) — the fix commit is
+informed reasoning from reading the CI log carefully, not verified execution.
+Watching the next CI run on PR #329 to confirm.
+
 ## #255: Test coverage epic (condition plugins) — remaining 13 plugins + list_string_equal
 
 **Context**: The `double_equal` item landed separately (see the entry above) and merged to

--- a/progress.txt
+++ b/progress.txt
@@ -4131,6 +4131,102 @@ string_match) plus `list_string_equal` are untouched; following #254's precedent
 PR for this session uses "Contributes to #255" rather than "Closes #255" so the epic
 stays open for them.
 
+## #254: Test coverage epic (measurement plugins) — remaining 11 plugins
+
+**Read**: Continuation of the #254 epic (see the earlier "camera plugin" entry above,
+which covers the epic's background/rationale and is on a sibling branch/PR since it
+was done first). This session does the remaining 11 checklist items — cmd_vel,
+distance_traveled, ip_camera, memory, map, network, permissions, position, speed,
+storage, tcp_health — in a separate branch/worktree cut from `origin/jazzy` (not
+stacked on the unmerged camera branch), so this PR doesn't depend on the camera one
+merging first.
+
+**Added**: one `dc_measurements/test/test_measurement_<plugin>.cpp` per plugin,
+registered in `CMakeLists.txt`'s `tests` list, all following the same lifecycle-node
+pattern as the camera suite (and `test_measurement_diagnostics.cpp` before it):
+synthetic input published/broadcast on the plugin's subscribed topic or tf, output
+topic asserted against.
+
+- **cmd_vel** / **speed**: publish a `Twist` / `Odometry` with linear x=3,y=4, assert
+  the echoed `linear`/`angular` fields and `computed` (`sqrt(x²+y²)` = 5).
+- **memory**: no external input; asserts `used` is a 0–100 percentage (mirrors
+  `test_measurement_os.cpp`'s bounds check).
+- **position**: broadcasts a `map`→`base_link` tf via `tf2_ros::TransformBroadcaster`
+  at a known (x, y, yaw) and asserts the Record matches; a second test asserts an
+  empty `{}` Record (not a crash/hang) when no transform is ever published.
+- **distance_traveled**: same tf-broadcast pattern, asserting `distance_traveled` =
+  straight-line distance from the origin on the first fix (state starts at (0, 0)),
+  plus the same no-transform-yields-empty-Record test.
+- **storage**: asserts `free`/`capacity`/`free_percent` for `path=/tmp` are sane
+  (`0 <= free <= capacity`, `0 <= free_percent <= 100`); a second test asserts that
+  omitting the mandatory `path` parameter disables the measurement (no publish, no
+  crash) rather than propagating the exception.
+- **permissions**: creates a real scratch file, `chmod 644`s it, asserts `exists`,
+  `uid`/`gid` (against `getuid()`/`getgid()`), `user` (against `getpwuid()`), and
+  `permissions` in both `"int"` (`"644"`) and `"rwx"` (`"rw-r--r--"`) formats.
+- **tcp_health**: opens a real listening socket on an OS-assigned free port (via
+  `boost::asio`, binding to port 0) to assert `active=true`; a second test releases
+  that port before configuring the plugin to assert `active=false`.
+- **network**: only asserts the parts of the Record that are deterministic on any
+  host — `interfaces` contains `"lo"`, and `ping`/`online` have the right JSON types —
+  since whether the ICMP ping itself succeeds depends on `CAP_NET_RAW`/root privileges
+  and real network reachability, both of which vary by CI/sandbox environment; a
+  second test asserts an invalid `ping_address` disables the measurement rather than
+  crashing.
+- **map**: `Map::collect()` shells out to `ros2 run nav2_map_server map_saver_cli`,
+  which is not a `dc_measurements` rosdep and isn't guaranteed installed, and even if
+  it is, needs a live `/map` topic to save from. Only the deterministic path is
+  tested: no `/map` data published means `map_saver_cli` (if present) times out
+  quickly (`save_map_timeout=1.0`) or (if absent) the shell command fails
+  immediately — either way `collect()` degrades to an empty Record instead of
+  crashing or hanging the node.
+- **ip_camera**: `IpCamera::onConfigure()` spawns a detached background `ffmpeg`
+  process and `collect()` picks up finished HLS segments from disk; a real
+  happy-path test would need an actual video source. `input` is pointed at a
+  nonexistent local path so ffmpeg fails immediately (no hang, no real video), and
+  the test asserts no Record is ever published while the storage directory stays
+  empty.
+
+**Found** (documented in-line as code comments in the relevant test, same as the
+camera entry's `draw_det_barcodes` finding):
+- `DistanceTraveled::onConfigure()` (`distance_traveled.cpp`) declares
+  `transform_tolerance` but reads back `transform_timeout` via the non-throwing
+  `get_parameter(name, out)` overload, without ever declaring it — a pre-existing bug
+  already flagged in a `NOTE` comment in that file. Left undeclared,
+  `transform_timeout_` (a `float` member with no default initializer) keeps whatever
+  garbage happened to be on the stack: undefined behaviour, not a deterministic
+  default. The test declares `distance_traveled.transform_timeout` explicitly to
+  sidestep the UB rather than assert on it.
+- `IpCamera::onConfigure()`'s parameter validation for `save_path` — intended to
+  require the value start with `%` (a strftime format) — is inverted in a way that
+  makes the plugin's own default value (`"ffmpeg_%Y-%m-%dT%H:%M:%S"`, which does
+  *not* start with `%`) fail validation and throw, silently disabling the
+  measurement via the base class's catch-and-disable path. With no override, the
+  `ip_camera` measurement never activates at all under its own shipped defaults. The
+  test overrides `save_path` to work around this and exercise the intended
+  "ffmpeg produced no segment yet" path instead. Both of these are pre-existing bugs
+  outside this issue's scope (test coverage only) — worth their own follow-up
+  issues, same as the `transform_tolerance`/`transform_timeout` one already flagged
+  in-repo.
+
+**Not done / left for follow-up**: same sandbox constraint as every prior entry — no
+local `colcon`/ROS install here, so `colcon test` could not be run directly; CI
+(`tools/e2e/scripts/test.sh`) is the real gate. Verified via `pre-commit`
+(`clang-format`, applied cleanly) and a manual read-through of each plugin's
+`onConfigure()`/`collect()` against the base `Measurement`/`MeasurementServer`
+classes' parameter-default and publish/empty-message-drop behaviour (established
+while writing the camera suite) to reason through each test's expected outcome.
+`black` again reformatted the unrelated `tools/e2e/scripts/verify_zero_loss.py` as a
+side effect of running pre-commit against the whole repo — reverted before
+committing, same as every prior entry. `map` and `ip_camera` only cover the
+"no data yet" idle path, not a real successful map-save or video-segment happy path
+— genuinely infeasible to exercise deterministically in a sandboxed unit test
+(no live `/map` publisher, no live camera stream, and `map_saver_cli`'s
+availability in the real CI container is unconfirmed); a real happy-path test for
+either would need the E2E harness (`tools/e2e/`) rather than a `colcon test` gtest.
+All 12 items of the #254 checklist (camera on the sibling branch/PR, these 11 here)
+are now covered; combined, both PRs should close #254 once merged.
+
 ## #255: Test coverage epic (condition plugins) — remaining 13 plugins + list_string_equal
 
 **Context**: The `double_equal` item landed separately (see the entry above) and merged to


### PR DESCRIPTION
## Summary
- Completes the #254 test-coverage epic's checklist: gtest coverage for the 11 plugins not covered by the separate camera PR (#328) — cmd_vel, distance_traveled, ip_camera, map, memory, network, permissions, position, speed, storage, tcp_health.
- Cut from `origin/jazzy` directly (not stacked on the unmerged camera branch), so this PR doesn't depend on #328 merging first and can land in either order.
- Same lifecycle-node pattern as camera/diagnostics: synthetic input published or tf-broadcast on the plugin's subscribed topic/frame, output Record asserted against.
- `cmd_vel`/`speed`: echoed Twist/Odometry fields plus the computed speed.
- `position`/`distance_traveled`: broadcast a `map`→`base_link` tf via `tf2_ros::TransformBroadcaster`, plus a no-transform-yields-empty-Record case.
- `memory`/`storage`/`permissions`/`tcp_health`/`network`: exercise real system state (memory usage, `/tmp` free space, a `chmod`'d scratch file, a real listening socket on an OS-assigned port, network interfaces) instead of mocks.
- `map`/`ip_camera`: limited to the deterministic "no data yet" idle path — a real map-save or video-segment happy path needs live ROS/video input this sandbox can't provide (`map_saver_cli` isn't a declared rosdep of this package and its CI availability is unconfirmed; a real happy path for either would belong in the E2E harness, not a `colcon test` gtest).

Two pre-existing bugs found and worked around in the tests (not fixed — out of scope for a test-coverage-only issue, documented inline):
- `DistanceTraveled::onConfigure()` reads an undeclared `transform_timeout` parameter via the non-throwing `get_parameter(name, out)` overload, leaving an uninitialized `float` (UB) if the caller doesn't declare it first.
- `IpCamera`'s own default `save_path` value fails its own `%`-prefix validation regex, which disables the measurement under its shipped defaults.

Together with #328 (camera), this covers all 12 items of the #254 epic checklist. Using "Contributes to #254" here too rather than "Closes #254", since whichever of these two PRs merges second is the one that should actually close the epic.

Contributes to #254

## Test plan
- [ ] CI (`colcon test` via `tools/e2e/scripts/test.sh`) passes on all 11 new `dc_measurements_test_measurement_*` targets
- [x] `pre-commit` (`clang-format`) clean on the changed files
- [x] Manual read-through of each plugin's `onConfigure()`/`collect()` against the base `Measurement`/`MeasurementServer` classes' parameter-default and publish/empty-message-drop behaviour to reason through each test's expected outcome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K3oDsbM2XY4hPgcSm86o2L