### PR TITLE
fix(demos): rewrite Streamlit dashboard onto the flat postgres schema

### DIFF
--- a/dc_demos/dc_demos/streamlit_dashboard/backend/pgsql.py
+++ b/dc_demos/dc_demos/streamlit_dashboard/backend/pgsql.py
@@ -1,8 +1,14 @@
+"""Queries against the flat `dc` table dc_bridge's `postgres` Destination writes.
+
+Every query here reads top-level columns. See `models/robot_data.py` for why there is no
+`data` JSON blob to path into any more (#272) and which demo this dashboard reads.
+"""
+
 import datetime
 
 from config import Storage
 from lib import pgsql_session
-from models import RobotData
+from models import RECORD_TIME, RobotData, to_epoch_nanos
 from sqlalchemy import asc, desc, func, select
 
 
@@ -13,21 +19,41 @@ def add_mode_query(
     end_date: datetime.datetime | None = None,
 ):
     if run_id:
-        query = query.where(RobotData.data["run_id"].as_string() == run_id)
+        query = query.where(RobotData.run_id == run_id)
     else:
         if start_date:
-            query = query.where(RobotData.time >= start_date)
+            query = query.where(RobotData.date >= to_epoch_nanos(start_date))
         if end_date:
-            query = query.where(RobotData.time <= end_date)
+            query = query.where(RobotData.date <= to_epoch_nanos(end_date))
     return query
+
+
+def remote_path(storage: Storage, key: str):
+    """Path into the `remote_paths` jsonb column, as text.
+
+    Measurements that upload Files record them as
+    `remote_paths.<destination name>.<file key>` (dc_measurements' camera.cpp / map.cpp),
+    so the storage level is the dc_bridge Destination the File went to.
+
+    Args:
+        storage (Storage): dc_bridge Destination the File was uploaded to
+        key (str): The Measurement's own name for that File, e.g. "png" or "raw"
+
+    Returns:
+        The object path as text, or NULL when this Record uploaded no such File
+    """
+    return RobotData.remote_paths[(storage.value, key)].astext
 
 
 class PGSQLService:
     @staticmethod
     def get_unique_robots():
-        query = select(RobotData.data["robot_name"].label("robot_name"))
-
-        query = query.group_by("robot_name").order_by(asc("robot_name"))
+        query = (
+            select(RobotData.robot_name.label("robot_name"))
+            .where(RobotData.robot_name.isnot(None))
+            .group_by("robot_name")
+            .order_by(asc("robot_name"))
+        )
         result = pgsql_session.execute(query)
         result = result.all()
 
@@ -39,12 +65,12 @@ class PGSQLService:
         robot_name: str | None = "",
     ):
         query = select(
-            func.min(RobotData.time).label("start_date"),
-            func.max(RobotData.time).label("end_date"),
+            func.min(RECORD_TIME).label("start_date"),
+            func.max(RECORD_TIME).label("end_date"),
         )
 
         if robot_name:
-            query = query.where(RobotData.data["robot_name"].as_string() == robot_name)
+            query = query.where(RobotData.robot_name == robot_name)
 
         result = pgsql_session.execute(query)
         result = result.one()
@@ -58,37 +84,33 @@ class PGSQLService:
         start_date: str | None = "",
         end_date: str | None = "",
     ):
-        if start_date:
-            subquery_start = select(RobotData.data["run_id"]).where(
-                RobotData.time >= datetime.datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S")
-            )
-            if robot_name:
-                subquery_start = subquery_start.where(
-                    RobotData.data["robot_name"].as_string() == robot_name
-                )
-
-        if end_date:
-            subquery_end = select(RobotData.data["run_id"]).where(
-                RobotData.time <= datetime.datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S")
-            )
-            if robot_name:
-                subquery_end = subquery_end.where(
-                    RobotData.data["robot_name"].as_string() == robot_name
-                )
-
         query = select(
-            RobotData.data["robot_name"].label("robot_name"),
-            RobotData.data["run_id"].label("run_id"),
-            func.min(RobotData.time).label("start_date"),
-            func.max(RobotData.time).label("end_date"),
-        )
+            RobotData.robot_name.label("robot_name"),
+            RobotData.run_id.label("run_id"),
+            func.min(RECORD_TIME).label("start_date"),
+            func.max(RECORD_TIME).label("end_date"),
+        ).where(RobotData.run_id.isnot(None))
 
         if start_date:
-            query = query.where(RobotData.data["run_id"].in_(subquery_start))
+            subquery_start = select(RobotData.run_id).where(
+                RobotData.date
+                >= to_epoch_nanos(datetime.datetime.strptime(start_date, "%Y-%m-%d %H:%M:%S"))
+            )
+            if robot_name:
+                subquery_start = subquery_start.where(RobotData.robot_name == robot_name)
+            query = query.where(RobotData.run_id.in_(subquery_start))
+
         if end_date:
