### PR TITLE
test(conditions): complete gtest coverage for the condition plugins epic

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -268,16 +268,30 @@ install(DIRECTORY plugins/measurements/json
 )
 
 set(tests
+  test_measurement_bool_equal
   test_measurement_camera
   test_measurement_diagnostics
   test_measurement_double_equal
+  test_measurement_double_inferior
+  test_measurement_double_superior
   test_measurement_driving_type
   test_measurement_dummy
+  test_measurement_exist
   test_measurement_gate_condition
+  test_measurement_integer_equal
+  test_measurement_integer_inferior
+  test_measurement_integer_superior
+  test_measurement_list_bool_equal
+  test_measurement_list_double_equal
+  test_measurement_list_integer_equal
+  test_measurement_list_string_equal
+  test_measurement_moving
   test_measurement_os
   test_measurement_parameters
   test_measurement_random
+  test_measurement_same_as_previous
   test_measurement_serial_interface
+  test_measurement_string_match
   test_measurement_thermal
   test_measurement_uptime
 )

--- a/dc_measurements/condition_plugin.xml
+++ b/dc_measurements/condition_plugin.xml
@@ -87,7 +87,7 @@
         </class>
     </library>
 
-    <library path="dc_list_bool_string_condition">
+    <library path="dc_list_string_equal_condition">
         <class name="dc_conditions/ListStringEqual" type="dc_conditions::ListStringEqual" base_class_type="dc_core::Condition">
             <description>
                 dc_condition_list_string_equal
@@ -111,7 +111,7 @@
         </class>
     </library>
 
-    <library path="dc_str_match_condition">
+    <library path="dc_string_match_condition">
         <class name="dc_conditions/StringMatch" type="dc_conditions::StringMatch" base_class_type="dc_core::Condition">
             <description>
                 dc_condition_string_match

--- a/dc_measurements/plugins/conditions/exist.cpp
+++ b/dc_measurements/plugins/conditions/exist.cpp
@@ -19,12 +19,17 @@ bool Exist::getState(dc_interfaces::msg::StringStamped msg)
   {
     json data_json = json::parse(msg.data);
     json flat_json = data_json.flatten();
-    std::string key_w_prefix = std::string("/") + key_ + "/";
+    std::string key_exact = std::string("/") + key_;
+    std::string key_w_prefix = key_exact + "/";
 
+    // A flattened key matches "key_" either exactly (key_ is itself a scalar leaf, e.g.
+    // {"level": 5.5} with key_="level" flattens to exactly "/level") or as a "key_/..." prefix
+    // (key_ names an object/array with descendants). Checking the prefix alone misses the
+    // exact-match case entirely, since flatten() never emits "/level/" for a leaf value.
     bool found = false;
     for (auto& x : flat_json.items())
     {
-      if (x.key().rfind(key_w_prefix, 0) == 0)
+      if (x.key() == key_exact || x.key().rfind(key_w_prefix, 0) == 0)
       {
         found = true;
         break;

--- a/dc_measurements/plugins/conditions/integer_equal.cpp
+++ b/dc_measurements/plugins/conditions/integer_equal.cpp
@@ -29,7 +29,10 @@ bool IntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::number_integer)
+  // is_number_integer(), not a strict type()==number_integer check: nlohmann::json parses
+  // non-negative integer literals (the common case) as number_unsigned, not number_integer, and
+  // is_number_integer() is the one that correctly treats both as "an integer".
+  if (!flat_json[key_w_prefix].is_number_integer())
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an integer");
     active_ = false;

--- a/dc_measurements/plugins/conditions/integer_inferior.cpp
+++ b/dc_measurements/plugins/conditions/integer_inferior.cpp
@@ -30,7 +30,10 @@ bool IntegerInferior::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::number_integer)
+  // is_number_integer(), not a strict type()==number_integer check: nlohmann::json parses
+  // non-negative integer literals (the common case) as number_unsigned, not number_integer, and
+  // is_number_integer() is the one that correctly treats both as "an integer".
+  if (!flat_json[key_w_prefix].is_number_integer())
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an integer");
     active_ = false;

--- a/dc_measurements/plugins/conditions/integer_superior.cpp
+++ b/dc_measurements/plugins/conditions/integer_superior.cpp
@@ -30,7 +30,10 @@ bool IntegerSuperior::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::number_integer)
+  // is_number_integer(), not a strict type()==number_integer check: nlohmann::json parses
+  // non-negative integer literals (the common case) as number_unsigned, not number_integer, and
+  // is_number_integer() is the one that correctly treats both as "an integer".
+  if (!flat_json[key_w_prefix].is_number_integer())
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an integer");
     active_ = false;

--- a/dc_measurements/plugins/conditions/list_bool_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_bool_equal.cpp
@@ -18,11 +18,14 @@ void ListBoolEqual::onConfigure()
 bool ListBoolEqual::getState(dc_interfaces::msg::StringStamped msg)
 {
   json data_json = json::parse(msg.data);
-  json flat_json = data_json.flatten();
 
-  std::string key_w_prefix = std::string("/") + key_;
+  // json::json_pointer navigates the unflattened data_json directly, unlike the flatten() +
+  // "/key" lookup pattern other Condition plugins use: flatten() explodes arrays into indexed
+  // keys ("/key/0", "/key/1", ...), so an array-valued "/key" would never be found by that
+  // pattern -- exactly the value type this Condition exists to compare.
+  json::json_pointer key_ptr(std::string("/") + key_);
 
-  if (!flat_json.contains(key_w_prefix))
+  if (!data_json.contains(key_ptr))
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not found in msg: " << msg.data);
     active_ = false;
@@ -30,7 +33,9 @@ bool ListBoolEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::array)
+  const json& field = data_json.at(key_ptr);
+
+  if (field.type() != json::value_t::array)
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an array");
     active_ = false;
@@ -38,8 +43,7 @@ bool ListBoolEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (!std::all_of(flat_json[key_w_prefix].begin(), flat_json[key_w_prefix].end(),
-                   [](const json& el) { return el.is_boolean(); }))
+  if (!std::all_of(field.begin(), field.end(), [](const json& el) { return el.is_boolean(); }))
   {
     RCLCPP_WARN_STREAM(logger_, "All values are not boolean in key " << key_);
     active_ = false;
@@ -47,7 +51,7 @@ bool ListBoolEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  std::vector<bool> data_bool = flat_json[key_w_prefix].get<std::vector<bool>>();
+  std::vector<bool> data_bool = field.get<std::vector<bool>>();
   std::vector<int> data_int(data_bool.begin(), data_bool.end());
   std::vector<int> value_int(value_.begin(), value_.end());
 

--- a/dc_measurements/plugins/conditions/list_double_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_double_equal.cpp
@@ -18,11 +18,14 @@ void ListDoubleEqual::onConfigure()
 bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)
 {
   json data_json = json::parse(msg.data);
-  json flat_json = data_json.flatten();
 
-  std::string key_w_prefix = std::string("/") + key_;
+  // json::json_pointer navigates the unflattened data_json directly, unlike the flatten() +
+  // "/key" lookup pattern other Condition plugins use: flatten() explodes arrays into indexed
+  // keys ("/key/0", "/key/1", ...), so an array-valued "/key" would never be found by that
+  // pattern -- exactly the value type this Condition exists to compare.
+  json::json_pointer key_ptr(std::string("/") + key_);
 
-  if (!flat_json.contains(key_w_prefix))
+  if (!data_json.contains(key_ptr))
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not found in msg: " << msg.data);
     active_ = false;
@@ -30,7 +33,9 @@ bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::array)
+  const json& field = data_json.at(key_ptr);
+
+  if (field.type() != json::value_t::array)
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an array");
     active_ = false;
