### PR TITLE
ci: build the workspace incrementally via a cache-mount based Containerfile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,13 +10,23 @@
 # :<branch> ref is added only once the repo publishes runnable images for others, which it
 # doesn't yet; here the images exist purely for CI-internal reuse + traceability.
 #
-#   build-workspace ─┬─▶ colcon-test        (pull dc-workspace, colcon test + coverage)
-#                    ├─▶ sim               (pull dc-workspace, simulation smoke check)
-#                    └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
+#   build-workspace (build + colcon test + coverage) ─┬─▶ sim               (pull dc-workspace, simulation smoke check)
+#                                                      └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
 #
-# No CI-only build/test scripts: every step calls the same tools/e2e/scripts/build.sh /
-# test.sh / run.sh a developer runs locally. run.sh drives the harness with plain podman
-# (no compose), so nothing extra is installed on the runner.
+# e2e calls the same tools/e2e/scripts/run.sh a developer runs locally, driving the
+# harness with plain podman (no compose) so nothing extra is installed on the runner;
+# build-e2e-image builds/pushes the E2E image directly via `podman build` (no shared
+# script — it's a single `podman build -f Containerfile.e2e` + push, nothing a local
+# dev script would add over). build-workspace runs the exact same
+# tools/e2e/scripts/build.sh a developer runs locally — `colcon test` happens as part
+# of that same build (see the Containerfile's `workspace` stage), so CI no longer
+# calls a separate test.sh. CI adds two things local dev doesn't need: CACHE_REF
+# (registry-backed --cache-from/--cache-to), which round-trips podman's *layer* cache
+# through ghcr.io so a cold GitHub-hosted runner still starts warm on the
+# rarely-changing apt/toolchain/aws_sdk_vendor layers; and BUILDAH_TMPDIR, which
+# relocates the workspace stage's ccache `RUN --mount=type=cache` mount (buildah
+# stores this under $TMPDIR/buildah-cache/<id>, a mechanism --cache-from/--cache-to
+# does not touch at all) into a directory `actions/cache` persists across runs.
 
 name: CI
 
@@ -84,42 +94,12 @@ jobs:
             echo "cache_ref=$IMAGE/dc-workspace-cache"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build the DC workspace image (coverage-instrumented)
-        env:
-          IMAGE_TAG: ${{ steps.refs.outputs.workspace_ref }}
-          CACHE_REF: ${{ steps.refs.outputs.cache_ref }}
-          CCOV: "true"
-        run: ./tools/e2e/scripts/build.sh
-
-      - name: Push the workspace image
-        env:
-          REF: ${{ steps.refs.outputs.workspace_ref }}
-        run: |
-          for attempt in 1 2 3; do
-            podman push "$REF" && exit 0
-            echo "push $REF attempt $attempt failed; retrying in 10s"; sleep 10
-          done
-          exit 1
-
-  colcon-test:
-    needs: build-workspace
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: read
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Verify podman
-        run: podman --version
-
-      # Only this job uses compose (for the stable test stores); the harness job is native
-      # podman. `podman compose` shells out to a host-side provider — it can't be baked
-      # into an image the way podman itself manages containers, since the provider has to
-      # run on the runner to drive the runner's podman. ~/.local is cached (keyed on the
-      # pinned version) so `pip install` below is a fast no-op against the cache instead of
-      # a fresh PyPI fetch on every run; pinning the provider avoids the docker-compose
-      # cli-plugin, which needs a Podman API socket that isn't running here.
+      # `podman compose` shells out to a host-side provider — it can't be baked into an
+      # image the way podman itself manages containers, since the provider has to run
+      # on the runner to drive the runner's podman. ~/.local is cached (keyed on the
+      # pinned version) so `pip install` below is a fast no-op against the cache instead
+      # of a fresh PyPI fetch on every run; pinning the provider avoids the
+      # docker-compose cli-plugin, which needs a Podman API socket that isn't running here.
       - name: Cache podman-compose
         uses: actions/cache@v4
         with:
@@ -130,15 +110,10 @@ jobs:
           pip install --user "podman-compose==1.5.0"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
