### PR TITLE
test(conditions): add gtest coverage for the double_equal condition plugin

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -270,6 +270,7 @@ install(DIRECTORY plugins/measurements/json
 set(tests
   test_measurement_camera
   test_measurement_diagnostics
+  test_measurement_double_equal
   test_measurement_driving_type
   test_measurement_dummy
   test_measurement_gate_condition

--- a/dc_measurements/test/test_measurement_double_equal.cpp
+++ b/dc_measurements/test/test_measurement_double_equal.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::DoubleEqual through the same if_all_conditions gating path a real
+// Measurement uses: given a fixed Record (the dummy Measurement's static "record" JSON) and a
+// condition config (key/value), assert whether collection is activated or suppressed.
+class MeasurementDoubleEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementDoubleEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementDoubleEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    // condition_plugins is declared by the constructor itself, so it must be supplied as a
+    // parameter override rather than via ms_node_->declare_parameter afterwards.
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "double_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementDoubleEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "double_eq" });
+    // Route collection entirely through if_all_conditions: disable the unconditional
+    // init-publish path (-1) and allow unlimited publishes once the condition is on (0).
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("double_eq.plugin", std::string("dc_conditions/DoubleEqual"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's key holds a JSON double equal to the configured value ->
+// the condition activates and collection proceeds, repeatedly, on every poll.
+TEST_F(MeasurementDoubleEqualTest, RecordValueMatchingConfiguredValueActivatesCondition)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.5}"));
+  ms_node_->declare_parameter("double_eq.key", std::string("level"));
+  ms_node_->declare_parameter("double_eq.value", 5.5);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  int first_count = dummy_callback_count_;
+
+  // Unlike gate_condition's latching semantics, if_all_conditions keeps being satisfied every
+  // poll here since the Record's value never changes, so publishing keeps happening.
+  spinFor(polling_interval_ * 3);
+  EXPECT_GT(dummy_callback_count_, first_count);
+}
+
+// Acceptance criterion: Record's key holds a JSON double different from the configured value ->
+// the condition never activates and nothing is ever published.
+TEST_F(MeasurementDoubleEqualTest, RecordValueDifferingFromConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.5}"));
+  ms_node_->declare_parameter("double_eq.key", std::string("level"));
+  ms_node_->declare_parameter("double_eq.value", 3.0);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: the configured key is absent from the Record -> DoubleEqual treats this
+// as inactive (logging a warning) rather than throwing or matching.
+TEST_F(MeasurementDoubleEqualTest, MissingKeyInRecordNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"other\": 5.5}"));
+  ms_node_->declare_parameter("double_eq.key", std::string("level"));
+  ms_node_->declare_parameter("double_eq.value", 5.5);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion / gotcha: DoubleEqual requires the JSON value to actually be encoded as a
+// float. A Record field written as an integer literal (no decimal point) is numerically equal to
+// the configured double value but parses to json::value_t::number_unsigned, not number_float, so
+// DoubleEqual treats it as "not a double" and never activates -- the comparison is type-strict,
+// not just numeric.
+TEST_F(MeasurementDoubleEqualTest, IntegerLiteralInRecordNeverMatchesDespiteNumericEquality)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5}"));
+  ms_node_->declare_parameter("double_eq.key", std::string("level"));
+  ms_node_->declare_parameter("double_eq.value", 5.0);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -4052,3 +4052,81 @@ remaining 11 checklist items (cmd_vel, distance_traveled, ip_camera, memory, map
 network, permissions, position, speed, storage, tcp_health) are untouched; the PR for
 this session uses "Contributes to #254" rather than "Closes #254" so the epic stays
 open for them.