-            query = query.where(RobotData.data["run_id"].in_(subquery_end))
+            subquery_end = select(RobotData.run_id).where(
+                RobotData.date
+                <= to_epoch_nanos(datetime.datetime.strptime(end_date, "%Y-%m-%d %H:%M:%S"))
+            )
+            if robot_name:
+                subquery_end = subquery_end.where(RobotData.robot_name == robot_name)
+            query = query.where(RobotData.run_id.in_(subquery_end))
+
         if robot_name:
-            query = query.where(RobotData.data["robot_name"].as_string() == robot_name)
+            query = query.where(RobotData.robot_name == robot_name)
 
         query = query.group_by("run_id", "robot_name").order_by(desc("start_date"))
         result = pgsql_session.execute(query)
@@ -106,17 +128,17 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.data["os"].label("os"),
-                RobotData.data["cpus"].label("cpus"),
-                RobotData.data["kernel"].label("kernel"),
-                RobotData.data["memory"].label("memory"),
+                RobotData.os.label("os"),
+                RobotData.cpus.label("cpus"),
+                RobotData.kernel.label("kernel"),
+                RobotData.memory.label("memory"),
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["os"].isnot(None))
-            .where(RobotData.data["cpus"].isnot(None))
-            .where(RobotData.data["kernel"].isnot(None))
-            .where(RobotData.data["memory"].isnot(None))
-            .order_by(desc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.os.isnot(None))
+            .where(RobotData.cpus.isnot(None))
+            .where(RobotData.kernel.isnot(None))
+            .where(RobotData.memory.isnot(None))
+            .order_by(desc(RobotData.date))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -136,13 +158,13 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["used"],
+                RECORD_TIME.label("time"),
+                RobotData.used,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "memory")
-            .where(RobotData.data["used"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "memory")
+            .where(RobotData.used.isnot(None))
+            .order_by(asc(RobotData.date))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -162,15 +184,15 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["average"],
-                RobotData.data["processes"],
+                RECORD_TIME.label("time"),
+                RobotData.average,
+                RobotData.processes,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "cpu")
-            .where(RobotData.data["average"].isnot(None))
-            .where(RobotData.data["processes"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "cpu")
+            .where(RobotData.average.isnot(None))
+            .where(RobotData.processes.isnot(None))
+            .order_by(asc(RobotData.date))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -190,13 +212,13 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["computed"],
+                RECORD_TIME.label("time"),
+                RobotData.computed,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "speed")
-            .where(RobotData.data["computed"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "speed")
+            .where(RobotData.computed.isnot(None))
+            .order_by(asc(RobotData.date))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -216,13 +238,13 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["computed"],
+                RECORD_TIME.label("time"),
+                RobotData.computed,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "cmd_vel")
-            .where(RobotData.data["computed"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "cmd_vel")
+            .where(RobotData.computed.isnot(None))
+            .order_by(asc(RobotData.date))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -241,10 +263,10 @@ class PGSQLService:
         end_date: datetime.datetime | None = None,
     ):
         query = (
-            select(func.sum(RobotData.data["distance_traveled"].as_float()))
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "distance_traveled")
-            .where(RobotData.data["distance_traveled"].isnot(None))
+            select(func.sum(RobotData.distance_traveled))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "distance_traveled")
+            .where(RobotData.distance_traveled.isnot(None))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -266,10 +288,10 @@ class PGSQLService:
         end_date: datetime.datetime | None = None,
     ):
         query = (
-            select(func.avg(RobotData.data["computed"].as_float()))
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "speed")
-            .where(RobotData.data["computed"].isnot(None))
+            select(func.avg(RobotData.computed))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.name == "speed")
+            .where(RobotData.computed.isnot(None))
         )
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
@@ -291,34 +313,33 @@ class PGSQLService:
         end_date: datetime.datetime | None = None,
         storage: Storage = Storage.RUSTFS,
     ):
-        # Find last time with map present
-        subquery_last = (
-            select(
-                func.max(RobotData.time).label("max_time"),
-            )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["name"].as_string() == "map")
-            .where(RobotData.data["remote_paths"][storage]["png"].isnot(None))
-            .where(RobotData.data["remote_paths"][storage]["pgm"].isnot(None))
-            .where(RobotData.data["remote_paths"][storage]["yaml"].isnot(None))
+        complete_map = (
+            (RobotData.name == "map")
+            & remote_path(storage, "png").isnot(None)
+            & remote_path(storage, "pgm").isnot(None)
+            & remote_path(storage, "yaml").isnot(None)
         )
 
+        # Newest Record that uploaded a complete map (all three Files) within the selected
+        # run / time range.
+        subquery_last = (
+            select(func.max(RobotData.date))
+            .where(RobotData.robot_name == robot_name)
+            .where(complete_map)
+        )
         subquery_last = add_mode_query(
             subquery_last, run_id=run_id, start_date=start_date, end_date=end_date
         )