-      - name: Log in to ghcr.io (to pull the workspace image)
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-
-      - name: Pull the workspace image
-        run: podman pull "${{ needs.build-workspace.outputs.workspace_ref }}"
-
-      # Stable dependencies (up for the whole job, no outage/restart) — a declarative
-      # compose file, unlike the harness which drives its own stores with native podman.
+      # colcon test runs as part of the image build below (the Containerfile's
+      # `workspace` stage), not a separate colcon-test job pulling a pushed image — the
+      # test-dependency stores need to already be up and reachable via --network host
+      # by the time that build step's `colcon test` runs.
       - name: Start the test-dependency stores (dc_bridge's store-backed tests hard-fail, never skip — see dc_bridge/README.md)
         env:
           PODMAN_COMPOSE_PROVIDER: podman-compose
@@ -154,16 +129,81 @@ jobs:
             docker.io/amazon/aws-cli:latest \
             --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-records
 
-      - name: colcon test (C++ gtest) + coverage
+      # buildah stores a `RUN --mount=type=cache` mount's content under
+      # $TMPDIR/buildah-cache/<id>, entirely separate from --cache-from/--cache-to's
+      # registry export (verified: --cache-to only carries layers, never cache-mount
+      # content — a real gap found by comparing two live runs' `ccache -s` output, not
+      # assumed). BUILDAH_TMPDIR below (see build.sh) relocates it into this cached
+      # directory instead, so the workspace stage's ccache mount actually survives
+      # between runs on GitHub's otherwise-ephemeral runners. Caching the parent dir,
+      # not `.../buildah-cache` itself: buildah names it `buildah-cache-<uid>`
+      # (confirmed via a diagnostic run — `buildah-cache-1001` on this runner user),
+      # a detail not worth hardcoding.
+      - name: Cache the ccache RUN --mount=type=cache content
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/buildah-tmp
+          key: buildah-ccache-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            buildah-ccache-${{ runner.os }}-
+
+      # Same script a developer runs locally (./tools/e2e/scripts/build.sh) — builds,
+      # rosdep-installs, colcon builds, and colcon tests the whole workspace in one
+      # `podman build`. CACHE_REF round-trips podman's layer cache (the rarely-changing
+      # apt/toolchain/aws_sdk_vendor layers) through the registry; BUILDAH_TMPDIR
+      # points the workspace stage's ccache mount at the actions/cache-managed
+      # directory above — together they mean a cold runner still starts warm, both for
+      # layers that didn't change and for object files ccache has already compiled. A
+      # failing `colcon test` does NOT fail this `podman build` (see the Containerfile's
+      # `workspace` stage) — it's recorded in the image's own /root/ws/TEST_RESULT
+      # instead, so the image still gets tagged and its coverage data is still
+      # extractable below even when tests fail.
+      - name: Build + test the DC workspace (coverage-instrumented)
         env:
-          IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
-        run: ./tools/e2e/scripts/test.sh "$PWD/coverage"
+          IMAGE_TAG: ${{ steps.refs.outputs.workspace_ref }}
+          CACHE_REF: ${{ steps.refs.outputs.cache_ref }}
+          BUILDAH_TMPDIR: ${{ runner.temp }}/buildah-tmp
+          CCOV: "true"
+        run: ./tools/e2e/scripts/build.sh
 
       - name: Stop the test-dependency stores
         if: always()
         env:
           PODMAN_COMPOSE_PROVIDER: podman-compose
         run: podman compose -f tools/e2e/compose.test.yaml down
+
+      # Extracted via a short-lived container reading the already-built image, not a
+      # bind mount during the build — coverage/cpp.info and TEST_RESULT are both just
+      # files colcon/the Containerfile's RUN wrote into the image's own filesystem.
+      - name: Extract C++ coverage and test result
+        if: always()
+        env:
+          REF: ${{ steps.refs.outputs.workspace_ref }}
+        run: |
+          mkdir -p coverage
+          podman run --rm --entrypoint bash -v "${{ github.workspace }}/coverage:/out:Z" "$REF" -c '
+            [ -f /root/ws/coverage/cpp.info ] && cp /root/ws/coverage/cpp.info /out/ || true
+            cp /root/ws/TEST_RESULT /out/TEST_RESULT
+          '
+
+      - name: Fail the job if colcon test reported failures
+        if: always()
+        run: |
+          if [ "$(cat coverage/TEST_RESULT)" != "0" ]; then
+            echo "colcon test reported failures" >&2
+            exit 1
+          fi
+
+      - name: Push the workspace image
+        if: success()
+        env:
+          REF: ${{ steps.refs.outputs.workspace_ref }}
+        run: |
+          for attempt in 1 2 3; do
+            podman push "$REF" && exit 0
+            echo "push $REF attempt $attempt failed; retrying in 10s"; sleep 10
+          done
+          exit 1
 
       - name: Upload C++ coverage
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,13 +45,26 @@ pip3 install -r requirements.txt   # or `poetry install`
 pre-commit run --all-files   # flake8, doc build, yaml/json/xml checks, etc. — see .pre-commit-config.yaml
 ```
 
-CI (`.github/workflows/ci.yaml`) builds the shared DC workspace image
-(`tools/e2e/Containerfile`) with Podman and runs `colcon test` (C++ gtest across every
-package) against it — see "Containers: Podman, not Docker" below. `tools/e2e/scripts/build.sh` /
-`test.sh` are the same scripts CI calls, runnable locally too. Note: `ci.yaml` on the
-`humble` branch is a *different* file (that branch's own tree, `industrial_ci` inside
-Docker) — same filename, unrelated content, since each branch keeps its own
-`.github/workflows/`.
+CI (`.github/workflows/ci.yaml`) builds the DC workspace with Podman and runs `colcon
+test` (C++ gtest across every package) against it — see "Containers: Podman, not
+Docker" below. Its `build-workspace` job runs the exact same `tools/e2e/scripts/build.sh`
+a developer runs locally, so CI and local dev build `tools/e2e/Containerfile` the same
+way; `colcon test` is part of that same build (the Containerfile's `workspace` stage),
+so CI no longer calls `test.sh` directly. CI adds two things local dev doesn't need:
+`CACHE_REF`, a registry ref `build.sh` passes to `podman build --cache-from`/
+`--cache-to` so the rarely-changing apt/toolchain/aws_sdk_vendor *layers* stay warm
+on a cold GitHub-hosted runner (podman's layer cache is otherwise local to one
+machine); and `BUILDAH_TMPDIR`, which relocates the `workspace` stage's ccache
+`RUN --mount=type=cache` mount into a directory `actions/cache` persists between
+runs — that mount lives under buildah's own `$TMPDIR`, a mechanism
+`--cache-from`/`--cache-to` does not touch at all (verified against two live CI runs:
+the mount showed a 0% hit rate under `--cache-to`/`--cache-from` alone). Together
+they mean a change to one source file only recompiles that file's translation units,
+not the whole workspace, on a cold runner too — no bind mounts, no separate
+incremental-build script. Note: `ci.yaml` on the `humble` branch is a *different*
+file (that branch's own tree, `industrial_ci` inside Docker) — same filename,
+unrelated content, since each
+branch keeps its own `.github/workflows/`.
 
 ## Containers: Podman, not Docker
 

--- a/progress.txt
+++ b/progress.txt
@@ -4469,6 +4469,91 @@ prior session in this log, which were all constrained to read-through + `clang-f
 `black` reformatted `tools/e2e/scripts/verify_zero_loss.py` again as a side effect of running
 pre-commit against the whole repo — reverted before committing, same as every prior entry.
 
+### CI incremental workspace build — stop full recompiles on any source change (PR #333)
+
+**Problem**: CI's `build-workspace` job recompiled the *entire* DC workspace on every
+push, no matter how small the change — a single test file edit paid the same cost as a
+from-scratch build, because the whole thing was one Containerfile layer (`COPY . +
+colcon build`): any changed file busted that layer's cache and forced `colcon build`
+to start from nothing.
+
+**Fix**: split the Containerfile into a `toolchain` stage (apt/rosdep/`aws_sdk_vendor`,
+registry-cached via `CACHE_REF` — unaffected by DC source changes at all) and a
+`workspace` stage built incrementally in CI via a new driver
+(`tools/e2e/scripts/ci_build_test.sh`) that runs `colcon build`/`colcon test` against a
+bind-mounted `build/`/`ccache`, restored between runs by `actions/cache` instead of
+recompiled from zero. The bind-mounted result is then assembled into a normal,
+mount-free shippable image via a narrow-context `podman build`/`COPY`
+(`tools/e2e/Containerfile.finalize`) rather than `podman commit`.
+
+**Two gotchas found by direct testing, not by reading docs, that shaped the design**:
+1. `podman commit` was considered and rejected for finalizing the image: it would
+   require manually reconstructing `ENTRYPOINT`/`CMD`, and unlike a plain `podman
+   build` it isn't `hadolint`-able and doesn't match the existing narrow-context
+   `Containerfile.e2e` pattern. (An earlier design also worried `podman commit` would
+   silently drop a bind-mounted `install/` — it only captures a container's own
+   writable layer — but the final design extracts `install/` via `podman cp` instead
+   of bind-mounting it, so that specific concern doesn't apply as stated; the two
+   reasons above are why `podman build`/`COPY` — `Containerfile.finalize` — was kept
+   regardless.)
+2. A fresh checkout (`actions/checkout`, same as a plain `git checkout`) stamps every
+   file's mtime to "now" at checkout time, which defeats colcon/CMake's mtime-based
+   staleness detection — every file looks simultaneously newer than its build outputs,
+   forcing a full rebuild regardless of caching. Fixed with a new
+   `tools/e2e/scripts/normalize_git_mtimes.sh`, run before the incremental build, that
+   rewrites each tracked file's mtime to its last commit's timestamp so only files
+   actually changed since the cached build look stale to colcon.
+
+**Five real bugs found and fixed via actual CI runs** (all in Containerfile/script
+content, not implementer typos — each confirmed by a real CI failure before the fix and
+a real CI pass after):
+1. `ARG CCOV` needed redeclaring in the `workspace` stage — `ARG` scope resets at every
+   `FROM`, so the coverage flag silently stopped propagating once the stage was split.
+2. `/opt/ros/jazzy/setup.sh` needed `set +u`/`set -u` bracketing around its sourcing —
+   it references unset variables, which is fine under a normal shell but fatal under
+   `set -u`.
+3. Bind-mounting `install/` masked the toolchain image's own pre-built `aws_sdk_vendor`
+   install (the bind mount shadows whatever was baked into the image at that path).
+   Fixed by extracting `install/` via `podman cp` after the build instead of
+   bind-mounting it.
+4. `colcon test` (not just `colcon build`) also needed `--packages-skip aws_sdk_vendor`,
+   since its `build/` dir is masked by the same `COLCON_BUILD_DIR` bind mount and looks
+   unbuilt from inside the container. `colcon test-result`, however, does **not** accept
+   `--packages-skip` at all — confirmed empirically, it errors on the flag — so the skip
+   only belongs on `colcon test`, not on `test-result`.
+5. The biggest one: the `toolchain` stage's `rosdep install` was scoped to only
+   `aws_sdk_vendor`'s `package.xml`, not the full workspace's (`COPY --parents` isn't
+   supported by this podman/buildah version, so all 16 `dc_*` `package.xml` files are
+   `COPY`'d in individually instead). System/apt dependencies like `nav2_common` were
+   therefore only ever installed in the ephemeral CI *build* container — discarded when
+   that container was removed — and never made it into the final shippable image,
+   causing `dc_bringup`'s launch to fail at runtime with `ModuleNotFoundError: No
+   module named 'nav2_common'`. Fixed by running `rosdep install` for the full
+   workspace in the `toolchain` stage.
+
+**Verified via two consecutive full-green real CI runs** (`build-workspace` +
+`build-e2e-image` + `e2e`, all passing both times) on Minipada/ros2_data_collection,
+branch `feature/ci-incremental-workspace-build`, PR #333: run 31741041974 and run
+31743266810. `colcon build`'s own summary went from "16 packages finished [1min 13s]"
+(a cold run that also freshly installed `nav2_common` et al. into the toolchain image
+for the first time) to "16 packages finished [46.4s]" (a subsequent run touching only
+two doc/comment files, no source) — but the `build-workspace` job's overall
+wall-clock only improved from ~14.5 minutes to ~11m38s, a far more modest gain than the
+compile-time number alone suggests, because most of the job's wall-clock is fixed-cost
+330-gtest test *execution* (unaffected by compile caching) plus registry round-trips
+(pulling/pushing image layers, `actions/cache`) rather than compilation, which was
+never the dominant cost at this codebase's size. The real, durable fix is architectural
+rather than a timing number: the `toolchain` layer (apt/rosdep/`aws_sdk_vendor`) no
+longer needs to rebuild or reinstall anything when an unrelated source file changes —
+confirmed by the `CACHE_REF`-backed toolchain build completing as a registry cache hit
+on both of the two consecutive full-green runs above.
+
+**Not done**: same residual risks flagged at plan time — GitHub Actions' repo-wide 10GB
+cache limit with LRU eviction could let concurrent PRs' `build/`/`ccache` caches evict
+each other under load (monitor via the Actions cache usage UI; not a blocker today),
+and rootful-vs-rootless podman bind-mount UID/GID mapping on `ubuntu-latest` was only
+verifiable via the real CI runs above, not locally.
+
 ## #256: Uploader — optional thumbnail/preview generation for uploaded images and videos
 
 **Read**: the issue, `dc_bridge/{include/dc_bridge,src}/uploader/*` (uploader, status, group,
@@ -5027,3 +5112,67 @@ Four bugs in my own harness, every one found by running it rather than reading i
 it on a filter update and `update_min_d` is 0.25 m. The assertion is now `map -> odom`,
 which AMCL re-broadcasts continuously and which every costmap and the planner chain
 actually depend on.
+
+### CI incremental workspace build — replace the bind-mount design with cache mounts
+
+The bind-mount design earlier in this file (`ci_build_test.sh` driving a container
+against host-cached `build/`/`ccache` dirs, `podman cp` to extract `install/`, a
+separate `Containerfile.finalize` to bake it onto the toolchain image) worked — 4 green
+CI runs, merged — but was hard to follow and diverged from what a developer runs
+locally. Asked to justify it against alternatives (industrial_ci, Nav2's
+colcon-cache/CircleCI approach, humble's own `docker/`+`industrial_ci` pipeline), the
+honest answer was that it was more machinery than the problem needed.
+
+**What replaced it.** `tools/e2e/Containerfile` is now three stages: `cacher` (extracts
+just `package.xml` manifests via `find | cp --parents`, so `toolchain`'s dependency
+layer keys its cache on dependency lists rather than one hardcoded `COPY` per package),
+`toolchain` (unchanged apt/rosdep/aws_sdk_vendor), and `workspace` (plain `COPY .` +
+`colcon build` + `colcon test` in one `RUN --mount=type=cache` for ccache). CI and local
+dev now build this file the identical way via `build.sh` — no bind mounts, no `podman
+cp`, no separate finalize image, no separate `colcon-test` job. `colcon test` failing
+doesn't fail the `podman build` (a failing `RUN` means no image gets tagged at all,
+which would make its `coverage/cpp.info` unextractable) — it's recorded in the image's
+own `/root/ws/TEST_RESULT`, and `ci.yaml` extracts coverage first, checks `TEST_RESULT`
+after, and only pushes on `0`. Deleted `ci_build_test.sh`,
+`in_container_build_test.sh`, `normalize_git_mtimes.sh`, `Containerfile.finalize`.
+
+**The mechanism was already in this repo's own history.** `RUN --mount=type=cache` was
+never used anywhere in jazzy's Containerfile history, but humble's own
+`docker/source/Dockerfile` used exactly this for ccache the whole time — it just never
+got carried forward when jazzy's CI was built from scratch as a Docker/industrial_ci
+replacement rather than a port-forward of what already worked.
+
+**A real bug in my own "empirical validation," found only by comparing two live CI
+runs' `ccache -s` output, not by re-reading the code:** earlier local testing (a
+busybox Containerfile, built from a completely separate `--root`/`--runroot` podman
+storage location) seemed to prove `--cache-from`/`--cache-to` round-trips a
+`RUN --mount=type=cache` mount's content through a registry, same as it does image
+layers. It doesn't — buildah stores a cache mount under `$TMPDIR/buildah-cache-<uid>`,
+entirely outside `--cache-from`/`--cache-to`'s reach (confirmed against podman/buildah
+docs, not just this repo's behavior). The busybox test never isolated `$TMPDIR`, only
+podman's storage root, so it was measuring same-machine `buildah-cache` reuse and
+calling it cross-machine persistence. On a real CI run this showed up as `ccache -s`
+reporting 0/177 hits on a "warm" second run — real evidence contradicting the earlier
+claim, caught by checking rather than trusting the prior validation.
+
+**The fix**, verified over four more CI round-trips (each one a single-file source
+change, to force a real recompile and catch a hit-rate regression rather than trusting
+green wall-clock time alone): `build.sh` accepts `BUILDAH_TMPDIR` to relocate `$TMPDIR`
+for the build; `ci.yaml` points it at a directory under `runner.temp` and caches that
+directory with `actions/cache` — GitHub's own proven cross-run mechanism, the same one
+the old bind-mount design used for ccache, just now backing the cache-mount path
+instead of a bind-mounted host directory. One more bug surfaced along the way: buildah
+names the cache directory `buildah-cache-<uid>` (`buildah-cache-1001` on GitHub's
+runner user), not plain `buildah-cache` — found by adding a temporary diagnostic step
+rather than guessing again, since guessing had already cost one wasted round-trip.
+Final state: `ccache -s` shows real hits (170/354, 48%) on a single-file change, and
+the `colcon build` step itself dropped from 8m25s (cold) to 58.6s (warm). A later
+`e2e` job failure (`startup latency 12.3s exceeds the 10s gate`) turned out to be a
+runner-contention flake, confirmed by re-running just that job to green.
+
+Local verification was largely infeasible this round: the machine's 5.9GB free disk
+couldn't fit even the `toolchain` stage's `aws_sdk_vendor` build (which alone needs
+more than that once buildah's own layer commit is added on top) — two local attempts
+both failed with "no space left on device" after the full ~20-minute compile. All
+verification after that point was via real CI runs, which is slower per round-trip but
+was the only environment with enough disk to actually exercise the design.

--- a/tools/e2e/Containerfile
+++ b/tools/e2e/Containerfile
@@ -1,27 +1,48 @@
-# Full DC workspace (every dc_* package, all C++) — the shared base both Jazzy CI
-# (.github/workflows/ci.yaml, `colcon test` run directly against this image) and the
-# zero-loss E2E harness (#249, Containerfile.e2e — a thin `FROM` layer adding the
-# harness's own runtime bits) build from. Built once, reused as-is by CI so its test
-# image doesn't carry anything harness-only.
+# Full DC workspace (every dc_* package, all C++) — three stages:
+# - `cacher`: extracts just the package manifests (package.xml) from the full source
+#   tree, so `toolchain`'s COPY --from below keys its own cache on dependency lists
+#   alone, not on every source edit — without having to hardcode one COPY per package.
+# - `toolchain`: ROS 2 + system packages + pre-built aws-sdk-cpp + full-workspace
+#   rosdep install. Stays a cache hit across ordinary source changes.
+# - `workspace`: inherits toolchain, COPYs the full source, then one `colcon build` +
+#   `colcon test`. The compiler's object-file cache (ccache) comes from a
+#   `RUN --mount=type=cache` mount, which persists across builds independently of the
+#   layer it's attached to — so a change to one file only recompiles that file's
+#   translation unit, not the whole workspace. That mount lives under buildah's own
+#   $TMPDIR/buildah-cache/<id>, entirely separate from --cache-from/--cache-to's
+#   registry export (which only carries *layers*, not cache-mount content — verified
+#   against two live CI runs, not assumed); on a fresh runner it survives only if the
+#   caller points $TMPDIR somewhere it persists itself, which is what CI's
+#   BUILDAH_TMPDIR (build.sh) + actions/cache does. Local dev gets no such
+#   persistence unless it does the same.
+#
+# CI and local dev build this exact same Containerfile the exact same way
+# (./tools/e2e/scripts/build.sh) — no bind-mounted host cache dirs, no podman-cp,
+# no separate finalize step producing the shippable image.
+#
+# `--packages-skip aws_sdk_vendor` on the workspace stage's build/test: its build/ and
+# install/ trees are already part of the toolchain stage this stage is FROM (built
+# once, in its own layer — see below), so skipping it here avoids re-running its
+# ~20-minute ExternalProject source build on every image, not just every source change.
 #
 # Plain ROS 2 + C++: no separate language toolchain, no source-built message repos.
 # dc_bridge builds with rosdep + colcon like every other dc_* package.
-#
-# Single stage on purpose: the build keeps everything it produces (no slim runtime to
-# `COPY --from` a subset into), so there's nothing for a second stage to earn. CI's
-# `--cache-from`/`--cache-to` (a registry-backed build cache — see ci.yaml) still gets
-# full value: Podman caches each RUN layer independently, so the apt/toolchain layer
-# below (no DC source) is a near-permanent cache hit; `aws_sdk_vendor` (its own layer,
-# #271) is a cache hit unless it or rosdep/ change; only the full-workspace
-# rosdep+colcon layer invalidates on a code change elsewhere.
 
 ARG ROS_DISTRO=jazzy
 
-FROM docker.io/library/ros:${ROS_DISTRO}-ros-base
+# --- cacher: nothing but the package manifests, so this stage's own frequent cache
+# invalidation (it COPYs the whole repo) costs nothing — it does no compilation, and
+# only its OUTPUT's content (not whether this stage itself was a cache hit) determines
+# whether the toolchain stage's COPY --from below stays a cache hit.
+FROM docker.io/library/ros:${ROS_DISTRO}-ros-base AS cacher
+WORKDIR /root/ws
+COPY . src/ros2_data_collection
+RUN mkdir -p /tmp/manifests && \
+    find src/ros2_data_collection -name package.xml | xargs cp --parents -t /tmp/manifests
+
+FROM docker.io/library/ros:${ROS_DISTRO}-ros-base AS toolchain
 
 ARG APT_CACHEBUST=unknown
-# ARG, not ENV: only affects this build's CMAKE_CXX_FLAGS below, not the running image.
-ARG CCOV=false
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Daily apt cache-bust (see CLAUDE.md "Containers: Podman, not Docker"): a date-valued
@@ -43,18 +64,20 @@ RUN echo "apt cache bust: ${APT_CACHEBUST}" && \
 
 WORKDIR /root/ws
 
-# aws_sdk_vendor built in its own layer, isolated from the rest of the workspace (#271):
-# `COPY <path>` keys Podman's layer cache on that path's own content, so copying only
-# `aws_sdk_vendor/` (plus the rosdep source it needs registered) here means this layer —
-# and its ~20-minute aws-sdk-cpp ExternalProject source build — stays a cache hit for a
-# source change anywhere *else* in the repo, instead of invalidating on every commit like
-# the old single `COPY . ` + one `RUN` layer did. The full-workspace build below reuses
-# this layer's already-built install/ via `colcon build --packages-skip aws_sdk_vendor`.
+# aws_sdk_vendor built in its own layer, isolated from the rest of the toolchain stage
+# (#271): `COPY <path>` keys Podman's layer cache on that path's own content, so
+# copying only `aws_sdk_vendor/` (plus the rosdep source it needs registered) here
+# means this layer — and its ~20-minute aws-sdk-cpp ExternalProject source build —
+# stays a cache hit for a source change anywhere *else* in the repo, instead of
+# invalidating on every commit like a single `COPY . ` + one `RUN` layer would.
+# The full-workspace build later reuses this layer's already-built install/ via
+# `colcon build --packages-skip aws_sdk_vendor`.
 #
 # rosdep/dc.yaml is registered as a local rosdep source so `rosdep install` resolves
 # tomlplusplus / msgpack-cxx (header-only C++ libs dc_bridge uses that upstream
-# rosdistro has no key for — see dc_bridge/package.xml). It's registered here, not in the
-# full-workspace layer below, so `rosdep update`'s index fetch only happens once.
+# rosdistro has no key for — see dc_bridge/package.xml). It's registered here, in the
+# `toolchain` stage, rather than beside the full-workspace rosdep install below, so
+# `rosdep update`'s index fetch only happens once.
 COPY rosdep src/ros2_data_collection/rosdep
 COPY aws_sdk_vendor src/ros2_data_collection/aws_sdk_vendor
 RUN echo "yaml file:///root/ws/src/ros2_data_collection/rosdep/dc.yaml" \
@@ -68,19 +91,71 @@ RUN echo "yaml file:///root/ws/src/ros2_data_collection/rosdep/dc.yaml" \
     colcon build --packages-select aws_sdk_vendor --event-handlers desktop_notification- status- && \
     rm -rf /var/lib/apt/lists/*
 
+# Full-workspace rosdep install for system (apt) dependencies — nav2_common,
+# cv_bridge, ffmpeg, etc. — baked into this image, not left to a later stage that
+# would never persist them into the final shippable image. `COPY --from=cacher` pulls
+# in every package.xml the `cacher` stage found (see above) in one instruction, so this
+# layer's cache key is the manifests' own content — it invalidates only when a
+# dependency list changes, not on an ordinary source edit.
+COPY --from=cacher /tmp/manifests/src ./src
+RUN apt-get -q update && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/*
+
+# --- workspace: full source + colcon build + colcon test, in one image both CI and
+# local dev build the same way (./tools/e2e/scripts/build.sh) ---
+FROM toolchain AS workspace
+
+# ARG scope resets at every `FROM`, even `FROM toolchain AS workspace` — without this
+# redeclaration, `--build-arg CCOV=true` would silently never reach this stage's RUN
+# below (CCOV would just read as unset/false here), producing a plain Release build
+# with no error. This exact bug was found and fixed earlier in this branch's history.
+ARG CCOV=false
+
 COPY . src/ros2_data_collection
 
-RUN apt-get -q update && \
+# The ccache mount persists across builds independently of this RUN's own layer cache
+# (which still invalidates on every source change, since COPY . above does) — so a
+# change to one file only recompiles that file's translation units; ccache serves the
+# rest from its mount, *provided* $TMPDIR points somewhere that persists between
+# invocations (buildah stores the mount under $TMPDIR/buildah-cache/dc-ccache — not
+# part of the image, not covered by --cache-from/--cache-to, which only carry
+# layers). CI arranges that via build.sh's BUILDAH_TMPDIR + an actions/cache step;
+# a plain local build gets no such persistence.
+#
+# colcon test-result doesn't accept --packages-skip (unlike colcon build/test) and
+# doesn't need it — it only scans build/ subdirectories that exist, and
+# aws_sdk_vendor's build/ dir is a vendored third-party dependency with no tests of
+# its own. colcon test's own exit code and colcon test-result's are captured
+# separately (rather than letting a test failure abort the RUN early) so the coverage
+# report below still runs even when a test fails. The combined result is written to
+# /root/ws/TEST_RESULT rather than failing the RUN/build itself: a failing `RUN` means
+# podman never tags an image at all, so the caller (ci.yaml) would have nothing to
+# `podman run` the coverage data out of. ci.yaml checks TEST_RESULT itself, after
+# extracting coverage, and only pushes the image when it reads 0.
+RUN --mount=type=cache,id=dc-ccache,target=/root/.ccache \
+    apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive \
     rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
     # shellcheck disable=SC1091
     . /opt/ros/jazzy/setup.sh && \
     if [ "$CCOV" = "true" ]; then \
-      CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-Wall -Wextra --coverage -O0 -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS=--coverage -DCMAKE_SHARED_LINKER_FLAGS=--coverage"; \
+      CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS='-Wall -Wextra --coverage -O0 -fno-omit-frame-pointer' -DCMAKE_EXE_LINKER_FLAGS=--coverage -DCMAKE_SHARED_LINKER_FLAGS=--coverage"; \
     else \
-      CMAKE_ARGS="-DCMAKE_BUILD_TYPE=Release"; \
+      CMAKE_ARGS="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release"; \
     fi && \
     eval colcon build --packages-skip aws_sdk_vendor --cmake-args "$CMAKE_ARGS" --event-handlers desktop_notification- status- && \
+    ccache -s && \
+    # shellcheck disable=SC1091
+    . install/setup.bash && \
+    ( colcon test --packages-skip aws_sdk_vendor --event-handlers desktop_notification- status- ; echo $? > /tmp/test_exit ) && \
+    ( colcon test-result --verbose ; echo $? > /tmp/result_exit ) && \
+    ( src/ros2_data_collection/tools/code_coverage_report.bash ci || echo "warning: coverage report generation produced no data (non-coverage build?)" >&2 ) && \
+    mkdir -p coverage && \
+    ( [ -f lcov/total_coverage.info ] && cp lcov/total_coverage.info coverage/cpp.info || true ) && \
+    TEST_EXIT=$(cat /tmp/test_exit) && RESULT_EXIT=$(cat /tmp/result_exit) && \
+    if [ "$TEST_EXIT" -ne 0 ] || [ "$RESULT_EXIT" -ne 0 ]; then echo "colcon test reported failures" >&2; echo 1 > TEST_RESULT; else echo 0 > TEST_RESULT; fi && \
     rm -rf /var/lib/apt/lists/*
 
 ENV ROS_UNDERLAY=/root/ws/install

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -21,11 +21,20 @@ hard assertion — the script exits non-zero (and, by default, tears the stack d
 dumping the `dc` container log to `tools/e2e/.run/`) on any violation. Set
 `DC_E2E_KEEP=true` to leave a failed stack running for interactive debugging instead.
 
-The images are the **same artifacts CI builds** — there's no CI-only build path. In CI
-each image is built and pushed by its own job, and `run.sh` is handed the prebuilt
-`dc-e2e` image via `DC_E2E_IMAGE` so it runs that exact artifact instead of rebuilding
-(`DC_WORKSPACE_IMAGE` similarly reuses a prebuilt workspace base). `build.sh` /
-`test.sh` / `run.sh` are the same plain scripts a developer runs locally.
+The images are the **same artifacts CI builds**, built the **same way** — there's no
+CI-only build path. In CI each image is built and pushed by its own job, and `run.sh`
+is handed the prebuilt `dc-e2e` image via `DC_E2E_IMAGE` so it runs that exact artifact
+instead of rebuilding (`DC_WORKSPACE_IMAGE` similarly reuses a prebuilt workspace
+base). `build.sh` / `test.sh` / `run.sh` are the same plain scripts a developer runs
+locally, and CI's `build-workspace` job (`ci.yaml`) calls `build.sh` directly — it adds
+two things a local build doesn't need: `CACHE_REF`, a registry ref `build.sh` passes to
+`podman build --cache-from/--cache-to` so a cold GitHub-hosted runner still starts from
+warm *layers* (the rarely-changing apt/toolchain/aws_sdk_vendor ones) rather than
+podman's otherwise local-only layer cache; and `BUILDAH_TMPDIR`, which relocates the
+`workspace` stage's `ccache` mount (see `Containerfile` below) into a directory
+`actions/cache` persists between runs — that mount lives entirely outside
+`--cache-from`/`--cache-to`'s reach (verified: it carries only layers, never
+cache-mount content).
 
 By default the induced outage is the PRD's full 10 minutes
 (`DC_E2E_OUTAGE_SECONDS=600`); override it for faster local iteration, e.g.:
@@ -151,11 +160,28 @@ below.
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
-  ADR-0007). Single stage: an apt/toolchain `RUN` (no DC source — rarely changes, so it
-  stays a build-cache hit) followed by the `rosdep install`/`colcon build` `RUN` (`ARG
-  CCOV` gates coverage-instrumented compiler flags). Jazzy CI (`ci.yaml`) builds and uses
-  **only** this image — `colcon test` runs directly against it, no harness-specific files
-  needed.
+  ADR-0007), in three stages: `cacher` (extracts just the `package.xml` manifests from
+  the full source tree, so `toolchain`'s own dependency-install layer keys its cache on
+  dependency lists, not on every source edit, without hardcoding one `COPY` per
+  package), `toolchain` (apt/rosdep + a full-workspace rosdep install off those
+  manifests + pre-built `aws_sdk_vendor` — rarely changes, so it stays a build-cache
+  hit), and `workspace` (inherits `toolchain`, `COPY`s full source, runs `rosdep
+  install`/`colcon build`/`colcon test`; `ARG CCOV` gates coverage-instrumented
+  compiler flags). The `workspace` stage's compile/test step uses a
+  `RUN --mount=type=cache` ccache mount, which persists independently of that RUN's own
+  layer (so it survives even though the layer itself invalidates on every source
+  change) — but only if `$TMPDIR` points somewhere that itself persists between
+  builds, since buildah stores the mount under `$TMPDIR/buildah-cache/<id>`, entirely
+  outside `--cache-from`/`--cache-to`'s reach (verified: it round-trips only layers
+  through the registry, never cache-mount content). CI arranges that persistence via
+  `scripts/build.sh`'s `BUILDAH_TMPDIR` + an `actions/cache` step in `ci.yaml` — so a
+  change to one file recompiles that file's translation units, not the whole
+  workspace, on a fresh runner too. `colcon test`
+  failing doesn't fail the `podman build` itself (see the Containerfile's own
+  comments) — it's recorded in the image's `/root/ws/TEST_RESULT` instead, so the image
+  still gets tagged and its `coverage/cpp.info` is still extractable even when a test
+  fails; `ci.yaml` checks `TEST_RESULT` after extracting coverage and only pushes the
+  image when it reads `0`.
 - `Containerfile.e2e` — a thin `FROM <workspace image>` layer adding just the harness's
   own runtime bits (the synthetic workload generator, its params, the entrypoint).
   Never built by CI. Its build context is `tools/e2e/` itself, not the repo root — it
@@ -188,12 +214,17 @@ below.
   place the `mcap` library is installed), invoked by `run.sh` as a one-off container on
   the `dc_e2e_data` volume, the same pattern used to extract the workload ledger and the
   NDJSON passthrough's output.
-- `scripts/build.sh` — builds `Containerfile` (the shared workspace image: handles the
-  `.dockerignore` dance below, the coverage `ARG`, and an optional registry-backed
-  `--cache-from`/`--cache-to`). Used by both `run.sh` and `ci.yaml`.
+- `scripts/build.sh` — builds `Containerfile` end to end (handles the `.dockerignore`
+  dance below, the coverage `ARG`, `--network host` so the `workspace` stage's `colcon
+  test` can reach the test-dependency stores, an optional registry-backed
+  `--cache-from`/`--cache-to` for layers, and an optional `BUILDAH_TMPDIR` to relocate
+  the ccache `RUN --mount=type=cache` mount somewhere the caller can persist across
+  runs). The one build path for local dev and CI alike; set `TARGET=toolchain` to
+  build only the `toolchain` stage instead, for debugging.
 - `scripts/test.sh` — runs `colcon test` (C++ gtest) plus coverage against an
-  already-built workspace image. Used by both a developer locally and CI's `colcon-test`
-  job.
+  already-built workspace image, for a developer who wants to re-run tests without a
+  full rebuild. CI doesn't call this — `colcon test` is part of the `workspace` stage's
+  own build step (see `Containerfile` above).
 - `scripts/run.sh` — the one-command harness orchestrator described above. Builds the
   workspace + `dc-e2e` images locally, or runs a prebuilt `dc-e2e` image when handed one
   via `DC_E2E_IMAGE` (as CI's `e2e` job does).

--- a/tools/e2e/compose.test.yaml
+++ b/tools/e2e/compose.test.yaml
@@ -4,7 +4,7 @@
 # tools/e2e/scripts/run.sh), these just need to be *up* for the duration of the test run,
 # which is exactly what a declarative compose file is for.
 #
-# Bring them up (locally or in CI's colcon-test job) with:
+# Bring them up (locally or in CI's build-workspace job) with:
 #   podman compose -f tools/e2e/compose.test.yaml up -d
 # then create the bucket the tests use and run tools/e2e/scripts/test.sh.
 #

--- a/tools/e2e/scripts/build.sh
+++ b/tools/e2e/scripts/build.sh
@@ -1,19 +1,37 @@
 #!/bin/bash
-# Builds tools/e2e/Containerfile — the shared DC workspace image both Jazzy CI
-# (.github/workflows/ci-jazzy.yaml, runs `colcon test` directly against this) and the
+# Builds tools/e2e/Containerfile — the shared DC workspace image both CI
+# (.github/workflows/ci.yaml's build-workspace job, which also runs `colcon test`
+# as part of this same build — see the Containerfile's `workspace` stage) and the
 # E2E harness (tools/e2e/Containerfile.e2e, a thin `FROM` layer adding the harness's
-# own runtime bits — see tools/e2e/scripts/run.sh) build from. No separate CI-only
-# build script (see CLAUDE.md "Containers: Podman, not Docker").
+# own runtime bits — see tools/e2e/scripts/run.sh) build from. CI and local dev run
+# this exact script the exact same way — no separate CI-only build script (see
+# CLAUDE.md "Containers: Podman, not Docker").
+#
+# --network host: the workspace stage's `colcon test` needs to reach the
+# Postgres/RustFS test-dependency stores (tools/e2e/compose.test.yaml) dc_bridge's
+# store-backed tests hard-fail without — the caller is responsible for having them
+# already running on the host before calling this script.
 #
 # Env vars (all optional):
-#   IMAGE_TAG   image tag to build (default dc-workspace:latest)
-#   CCOV        "true" to build with C++ coverage instrumentation (default false)
-#   CACHE_REF   a registry ref (e.g. ghcr.io/<repo>/dc-e2e-cache) to use as a
-#               podman --cache-from/--cache-to target. podman's build cache is
-#               otherwise local-only and doesn't survive a fresh machine/runner —
-#               CI sets this so a cold GitHub-hosted runner still gets warm layers
-#               for the (rarely-changing) apt/toolchain RUN. Omit for a plain local
-#               build with no registry round-trip.
+#   IMAGE_TAG      image tag to build (default dc-workspace:latest)
+#   CCOV           "true" to build with C++ coverage instrumentation (default false)
+#   TARGET         stage to build, e.g. `toolchain` — omit to build the full
+#                  `workspace` stage as today
+#   CACHE_REF      a registry ref (e.g. ghcr.io/<repo>/dc-e2e-cache) to use as a
+#                  podman --cache-from/--cache-to target for LAYER caching (the
+#                  rarely-changing apt/toolchain/aws_sdk_vendor layers). podman's
+#                  layer cache is otherwise local-only and doesn't survive a fresh
+#                  machine/runner. Omit for a plain local build with no registry
+#                  round-trip.
+#   BUILDAH_TMPDIR a directory to use as $TMPDIR for this build, so the workspace
+#                  stage's `RUN --mount=type=cache` ccache mount — which buildah
+#                  stores under $TMPDIR/buildah-cache/<id>, entirely separate from
+#                  --cache-from/--cache-to's registry export (verified: --cache-to
+#                  does not carry cache-mount content, only layers) — lands
+#                  somewhere the caller can persist across runs (see ci.yaml's
+#                  actions/cache step) instead of the default $TMPDIR (/tmp on a
+#                  GitHub-hosted runner, gone once the job ends). Omit for a plain
+#                  local build using the system default.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -21,6 +39,11 @@ REPO_ROOT="$(dirname "$(dirname "$(dirname "$SCRIPT_DIR")")")"
 
 IMAGE_TAG="${IMAGE_TAG:-dc-workspace:latest}"
 CCOV="${CCOV:-false}"
+
+if [ -n "${BUILDAH_TMPDIR:-}" ]; then
+  mkdir -p "$BUILDAH_TMPDIR"
+  export TMPDIR="$BUILDAH_TMPDIR"
+fi
 
 # The repo's .dockerignore is an "ignore everything, whitelist package.xml" allowlist
 # meant for a deps-only image — this build needs every source file. `--ignorefile`
@@ -39,11 +62,15 @@ ARGS=(
   # using a pipe actually get -o pipefail instead of always "succeeding" even if an
   # earlier stage in the pipe failed.
   --format docker
+  --network host
   --build-arg "APT_CACHEBUST=$(date -u +%Y-%m-%d)"
   --build-arg "CCOV=$CCOV"
   -t "$IMAGE_TAG"
   -f "$REPO_ROOT/tools/e2e/Containerfile"
 )
+if [ -n "${TARGET:-}" ]; then
+  ARGS+=(--target "$TARGET")
+fi
 if [ -n "${CACHE_REF:-}" ]; then
   ARGS+=(--cache-from "$CACHE_REF" --cache-to "$CACHE_REF")
 fi


### PR DESCRIPTION
## Summary

Stops CI from recompiling the whole DC workspace on every source change, without diverging from what a developer runs locally.

`tools/e2e/Containerfile` is now three stages:
- **`cacher`** — extracts just the `package.xml` manifests from the full source tree (`find | cp --parents`), so `toolchain`'s dependency-install layer keys its cache on dependency lists rather than one hardcoded `COPY` per package.
- **`toolchain`** — apt + rosdep + pre-built `aws_sdk_vendor` (unchanged, still a near-permanent cache hit).
- **`workspace`** — plain `COPY .` + `colcon build` + `colcon test` in one `RUN --mount=type=cache` for ccache, so a single-file change only recompiles that file's translation units.

CI and local dev now build this file the *identical* way via `./tools/e2e/scripts/build.sh` — no bind mounts, no `podman cp`, no separate finalize image, no separate `colcon-test` job. `colcon test` failing doesn't fail the `podman build` itself (a failing `RUN` means no image gets tagged, which would make its coverage data unextractable) — it's recorded in the image's own `/root/ws/TEST_RESULT`, and `ci.yaml` extracts coverage first, checks `TEST_RESULT` after, and only pushes the image on success.

Two caching mechanisms, doing two different jobs:
- `CACHE_REF` (`--cache-from`/`--cache-to`, registry-backed) — warms the rarely-changing apt/toolchain/aws_sdk_vendor **layers** on a cold runner.
- `BUILDAH_TMPDIR` + an `actions/cache` step — buildah stores a `RUN --mount=type=cache` mount under `$TMPDIR/buildah-cache-<uid>`, entirely separate from `--cache-from`/`--cache-to` (verified: that only carries layers, never cache-mount content — found by comparing `ccache -s` across two live CI runs, not by re-reading code). `BUILDAH_TMPDIR` relocates it into a directory `actions/cache` persists across runs.

`progress.txt` has the full investigation history, including a flawed earlier local validation of the cache-mount mechanism and the fix.

## Test plan

- [x] Full green run (`build-workspace`, `sim`, `build-e2e-image`, `e2e`) on a cold cache
- [x] Full green run on a warm cache
- [x] `ccache -s` shows real hits (170/354, 48%) on a single-file source change, not just a faster wall clock — `colcon build` dropped from 8m25s (cold) to 58.6s (warm)
- [x] `TEST_RESULT` gate: coverage still extractable and uploaded even when `colcon test` fails, and a failing test still fails the job before push
- [x] History squashed to one commit, no merge commits, force-pushed; net diff against the prior (verified) tip is empty aside from a leftover debug artifact reverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UW6eJqr5aQqWmdWoMPTSV