+
+## #255: Test coverage epic (condition plugins) — double_equal
+
+**Read**: Issue #255 consolidates the individually-closed #158–#171 into one 14-item
+checklist of `dc_measurements/plugins/conditions/` plugins with no tests yet (plus
+`list_string_equal.cpp`, called out as missing from the original list). The issue
+directs testing "external behaviour only: given a Record and a condition config,
+assert the activation outcome" rather than white-box unit-testing `getState()`
+directly. Per `CLAUDE.md`'s one-task-per-run convention and #254's precedent, this
+session does one item — `double_equal`, the first in the list.
+
+**Found**: `Condition::getState()` is invoked by `Measurement::isConditionOn()` /
+`isGateArmed()` (`measurement.hpp`) with the *Measurement's own* just-collected
+`StringStamped` (its Record, before tags/nesting/flatten are applied) — so a Condition
+like `DoubleEqual` that reads a key out of `msg.data` is actually inspecting the gated
+Measurement's own output, not some independent input topic (unlike `moving`, which
+reads Odometry via its own subscription and is what `test_measurement_gate_condition.cpp`
+already covers). This made the `dc_measurements/Dummy` plugin's static `record` param
+an ideal fixture: it deterministically republishes a fixed JSON payload every poll, so
+the Record content given to the Condition is exactly what the test declares.
+
+**Found (the load-bearing gotcha)**: `if_all_conditions`/`if_any_conditions` are only
+ever consulted from the "Infinite measurements on condition" / "Trigger publish with
+maximum" branches of `Measurement::publish()` — both of which are gated behind the
+"Init publish" branch running first. With the default `init_max_measurements=0`
+("infinite init publishes"), that branch **always** fires and publishing never falls
+through to the condition check at all, so `if_all_conditions` would silently appear to
+do nothing in a naively-configured test. Real configs (`dc_demos/params/
+qrcodes_minio_pgsql.yaml`) always pair `if_all_conditions`/`if_none_conditions` with
+`init_max_measurements: -1` (disables the init path outright) and
+`condition_max_measurements: 0` or a positive cap — the test fixture follows the same
+pairing, which is also now the reusable pattern for testing any other list/scalar
+condition plugin the same way.
+
+**Also found**: `DoubleEqual::getState()` is type-strict, not just numeric — it checks
+`flat_json[key].type() != json::value_t::number_float` before comparing, so a Record
+field written as a bare JSON integer (`{"level": 5}`, `number_unsigned`/`number_integer`
+in nlohmann::json) never matches a configured double value even when numerically equal
+(`5 == 5.0`). Captured as its own test
+(`IntegerLiteralInRecordNeverMatchesDespiteNumericEquality`) since it's a real footgun
+for anyone hand-writing a `dummy.record` or a Measurement's JSON output expecting
+`double_equal` to treat integers and floats interchangeably.
+
+**Added**: `dc_measurements/test/test_measurement_double_equal.cpp`, registered in
+`CMakeLists.txt`'s `tests` list (alphabetically, after `test_measurement_diagnostics`).
+Follows `test_measurement_gate_condition.cpp`'s node/parameter-override setup pattern
+(condition_plugins supplied via `NodeOptions().parameter_overrides()` since it's read
+in the `MeasurementServer` constructor itself) but drives activation via
+`if_all_conditions` instead of `gate_condition`, since `if_all_conditions` is
+re-evaluated every poll and doesn't have gate_condition's one-way latch semantics —
+simpler to reason about for a Condition whose input (the fixed dummy Record) never
+changes within a test. Four tests:
+- `RecordValueMatchingConfiguredValueActivatesCondition`: record `{"level": 5.5}`,
+  configured `value: 5.5` — collection proceeds and keeps proceeding on every poll.
+- `RecordValueDifferingFromConfiguredValueNeverActivates`: `value: 3.0` against the
+  same record — nothing is ever published.
+- `MissingKeyInRecordNeverActivates`: record has no `level` key — `DoubleEqual` logs a
+  warning and reports inactive rather than throwing.
+- `IntegerLiteralInRecordNeverMatchesDespiteNumericEquality`: the type-strictness
+  gotcha above.
+
+**Not done / left for follow-up**: no local `colcon`/ROS install in this sandbox (same
+constraint as #242/#243/#254), so `colcon test` could not be run directly; CI
+(`tools/e2e/scripts/test.sh`) is the real gate. Verified via `pre-commit`
+(`clang-format` — no changes needed) and a manual read-through of
+`double_equal.cpp`/`.hpp`, `condition.hpp` (both `dc_core` and `dc_measurements`
+versions), `measurement.hpp`'s `publish()`/`isConditionOn()`/`isGateArmed()`, and
+`node_utils.hpp`'s `declare_and_get` (confirmed pre-declaring a parameter in the test
+before a plugin's own `get_*_type_param` call is safe — `declare_parameter_if_not_declared`
+is idempotent, same pattern `test_measurement_gate_condition.cpp` already relies on).
+`black` reformatted an unrelated file (`tools/e2e/scripts/verify_zero_loss.py`) as a
+side effect of running pre-commit against the whole repo — reverted before committing,
+same as prior entries. The remaining 13 checklist items (bool_equal, double_superior,
+double_inferior, exist, integer_equal, integer_inferior, integer_superior,
+list_bool_equal, list_integer_equal, list_double_equal, moving, same_as_previous,
+string_match) plus `list_string_equal` are untouched; following #254's precedent, the
+PR for this session uses "Contributes to #255" rather than "Closes #255" so the epic
+stays open for them.


### PR DESCRIPTION
## Summary
- Adds `dc_measurements/test/test_measurement_double_equal.cpp`, gtest coverage for the `dc_conditions::DoubleEqual` condition plugin, driven through the real `if_all_conditions` gating path (a `dummy` Measurement's Record + a condition config -> activation outcome), per #255's "test external behaviour only" guidance.
- Covers: matching value activates and keeps activating, mismatched value never activates, missing key never activates, and a type-strictness gotcha where a JSON integer literal (`{"level": 5}`) never matches a configured double value even though numerically equal (`DoubleEqual` requires `json::value_t::number_float`).
- Registers the new test in `dc_measurements/CMakeLists.txt`'s `tests` list.

Contributes to #255 (the epic tracks 15 condition plugins across `dc_measurements/plugins/conditions/`; per `CLAUDE.md`'s one-task-per-run convention and #254's precedent for the sibling measurement-plugin epic, this PR does `double_equal` only and does not close the epic).

## Test plan
- [x] `pre-commit run --files dc_measurements/test/test_measurement_double_equal.cpp dc_measurements/CMakeLists.txt` — `clang-format` clean.
- [ ] `colcon test` / CI (`tools/e2e/scripts/test.sh`) — not runnable locally in this sandbox (no ROS/colcon install); relying on CI as the real gate, same constraint noted in the #242/#243/#254 sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018okuEBoqHPnQKjvxHFepCQ