-        subquery_last.alias("subquery_last")
 
         query = (
             select(
-                RobotData.data["remote_paths"][storage]["png"],
-                RobotData.data["remote_paths"][storage]["pgm"],
-                RobotData.data["remote_paths"][storage]["yaml"],
+                remote_path(storage, "png"),
+                remote_path(storage, "pgm"),
+                remote_path(storage, "yaml"),
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["remote_paths"][storage]["png"].isnot(None))
-            .where(RobotData.data["remote_paths"][storage]["pgm"].isnot(None))
-            .where(RobotData.data["remote_paths"][storage]["yaml"].isnot(None))
-            .where(RobotData.time == subquery_last.c.max_time)
+            .where(RobotData.robot_name == robot_name)
+            .where(complete_map)
+            .where(RobotData.date == subquery_last.scalar_subquery())
         )
 
         result = pgsql_session.execute(query)
@@ -336,15 +357,15 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["active"],
-                RobotData.data["server_name"],
-                RobotData.data["host"],
-                RobotData.data["port"],
+                RECORD_TIME.label("time"),
+                RobotData.active,
+                RobotData.server_name,
+                RobotData.host,
+                RobotData.port,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["server_name"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.server_name.isnot(None))
+            .order_by(asc(RobotData.date))
         )
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
 
@@ -365,24 +386,20 @@ class PGSQLService:
     ):
         query = (
             select(
-                RobotData.time.label("time"),
-                RobotData.data["camera_name"].label("camera_name"),
-                RobotData.data["remote_paths"][storage]["raw"].label(f"remote_paths.{storage}.raw"),
-                RobotData.data["remote_paths"][storage]["rotated"].label(
-                    f"remote_paths.{storage}.rotated"
-                ),
-                RobotData.data["remote_paths"][storage]["inspected"].label(
-                    f"remote_paths.{storage}.inspected"
-                ),
-                RobotData.data["run_id"],
+                RECORD_TIME.label("time"),
+                RobotData.camera_name.label("camera_name"),
+                remote_path(storage, "raw").label("raw"),
+                remote_path(storage, "rotated").label("rotated"),
+                remote_path(storage, "inspected").label("inspected"),
+                RobotData.run_id,
             )
-            .where(RobotData.data["robot_name"].as_string() == robot_name)
-            .where(RobotData.data["camera_name"].isnot(None))
-            .order_by(asc("time"))
+            .where(RobotData.robot_name == robot_name)
+            .where(RobotData.camera_name.isnot(None))
+            .order_by(asc(RobotData.date))
         )
 
         if camera_name:
-            query = query.where(RobotData.data["camera_name"] == camera_name)
+            query = query.where(RobotData.camera_name == camera_name)
 
         query = add_mode_query(query, run_id=run_id, start_date=start_date, end_date=end_date)
 

--- a/dc_demos/dc_demos/streamlit_dashboard/lib/pgsql.py
+++ b/dc_demos/dc_demos/streamlit_dashboard/lib/pgsql.py
@@ -1,20 +1,11 @@
-import datetime
-import json
-
 from config import config
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-
-class DatetimeEncoder(json.JSONEncoder):
-    def default(self, obj: datetime.datetime):
-        try:
-            return super().default(obj)
-        except TypeError:
-            return obj.isoformat()
-
-
-engine = create_engine(config.READER_DB_URL_DATA, json_serializer=DatetimeEncoder)
+# Read-only: the dashboard only ever SELECTs. dc_bridge's `postgres` Destination (Vector's
+# postgres sink) is what writes this table, and it writes flat columns rather than a JSON
+# blob — so nothing here serialises JSON on the way in any more (#272).
+engine = create_engine(config.READER_DB_URL_DATA)
 
 PGBase = declarative_base()
 

--- a/dc_demos/dc_demos/streamlit_dashboard/models/__init__.py
+++ b/dc_demos/dc_demos/streamlit_dashboard/models/__init__.py
@@ -1,3 +1,3 @@
-from .robot_data import RobotData
+from .robot_data import RECORD_TIME, RobotData, to_epoch_nanos
 
-__all__ = ["RobotData"]
+__all__ = ["RECORD_TIME", "RobotData", "to_epoch_nanos"]

--- a/dc_demos/dc_demos/streamlit_dashboard/models/robot_data.py
+++ b/dc_demos/dc_demos/streamlit_dashboard/models/robot_data.py
@@ -1,11 +1,117 @@
+"""ORM view of the flat `dc` table dc_bridge's `postgres` Destination writes into.
+
+The DC 1.x embedded Fluent Bit `out_pgsql` plugin stored a whole Record as one JSON blob
+under a single `data` column. DC 2.0's Destination is Vector's built-in `postgres` sink
+(`dc_bridge/src/render.cpp`), which maps each **top-level key** of a Record's JSON payload
+onto an **existing column of the same name** — it creates neither tables nor columns. So
+there is no `data` blob to path into any more: every field is its own column, and a column
+that no Record populates simply stays NULL (see #272).
+
+The column list below mirrors `tools/infrastructure/docker/config/postgresql/init.sql`,
+which is the schema the demo compose stack creates. Columns are a superset across the demos,
+so most are NULL for any given row; the measurement that populates each one is noted.
+
+**Which demo this dashboard reads**: `dc_demos/params/tb3_simulation_pgsql_minio.yaml`. Its
+Measurements are exactly this dashboard's pages (cpu/memory/os -> System, speed/cmd_vel/
+distance_traveled/camera -> Robot, map -> Environment, `*_health` -> Infrastructure), and
+each is shipped to Postgres as its own Record, so its fields land on top-level columns.
+The other pgsql demo (`qrcodes_minio_pgsql.yaml`) ships a merged **Group** Record instead,
+whose top-level keys are its members' `group_key`s (`cmd_vel`, `position`, `speed` as jsonb
+objects) and which carries no top-level `robot_name`/`run_id` at all — it cannot drive this
+dashboard's robot/run selectors. That demo is covered by the Grafana dashboards in
+`tools/infrastructure/docker/config/grafana/dashboards/` instead.
+"""
+
 from config import config
 from lib import PGBase