@@ -38,8 +43,7 @@ bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (!std::all_of(flat_json[key_w_prefix].begin(), flat_json[key_w_prefix].end(),
-                   [](const json& el) { return el.is_number_float(); }))
+  if (!std::all_of(field.begin(), field.end(), [](const json& el) { return el.is_number_float(); }))
   {
     RCLCPP_WARN_STREAM(logger_, "All values are not double in key " << key_);
     active_ = false;
@@ -47,7 +51,7 @@ bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  std::vector<double> data_double = flat_json[key_w_prefix].get<std::vector<double>>();
+  std::vector<double> data_double = field.get<std::vector<double>>();
 
   if (order_matters_ && data_double == value_)
   {
@@ -69,7 +73,7 @@ bool ListDoubleEqual::getState(dc_interfaces::msg::StringStamped msg)
   {
     active_ = true;
   }
-  else if (!order_matters_ && data_double == value_)
+  else if (!order_matters_ && data_double != value_)
   {
     active_ = false;
   }

--- a/dc_measurements/plugins/conditions/list_integer_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_integer_equal.cpp
@@ -18,11 +18,14 @@ void ListIntegerEqual::onConfigure()
 bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
 {
   json data_json = json::parse(msg.data);
-  json flat_json = data_json.flatten();
 
-  std::string key_w_prefix = std::string("/") + key_;
+  // json::json_pointer navigates the unflattened data_json directly, unlike the flatten() +
+  // "/key" lookup pattern other Condition plugins use: flatten() explodes arrays into indexed
+  // keys ("/key/0", "/key/1", ...), so an array-valued "/key" would never be found by that
+  // pattern -- exactly the value type this Condition exists to compare.
+  json::json_pointer key_ptr(std::string("/") + key_);
 
-  if (!flat_json.contains(key_w_prefix))
+  if (!data_json.contains(key_ptr))
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not found in msg: " << msg.data);
     active_ = false;
@@ -30,7 +33,9 @@ bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::array)
+  const json& field = data_json.at(key_ptr);
+
+  if (field.type() != json::value_t::array)
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an array");
     active_ = false;
@@ -38,8 +43,7 @@ bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (!std::all_of(flat_json[key_w_prefix].begin(), flat_json[key_w_prefix].end(),
-                   [](const json& el) { return el.is_number_integer(); }))
+  if (!std::all_of(field.begin(), field.end(), [](const json& el) { return el.is_number_integer(); }))
   {
     RCLCPP_WARN_STREAM(logger_, "All values are not integer in key " << key_);
     active_ = false;
@@ -47,7 +51,7 @@ bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  std::vector<long int> data = flat_json[key_w_prefix].get<std::vector<long int>>();
+  std::vector<long int> data = field.get<std::vector<long int>>();
 
   if (order_matters_ && data == value_)
   {
@@ -69,7 +73,7 @@ bool ListIntegerEqual::getState(dc_interfaces::msg::StringStamped msg)
   {
     active_ = true;
   }
-  else if (!order_matters_ && data == value_)
+  else if (!order_matters_ && data != value_)
   {
     active_ = false;
   }

--- a/dc_measurements/plugins/conditions/list_string_equal.cpp
+++ b/dc_measurements/plugins/conditions/list_string_equal.cpp
@@ -28,11 +28,14 @@ void ListStringEqual::sortStringVector(std::vector<std::string>& str_vector)
 bool ListStringEqual::getState(dc_interfaces::msg::StringStamped msg)
 {
   json data_json = json::parse(msg.data);
-  json flat_json = data_json.flatten();
 
-  std::string key_w_prefix = std::string("/") + key_;
+  // json::json_pointer navigates the unflattened data_json directly, unlike the flatten() +
+  // "/key" lookup pattern other Condition plugins use: flatten() explodes arrays into indexed
+  // keys ("/key/0", "/key/1", ...), so an array-valued "/key" would never be found by that
+  // pattern -- exactly the value type this Condition exists to compare.
+  json::json_pointer key_ptr(std::string("/") + key_);
 
-  if (!flat_json.contains(key_w_prefix))
+  if (!data_json.contains(key_ptr))
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not found in msg: " << msg.data);
     active_ = false;
@@ -40,7 +43,9 @@ bool ListStringEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (flat_json[key_w_prefix].type() != json::value_t::array)
+  const json& field = data_json.at(key_ptr);
+
+  if (field.type() != json::value_t::array)
   {
     RCLCPP_WARN_STREAM(logger_, "Key " << key_ << " not an array");
     active_ = false;
@@ -48,8 +53,7 @@ bool ListStringEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  if (!std::all_of(flat_json[key_w_prefix].begin(), flat_json[key_w_prefix].end(),
-                   [](const json& el) { return el.is_string(); }))
+  if (!std::all_of(field.begin(), field.end(), [](const json& el) { return el.is_string(); }))
   {
     RCLCPP_WARN_STREAM(logger_, "All values are not string in key " << key_);
     active_ = false;
@@ -57,7 +61,7 @@ bool ListStringEqual::getState(dc_interfaces::msg::StringStamped msg)
     return active_;
   }
 
-  std::vector<std::string> data = flat_json[key_w_prefix].get<std::vector<std::string>>();
+  std::vector<std::string> data = field.get<std::vector<std::string>>();
 
   if (order_matters_ && data == value_)
   {

--- a/dc_measurements/test/test_measurement_bool_equal.cpp
+++ b/dc_measurements/test/test_measurement_bool_equal.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_core/condition.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+// dc_conditions::BoolEqual has a known, already-flagged bug: its `value_` member is declared
+// `double` (dc_measurements/plugins/conditions/bool_equal.hpp) even though the "value" parameter
+// is declared PARAMETER_BOOL. bool_equal.cpp's onConfigure() carries a NOTE explaining this was
+// deliberately left alone during #178 (a parameter-declaration-unification pass) as "worth its
+// own follow-up" rather than fixed inline. Given that documented, deliberate deferral, this test
+// file documents the *actual* current behavior rather than silently fixing or working around it.
+//
+// Loads the plugin directly (bypassing the Measurement/if_all_conditions harness used elsewhere
+// in this directory) so the failure surfaces as a plain, isolated exception from configure()
+// instead of being swallowed by MeasurementServer's own lifecycle-transition error handling.
+TEST(BoolEqualDirectTest, ConfiguringWithABooleanValueThrowsDueToKnownTypeMismatch)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("bool_eq_direct_test_node");
+  node->declare_parameter("bool_eq.key", std::string("flag"));
+  node->declare_parameter("bool_eq.value", true);
+
+  pluginlib::ClassLoader<dc_core::Condition> loader("dc_core", "dc_core::Condition");
+  auto condition = loader.createUniqueInstance("dc_conditions/BoolEqual");
+
+  // rclcpp::Node::get_parameter(name, double&) on a PARAMETER_BOOL-typed parameter throws
+  // rclcpp::exceptions::InvalidParameterTypeException -- BoolEqual::onConfigure() does not catch
+  // it, so it propagates straight out of configure().
+  EXPECT_THROW(condition->configure(node, "bool_eq"), rclcpp::exceptions::InvalidParameterTypeException);
+}
+
+// Through the real MeasurementServer wiring, the same exception is thrown from inside
+// loadConditionPlugins()'s plugin-creation loop, which only catches
+// pluginlib::PluginlibException -- but rclcpp_lifecycle's transition machinery wraps every
+// registered transition callback (on_configure here) in its own catch, converting an uncaught
+// exception into a CallbackReturn::ERROR rather than letting it propagate to the caller of
+// configure() (confirmed empirically: "Callback returned ERROR during the transition: configure").
+// So unlike the direct-load case above, no exception crosses this test's own call to configure();
+// the observable, end-to-end consequence for anyone who configures a `dc_conditions/BoolEqual`
+// condition with a "value" parameter at all is instead that the whole MeasurementServer fails to
+// reach the "inactive" state.
+TEST(BoolEqualDirectTest, MeasurementServerConfigureFailsToReachInactiveState)
+{
+  auto options = rclcpp::NodeOptions().parameter_overrides(
+      { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "bool_eq" }) });
+  auto ms_node = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+
+  ms_node->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+  ms_node->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+
+  ms_node->declare_parameter("bool_eq.plugin", std::string("dc_conditions/BoolEqual"));
+  ms_node->declare_parameter("bool_eq.key", std::string("flag"));
+  ms_node->declare_parameter("bool_eq.value", true);
+
+  auto result_state = ms_node->configure();
+  EXPECT_NE(result_state.id(), lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_double_inferior.cpp
+++ b/dc_measurements/test/test_measurement_double_inferior.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::DoubleInferior through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/include_value), assert whether collection is activated or suppressed.
+class MeasurementDoubleInferiorTest : public ::testing::Test
+{
+protected:
+  MeasurementDoubleInferiorTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementDoubleInferiorTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "double_inf" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementDoubleInferiorTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.0}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "double_inf" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("double_inf.plugin", std::string("dc_conditions/DoubleInferior"));
+    ms_node_->declare_parameter("double_inf.key", std::string("level"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's value is strictly below the configured value -> activates.
+TEST_F(MeasurementDoubleInferiorTest, ValueBelowConfiguredValueActivates)
+{
+  ms_node_->declare_parameter("double_inf.value", 8.0);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: Record's value is strictly above the configured value -> never activates.
+TEST_F(MeasurementDoubleInferiorTest, ValueAboveConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("double_inf.value", 3.0);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: at the boundary, "include_value" (default true) makes equal-to-value
+// count as satisfying the condition ("inferior or equal").
+TEST_F(MeasurementDoubleInferiorTest, ValueEqualToConfiguredValueActivatesWhenIncludeValueDefaultTrue)
+{
+  ms_node_->declare_parameter("double_inf.value", 5.0);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: with include_value=false, an exactly-equal value does not satisfy a
+// strict "less than" comparison.
+TEST_F(MeasurementDoubleInferiorTest, ValueEqualToConfiguredValueNeverActivatesWhenIncludeValueFalse)
+{
+  ms_node_->declare_parameter("double_inf.value", 5.0);
+  ms_node_->declare_parameter("double_inf.include_value", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_double_superior.cpp
+++ b/dc_measurements/test/test_measurement_double_superior.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::DoubleSuperior through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/include_value), assert whether collection is activated or suppressed.
+class MeasurementDoubleSuperiorTest : public ::testing::Test
+{
+protected:
+  MeasurementDoubleSuperiorTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementDoubleSuperiorTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "double_sup" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementDoubleSuperiorTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.0}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "double_sup" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("double_sup.plugin", std::string("dc_conditions/DoubleSuperior"));
+    ms_node_->declare_parameter("double_sup.key", std::string("level"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's value is strictly above the configured value -> activates.
+TEST_F(MeasurementDoubleSuperiorTest, ValueAboveConfiguredValueActivates)
+{
+  ms_node_->declare_parameter("double_sup.value", 3.0);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: Record's value is strictly below the configured value -> never activates.
+TEST_F(MeasurementDoubleSuperiorTest, ValueBelowConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("double_sup.value", 8.0);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: at the boundary, "include_value" (default true) makes equal-to-value
+// count as satisfying the condition ("superior or equal").
+TEST_F(MeasurementDoubleSuperiorTest, ValueEqualToConfiguredValueActivatesWhenIncludeValueDefaultTrue)
+{
+  ms_node_->declare_parameter("double_sup.value", 5.0);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: with include_value=false, an exactly-equal value does not satisfy a
+// strict "greater than" comparison.
+TEST_F(MeasurementDoubleSuperiorTest, ValueEqualToConfiguredValueNeverActivatesWhenIncludeValueFalse)
+{
+  ms_node_->declare_parameter("double_sup.value", 5.0);
+  ms_node_->declare_parameter("double_sup.include_value", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_exist.cpp
+++ b/dc_measurements/test/test_measurement_exist.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::Exist through the if_all_conditions gating path: given a fixed Record
+// (the dummy Measurement's static "record" JSON) and a condition config (key), assert whether
+// collection is activated or suppressed.
+class MeasurementExistTest : public ::testing::Test
+{
+protected:
+  MeasurementExistTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementExistTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "exist" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementExistTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "exist" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("exist.plugin", std::string("dc_conditions/Exist"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: the configured key is present in the Record -> the condition activates.
+TEST_F(MeasurementExistTest, KeyPresentInRecordActivatesCondition)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.5}"));
+  ms_node_->declare_parameter("exist.key", std::string("level"));
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  int first_count = dummy_callback_count_;
+
+  spinFor(polling_interval_ * 3);
+  EXPECT_GT(dummy_callback_count_, first_count);
+}
+
+// Acceptance criterion: the configured key is absent from the Record -> the condition never
+// activates and nothing is ever published.
+TEST_F(MeasurementExistTest, KeyAbsentFromRecordNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"other\": 5.5}"));
+  ms_node_->declare_parameter("exist.key", std::string("level"));
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: a nested key (found via the flattened "/parent/child" prefix match, not
+// an exact top-level key) still counts as existing.
+TEST_F(MeasurementExistTest, NestedKeyIsFoundAndActivatesCondition)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"parent\": {\"child\": 1}}"));
+  ms_node_->declare_parameter("exist.key", std::string("parent"));
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_integer_equal.cpp
+++ b/dc_measurements/test/test_measurement_integer_equal.cpp
@@ -1,0 +1,152 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::IntegerEqual through the if_all_conditions gating path: given a fixed
+// Record (the dummy Measurement's static "record" JSON) and a condition config (key/value),
+// assert whether collection is activated or suppressed.
+class MeasurementIntegerEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementIntegerEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementIntegerEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "integer_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementIntegerEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "integer_eq" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("integer_eq.plugin", std::string("dc_conditions/IntegerEqual"));
+    ms_node_->declare_parameter("integer_eq.key", std::string("level"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's key holds a JSON integer equal to the configured value ->
+// activates and keeps activating on every poll.
+TEST_F(MeasurementIntegerEqualTest, RecordValueMatchingConfiguredValueActivatesCondition)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5}"));
+  ms_node_->declare_parameter("integer_eq.value", 5);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  int first_count = dummy_callback_count_;
+
+  spinFor(polling_interval_ * 3);
+  EXPECT_GT(dummy_callback_count_, first_count);
+}
+
+// Acceptance criterion: Record's key holds a different integer -> never activates.
+TEST_F(MeasurementIntegerEqualTest, RecordValueDifferingFromConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5}"));
+  ms_node_->declare_parameter("integer_eq.value", 3);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: the configured key is absent from the Record -> never activates.
+TEST_F(MeasurementIntegerEqualTest, MissingKeyInRecordNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"other\": 5}"));
+  ms_node_->declare_parameter("integer_eq.value", 5);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion / gotcha (mirrors DoubleEqual's type-strictness): a Record field written
+// as a float literal is numerically equal to the configured integer value but parses to
+// json::value_t::number_float, not number_integer, so IntegerEqual treats it as "not an integer"
+// and never activates.
+TEST_F(MeasurementIntegerEqualTest, DoubleLiteralInRecordNeverMatchesDespiteNumericEquality)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.0}"));
+  ms_node_->declare_parameter("integer_eq.value", 5);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_integer_inferior.cpp
+++ b/dc_measurements/test/test_measurement_integer_inferior.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::IntegerInferior through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/include_value), assert whether collection is activated or suppressed.
+class MeasurementIntegerInferiorTest : public ::testing::Test
+{
+protected:
+  MeasurementIntegerInferiorTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementIntegerInferiorTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "integer_inf" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementIntegerInferiorTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "integer_inf" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("integer_inf.plugin", std::string("dc_conditions/IntegerInferior"));
+    ms_node_->declare_parameter("integer_inf.key", std::string("level"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's value is strictly below the configured value -> activates.
+TEST_F(MeasurementIntegerInferiorTest, ValueBelowConfiguredValueActivates)
+{
+  ms_node_->declare_parameter("integer_inf.value", 8);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: Record's value is strictly above the configured value -> never activates.
+TEST_F(MeasurementIntegerInferiorTest, ValueAboveConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("integer_inf.value", 3);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: at the boundary, "include_value" (default true) makes equal-to-value
+// count as satisfying the condition ("inferior or equal").
+TEST_F(MeasurementIntegerInferiorTest, ValueEqualToConfiguredValueActivatesWhenIncludeValueDefaultTrue)
+{
+  ms_node_->declare_parameter("integer_inf.value", 5);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: with include_value=false, an exactly-equal value does not satisfy a
+// strict "less than" comparison.
+TEST_F(MeasurementIntegerInferiorTest, ValueEqualToConfiguredValueNeverActivatesWhenIncludeValueFalse)
+{
+  ms_node_->declare_parameter("integer_inf.value", 5);
+  ms_node_->declare_parameter("integer_inf.include_value", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_integer_superior.cpp
+++ b/dc_measurements/test/test_measurement_integer_superior.cpp
@@ -1,0 +1,148 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::IntegerSuperior through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/include_value), assert whether collection is activated or suppressed.
+class MeasurementIntegerSuperiorTest : public ::testing::Test
+{
+protected:
+  MeasurementIntegerSuperiorTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementIntegerSuperiorTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "integer_sup" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementIntegerSuperiorTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "integer_sup" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("integer_sup.plugin", std::string("dc_conditions/IntegerSuperior"));
+    ms_node_->declare_parameter("integer_sup.key", std::string("level"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's value is strictly above the configured value -> activates.
+TEST_F(MeasurementIntegerSuperiorTest, ValueAboveConfiguredValueActivates)
+{
+  ms_node_->declare_parameter("integer_sup.value", 3);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: Record's value is strictly below the configured value -> never activates.
+TEST_F(MeasurementIntegerSuperiorTest, ValueBelowConfiguredValueNeverActivates)
+{
+  ms_node_->declare_parameter("integer_sup.value", 8);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: at the boundary, "include_value" (default true) makes equal-to-value
+// count as satisfying the condition ("superior or equal").
+TEST_F(MeasurementIntegerSuperiorTest, ValueEqualToConfiguredValueActivatesWhenIncludeValueDefaultTrue)
+{
+  ms_node_->declare_parameter("integer_sup.value", 5);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: with include_value=false, an exactly-equal value does not satisfy a
+// strict "greater than" comparison.
+TEST_F(MeasurementIntegerSuperiorTest, ValueEqualToConfiguredValueNeverActivatesWhenIncludeValueFalse)
+{
+  ms_node_->declare_parameter("integer_sup.value", 5);
+  ms_node_->declare_parameter("integer_sup.include_value", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_list_bool_equal.cpp
+++ b/dc_measurements/test/test_measurement_list_bool_equal.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::ListBoolEqual through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/order_matters), assert whether collection is activated or suppressed.
+class MeasurementListBoolEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementListBoolEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementListBoolEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "list_bool_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementListBoolEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"flags\": [true, false, true]}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "list_bool_eq" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("list_bool_eq.plugin", std::string("dc_conditions/ListBoolEqual"));
+    ms_node_->declare_parameter("list_bool_eq.key", std::string("flags"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's array exactly matches the configured value, same order ->
+// activates (order_matters defaults to true).
+TEST_F(MeasurementListBoolEqualTest, ExactOrderedMatchActivates)
+{
+  ms_node_->declare_parameter("list_bool_eq.value", std::vector<bool>{ true, false, true });
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: same elements, different order, order_matters (default true) -> the
+// exact-order comparison fails and never activates.
+TEST_F(MeasurementListBoolEqualTest, SameElementsDifferentOrderNeverActivatesWhenOrderMattersTrue)
+{
+  ms_node_->declare_parameter("list_bool_eq.value", std::vector<bool>{ false, true, true });
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: same elements, different order, order_matters=false -> the sorted
+// comparison succeeds and activates.
+TEST_F(MeasurementListBoolEqualTest, SameElementsDifferentOrderActivatesWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_bool_eq.value", std::vector<bool>{ false, true, true });
+  ms_node_->declare_parameter("list_bool_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: genuinely different elements (not just reordered), order_matters=false
+// -> never activates even after sorting both sides.
+TEST_F(MeasurementListBoolEqualTest, DifferentElementsNeverActivateWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_bool_eq.value", std::vector<bool>{ false, false, false });
+  ms_node_->declare_parameter("list_bool_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_list_double_equal.cpp
+++ b/dc_measurements/test/test_measurement_list_double_equal.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_core/condition.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+// Exercises dc_conditions::ListDoubleEqual through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/order_matters), assert whether collection is activated or suppressed.
+class MeasurementListDoubleEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementListDoubleEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementListDoubleEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "list_double_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementListDoubleEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"values\": [1.1, 2.2, 3.3]}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "list_double_eq" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("list_double_eq.plugin", std::string("dc_conditions/ListDoubleEqual"));
+    ms_node_->declare_parameter("list_double_eq.key", std::string("values"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's array exactly matches the configured value, same order ->
+// activates (order_matters defaults to true).
+TEST_F(MeasurementListDoubleEqualTest, ExactOrderedMatchActivates)
+{
+  ms_node_->declare_parameter("list_double_eq.value", std::vector<double>{ 1.1, 2.2, 3.3 });
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: same elements, different order, order_matters (default true) -> the
+// exact-order comparison fails and never activates.
+TEST_F(MeasurementListDoubleEqualTest, SameElementsDifferentOrderNeverActivatesWhenOrderMattersTrue)
+{
+  ms_node_->declare_parameter("list_double_eq.value", std::vector<double>{ 3.3, 1.1, 2.2 });
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: same elements, different order, order_matters=false -> the sorted
+// comparison succeeds and activates.
+TEST_F(MeasurementListDoubleEqualTest, SameElementsDifferentOrderActivatesWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_double_eq.value", std::vector<double>{ 3.3, 1.1, 2.2 });
+  ms_node_->declare_parameter("list_double_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Regression test for a copy-paste typo in the order_matters=false branch of getState():
+// `else if (!order_matters_ && data_double == value_)` duplicated the `if`'s condition instead
+// of negating it (`data_double != value_`), so the "reset to inactive" branch was unreachable
+// dead code. Once the condition matched once, it stayed stuck active_=true forever, even for
+// Records that plainly no longer matched -- an undocumented bug (unlike gate_condition's
+// intentional latch), confirmed absent from the sibling ListBoolEqual/ListStringEqual plugins,
+// which use `!=` correctly. Loads the plugin directly (bypassing the Measurement/
+// if_all_conditions harness used elsewhere in this file) since demonstrating the transition
+// needs two different Records fed to the *same* Condition instance over time, which a Dummy
+// Measurement's static "record" param can't produce.
+TEST(ListDoubleEqualDirectTest, UnorderedMatchTransitionsBackToInactiveWhenListsDiverge)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("list_double_eq_direct_test_node");
+  node->declare_parameter("list_double_eq.key", std::string("values"));
+  node->declare_parameter("list_double_eq.value", std::vector<double>{ 1.1, 2.2, 3.3 });
+  node->declare_parameter("list_double_eq.order_matters", false);
+
+  pluginlib::ClassLoader<dc_core::Condition> loader("dc_core", "dc_core::Condition");
+  auto condition = loader.createUniqueInstance("dc_conditions/ListDoubleEqual");
+  condition->configure(node, "list_double_eq");
+  condition->activate();
+
+  dc_interfaces::msg::StringStamped matching_msg;
+  matching_msg.data = "{\"values\": [3.3, 1.1, 2.2]}";  // same elements, different order
+  EXPECT_TRUE(condition->getState(matching_msg));
+
+  dc_interfaces::msg::StringStamped differing_msg;
+  differing_msg.data = "{\"values\": [9.9, 9.9, 9.9]}";
+  EXPECT_FALSE(condition->getState(differing_msg));
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_list_integer_equal.cpp
+++ b/dc_measurements/test/test_measurement_list_integer_equal.cpp
@@ -1,0 +1,172 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_core/condition.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "pluginlib/class_loader.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+// Exercises dc_conditions::ListIntegerEqual through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config
+// (key/value/order_matters), assert whether collection is activated or suppressed.
+class MeasurementListIntegerEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementListIntegerEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementListIntegerEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "list_int_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementListIntegerEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"values\": [1, 2, 3]}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "list_int_eq" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("list_int_eq.plugin", std::string("dc_conditions/ListIntegerEqual"));
+    ms_node_->declare_parameter("list_int_eq.key", std::string("values"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's array exactly matches the configured value, same order ->
+// activates (order_matters defaults to true).
+TEST_F(MeasurementListIntegerEqualTest, ExactOrderedMatchActivates)
+{
+  ms_node_->declare_parameter("list_int_eq.value", std::vector<int64_t>{ 1, 2, 3 });
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: same elements, different order, order_matters (default true) -> the
+// exact-order comparison fails and never activates.
+TEST_F(MeasurementListIntegerEqualTest, SameElementsDifferentOrderNeverActivatesWhenOrderMattersTrue)
+{
+  ms_node_->declare_parameter("list_int_eq.value", std::vector<int64_t>{ 3, 1, 2 });
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: same elements, different order, order_matters=false -> the sorted
+// comparison succeeds and activates.
+TEST_F(MeasurementListIntegerEqualTest, SameElementsDifferentOrderActivatesWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_int_eq.value", std::vector<int64_t>{ 3, 1, 2 });
+  ms_node_->declare_parameter("list_int_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Regression test for a copy-paste typo in the order_matters=false branch of getState():
+// `else if (!order_matters_ && data == value_)` duplicated the `if`'s condition instead of
+// negating it (`data != value_`), so the "reset to inactive" branch was unreachable dead code.
+// Once the condition matched once, it stayed stuck active_=true forever, even for Records that
+// plainly no longer matched -- an undocumented bug (unlike gate_condition's intentional latch),
+// confirmed absent from the sibling ListBoolEqual/ListStringEqual plugins, which use `!=`
+// correctly. Loads the plugin directly (bypassing the Measurement/if_all_conditions harness used
+// elsewhere in this file) since demonstrating the transition needs two different Records fed to
+// the *same* Condition instance over time, which a Dummy Measurement's static "record" param
+// can't produce.
+TEST(ListIntegerEqualDirectTest, UnorderedMatchTransitionsBackToInactiveWhenListsDiverge)
+{
+  auto node = std::make_shared<rclcpp_lifecycle::LifecycleNode>("list_int_eq_direct_test_node");
+  node->declare_parameter("list_int_eq.key", std::string("values"));
+  node->declare_parameter("list_int_eq.value", std::vector<int64_t>{ 1, 2, 3 });
+  node->declare_parameter("list_int_eq.order_matters", false);
+
+  pluginlib::ClassLoader<dc_core::Condition> loader("dc_core", "dc_core::Condition");
+  auto condition = loader.createUniqueInstance("dc_conditions/ListIntegerEqual");
+  condition->configure(node, "list_int_eq");
+  condition->activate();
+
+  dc_interfaces::msg::StringStamped matching_msg;
+  matching_msg.data = "{\"values\": [3, 1, 2]}";  // same elements, different order
+  EXPECT_TRUE(condition->getState(matching_msg));
+
+  dc_interfaces::msg::StringStamped differing_msg;
+  differing_msg.data = "{\"values\": [9, 9, 9]}";
+  EXPECT_FALSE(condition->getState(differing_msg));
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_list_string_equal.cpp
+++ b/dc_measurements/test/test_measurement_list_string_equal.cpp
@@ -1,0 +1,155 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// dc_conditions::ListStringEqual is not in the original #158-#171 checklist but ships without a
+// test either -- #255 calls it out explicitly as worth adding while sweeping the epic.
+//
+// Exercises it through the if_all_conditions gating path: given a fixed Record (the dummy
+// Measurement's static "record" JSON) and a condition config (key/value/order_matters), assert
+// whether collection is activated or suppressed.
+class MeasurementListStringEqualTest : public ::testing::Test
+{
+protected:
+  MeasurementListStringEqualTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementListStringEqualTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "list_str_eq" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementListStringEqualTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"tags\": [\"a\", \"b\", \"c\"]}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "list_str_eq" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("list_str_eq.plugin", std::string("dc_conditions/ListStringEqual"));
+    ms_node_->declare_parameter("list_str_eq.key", std::string("tags"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's array exactly matches the configured value, same order ->
+// activates (order_matters defaults to true).
+TEST_F(MeasurementListStringEqualTest, ExactOrderedMatchActivates)
+{
+  ms_node_->declare_parameter("list_str_eq.value", std::vector<std::string>{ "a", "b", "c" });
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: same elements, different order, order_matters (default true) -> the
+// exact-order comparison fails and never activates.
+TEST_F(MeasurementListStringEqualTest, SameElementsDifferentOrderNeverActivatesWhenOrderMattersTrue)
+{
+  ms_node_->declare_parameter("list_str_eq.value", std::vector<std::string>{ "c", "a", "b" });
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: same elements, different order, order_matters=false -> the sorted
+// comparison succeeds and activates.
+TEST_F(MeasurementListStringEqualTest, SameElementsDifferentOrderActivatesWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_str_eq.value", std::vector<std::string>{ "c", "a", "b" });
+  ms_node_->declare_parameter("list_str_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: genuinely different elements (not just reordered), order_matters=false
+// -> never activates even after sorting both sides. (ListStringEqual's reset branch already uses
+// `!=` correctly, unlike the ListIntegerEqual/ListDoubleEqual bug fixed alongside this test.)
+TEST_F(MeasurementListStringEqualTest, DifferentElementsNeverActivateWhenOrderMattersFalse)
+{
+  ms_node_->declare_parameter("list_str_eq.value", std::vector<std::string>{ "x", "y", "z" });
+  ms_node_->declare_parameter("list_str_eq.order_matters", false);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_moving.cpp
+++ b/dc_measurements/test/test_measurement_moving.cpp
@@ -1,0 +1,177 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+// dc_conditions::Moving is unlike the other condition plugins covered in this directory: it
+// doesn't derive its state from the gated Measurement's own Record at all -- getState() is the
+// base class's default (just returns the internally tracked active_), and that internal state is
+// instead driven asynchronously by Moving's own /odom subscription and a hysteresis counter
+// (moving_count_). test_measurement_gate_condition.cpp already exercises Moving incidentally
+// (count_hysteresis=1, a single message flips it) to cover gate_condition's latch semantics; this
+// file is Moving's own dedicated coverage and focuses on the hysteresis counting itself, using
+// if_all_conditions (re-evaluated every poll, no latch) so the on/off transitions are directly
+// observable.
+class MeasurementMovingTest : public ::testing::Test
+{
+protected:
+  MeasurementMovingTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementMovingTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "moving" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMovingTest::dummyDataCallback, this, std::placeholders::_1));
+    odom_pub_ = ms_node_->create_publisher<nav_msgs::msg::Odometry>("/odom", rclcpp::QoS(10));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.record", std::string("{\"message\": \"hello\"}"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "moving" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("moving.plugin", std::string("dc_conditions/Moving"));
+    ms_node_->declare_parameter("moving.odom_topic", std::string("/odom"));
+    ms_node_->declare_parameter("moving.speed_threshold", 0.2);
+    // 3 consecutive above/below-threshold Odometry messages required to flip state -- large
+    // enough to distinguish "not yet enough messages" from "flipped" in the tests below.
+    ms_node_->declare_parameter("moving.count_hysteresis", 3);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void publishOdom(double linear_x)
+  {
+    nav_msgs::msg::Odometry msg;
+    msg.twist.twist.linear.x = linear_x;
+    odom_pub_->publish(msg);
+    // Give the subscription callback a chance to run before the next publish.
+    spinFor(polling_interval_ / 5);
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: fewer than count_hysteresis consecutive above-threshold Odometry
+// messages -- the condition has not yet flipped, so collection is still suppressed.
+TEST_F(MeasurementMovingTest, FewerThanCountHysteresisMessagesNeverActivates)
+{
+  startLifecycleNode();
+
+  publishOdom(1.0);
+  publishOdom(1.0);
+  spinFor(polling_interval_ * 3);
+
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: exactly count_hysteresis consecutive above-threshold Odometry messages
+// flips Moving active, and collection proceeds.
+TEST_F(MeasurementMovingTest, CountHysteresisConsecutiveMessagesActivatesCondition)
+{
+  startLifecycleNode();
+
+  publishOdom(1.0);
+  publishOdom(1.0);
+  publishOdom(1.0);
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: unlike gate_condition's one-way latch, if_all_conditions is
+// re-evaluated every poll -- once Moving flips back to inactive (count_hysteresis consecutive
+// below-threshold messages), collection stops again.
+TEST_F(MeasurementMovingTest, ReturnsToInactiveAfterCountHysteresisConsecutiveBelowThresholdMessages)
+{
+  startLifecycleNode();
+
+  publishOdom(1.0);
+  publishOdom(1.0);
+  publishOdom(1.0);
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  // moving_count_ is at +count_hysteresis (3) after activation; each below-threshold message
+  // only decrements it by 1, so flipping back to inactive (moving_count_ <= -count_hysteresis)
+  // needs the full swing across the hysteresis band, not just count_hysteresis messages.
+  for (int i = 0; i < 8; ++i)
+  {
+    publishOdom(0.0);
+  }
+  // Let any in-flight collection triggered just before the flip drain out.
+  spinFor(polling_interval_ * 2);
+  int count_after_stopping = dummy_callback_count_;
+
+  spinFor(polling_interval_ * 3);
+  EXPECT_EQ(dummy_callback_count_, count_after_stopping);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_same_as_previous.cpp
+++ b/dc_measurements/test/test_measurement_same_as_previous.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::SameAsPrevious through the if_all_conditions gating path: given a
+// fixed Record (the dummy Measurement's static "record" JSON) and a condition config (no "keys"
+// configured, so it compares the whole flattened Record rather than hashing specific file
+// fields), assert whether collection is activated or suppressed.
+//
+// A Dummy Measurement's "record" param is static for the node's lifetime (read once in
+// onConfigure(), never re-read per poll), so this fixture can only observe "the Record never
+// changes" -- SameAsPrevious's active_=false transition when a *changed* Record arrives is not
+// covered here; it would need a Record source whose content can vary between polls, which no
+// existing Measurement plugin exposes as a live-updatable parameter.
+class MeasurementSameAsPreviousTest : public ::testing::Test
+{
+protected:
+  MeasurementSameAsPreviousTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementSameAsPreviousTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "same_prev" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementSameAsPreviousTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.record", std::string("{\"level\": 5.5}"));
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "same_prev" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("same_prev.plugin", std::string("dc_conditions/SameAsPrevious"));
+    ms_node_->declare_parameter("same_prev.keys", std::vector<std::string>());
+    ms_node_->declare_parameter("same_prev.exclude", std::vector<std::string>());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  // Deliberately wider than the other test files here: the very first poll is guaranteed
+  // suppressed (previous_json_ starts empty) while the second poll is guaranteed to activate
+  // (the record never changes), so distinguishing "before poll #2" from "at/after poll #2" needs
+  // a window with real margin instead of racing a tight timer.
+  int polling_interval_{ 200 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: the very first Record has nothing to compare against
+// (previous_json_.empty()) -> the condition is inactive and collection is suppressed. Checked
+// well inside the first polling_interval_ window, before a second poll could activate it.
+TEST_F(MeasurementSameAsPreviousTest, FirstCollectionNeverActivates)
+{
+  startLifecycleNode();
+
+  spinFor(polling_interval_ - 100);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: once a previous Record exists, an identical subsequent Record activates
+// the condition -- and since the dummy Record never changes, it keeps activating from then on.
+TEST_F(MeasurementSameAsPreviousTest, IdenticalSubsequentRecordsActivateFromSecondCollectionOnward)
+{
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  int first_count = dummy_callback_count_;
+
+  spinFor(polling_interval_ * 3);
+  EXPECT_GT(dummy_callback_count_, first_count);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_string_match.cpp
+++ b/dc_measurements/test/test_measurement_string_match.cpp
@@ -1,0 +1,147 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+
+// Exercises dc_conditions::StringMatch through the if_all_conditions gating path: given a fixed
+// Record (the dummy Measurement's static "record" JSON) and a condition config (key/regex),
+// assert whether collection is activated or suppressed.
+class MeasurementStringMatchTest : public ::testing::Test
+{
+protected:
+  MeasurementStringMatchTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementStringMatchTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "str_match" }) });
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(options, std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementStringMatchTest::dummyDataCallback, this, std::placeholders::_1));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+    ms_node_->declare_parameter("dummy.if_all_conditions", std::vector<std::string>{ "str_match" });
+    ms_node_->declare_parameter("dummy.init_max_measurements", -1);
+    ms_node_->declare_parameter("dummy.condition_max_measurements", 0);
+
+    ms_node_->declare_parameter("str_match.plugin", std::string("dc_conditions/StringMatch"));
+    ms_node_->declare_parameter("str_match.key", std::string("status"));
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    (void)msg;
+    dummy_callback_count_++;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  int polling_interval_{ 50 };
+
+public:
+  int dummy_callback_count_{ 0 };
+};
+
+// Acceptance criterion: Record's string value matches the configured regex -> activates.
+TEST_F(MeasurementStringMatchTest, StringMatchingRegexActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"status\": \"ok-123\"}"));
+  ms_node_->declare_parameter("str_match.regex", std::string("ok-[0-9]+"));
+
+  startLifecycleNode();
+
+  while (dummy_callback_count_ == 0)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GE(dummy_callback_count_, 1);
+}
+
+// Acceptance criterion: Record's string value does not match the configured regex -> never
+// activates.
+TEST_F(MeasurementStringMatchTest, StringNotMatchingRegexNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"status\": \"ok-123\"}"));
+  ms_node_->declare_parameter("str_match.regex", std::string("error-[0-9]+"));
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: std::regex_match requires a *full* match, not a substring search -- a
+// regex matching only part of the value never activates.
+TEST_F(MeasurementStringMatchTest, PartialSubstringMatchNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"status\": \"ok-123\"}"));
+  ms_node_->declare_parameter("str_match.regex", std::string("ok"));
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+// Acceptance criterion: the configured key is absent from the Record -> never activates.
+TEST_F(MeasurementStringMatchTest, MissingKeyNeverActivates)
+{
+  ms_node_->declare_parameter("dummy.record", std::string("{\"other\": \"ok-123\"}"));
+  ms_node_->declare_parameter("str_match.regex", std::string("ok-[0-9]+"));
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(dummy_callback_count_, 0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -4130,3 +4130,115 @@ list_bool_equal, list_integer_equal, list_double_equal, moving, same_as_previous
 string_match) plus `list_string_equal` are untouched; following #254's precedent, the
 PR for this session uses "Contributes to #255" rather than "Closes #255" so the epic
 stays open for them.
+
+## #255: Test coverage epic (condition plugins) — remaining 13 plugins + list_string_equal
+
+**Context**: The `double_equal` item landed separately (see the entry above) and merged to
+`jazzy` before this session continued. Once merged, this worktree's branch was reset onto
+fresh `origin/jazzy` (a new branch, `feature/255-condition-plugins-remaining`) to avoid
+duplicating already-merged commits, and work continued from there rather than one-task-per-run:
+the user explicitly asked for the whole epic ("we need to test all, no?"), overriding
+`CLAUDE.md`'s default one-task-per-run convention for this interactive session.
+
+**Read**: The remaining 13 checklist items (bool_equal, double_inferior, double_superior,
+exist, integer_equal, integer_inferior, integer_superior, list_bool_equal, list_double_equal,
+list_integer_equal, moving, same_as_previous, string_match) plus `list_string_equal` (called
+out in the issue body as missing from the original #158–#171 list). Read every plugin's
+source/header before writing its test, plus `dc_core/condition.hpp`, `dc_measurements/
+condition.hpp`, and `measurement.hpp`'s `isConditionOn()`/`isGateArmed()`/`publish()` (already
+read for the `double_equal` session) to confirm `getState(msg)` always receives the *gated
+Measurement's own* just-collected Record, not an independent input.
+
+**Verified for real, not just read-through**: this machine has `localhost/dc-workspace:latest`
+(and `dc-e2e:latest`), the same Podman image `tools/e2e/scripts/build.sh`/`test.sh` build/use
+for CI, already built (~24h old at session start). Rather than relying on a manual read-through
+(the constraint every prior test-coverage session in this log hit — no local colcon/ROS
+install), this session mounted the current worktree over `/root/ws/src/ros2_data_collection`
+inside a container from that image and ran real `colcon build --packages-select
+dc_measurements` + `colcon test --packages-select dc_measurements` + `colcon test-result
+--all --verbose`, redirecting output to files on the host (`/tmp/.../dc-test-logs/`) instead of
+piping through `tail`, which was tried first and silently truncated colcon's carriage-return-
+heavy progress output into something misleading. Each full cycle (mounting invalidates every
+file's mtime, forcing a nearly-full rebuild of `dc_measurements` even for a one-line change)
+took 15–27 minutes; this session ran it three times as tests and fixes iterated, landing at
+**26/26 `dc_measurements` tests passing, 0 failures** on the final run.
+
+**Found — real, previously-undiscovered production bugs, not test artifacts** (all confirmed
+by the container run actually failing/hanging before the fix, and passing after):
+
+- `condition_plugin.xml`: `ListStringEqual`'s and `StringMatch`'s `<library path>` didn't match
+  their actual built library name (`dc_list_bool_string_condition` vs the real
+  `dc_list_string_equal_condition`; `dc_str_match_condition` vs the real
+  `dc_string_match_condition`). pluginlib could never load either — both conditions were 100%
+  non-functional in any real deployment. A systematic diff of every CMake `add_library` name
+  against every XML `<library path>` confirmed these were the only two mismatches. Fixed both.
+- `integer_equal.cpp`/`integer_inferior.cpp`/`integer_superior.cpp`: checked `flat_json[key]
+  .type() != json::value_t::number_integer`, but nlohmann::json parses *non-negative* integer
+  literals — the overwhelmingly common case — as `number_unsigned`, not `number_integer`; only
+  negative integers ever satisfied the check. `list_integer_equal.cpp` already used the correct
+  `is_number_integer()` (which covers both representations); switched the other three to match.
+- `list_bool_equal.cpp`/`list_integer_equal.cpp`/`list_double_equal.cpp`/`list_string_equal
+  .cpp`: all looked up their key via `data_json.flatten()` then `flat_json.contains("/key")`.
+  `flatten()` explodes JSON arrays into indexed keys (`/key/0`, `/key/1`, ...), so an
+  array-valued `/key` — the *one* value type these conditions exist to compare — could never be
+  found; every "list equals" condition was completely non-functional for its sole purpose.
+  Replaced with `json::json_pointer` lookup (`contains(ptr)`/`at(ptr)`) directly on the
+  unflattened JSON, which resolves nested paths the same way flatten()'s keys did while leaving
+  array values intact.
+- `exist.cpp`: `key_w_prefix = "/" + key_ + "/"` (trailing slash) only matches a flattened key
+  that has *descendants* under that path; a plain scalar leaf like `{"level": 5.5}` flattens to
+  exactly `/level` (no trailing slash), so `Exist` could never detect existence of an ordinary
+  top-level scalar field — only of a path with nested children underneath it. Added an
+  exact-match fallback (`x.key() == key_exact || x.key().rfind(key_w_prefix, 0) == 0`) alongside
+  the existing prefix check.
+- `list_integer_equal.cpp`/`list_double_equal.cpp` (fixed in this session before the container
+  run even started, from reading the source): the `order_matters_=false` "reset to inactive"
+  branch read `else if (!order_matters_ && data == value_)` — a duplicate of the `if`'s
+  condition instead of its negation (`data != value_`) — making it unreachable dead code; once
+  matched, the condition stayed stuck `active_=true` forever regardless of later Records. Fixed
+  to `!=`, confirmed the sibling `list_bool_equal.cpp`/`list_string_equal.cpp` already had it
+  right.
+
+**Found and deliberately left alone**: `dc_conditions::BoolEqual` has the same class of bug
+(`value_` is `double` despite the "value" parameter being declared `PARAMETER_BOOL`) — but
+`bool_equal.cpp`'s own NOTE comment says this was deliberately deferred past #178 ("worth its
+own follow-up") rather than fixed inline, so this session respected that and did not fix it
+either. `test_measurement_bool_equal.cpp` instead documents the actual, verified behavior: a
+direct pluginlib-loaded `configure()` throws `rclcpp::exceptions::InvalidParameterTypeException`
+(confirmed by the container run's exact error: `parameter 'bool_eq.value' has invalid type:
+expected [double] got [bool]`); through the full `MeasurementServer` lifecycle, the same
+exception is instead caught by `rclcpp_lifecycle`'s transition machinery and converted to a
+failed `configure()` transition rather than propagating (also confirmed empirically — the first
+container run's assumption that it *would* propagate was wrong and had to be corrected once the
+real log showed "Callback returned ERROR during the transition: configure" with no thrown
+exception reaching the test). A maintainer should open the dedicated follow-up issue the NOTE
+already calls for.
+
+**Added**: 14 new test files under `dc_measurements/test/` (one per remaining plugin +
+`list_string_equal`), registered alphabetically in `CMakeLists.txt`. Every file follows
+`test_measurement_double_equal.cpp`'s pattern (a `dummy` Measurement gated by `if_all_conditions`,
+`init_max_measurements: -1` + `condition_max_measurements: 0` to route every collection through
+the condition check instead of the unconditional init-publish path) with 2–4 tests per plugin
+covering match/mismatch/missing-key/type-strictness as applicable to that plugin's own
+semantics (superior/inferior `include_value` boundary, list `order_matters` ordered vs.
+sorted-unordered comparison, `moving`'s hysteresis counter needing the *full* band swing to
+flip back — not just `count_hysteresis` messages from a neutral start, a bug in this session's
+own first draft of that test, caught and fixed before the final container run). Two files use
+direct pluginlib loading instead of the dummy-Measurement harness where the dummy's static
+`record` parameter can't produce what the test needs: `list_integer_equal`'s and
+`list_double_equal`'s regression tests need two *different* Records fed to the *same* Condition
+instance over time (to prove the sticky-active fix), and `bool_equal`'s only observable behavior
+is a `configure()`-time failure, not a Record-driven activation outcome.
+
+**Not done**: `same_as_previous`'s "an actually-changed Record deactivates it again" transition
+isn't covered — a Dummy Measurement's `record` param is read once at `onConfigure()` and never
+re-read per poll, so there's no existing Measurement plugin whose output can be made to change
+between polls without a deeper harness change; only "first collection is always suppressed" and
+"a Record that never changes stays active from the second collection on" are covered. Flagged
+in the test file's own header comment rather than left silent.
+
+**Verified**: `pre-commit` (`clang-format` — clean on every changed/new file; `codespell` clean)
+plus the real container build+test run described above as the primary gate (stronger than any
+prior session in this log, which were all constrained to read-through + `clang-format` only).
+`black` reformatted `tools/e2e/scripts/verify_zero_loss.py` again as a side effect of running
+pre-commit against the whole repo — reverted before committing, same as every prior entry.


### PR DESCRIPTION
## Summary

Completes #255: gtest coverage for the remaining 13 checklist items (`bool_equal`,
`double_inferior`, `double_superior`, `exist`, `integer_equal`, `integer_inferior`,
`integer_superior`, `list_bool_equal`, `list_double_equal`, `list_integer_equal`,
`list_string_equal`, `moving`, `same_as_previous`, `string_match`) plus `list_string_equal`
(called out in the issue body as missing from the original list). `double_equal` landed
separately in #330.

**While writing real black-box tests and verifying them with an actual `colcon build` +
`colcon test` run** (this machine has the same Podman workspace image CI uses,
`localhost/dc-workspace:latest`, already built — so this could be verified end-to-end instead
of read-through-only), **8 genuine, previously-undiscovered production bugs surfaced** — most
condition plugins didn't actually work for their stated purpose:

- `condition_plugin.xml`: `ListStringEqual` and `StringMatch` each had a `<library path>` that
  didn't match their real built library name, so pluginlib could never load either — both were
  **100% non-functional** in any deployment.
- `integer_equal`/`integer_inferior`/`integer_superior`: checked for nlohmann::json's
  `number_integer` type, but non-negative integer literals (the common case) parse as
  `number_unsigned` — these conditions **never matched positive integers**.
- All four `list_*_equal` plugins (bool/integer/double/string): looked up their key via
  `.flatten()`, which explodes JSON arrays into indexed keys — an array-valued key (the one
  type these conditions exist to compare) **could never be found**. Switched to
  `json::json_pointer` lookup on the unflattened JSON.
- `exist`: its prefix-match required a trailing `/`, which only matches nested paths — a plain
  scalar leaf field **could never be detected as existing**. Added an exact-match fallback.
- `list_integer_equal`/`list_double_equal`: a copy-paste `==`/`!=` typo made the
  `order_matters: false` "reset to inactive" branch unreachable dead code — once matched, these
  conditions got **stuck active forever**.

`dc_conditions::BoolEqual` has a similar, already-flagged type mismatch (`value_` is `double`
despite a `PARAMETER_BOOL` parameter), but its own NOTE comment says this was deliberately
deferred past #178 rather than fixed inline — left alone here too, and documented via a test
instead (a maintainer should open the follow-up issue that comment calls for).

Each condition is exercised through the real `if_all_conditions` gating path (a `dummy`
Measurement's Record + a condition config → activation outcome), per the issue's "test
external behaviour only" guidance, with direct pluginlib loading only where the harness can't
produce what the test needs (see the test files' own header comments for why).

## Test plan
- [x] `pre-commit run` on all changed/new files — `clang-format` and `codespell` clean.
- [x] Real `colcon build --packages-select dc_measurements` + `colcon test` inside the
  `tools/e2e/Containerfile` workspace image (podman), run three times as tests/fixes iterated —
  **26/26 `dc_measurements` tests passing, 0 failures** on the final run.

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018okuEBoqHPnQKjvxHFepCQ