-from sqlalchemy import Column, DateTime
-from sqlalchemy.dialects.postgresql import JSON
+from sqlalchemy import BigInteger, Boolean, Column, Float, Integer, Text, cast, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import TIMESTAMP
 
 
 class RobotData(PGBase):
+    """One row of the `dc` table — a single Record, one column per top-level JSON key."""
+
     __tablename__ = config.PGSQL_TABLE
 
-    time = Column(DateTime, nullable=False, primary_key=True)
-    data = Column(JSON, nullable=False)
+    # --- Common to every Record -------------------------------------------------------
+    # The Record timestamp, as epoch **nanoseconds** — see `RECORD_TIME` below. Declared
+    # primary key because SQLAlchemy's declarative mapper requires one; the real table has
+    # none (Vector only ever INSERTs). Harmless here: this model is read-only and every
+    # query selects columns rather than entities, so no identity map is involved.
+    date = Column(BigInteger, primary_key=True)
+    name = Column(Text)
+    robot_name = Column(Text)
+    # `id` is the machine-id the demo reads out of /etc/machine-id, mapped under a
+    # non-builtin attribute name.
+    machine_id = Column("id", Text)
+    run_id = Column(Text)
+    flattened = Column(Boolean)
+    nested = Column(Boolean)
+    tags = Column(JSONB)
+    plugins = Column(JSONB)
+
+    # --- System: memory / os / uptime / cpu --------------------------------------------
+    used = Column(Float)  # memory
+    os = Column(Text)
+    kernel = Column(Text)
+    cpus = Column(Integer)
+    memory = Column(Float)
+    free_percent = Column(Float)
+    free = Column(BigInteger)
+    capacity = Column(BigInteger)
+    # `time` is the **uptime** Measurement's seconds-since-boot, not the Record timestamp
+    # (that is `date`). Mapped under a different attribute name so the two can't be
+    # confused the way they were before #272.
+    uptime = Column("time", Float)
+    average = Column(Float)  # cpu
+    processes = Column(Integer)  # cpu
+
+    # --- Robot: camera / map / speed / cmd_vel / distance_traveled ---------------------
+    camera_name = Column(Text)
+    local_paths = Column(JSONB)
+    remote_paths = Column(JSONB)
+    base64 = Column(JSONB)
+    inspected = Column(JSONB)
+    resolution = Column(Float)  # map
+    origin = Column(JSONB)  # map
+    width = Column(Integer)  # map
+    height = Column(Integer)  # map
+    # Magnitude of the twist, emitted by both the speed and the cmd_vel Measurements —
+    # they are separate Records, told apart by `name`.
+    computed = Column(Float)
+    distance_traveled = Column(Float)
+    # Group-Record columns, populated by qrcodes_minio_pgsql.yaml's "robot" Group only.
+    cmd_vel = Column(JSONB)
+    position = Column(JSONB)
+    speed = Column(JSONB)
+
+    # --- Infrastructure: tcp_health ----------------------------------------------------
+    host = Column(Text)
+    port = Column(Integer)
+    server_name = Column(Text)
+    active = Column(Boolean)
+
+
+# The demos configure the postgres Destination with `time_key: "date"` and leave
+# `time_format` at its `epoch_nanos` default (dc_bridge/src/render.cpp), so the Record
+# timestamp arrives as an i64 of nanoseconds. Every page here wants a real timestamp, so
+# queries select and order on this expression — the same conversion the demo's Grafana
+# dashboards use. Cast back down to a naive `timestamp` (local time, as the server sees it)
+# so pandas/Streamlit keep comparing it against the naive datetimes the sidebar produces.
+RECORD_TIME = cast(func.to_timestamp(RobotData.date / 1e9), TIMESTAMP)
+
+
+def to_epoch_nanos(moment) -> int:
+    """Convert a Python datetime to the epoch-nanosecond integer stored in `date`.
+
+    Filtering on the raw `date` column keeps the comparison exact and index-friendly,
+    rather than converting every row before comparing it.
+
+    Args:
+        moment (datetime.datetime): Naive local, or timezone-aware, datetime to convert
+
+    Returns:
+        int: Nanoseconds since the epoch, as dc_bridge's postgres Destination stores them
+    """
+    return int(moment.timestamp() * 1e9)

--- a/dc_demos/dc_demos/streamlit_dashboard/pages/2_Robot.py
+++ b/dc_demos/dc_demos/streamlit_dashboard/pages/2_Robot.py
@@ -85,7 +85,7 @@ class Speed(Section):
                 end_date=st.session_state.get("end_date", None),
             )
             if average_speed_run:
-                speed_annotation_text = f"Avg speed ({round(average_speed_run,2)})"
+                speed_annotation_text = f"Avg speed ({round(average_speed_run, 2)})"
             else:
                 speed_annotation_text = 0
             self.fig.add_hline(
@@ -240,74 +240,44 @@ class CameraImages(Section):
             )
         assert self.df.empty is False
 
+    # A gallery grid — the case the Uploader's optional thumbnails (#256) exist for.
+    # `gallery_url` serves the `.thumb.jpg` preview when one was uploaded and the
+    # full-size File otherwise, so the grid stays correct whether or not
+    # `files.thumbnails` is enabled on the Bridge.
+    def display_gallery(self, tab, images, column: str) -> None:
+        """Lay the Files named by `column` out as a three-wide grid of previews."""
+        # `images` is a filtered slice, so its index is the parent frame's, not 0..n-1 —
+        # iterate the rows themselves rather than positions that may not be labels.
+        rows = [row for _, row in images.iterrows() if row[column]]
+        if not rows:
+            st.info("No data")
+            return
+        cols = tab.columns(3)
+        for count, row in enumerate(rows):
+            cols[count % 3].image(image=gallery_url(row[column]), caption=row["Date"])
+
     @Section.handler_display_data_backend_not_implemented
     @Section.handler_display_data_storage_not_implemented
     @Section.handler_display_data_none
     def display_data(self) -> None:
         assert self.df.empty is False
+        if self.storage != Storage.RUSTFS:
+            return
         camera_names = self.df["Camera Name"].unique()
-        if self.storage == Storage.RUSTFS:
-            camera_tabs = st.tabs(camera_names)
+        camera_tabs = st.tabs(list(camera_names))
 
-            for camera_tab_index, camera_tab in enumerate(camera_tabs):
-                with camera_tab:
-                    images_camera = self.df[
-                        self.df["Camera Name"] == camera_names[camera_tab_index]
-                    ]
-                    df_images_camera_raw = images_camera[images_camera["Raw remote path"].notna()]
-                    df_images_camera_rotated = images_camera[
-                        images_camera["Rotated remote path"].notna()
-                    ]
-                    df_images_camera_inspected = images_camera[
-                        images_camera["Inspected remote path"].notna()
-                    ]
+        for camera_tab_index, camera_tab in enumerate(camera_tabs):
+            with camera_tab:
+                images_camera = self.df[self.df["Camera Name"] == camera_names[camera_tab_index]]
 
-                    raw_tab, rotated_tab, inspected_tab = st.tabs(["Raw", "Rotated", "Inspected"])
+                raw_tab, rotated_tab, inspected_tab = st.tabs(["Raw", "Rotated", "Inspected"])
 
-                    # These three tabs are gallery grids — the case the Uploader's
-                    # optional thumbnails (#256) exist for. `gallery_url` serves the
-                    # `.thumb.jpg` preview when one was uploaded and the full-size File
-                    # otherwise, so the grid stays correct whether or not
-                    # `files.thumbnails` is enabled on the Bridge.
-                    with raw_tab:
-                        if self.storage == Storage.RUSTFS:
-                            if len(df_images_camera_raw):
-                                cols = raw_tab.columns(3)
-                                for i in range(len(df_images_camera_raw)):
-                                    cols[i % 3].image(
-                                        image=gallery_url(
-                                            df_images_camera_raw.loc[i, "Raw remote path"]
-                                        ),
-                                        caption=df_images_camera_raw.loc[i, "Date"],
-                                    )
-                            else:
-                                st.info("No data")
-                    with rotated_tab:
-                        if self.storage == Storage.RUSTFS:
-                            if len(df_images_camera_rotated):
-                                cols = rotated_tab.columns(3)
-                                for i in range(len(df_images_camera_rotated)):
-                                    cols[i % 3].image(
-                                        image=gallery_url(
-                                            df_images_camera_rotated.loc[i, "Rotated remote path"]
-                                        ),
-                                        caption=df_images_camera_raw.loc[i, "Date"],
-                                    )
-                            else:
-                                st.info("No data")
-                    with inspected_tab:
-                        if self.storage == Storage.RUSTFS:
-                            cols = inspected_tab.columns(3)
-                            if len(df_images_camera_inspected):
-                                for i in range(len(df_images_camera_inspected)):
-                                    cols[i % 3].image(
-                                        image=gallery_url(
-                                            df_images_camera_inspected.loc[i, "Rotated remote path"]
-                                        ),
-                                        caption=df_images_camera_inspected.loc[i, "Date"],
-                                    )
-                            else:
-                                st.info("No data")
+                with raw_tab:
+                    self.display_gallery(raw_tab, images_camera, "Raw remote path")
+                with rotated_tab:
+                    self.display_gallery(rotated_tab, images_camera, "Rotated remote path")
+                with inspected_tab:
+                    self.display_gallery(inspected_tab, images_camera, "Inspected remote path")
 
 
 def main():

--- a/progress.txt
+++ b/progress.txt
@@ -4552,3 +4552,91 @@ left alone: `pycln` and the two `poetry-requirements` hooks are broken in this e
 flags `dc_bringup/launch/dc_bringup.launch.py` and `tools/e2e/scripts/workload_generator.py`
 on this branch. `black` reformatted `tools/e2e/scripts/verify_zero_loss.py` again as a
 whole-repo side effect — reverted before committing, same as every prior entry.
+
+## #272: dc_demos Streamlit dashboard — flat-column ORM instead of a single JSON blob
+
+**Read**: the issue, `dc_demos/dc_demos/streamlit_dashboard/**` (config, `models/robot_data.py`,
+`backend/{pgsql,rustfs}.py`, `lib/{pgsql,common,section}.py`, all five `pages/*.py`),
+`dc_bridge/src/render.cpp`'s postgres sink + `render_normalize_source`,
+`tools/infrastructure/docker/config/postgresql/init.sql`, the demo Grafana dashboards, both
+pgsql demo params files, `dc_group/dc_group/group_server.py`, and the JSON-building code of
+every Measurement the dashboard reads (`camera/map/speed/cmd_vel/distance_traveled/position/
+cpu/memory/os/uptime/tcp_health.cpp`).
+
+**The bug**: `RobotData` still declared `time DateTime` + `data JSON`, the DC 1.x embedded
+Fluent Bit `out_pgsql` shape, and every query pathed into `RobotData.data[...]` JSONB. DC 2.0
+writes through Vector's built-in `postgres` sink, which maps each **top-level key** of a
+Record onto an **existing column of the same name** and creates nothing itself. There is no
+`data` column, so *every* query in `backend/pgsql.py` was dead against a real demo database.
+
+**Rewritten**:
+
+- `models/robot_data.py` — flat-column model mirroring `init.sql` column-for-column, grouped
+  by the Measurement that populates each one. Two columns are mapped under different
+  attribute names on purpose: `time` -> `uptime` (it is the uptime Measurement's
+  seconds-since-boot, *not* the Record timestamp — precisely the confusion that produced
+  this bug) and `id` -> `machine_id` (shadows a builtin; flake8 A003/VNE003).
+- The timestamp. The demos set `time_key: "date"` and leave `time_format` at its
+  `epoch_nanos` default, so the Record timestamp is a bigint of nanoseconds, not a
+  `DateTime`. Added `RECORD_TIME` (`to_timestamp(date / 1e9)`, cast back to a naive local
+  `timestamp` so the pages keep comparing it against the naive datetimes the sidebar builds)
+  — the same conversion the demo's Grafana dashboards use — and `to_epoch_nanos()` for the
+  reverse. Filters run on the raw `date` column (exact, index-friendly); only selected/
+  aggregated values go through `RECORD_TIME`.
+- `backend/pgsql.py` — all 12 queries onto flat columns. `get_last_map` also had a broken
+  correlated subquery (`.alias()` on a discarded value, then `RobotData.time ==
+  subquery_last.c.max_time`); it is now a real `scalar_subquery()`. `remote_paths` traversal
+  is factored into one `remote_path(storage, key)` helper that uses `.astext`, so the map and
+  camera pages get plain object paths rather than JSON-quoted strings.
+- `lib/pgsql.py` — dropped `DatetimeEncoder`/`json_serializer`, dead once nothing round-trips
+  a JSON blob (the dashboard only ever SELECTs).
+- `pages/2_Robot.py` — the camera gallery indexed filtered frames with `.loc[i]` for
+  `i in range(len(...))`, which `KeyError`s the moment any row is filtered out (the index is
+  the parent frame's), and the Inspected tab read the *Rotated* column while the Rotated tab
+  captioned from the *Raw* frame. Replaced the three near-duplicate blocks with one
+  `display_gallery()` that iterates rows.
+
+**Schema**: `init.sql` gained `computed` (twist magnitude — emitted by both speed.cpp and
+cmd_vel.cpp as standalone Records, told apart by `name`; nested under the `speed`/`cmd_vel`
+jsonb columns instead when the Records go through a Group) plus `average`/`processes` for the
+CPU panel. Without them the sink silently drops those keys and the Robot/System pages chart
+nothing. The header comment's "CPU fields are intentionally not enumerated" note was updated
+to name what genuinely stays unlisted (`sorted`, `linear`/`angular`, `x`/`y`/`yaw`).
+
+**Which demo the dashboard reads — documented in the model's docstring**:
+`tb3_simulation_pgsql_minio.yaml`, whose Measurements map one-to-one onto the dashboard's
+pages and each reach Postgres as their own Record. `qrcodes_minio_pgsql.yaml` ships a merged
+Group Record whose top-level keys are its members' `group_key`s and which carries no
+top-level `robot_name`/`run_id` at all (`nested_data` defaults true, and custom keys land
+nested under each member) — it cannot drive the robot/run selectors, so it is not a target;
+the Grafana dashboards cover it.
+
+**Verified for real, against live services** (not read-through): a `postgres:16-alpine`
+container created from the *actual* demo `init.sql`, seeded by a script that reproduces the
+JSON each Measurement plugin emits and then inserts it the way the sink does (top-level keys
+onto same-named columns, everything else dropped) — 62 Records, two robots, two runs, two
+maps. All 33 query assertions pass in both filter modes (run-id and time-range): correct row
+counts and values, real `datetime`s out of `RECORD_TIME`, the *newest* of the two maps from
+`get_last_map`, unquoted object paths, and `[]`/`None`/`-1` for a robot with no data.
+
+Then every page Section was rendered against that database plus a live MinIO holding the
+Files the Records point at (Streamlit 1.21 predates `streamlit.testing`, so the module was
+swapped for a recording stub and the Section classes driven directly — everything below the
+UI is the real thing, including the presigned URLs and the thumbnail probe). All 8 Sections
+render: OS 4 metrics, Memory/CPU/Speed/TCPServerHealth their charts (two, one per server),
+Robot its 2 metrics, Map three working download buttons whose bytes really came out of the
+store plus the image, and CameraImages 4 gallery tiles — 2 of them served as `.thumb.jpg`
+previews and 2 falling back to the original, so both sides of #256's optional-thumbnail path
+are exercised. The Rotated/Inspected tabs correctly show "No data": that demo runs the camera
+with `save_rotated_img`/`save_detections_img` false.
+
+**Not done, deliberately**: the issue asks whether the Streamlit dashboard is still wanted at
+all now that #251 ships Grafana over the same data, and notes deleting it would be less work.
+That is a product call, not one to make unilaterally — this fixes it as the checklist asks.
+Nothing in the repo depends on it either way (no launch file, no docs reference).
+
+**Verified**: `pre-commit` — `flake8` clean on all five changed Python files (including the
+pre-existing `E231` on `2_Robot.py:88`, fixed in passing), `black`/`isort`/`codespell` clean.
+Pre-existing, unrelated failures left alone: `pycln` and the two `poetry-requirements` hooks
+are broken in this environment. `black` reformatted `tools/e2e/scripts/verify_zero_loss.py`
+again as a whole-repo side effect — reverted before committing, same as every prior entry.

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -19,10 +19,10 @@
 -- (a merged Group Record's top-level keys are its members' own `group_key` names —
 -- `cmd_vel`, `position`, `speed` for the "robot" group used here — plus `tags`).
 --
--- CPU measurement fields are intentionally not enumerated below: no demo's Grafana
--- dashboard currently charts them (see doc/src/dc/demos/), so their JSON keys are
--- silently dropped by the sink rather than stored — add columns here first if you
--- wire up a CPU panel.
+-- The cpu Measurement's `sorted` per-process array and the position/speed/cmd_vel
+-- Measurements' `linear`/`angular`/`x`/`y`/`yaw` components are still intentionally not
+-- enumerated below: nothing charts them, so the sink silently drops those keys rather
+-- than storing them — add columns here first if you wire up a panel that needs one.
 CREATE TABLE IF NOT EXISTS dc (
   -- Common (every Record)
   date bigint,
@@ -44,6 +44,9 @@ CREATE TABLE IF NOT EXISTS dc (
   free bigint,
   capacity bigint,
   time double precision,
+  -- cpu.cpp's average CPU load and total process count (the demo dashboard's CPU panel)
+  average double precision,
+  processes integer,
   -- Robot (camera.cpp, map.cpp, and the "robot" group's merged cmd_vel/position/speed)
   camera_name text,
   local_paths jsonb,
@@ -58,6 +61,10 @@ CREATE TABLE IF NOT EXISTS dc (
   position jsonb,
   speed jsonb,
   distance_traveled double precision,
+  -- Twist magnitude, emitted by both speed.cpp and cmd_vel.cpp as standalone Records
+  -- (tb3_simulation_pgsql_minio); told apart by `name`. Nested under the `speed`/`cmd_vel`
+  -- jsonb columns above instead when the Records go through a Group (qrcodes_minio_pgsql).
+  computed double precision,
   -- Infrastructure (tcp_health.cpp)
   host text,
   port integer,


### PR DESCRIPTION
Closes #272

## The problem

`dc_demos`' Streamlit dashboard still assumed the DC 1.x embedded Fluent Bit `out_pgsql` shape:

```python
time = Column(DateTime, nullable=False, primary_key=True)
data = Column(JSON, nullable=False)
```

DC 2.0's Destination is Vector's built-in `postgres` sink (`dc_bridge/src/render.cpp`), which maps each **top-level key** of a Record onto an **existing column of the same name** and creates neither tables nor columns. There is no `data` column — so all 12 queries in `backend/pgsql.py` were dead against a real demo database, not just the two named in the issue.

## What changed

- **`models/robot_data.py`** — flat-column model mirroring `tools/infrastructure/docker/config/postgresql/init.sql`, grouped by the Measurement that populates each column. Two are mapped under different attribute names on purpose: `time` → `uptime` (it is the uptime Measurement's seconds-since-boot, *not* the Record timestamp — precisely the confusion that produced this bug) and `id` → `machine_id` (shadows a builtin).
- **The timestamp.** The demos set `time_key: "date"` and leave `time_format` at its `epoch_nanos` default, so the Record timestamp is a bigint of nanoseconds. Added `RECORD_TIME` (`to_timestamp(date / 1e9)`, cast back to a naive local `timestamp` so the pages keep comparing against the naive datetimes the sidebar builds — the same conversion the demo's Grafana dashboards use) and `to_epoch_nanos()` for the reverse. Filters run on the raw `date` column; only selected/aggregated values go through `RECORD_TIME`.
- **`backend/pgsql.py`** — all 12 queries onto flat columns, with `remote_paths` traversal factored into one `remote_path(storage, key)` helper using `.astext` so the map/camera pages get plain object paths rather than JSON-quoted strings.
- **`lib/pgsql.py`** — dropped `DatetimeEncoder`/`json_serializer`, dead once nothing round-trips a JSON blob.
- **`tools/infrastructure/docker/config/postgresql/init.sql`** — added `computed` (twist magnitude, emitted by both `speed.cpp` and `cmd_vel.cpp` as standalone Records, told apart by `name`) plus `average`/`processes` for the CPU panel. Without them the sink silently drops those keys and the Robot/System pages chart nothing.

### Bugs found and fixed along the way

- `get_last_map`'s correlated subquery never worked: `.alias()` was called on a discarded value and the outer query compared against `subquery_last.c.max_time`. It is now a real `scalar_subquery()`, so the newest map actually wins.
- The camera gallery indexed filtered frames with `.loc[i]` over `range(len(...))`, which `KeyError`s the moment any row is filtered out (the index is the parent frame's). The Inspected tab also read the *Rotated* column, and the Rotated tab captioned from the *Raw* frame. The three near-duplicate blocks are now one `display_gallery()`.
- Pre-existing `E231` on `2_Robot.py:88`, fixed in passing.

## Which demo the dashboard reads

Documented in the model's docstring: **`tb3_simulation_pgsql_minio.yaml`**, whose Measurements map one-to-one onto the dashboard's pages and each reach Postgres as their own Record. `qrcodes_minio_pgsql.yaml` ships a merged **Group** Record whose top-level keys are its members' `group_key`s and which carries no top-level `robot_name`/`run_id` at all (`nested_data` defaults true) — it cannot drive the robot/run selectors, so it is not a target. The Grafana dashboards cover that demo.

## Verification — against live services, not read-through

A `postgres:16-alpine` container created from the **actual** demo `init.sql`, seeded by a script that reproduces the JSON each Measurement plugin emits and inserts it the way the sink does (top-level keys onto same-named columns, everything else dropped): 62 Records, two robots, two runs, two maps.

**33 query assertions pass in both filter modes** (run-id and time-range): correct row counts and values, real `datetime`s out of `RECORD_TIME`, the newest of the two maps from `get_last_map`, unquoted object paths, and `[]`/`None`/`-1` for a robot with no data.

Then every page Section was rendered against that database plus a live MinIO holding the Files the Records point at (Streamlit 1.21 predates `streamlit.testing`, so the module was swapped for a recording stub and the Section classes driven directly — everything below the UI is real, including the presigned URLs and the thumbnail probe):

```
PASS  1_System.OS: 4 rendered ['metric', 'metric', 'metric', 'metric']
PASS  1_System.Memory: 1 rendered ['plotly_chart']
PASS  1_System.CPU: 1 rendered ['plotly_chart']
PASS  2_Robot.Robot: 2 rendered ['metric', 'metric']
PASS  2_Robot.Speed: 1 rendered ['plotly_chart']
PASS  2_Robot.CameraImages: 4 rendered ['image', 'image', 'image', 'image']
      -> 4 gallery tiles, 2 served as thumbnails
PASS  3_Environment.Map: 4 rendered ['download_button', ..., 'image']
      -> map downloads fetched from the store: [67, 12, 15] bytes
PASS  4_Infrastructure.TCPServerHealth: 2 rendered ['plotly_chart', 'plotly_chart']

every section rendered data
```

Half the camera Files were given a `.thumb.jpg` preview and half were not, so both sides of #256's optional-thumbnail path are exercised. The gallery's Rotated/Inspected tabs correctly show "No data": that demo runs the camera with `save_rotated_img`/`save_detections_img` false.

`pre-commit`: `flake8` clean on all five changed Python files, `black`/`isort`/`codespell` clean. `pycln` and the two `poetry-requirements` hooks are broken in this environment (pre-existing, unrelated).

## Open question left to you

The issue asks whether the Streamlit dashboard is still wanted at all now that #251 ships Grafana over the same data, and notes that deleting it would be less work than rewriting it. That is a product call, so this PR fixes it as the checklist asks rather than making it. Nothing in the repo depends on it either way — no launch file, no docs reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrZyqMouhNS3uZcBQLwmog