### PR TITLE
fix(demos): port the Nav2 QR-codes waypoint demo onto #268's gz-sim simulation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,7 @@
 # doesn't yet; here the images exist purely for CI-internal reuse + traceability.
 #
 #   build-workspace ─┬─▶ colcon-test        (pull dc-workspace, colcon test + coverage)
+#                    ├─▶ sim               (pull dc-workspace, simulation smoke check)
 #                    └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
 #
 # No CI-only build/test scripts: every step calls the same tools/e2e/scripts/build.sh /
@@ -158,19 +159,6 @@ jobs:
           IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
         run: ./tools/e2e/scripts/test.sh "$PWD/coverage"
 
-      # The static half of the daily simulation check (.github/workflows/sim.yaml),
-      # pulled forward to every PR because it costs seconds and covers a class of bug
-      # `colcon test` structurally cannot see: launch files, SDF and bridge configs are
-      # data, so a launch default pointing at a file Jazzy deleted, a model with two
-      # identically-named collisions, or a camera topic nothing bridges all compile and
-      # test perfectly while the demo is dead (#279, #324). The stages that need a
-      # running simulator stay in the daily job — they take tens of minutes.
-      - name: Lint launch files, SDF and the bridge config
-        env:
-          DC_SIM_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
-          DC_SIM_STAGES: lint
-        run: ./tools/sim/scripts/run.sh
-
       - name: Stop the test-dependency stores
         if: always()
         env:
@@ -184,6 +172,57 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/cpp.info
           flags: cpp-jazzy
+
+  # The simulation and demo layer is structurally invisible to the two jobs above:
+  # `colcon build` compiles dc_simulation and dc_demos, but their content is SDF, launch
+  # files, bridge configs and nav params -- data, not code -- and neither package has a
+  # single gtest. The e2e harness deliberately feeds the pipeline a synthetic workload so
+  # its zero-loss proof doesn't depend on a simulator. The result was a demo whose robot
+  # never spawned passing CI for two weeks (#324), next to a lidar that aborted the
+  # server and a nav params file still full of Humble-era keys (#279, #325).
+  #
+  # All four stages run here rather than only nightly: together they are roughly the
+  # length of the e2e job, and a broken demo is worth catching in review rather than the
+  # next morning. Only the *full* 60-waypoint pass is too slow for a PR, and that is what
+  # .github/workflows/sim.yaml runs daily.
+  sim:
+    needs: build-workspace
+    runs-on: ubuntu-latest
+    # Roughly 20 minutes when green on a 4-core runner; the headroom is for a contended
+    # runner, since the world already runs well under real time without a GPU.
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Log in to ghcr.io (to pull the workspace image)
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull the workspace image
+        run: podman pull "${{ needs.build-workspace.outputs.workspace_ref }}"
+
+      - name: Simulation smoke check
+        env:
+          DC_SIM_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
+          # Three waypoints is enough to prove planning, control, localization and the
+          # goal checker all work end to end -- each one costs about a minute and a half
+          # of wall clock here, and the daily job covers the full pass.
+          DC_SIM_WAYPOINTS: "3"
+        run: ./tools/sim/scripts/run.sh
+
+      - name: Upload simulation logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-logs
+          path: tools/sim/.run/**
+          if-no-files-found: ignore
 
   build-e2e-image:
     needs: build-workspace

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,6 +158,19 @@ jobs:
           IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
         run: ./tools/e2e/scripts/test.sh "$PWD/coverage"
 
+      # The static half of the daily simulation check (.github/workflows/sim.yaml),
+      # pulled forward to every PR because it costs seconds and covers a class of bug
+      # `colcon test` structurally cannot see: launch files, SDF and bridge configs are
+      # data, so a launch default pointing at a file Jazzy deleted, a model with two
+      # identically-named collisions, or a camera topic nothing bridges all compile and
+      # test perfectly while the demo is dead (#279, #324). The stages that need a
+      # running simulator stay in the daily job — they take tens of minutes.
+      - name: Lint launch files, SDF and the bridge config
+        env:
+          DC_SIM_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
+          DC_SIM_STAGES: lint
+        run: ./tools/sim/scripts/run.sh
+
       - name: Stop the test-dependency stores
         if: always()
         env:

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -1,0 +1,99 @@
+# Daily simulation check (#279).
+#
+# ci.yaml covers the code; nothing covers the simulation. `colcon build` and `colcon
+# test` never look at SDF, launch files, bridge configs or nav params — that layer is
+# data, not code — and the E2E harness deliberately feeds the pipeline a synthetic
+# workload so its zero-loss proof doesn't depend on a simulator. The result was a demo
+# whose robot never spawned passing CI for two weeks (#324), alongside a lidar that
+# aborted the server, a bridge on a dead topic, and a nav params file still full of
+# Humble-era keys (#279, #325).
+#
+# Not on push: the warehouse is 317 model instances and CI has no GPU, so it runs well
+# under real time (see dc_simulation/README.md). Daily is the right cadence — nothing
+# here changes often, and a failure a day after the fact is still far better than two
+# weeks.
+#
+# The waypoint stage asserts *progress*, not completion: reaching a handful of waypoints
+# proves planning, control, localization and the goal checker all work, where the full
+# 60-waypoint pass is an hour-plus even on a fast machine. Run the whole thing by hand
+# with workflow_dispatch and waypoints=60 when you want the real proof.
+
+name: Simulation
+
+on:
+  schedule:
+    # 03:17 UTC daily. Off the hour on purpose: GitHub's scheduler queues heavily at
+    # :00 and delays are common, which matters for a job that already takes a while.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      waypoints:
+        description: "Waypoints the follower must reach (60 = the full pass, ~1h+)"
+        required: false
+        default: "6"
+      stages:
+        description: "Subset of: lint sim nav waypoints"
+        required: false
+        default: "lint sim nav waypoints"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sim:
+    runs-on: ubuntu-latest
+    # Generously above the ~40 min a green run takes on a 4-core runner, so a slow day
+    # fails on an assertion rather than on the clock.
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Compute image refs
+        id: refs
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          IMAGE="ghcr.io/$(printf '%s' "$REPO" | tr '[:upper:]' '[:lower:]')"
+          {
+            echo "workspace_ref=$IMAGE/dc-workspace:sim-${{ github.sha }}"
+            echo "cache_ref=$IMAGE/dc-workspace-cache-sim"
+          } >> "$GITHUB_OUTPUT"
+
+      # Built here rather than pulled: a scheduled run has no upstream job to depend on,
+      # and the :<sha> image ci.yaml pushes only exists for commits CI actually ran.
+      # Its own cache ref, not ci.yaml's: build.sh's CACHE_REF is both --cache-from and
+      # --cache-to, and this job builds with CCOV=false, so sharing would keep
+      # overwriting the cached workspace layer with an uninstrumented one and cost
+      # ci.yaml a rebuild every morning. No coverage here — this measures behaviour.
+      - name: Build the DC workspace image
+        env:
+          IMAGE_TAG: ${{ steps.refs.outputs.workspace_ref }}
+          CACHE_REF: ${{ steps.refs.outputs.cache_ref }}
+          CCOV: "false"
+        run: ./tools/e2e/scripts/build.sh
+
+      - name: Run the simulation check
+        env:
+          DC_SIM_IMAGE: ${{ steps.refs.outputs.workspace_ref }}
+          DC_SIM_WAYPOINTS: ${{ inputs.waypoints || '6' }}
+          DC_SIM_STAGES: ${{ inputs.stages || 'lint sim nav waypoints' }}
+        run: ./tools/sim/scripts/run.sh
+
+      - name: Upload simulation logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sim-logs
+          path: tools/sim/.run/**
+          if-no-files-found: ignore

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -1,22 +1,16 @@
 # Daily simulation check (#279).
 #
-# ci.yaml covers the code; nothing covers the simulation. `colcon build` and `colcon
-# test` never look at SDF, launch files, bridge configs or nav params — that layer is
-# data, not code — and the E2E harness deliberately feeds the pipeline a synthetic
-# workload so its zero-loss proof doesn't depend on a simulator. The result was a demo
-# whose robot never spawned passing CI for two weeks (#324), alongside a lidar that
-# aborted the server, a bridge on a dead topic, and a nav params file still full of
-# Humble-era keys (#279, #325).
+# ci.yaml's `sim` job already runs the whole simulation check on every PR -- lint, the
+# headless sim, Nav2, and the waypoint follower far enough to prove planning, control,
+# localization and the goal checker all work. That is roughly twenty minutes and belongs
+# in review.
 #
-# Not on push: the warehouse is 317 model instances and CI has no GPU, so it runs well
-# under real time (see dc_simulation/README.md). Daily is the right cadence — nothing
-# here changes often, and a failure a day after the fact is still far better than two
-# weeks.
-#
-# The waypoint stage asserts *progress*, not completion: reaching a handful of waypoints
-# proves planning, control, localization and the goal checker all work, where the full
-# 60-waypoint pass is an hour-plus even on a fast machine. Run the whole thing by hand
-# with workflow_dispatch and waypoints=60 when you want the real proof.
+# What does *not* fit in a PR is the real thing: all 60 waypoints, three aisles, every
+# QR-coded pallet. That took 63 minutes of wall clock for 8 minutes of simulated time on
+# an 8-core machine with no GPU (RTF 0.198 -- see dc_simulation/README.md), so expect
+# appreciably longer on a runner. Once a day is the right cadence for it: it is the only
+# check that exercises the demo the way the documentation tells a user to run it, and
+# nothing in this layer changes often enough to need it per-push.
 
 name: Simulation
 
@@ -28,9 +22,9 @@ on:
   workflow_dispatch:
     inputs:
       waypoints:
-        description: "Waypoints the follower must reach (60 = the full pass, ~1h+)"
+        description: "Waypoints the follower must reach (60 = the full pass)"
         required: false
-        default: "6"
+        default: "60"
       stages:
         description: "Subset of: lint sim nav waypoints"
         required: false
@@ -43,9 +37,11 @@ concurrency:
 jobs:
   sim:
     runs-on: ubuntu-latest
-    # Generously above the ~40 min a green run takes on a 4-core runner, so a slow day
-    # fails on an assertion rather than on the clock.
-    timeout-minutes: 180
+    # The full pass was 63 min on 8 cores; a 4-core runner roughly doubles that, and the
+    # earlier stages and the image build come on top. Generous on purpose so a contended
+    # runner fails on an assertion rather than on the clock -- but well inside GitHub's
+    # 6-hour job ceiling, so a genuinely hung run still gets killed.
+    timeout-minutes: 300
     permissions:
       contents: read
       packages: write
@@ -83,10 +79,13 @@ jobs:
           CCOV: "false"
         run: ./tools/e2e/scripts/build.sh
 
-      - name: Run the simulation check
+      - name: Run the full simulation pass
         env:
           DC_SIM_IMAGE: ${{ steps.refs.outputs.workspace_ref }}
-          DC_SIM_WAYPOINTS: ${{ inputs.waypoints || '6' }}
+          DC_SIM_WAYPOINTS: ${{ inputs.waypoints || '60' }}
+          # The follower needs the whole pass to finish inside this; run.sh gives up on
+          # it rather than waiting for the job timeout, so the failure names the stage.
+          DC_SIM_WAYPOINT_TIMEOUT: "14400"
           DC_SIM_STAGES: ${{ inputs.stages || 'lint sim nav waypoints' }}
         run: ./tools/sim/scripts/run.sh
 

--- a/dc_demos/CMakeLists.txt
+++ b/dc_demos/CMakeLists.txt
@@ -30,10 +30,12 @@ install(
 # Install Python modules
 ament_python_install_package(${PROJECT_NAME})
 
-# Install Python executables
+# Install Python executables. RENAME drops the .py so the demo is run as
+# `ros2 run dc_demos qrcodes_waypoint_follower`, the usual ROS 2 spelling.
 install(PROGRAMS
   ${PROJECT_NAME}/qrcodes_waypoint_follower.py
   DESTINATION lib/${PROJECT_NAME}
+  RENAME qrcodes_waypoint_follower
 )
 
 include_directories(

--- a/dc_demos/dc_demos/qrcodes_waypoint_follower.py
+++ b/dc_demos/dc_demos/qrcodes_waypoint_follower.py
@@ -1,4 +1,7 @@
+#!/usr/bin/env python3
 """Follow waypoints using the ROS 2 Navigation Stack (Nav2)."""
+import sys
+
 import rclpy
 from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
 from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
@@ -19,8 +22,13 @@ def main():
     initial_pose.header.stamp = navigator.get_clock().now().to_msg()
     initial_pose.pose.position.x = -23.910843605740368
     initial_pose.pose.position.y = -13.887905581663327
-    initial_pose.pose.orientation.z = 0.7071068967259818
-    initial_pose.pose.orientation.w = 0.7248122257854975
+    # yaw 1.570796, the same pose qrcodes_nav.yaml's amcl initial_pose.* carries.
+    # The value transcribed here used to be (z=0.7071068967, w=0.7248122258),
+    # whose norm is 1.012 -- AMCL answers a non-unit quaternion with "Received
+    # initialpose message is malformed. Rejecting.", so this call did nothing and
+    # the demo silently relied on amcl's set_initial_pose instead (#279).
+    initial_pose.pose.orientation.z = 0.7071067811865476
+    initial_pose.pose.orientation.w = 0.7071067811865476
     navigator.setInitialPose(initial_pose)
     # Wait for navigation to fully activate. Use this line if autostart is set to true.
     navigator.waitUntilNav2Active()
@@ -91,35 +99,40 @@ def main():
     navigator.followWaypoints(goal_poses)
 
     i = 0
-    while rclpy.ok():
-        while not navigator.isTaskComplete():
-            # Do something with the feedback
-            i = i + 1
-            feedback = navigator.getFeedback()
-            if feedback and i % 5 == 0:
-                print(
-                    "Executing current waypoint: "
-                    + str(feedback.current_waypoint + 1)
-                    + "/"
-                    + str(len(goal_poses))
-                )
-                now = navigator.get_clock().now()
+    while not navigator.isTaskComplete():
+        # Do something with the feedback
+        i = i + 1
+        feedback = navigator.getFeedback()
+        if feedback and i % 5 == 0:
+            print(
+                "Executing current waypoint: "
+                + str(feedback.current_waypoint + 1)
+                + "/"
+                + str(len(goal_poses))
+            )
+            now = navigator.get_clock().now()
 
-                # Some navigation timeout to demo cancellation
-                if now - nav_start > Duration(seconds=100000000.0):
-                    navigator.cancelTask()
+            # Some navigation timeout to demo cancellation
+            if now - nav_start > Duration(seconds=100000000.0):
+                navigator.cancelTask()
 
-        # Do something depending on the return code
-        result = navigator.getResult()
-        if result == TaskResult.SUCCEEDED:
-            print("Goal succeeded!")
-        elif result == TaskResult.CANCELED:
-            print("Goal was canceled!")
-        elif result == TaskResult.FAILED:
-            print("Goal failed!")
-        else:
-            print("Goal has an invalid return status!")
+    # Do something depending on the return code
+    result = navigator.getResult()
+    if result == TaskResult.SUCCEEDED:
+        print("Goal succeeded!")
+    elif result == TaskResult.CANCELED:
+        print("Goal was canceled!")
+    elif result == TaskResult.FAILED:
+        print("Goal failed!")
+    else:
+        print("Goal has an invalid return status!")
+
+    # The pass is over once every waypoint has been visited. This used to sit
+    # inside a `while rclpy.ok():` loop, which re-entered with the task already
+    # complete and reprinted the result forever instead of exiting (#279).
+    rclpy.shutdown()
+    return 0 if result == TaskResult.SUCCEEDED else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/dc_demos/launch/tb3_qrcodes.launch.py
+++ b/dc_demos/launch/tb3_qrcodes.launch.py
@@ -18,6 +18,7 @@ def generate_launch_description():
     dc_description_dir = get_package_share_directory("dc_description")
     dc_bringup_dir = get_package_share_directory("dc_bringup")
     nav2_bringup_dir = get_package_share_directory("nav2_bringup")
+    nav2_launch_dir = os.path.join(nav2_bringup_dir, "launch")
 
     # Data Collection
     dc_params_file = LaunchConfiguration("dc_params_file")
@@ -37,12 +38,14 @@ def generate_launch_description():
     map_yaml_file = LaunchConfiguration("map")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
     use_simulator = LaunchConfiguration("use_simulator")
-    use_robot_state_pub = LaunchConfiguration("use_robot_state_pub")  # Should always be false
+    use_robot_state_pub = LaunchConfiguration("use_robot_state_pub")
     use_rviz = LaunchConfiguration("use_rviz")
     slam = LaunchConfiguration("slam")
     use_namespace = LaunchConfiguration("use_namespace")
     headless = LaunchConfiguration("headless")
     world = LaunchConfiguration("world")
+    robot_name = LaunchConfiguration("robot_name")
+    robot_sdf = LaunchConfiguration("robot_sdf")
     x_pose = LaunchConfiguration("x_pose", default="-16.679400")
     y_pose = LaunchConfiguration("y_pose", default="-15.300200")
     z_pose = LaunchConfiguration("z_pose", default="0.01")
@@ -67,12 +70,14 @@ def generate_launch_description():
     )
 
     declare_simulator_cmd = DeclareLaunchArgument(
-        "headless", default_value="True", description="Whether to execute gzclient"
+        "headless",
+        default_value="True",
+        description="Whether to run gz-sim server-only (no GUI)",
     )
 
     declare_use_robot_state_pub_cmd = DeclareLaunchArgument(
         "use_robot_state_pub",
-        default_value="False",
+        default_value="True",
         description="Whether to start the robot state publisher.",
     )
     declare_rviz_config_file_cmd = DeclareLaunchArgument(
@@ -91,7 +96,7 @@ def generate_launch_description():
     declare_robot_sdf_cmd = DeclareLaunchArgument(
         "robot_sdf",
         default_value=os.path.join(sim_dir, "worlds", "waffle.model"),
-        description="Full path to robot sdf file to spawn the robot in gazebo",
+        description="Full path to robot sdf file to spawn the robot in gz-sim",
     )
     declare_nav2_params_file_cmd = DeclareLaunchArgument(
         "nav2_params_file",
@@ -169,6 +174,7 @@ def generate_launch_description():
     remappings = [("/tf", "tf"), ("/tf_static", "tf_static")]
 
     start_robot_state_publisher_cmd = Node(
+        condition=IfCondition(use_robot_state_pub),
         package="robot_state_publisher",
         executable="robot_state_publisher",
         name="robot_state_publisher",
@@ -203,10 +209,35 @@ def generate_launch_description():
         }.items(),
     )
 
+    # The simulator half runs dc_simulation's own gz-sim bringup rather than
+    # nav2_bringup's tb3_simulation_launch.py. That launch file spawns
+    # nav2_minimal_tb3_sim's gz_waffle.sdf.xacro into nav2's own sandbox world
+    # with nav2's own ros_gz_bridge config -- a robot with one camera, nav2's
+    # topic names and none of the QR-code warehouse's props. Delegating to it
+    # meant this demo never ran against the robot/world/bridge #268 ported, and
+    # made the declared robot_sdf argument below unusable (it was never
+    # forwarded). warehouse.launch.py takes world, robot_sdf, robot_name and the
+    # full spawn pose, so all three now line up (#279).
+    warehouse_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(sim_dir, "launch", "warehouse.launch.py")),
+        condition=IfCondition(use_simulator),
+        launch_arguments={
+            "headless": headless,
+            "world": world,
+            "robot_name": robot_name,
+            "robot_sdf": robot_sdf,
+            "x_pose": x_pose,
+            "y_pose": y_pose,
+            "z_pose": z_pose,
+            "roll": roll,
+            "pitch": pitch,
+            "yaw": yaw,
+        }.items(),
+    )
+
+    # Nav2 itself (map_server + AMCL + planner/controller/behaviors/BT).
     nav2_bringup_cmd = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(nav2_bringup_dir, "launch", "tb3_simulation_launch.py")
-        ),
+        PythonLaunchDescriptionSource(os.path.join(nav2_launch_dir, "bringup_launch.py")),
         launch_arguments={
             "map": map_yaml_file,
             "params_file": nav2_params_file,
@@ -218,18 +249,16 @@ def generate_launch_description():
             "use_composition": use_composition,
             "use_respawn": use_respawn,
             "log_level": log_level,
-            "rviz_config_file": rviz_config_file,
-            "use_simulator": use_simulator,
-            "use_rviz": use_rviz,
-            "headless": headless,
-            "world": world,
-            "x_pose": x_pose,
-            "y_pose": y_pose,
-            "z_pose": z_pose,
-            "roll": roll,
-            "pitch": pitch,
-            "yaw": yaw,
-            "use_robot_state_pub": use_robot_state_pub,
+        }.items(),
+    )
+
+    rviz_cmd = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(nav2_launch_dir, "rviz_launch.py")),
+        condition=IfCondition(use_rviz),
+        launch_arguments={
+            "namespace": namespace,
+            "use_namespace": use_namespace,
+            "rviz_config": rviz_config_file,
         }.items(),
     )
 
@@ -266,6 +295,8 @@ def generate_launch_description():
     # Declare the launch options
     ld.add_action(dc_bringup_cmd)
     ld.add_action(start_robot_state_publisher_cmd)
+    ld.add_action(warehouse_cmd)
     ld.add_action(nav2_bringup_cmd)
+    ld.add_action(rviz_cmd)
 
     return ld

--- a/dc_demos/launch/tb3_simulation_influxdb.launch.py
+++ b/dc_demos/launch/tb3_simulation_influxdb.launch.py
@@ -13,7 +13,6 @@ def generate_launch_description():
     # Get the launch directory
     demos_dir = get_package_share_directory("dc_demos")
     dc_bringup_dir = get_package_share_directory("dc_bringup")
-    nav2_bringup_dir = get_package_share_directory("nav2_bringup")
 
     # Data Collection
     dc_params_file = LaunchConfiguration("dc_params_file")
@@ -25,42 +24,6 @@ def generate_launch_description():
     use_respawn = LaunchConfiguration("use_respawn")
     log_level = LaunchConfiguration("log_level")
     group_node = LaunchConfiguration("group_node")
-
-    declare_slam_cmd = DeclareLaunchArgument(
-        "slam", default_value="False", description="Whether run a SLAM"
-    )
-
-    declare_map_yaml_cmd = DeclareLaunchArgument(
-        "map",
-        default_value=os.path.join(nav2_bringup_dir, "maps", "turtlebot3_world.yaml"),
-        description="Full path to map file to load",
-    )
-
-    declare_use_namespace_cmd = DeclareLaunchArgument(
-        "use_namespace",
-        default_value="False",
-        description="Whether to apply a namespace to the navigation stack",
-    )
-
-    declare_simulator_cmd = DeclareLaunchArgument(
-        "headless", default_value="True", description="Whether to execute gzclient"
-    )
-
-    declare_rviz_config_file_cmd = DeclareLaunchArgument(
-        "rviz_config_file",
-        default_value=os.path.join(nav2_bringup_dir, "rviz", "nav2_default_view.rviz"),
-        description="Full path to the RVIZ config file to use",
-    )
-
-    declare_world_cmd = DeclareLaunchArgument(
-        "world",
-        # TODO(orduno) Switch back once ROS argument passing has been fixed upstream
-        #              https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/91
-        # default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-        # worlds/turtlebot3_worlds/waffle.model')
-        default_value=os.path.join(nav2_bringup_dir, "worlds", "world_only.model"),
-        description="Full path to world model file to load",
-    )
 
     # DC
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -107,15 +70,6 @@ def generate_launch_description():
         "log_level", default_value="info", description="log level"
     )
 
-    declare_use_simulator_cmd = DeclareLaunchArgument(
-        "use_simulator",
-        default_value="True",
-        description="Whether to start the simulator",
-    )
-
-    declare_use_rviz_cmd = DeclareLaunchArgument(
-        "use_rviz", default_value="True", description="Whether to start RVIZ"
-    )
     declare_group_node = DeclareLaunchArgument(
         "group_node", default_value="False", description="Start group_node"
     )
@@ -137,12 +91,19 @@ def generate_launch_description():
         }.items(),
     )
 
+    # This launch file starts DC only -- Nav2 and the simulator are launched
+    # separately (see the demo page). It used to also declare slam / map / world /
+    # headless / use_simulator / use_rviz / rviz_config_file / use_namespace, none
+    # of which it ever read: they were advertised by `--show-args` as if they
+    # controlled something, and their defaults pointed at
+    # nav2_bringup/worlds/world_only.model and nav2_bringup/maps/turtlebot3_world.yaml,
+    # both of which Jazzy's nav2_bringup no longer ships (#279).
+
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
     ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_dc_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
@@ -151,15 +112,7 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
 
-    ld.add_action(declare_slam_cmd)
-    ld.add_action(declare_map_yaml_cmd)
-    ld.add_action(declare_simulator_cmd)
-    ld.add_action(declare_use_simulator_cmd)
-    ld.add_action(declare_use_rviz_cmd)
-    ld.add_action(declare_world_cmd)
     ld.add_action(declare_group_node)
-
-    ld.add_action(declare_rviz_config_file_cmd)
 
     # Declare the launch options
     ld.add_action(dc_bringup_cmd)

--- a/dc_demos/launch/tb3_simulation_pgsql_minio.launch.py
+++ b/dc_demos/launch/tb3_simulation_pgsql_minio.launch.py
@@ -13,7 +13,6 @@ def generate_launch_description():
     # Get the launch directory
     demos_dir = get_package_share_directory("dc_demos")
     dc_bringup_dir = get_package_share_directory("dc_bringup")
-    nav2_bringup_dir = get_package_share_directory("nav2_bringup")
 
     # Data Collection
     dc_params_file = LaunchConfiguration("dc_params_file")
@@ -25,42 +24,6 @@ def generate_launch_description():
     use_respawn = LaunchConfiguration("use_respawn")
     log_level = LaunchConfiguration("log_level")
     group_node = LaunchConfiguration("group_node")
-
-    declare_slam_cmd = DeclareLaunchArgument(
-        "slam", default_value="False", description="Whether run a SLAM"
-    )
-
-    declare_map_yaml_cmd = DeclareLaunchArgument(
-        "map",
-        default_value=os.path.join(nav2_bringup_dir, "maps", "turtlebot3_world.yaml"),
-        description="Full path to map file to load",
-    )
-
-    declare_use_namespace_cmd = DeclareLaunchArgument(
-        "use_namespace",
-        default_value="False",
-        description="Whether to apply a namespace to the navigation stack",
-    )
-
-    declare_simulator_cmd = DeclareLaunchArgument(
-        "headless", default_value="True", description="Whether to execute gzclient"
-    )
-
-    declare_rviz_config_file_cmd = DeclareLaunchArgument(
-        "rviz_config_file",
-        default_value=os.path.join(nav2_bringup_dir, "rviz", "nav2_default_view.rviz"),
-        description="Full path to the RVIZ config file to use",
-    )
-
-    declare_world_cmd = DeclareLaunchArgument(
-        "world",
-        # TODO(orduno) Switch back once ROS argument passing has been fixed upstream
-        #              https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/91
-        # default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-        # worlds/turtlebot3_worlds/waffle.model')
-        default_value=os.path.join(nav2_bringup_dir, "worlds", "world_only.model"),
-        description="Full path to world model file to load",
-    )
 
     # DC
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -107,15 +70,6 @@ def generate_launch_description():
         "log_level", default_value="info", description="log level"
     )
 
-    declare_use_simulator_cmd = DeclareLaunchArgument(
-        "use_simulator",
-        default_value="True",
-        description="Whether to start the simulator",
-    )
-
-    declare_use_rviz_cmd = DeclareLaunchArgument(
-        "use_rviz", default_value="True", description="Whether to start RVIZ"
-    )
     declare_group_node = DeclareLaunchArgument(
         "group_node", default_value="False", description="Start group_node"
     )
@@ -137,12 +91,19 @@ def generate_launch_description():
         }.items(),
     )
 
+    # This launch file starts DC only -- Nav2 and the simulator are launched
+    # separately (see the demo page). It used to also declare slam / map / world /
+    # headless / use_simulator / use_rviz / rviz_config_file / use_namespace, none
+    # of which it ever read: they were advertised by `--show-args` as if they
+    # controlled something, and their defaults pointed at
+    # nav2_bringup/worlds/world_only.model and nav2_bringup/maps/turtlebot3_world.yaml,
+    # both of which Jazzy's nav2_bringup no longer ships (#279).
+
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
     ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_dc_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
@@ -151,15 +112,7 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
 
-    ld.add_action(declare_slam_cmd)
-    ld.add_action(declare_map_yaml_cmd)
-    ld.add_action(declare_simulator_cmd)
-    ld.add_action(declare_use_simulator_cmd)
-    ld.add_action(declare_use_rviz_cmd)
-    ld.add_action(declare_world_cmd)
     ld.add_action(declare_group_node)
-
-    ld.add_action(declare_rviz_config_file_cmd)
 
     # Declare the launch options
     ld.add_action(dc_bringup_cmd)

--- a/dc_demos/launch/tb3_simulation_stdout.launch.py
+++ b/dc_demos/launch/tb3_simulation_stdout.launch.py
@@ -13,7 +13,6 @@ def generate_launch_description():
     # Get the launch directory
     demos_dir = get_package_share_directory("dc_demos")
     dc_bringup_dir = get_package_share_directory("dc_bringup")
-    nav2_bringup_dir = get_package_share_directory("nav2_bringup")
 
     # Data Collection
     dc_params_file = LaunchConfiguration("dc_params_file")
@@ -25,42 +24,6 @@ def generate_launch_description():
     use_respawn = LaunchConfiguration("use_respawn")
     log_level = LaunchConfiguration("log_level")
     group_node = LaunchConfiguration("group_node")
-
-    declare_slam_cmd = DeclareLaunchArgument(
-        "slam", default_value="False", description="Whether run a SLAM"
-    )
-
-    declare_map_yaml_cmd = DeclareLaunchArgument(
-        "map",
-        default_value=os.path.join(nav2_bringup_dir, "maps", "turtlebot3_world.yaml"),
-        description="Full path to map file to load",
-    )
-
-    declare_use_namespace_cmd = DeclareLaunchArgument(
-        "use_namespace",
-        default_value="False",
-        description="Whether to apply a namespace to the navigation stack",
-    )
-
-    declare_simulator_cmd = DeclareLaunchArgument(
-        "headless", default_value="True", description="Whether to execute gzclient"
-    )
-
-    declare_rviz_config_file_cmd = DeclareLaunchArgument(
-        "rviz_config_file",
-        default_value=os.path.join(nav2_bringup_dir, "rviz", "nav2_default_view.rviz"),
-        description="Full path to the RVIZ config file to use",
-    )
-
-    declare_world_cmd = DeclareLaunchArgument(
-        "world",
-        # TODO(orduno) Switch back once ROS argument passing has been fixed upstream
-        #              https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/91
-        # default_value=os.path.join(get_package_share_directory('turtlebot3_gazebo'),
-        # worlds/turtlebot3_worlds/waffle.model')
-        default_value=os.path.join(nav2_bringup_dir, "worlds", "world_only.model"),
-        description="Full path to world model file to load",
-    )
 
     # DC
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -107,15 +70,6 @@ def generate_launch_description():
         "log_level", default_value="info", description="log level"
     )
 
-    declare_use_simulator_cmd = DeclareLaunchArgument(
-        "use_simulator",
-        default_value="True",
-        description="Whether to start the simulator",
-    )
-
-    declare_use_rviz_cmd = DeclareLaunchArgument(
-        "use_rviz", default_value="True", description="Whether to start RVIZ"
-    )
     declare_group_node = DeclareLaunchArgument(
         "group_node", default_value="True", description="Start group_node"
     )
@@ -137,12 +91,19 @@ def generate_launch_description():
         }.items(),
     )
 
+    # This launch file starts DC only -- Nav2 and the simulator are launched
+    # separately (see the demo page). It used to also declare slam / map / world /
+    # headless / use_simulator / use_rviz / rviz_config_file / use_namespace, none
+    # of which it ever read: they were advertised by `--show-args` as if they
+    # controlled something, and their defaults pointed at
+    # nav2_bringup/worlds/world_only.model and nav2_bringup/maps/turtlebot3_world.yaml,
+    # both of which Jazzy's nav2_bringup no longer ships (#279).
+
     # Create the launch description and populate
     ld = LaunchDescription()
 
     # Declare the launch options
     ld.add_action(declare_namespace_cmd)
-    ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_use_sim_time_cmd)
     ld.add_action(declare_dc_params_file_cmd)
     ld.add_action(declare_autostart_cmd)
@@ -151,15 +112,7 @@ def generate_launch_description():
     ld.add_action(declare_use_respawn_cmd)
     ld.add_action(declare_log_level_cmd)
 
-    ld.add_action(declare_slam_cmd)
-    ld.add_action(declare_map_yaml_cmd)
-    ld.add_action(declare_simulator_cmd)
-    ld.add_action(declare_use_simulator_cmd)
-    ld.add_action(declare_use_rviz_cmd)
-    ld.add_action(declare_world_cmd)
     ld.add_action(declare_group_node)
-
-    ld.add_action(declare_rviz_config_file_cmd)
 
     # Declare the launch options
     ld.add_action(dc_bringup_cmd)

--- a/dc_demos/params/qrcodes_nav.yaml
+++ b/dc_demos/params/qrcodes_nav.yaml
@@ -45,14 +45,6 @@ amcl:
     initial_pose.z: 0.0
     initial_pose.yaw: 1.570796
 
-amcl_map_client:
-  ros__parameters:
-    use_sim_time: True
-
-amcl_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
 bt_navigator:
   ros__parameters:
     use_sim_time: True
@@ -65,45 +57,17 @@ bt_navigator:
     # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
     # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
     # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
-    plugin_lib_names:
-      - nav2_compute_path_to_pose_action_bt_node
-      - nav2_compute_path_through_poses_action_bt_node
-      - nav2_smooth_path_action_bt_node
-      - nav2_follow_path_action_bt_node
-      - nav2_back_up_action_bt_node
-      - nav2_spin_action_bt_node
-      - nav2_wait_action_bt_node
-      - nav2_clear_costmap_service_bt_node
-      - nav2_is_stuck_condition_bt_node
-      - nav2_goal_reached_condition_bt_node
-      - nav2_goal_updated_condition_bt_node
-      - nav2_globally_updated_goal_condition_bt_node
-      - nav2_is_path_valid_condition_bt_node
-      - nav2_initial_pose_received_condition_bt_node
-      - nav2_reinitialize_global_localization_service_bt_node
-      - nav2_rate_controller_bt_node
-      - nav2_distance_controller_bt_node
-      - nav2_speed_controller_bt_node
-      - nav2_truncate_path_action_bt_node
-      - nav2_goal_updater_node_bt_node
-      - nav2_recovery_node_bt_node
-      - nav2_pipeline_sequence_bt_node
-      - nav2_round_robin_node_bt_node
-      - nav2_transform_available_condition_bt_node
-      - nav2_time_expired_condition_bt_node
-      - nav2_distance_traveled_condition_bt_node
-      - nav2_single_trigger_bt_node
-      - nav2_is_battery_low_condition_bt_node
-      - nav2_navigate_through_poses_action_bt_node
-      - nav2_navigate_to_pose_action_bt_node
-      - nav2_remove_passed_goals_action_bt_node
-      - nav2_planner_selector_bt_node
-      - nav2_controller_selector_bt_node
-      - nav2_goal_checker_selector_bt_node
-
-bt_navigator_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
+    #
+    # plugin_lib_names is deliberately left unset: the Humble-era list this demo
+    # used to carry names BT node libraries that no longer exist on Jazzy (for
+    # instance nav2_goal_reached_condition_bt_node), and bt_navigator throws
+    # while loading a missing library rather than skipping it. Jazzy's built-in
+    # default list already covers every node the two default trees use (#279).
+    navigators: ["navigate_to_pose", "navigate_through_poses"]
+    navigate_to_pose:
+      plugin: "nav2_bt_navigator::NavigateToPoseNavigator"
+    navigate_through_poses:
+      plugin: "nav2_bt_navigator::NavigateThroughPosesNavigator"
 
 controller_server:
   ros__parameters:
@@ -113,7 +77,7 @@ controller_server:
     min_y_velocity_threshold: 0.5
     min_theta_velocity_threshold: 0.001
     failure_tolerance: 0.3
-    progress_checker_plugin: "progress_checker"
+    progress_checker_plugins: ["progress_checker"]
     goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
     controller_plugins: ["FollowPath"]
 
@@ -185,10 +149,6 @@ controller_server:
       RotateToGoal.slowing_factor: 5.0
       RotateToGoal.lookahead_time: -1.0
 
-controller_server_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
 local_costmap:
   local_costmap:
     ros__parameters:
@@ -246,12 +206,6 @@ local_costmap:
         plugin: "nav2_costmap_2d::StaticLayer"
         map_subscribe_transient_local: True
       always_send_full_costmap: True
-  local_costmap_client:
-    ros__parameters:
-      use_sim_time: True
-  local_costmap_rclcpp_node:
-    ros__parameters:
-      use_sim_time: True
 
 global_costmap:
   global_costmap:
@@ -287,17 +241,19 @@ global_costmap:
         cost_scaling_factor: 3.0
         inflation_radius: 0.55
       always_send_full_costmap: True
-  global_costmap_client:
-    ros__parameters:
-      use_sim_time: True
-  global_costmap_rclcpp_node:
-    ros__parameters:
-      use_sim_time: True
 
 map_server:
   ros__parameters:
     use_sim_time: True
-    yaml_filename: "qrcodes.yaml"
+    # yaml_filename is deliberately absent. nav2_bringup's
+    # localization_launch.py supplies it from the `map` launch argument as an
+    # extra wildcard-scoped ("/**") parameter layered on top of this file, and a
+    # node-name-scoped ("map_server:") entry here takes precedence over that
+    # wildcard whatever the layering order -- so anything set here is what
+    # map_server really loads. The relative "qrcodes.yaml" this used to carry
+    # resolved against the process CWD and aborted the whole localization
+    # bringup; an empty string is no better, it just activates map_server with
+    # no map at all (#279).
 
 map_saver:
   ros__parameters:
@@ -313,41 +269,44 @@ planner_server:
     use_sim_time: True
     planner_plugins: ["GridBased"]
     GridBased:
-      plugin: "nav2_navfn_planner/NavfnPlanner"
+      plugin: "nav2_navfn_planner::NavfnPlanner"
       tolerance: 0.1
       use_astar: false
       allow_unknown: true
 
-planner_server_rclcpp_node:
-  ros__parameters:
-    use_sim_time: True
-
 smoother_server:
   ros__parameters:
     use_sim_time: True
-    plugin: "nav2_smoother::SimpleSmoother"
-    tolerance: 1.0e-10
-    do_refinement: True
-    max_its: 1000
-    w_data: 0.2
-    w_smooth: 0.3
+    smoother_plugins: ["simple_smoother"]
+    simple_smoother:
+      plugin: "nav2_smoother::SimpleSmoother"
+      tolerance: 1.0e-10
+      do_refinement: True
+      max_its: 1000
+      w_data: 0.2
+      w_smooth: 0.3
 
-recoveries_server:
+behavior_server:
   ros__parameters:
-    costmap_topic: local_costmap/costmap_raw
-    footprint_topic: local_costmap/published_footprint
+    use_sim_time: True
+    local_costmap_topic: local_costmap/costmap_raw
+    global_costmap_topic: global_costmap/costmap_raw
+    local_footprint_topic: local_costmap/published_footprint
+    global_footprint_topic: global_costmap/published_footprint
     cycle_frequency: 10.0
-    recovery_plugins: ["spin", "backup", "wait"]
+    behavior_plugins: ["spin", "backup", "drive_on_heading", "wait"]
     spin:
-      plugin: "nav2_behaviors/Spin"
+      plugin: "nav2_behaviors::Spin"
     backup:
-      plugin: "nav2_behaviors/BackUp"
+      plugin: "nav2_behaviors::BackUp"
+    drive_on_heading:
+      plugin: "nav2_behaviors::DriveOnHeading"
     wait:
-      plugin: "nav2_behaviors/Wait"
-    global_frame: odom
+      plugin: "nav2_behaviors::Wait"
+    local_frame: odom
+    global_frame: map
     robot_base_frame: base_link
     transform_tolerance: 0.1
-    use_sim_time: true
     simulate_ahead_time: 2.0
     max_rotational_vel: 1.0
     min_rotational_vel: 0.4
@@ -366,3 +325,76 @@ waypoint_follower:
       plugin: "nav2_waypoint_follower::WaitAtWaypoint"
       enabled: True
       waypoint_pause_duration: 200
+
+velocity_smoother:
+  ros__parameters:
+    use_sim_time: True
+    smoothing_frequency: 20.0
+    scale_velocities: False
+    feedback: "OPEN_LOOP"
+    # x, y, theta -- matched to controller_server's FollowPath limits
+    max_velocity: [0.26, 0.0, 1.0]
+    min_velocity: [-0.26, 0.0, -1.0]
+    max_accel: [2.5, 0.0, 3.2]
+    max_decel: [-2.5, 0.0, -3.2]
+    odom_topic: "odom"
+    odom_duration: 0.1
+    deadband_velocity: [0.0, 0.0, 0.0]
+    velocity_timeout: 1.0
+
+collision_monitor:
+  ros__parameters:
+    use_sim_time: True
+    base_frame_id: "base_footprint"
+    odom_frame_id: "odom"
+    cmd_vel_in_topic: "cmd_vel_smoothed"
+    cmd_vel_out_topic: "cmd_vel"
+    state_topic: "collision_monitor_state"
+    transform_tolerance: 0.2
+    source_timeout: 1.0
+    base_shift_correction: True
+    stop_pub_timeout: 2.0
+    polygons: ["FootprintApproach"]
+    FootprintApproach:
+      type: "polygon"
+      action_type: "approach"
+      footprint_topic: "/local_costmap/published_footprint"
+      time_before_collision: 1.2
+      simulation_time_step: 0.1
+      min_points: 6
+      visualize: False
+      enabled: True
+    observation_sources: ["scan"]
+    scan:
+      type: "scan"
+      topic: "scan"
+      min_height: 0.15
+      max_height: 2.0
+      enabled: True
+
+# opennav_docking is a Jazzy addition to navigation_launch.py's lifecycle_nodes.
+# This demo never docks, but the node still has to construct and configure or
+# lifecycle_manager aborts the entire navigation bringup. Both blocks below are
+# mandatory for that: without dock_plugins it fails to configure ("An error
+# occurred while getting the dock plugins!"), and without a docks list it throws
+# InvalidParameterValueException on 'docks' at construction and dies outright.
+# nav2's own nav2_params.yaml leaves docks commented out and hits exactly that,
+# so the placeholder dock here follows nav2_multirobot_params_1.yaml, which
+# spells out the shape the parser wants (#279).
+docking_server:
+  ros__parameters:
+    use_sim_time: True
+    controller_frequency: 50.0
+    dock_plugins: ["simple_charging_dock"]
+    simple_charging_dock:
+      plugin: "opennav_docking::SimpleChargingDock"
+      docking_threshold: 0.05
+      staging_x_offset: -0.7
+      use_external_detection_pose: false
+      use_battery_status: false
+      use_stall_detection: false
+    docks: ["home_dock"]
+    home_dock:
+      type: "simple_charging_dock"
+      frame: map
+      pose: [0.0, 0.0, 0.0]

--- a/dc_demos/params/tb3_simulation_influxdb.yaml
+++ b/dc_demos/params/tb3_simulation_influxdb.yaml
@@ -192,7 +192,10 @@ measurement_server:
       init_max_measurements: 0
       polling_interval: 3000
       node_name: "dc_measurement_camera"
-      cam_topic: "/intel_realsense_r200_depth/image_raw"
+      # dc_simulation's warehouse robot. Nav2's own sandbox waffle, which this
+      # demo used to run against, carries a 320x240 depth-only sensor and no RGB
+      # camera at all on Jazzy -- there was no topic here to subscribe to (#279).
+      cam_topic: "/left_intel_realsense_r200_depth/image_raw"
       cam_name: "Intel Realsense"
       draw_det_barcodes: false
       save_raw_img: false

--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -187,7 +187,10 @@ measurement_server:
       init_max_measurements: 0
       polling_interval: 3000
       node_name: "dc_measurement_camera"
-      cam_topic: "/intel_realsense_r200_depth/image_raw"
+      # dc_simulation's warehouse robot. Nav2's own sandbox waffle, which this
+      # demo used to run against, carries a 320x240 depth-only sensor and no RGB
+      # camera at all on Jazzy -- there was no topic here to subscribe to (#279).
+      cam_topic: "/left_intel_realsense_r200_depth/image_raw"
       cam_name: "Intel Realsense"
       enable_validator: true
       draw_det_barcodes: false

--- a/dc_description/package.xml
+++ b/dc_description/package.xml
@@ -7,6 +7,10 @@
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>
 
+    <!-- Ships the TurtleBot3 meshes the waffle URDF's visuals reference.
+         turtlebot3_gazebo, which used to provide them, has no Jazzy release, so
+         RViz rendered a robot with no geometry at all until #279. -->
+    <exec_depend>nav2_minimal_tb3_sim</exec_depend>
     <exec_depend>realsense2_description</exec_depend>
     <exec_depend>urdf</exec_depend>
     <exec_depend>xacro</exec_depend>

--- a/dc_description/urdf/turtlebot3_waffle_qrcodes.xacro
+++ b/dc_description/urdf/turtlebot3_waffle_qrcodes.xacro
@@ -70,7 +70,7 @@
     <visual>
       <origin xyz="-0.064 0 0.0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://turtlebot3_gazebo/models/turtlebot3_common/meshes/waffle_base.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/waffle_base.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="light_black"/>
     </visual>
@@ -100,7 +100,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://turtlebot3_gazebo/models/turtlebot3_common/meshes/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -130,7 +130,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="1.57 0 0"/>
       <geometry>
-        <mesh filename="package://turtlebot3_gazebo/models/turtlebot3_common/meshes/tire.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/tire.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>
@@ -209,7 +209,7 @@
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0"/>
       <geometry>
-        <mesh filename="package://turtlebot3_gazebo/models/turtlebot3_common/meshes/lds.dae" scale="0.001 0.001 0.001"/>
+        <mesh filename="package://nav2_minimal_tb3_sim/models/turtlebot3_model/meshes/lds.dae" scale="0.001 0.001 0.001"/>
       </geometry>
       <material name="dark"/>
     </visual>

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -470,7 +470,14 @@ public:
     }
     else
     {
-      RCLCPP_WARN_STREAM(logger_, "Message empty from measurement " << measurement_name_);
+      // Not necessarily a fault: a Measurement that found nothing to report
+      // returns an empty message on purpose -- Camera does exactly that on every
+      // frame with no barcode in view, which is most frames of the QR-code demo.
+      // Throttled and worded accordingly, because at the polling rate this used
+      // to read like a broken pipeline and sent #279 chasing one that was fine.
+      RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                  "No data collected from measurement "
+                                      << measurement_name_ << " (nothing to report, or it is not receiving input)");
     }
   }
 

--- a/dc_services/package.xml
+++ b/dc_services/package.xml
@@ -9,6 +9,13 @@
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>dc_interfaces</exec_depend>
+  <!-- draw_image.py / save_image.py import these directly. Undeclared until
+       #279: the workspace image installs dependencies through rosdep alone, so
+       draw_image died on "No module named 'pydantic'" and every Camera
+       measurement with draw_det_barcodes set waited forever on its service. -->
+  <exec_depend>cv_bridge</exec_depend>
+  <exec_depend>python3-opencv</exec_depend>
+  <exec_depend>python3-pydantic</exec_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/dc_services/package.xml
+++ b/dc_services/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>dc_services</name>
   <version>0.1.0</version>
   <description>Collect uptime data</description>

--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -1,0 +1,80 @@
+# dc_simulation
+
+The warehouse simulation the QR-code demos run in: a gz-sim (Gazebo Harmonic) world of
+QR-coded pallets, a TurtleBot3-Waffle with two RGBD cameras and a lidar, and the
+`ros_gz_bridge` config that re-exposes both as ROS topics.
+
+```bash
+ros2 launch dc_simulation warehouse.launch.py            # world + robot + bridge
+ros2 launch dc_simulation warehouse.launch.py headless:=True   # no GUI
+```
+
+`dc_demos`' `tb3_qrcodes.launch.py` includes this launch file and adds Nav2 and DC on
+top; see [the demo page](../doc/src/dc/demos/qrcodes_minio_pgsql.md).
+
+## Topics
+
+`config/warehouse_bridge.yaml` maps gz-transport onto ROS. The ROS-side names are the
+ones the Gazebo Classic `gazebo_ros` plugins used to publish directly, so
+`dc_measurements` params, the RViz config and the docs did not have to change when the
+simulation moved to gz-sim:
+
+| ROS topic | Source |
+|---|---|
+| `/clock` | gz-sim |
+| `/cmd_vel` (ROS→gz), `/odom`, `/tf` | `DiffDrive` system plugin |
+| `/joint_states` | `JointStatePublisher` system plugin |
+| `/scan` | `gpu_lidar` sensor |
+| `/imu` | `imu` sensor |
+| `/{left,right}_intel_realsense_r200_depth/{image_raw,camera_info,depth/image_raw}` | two `rgbd_camera` sensors |
+
+Every sensor sets `<gz_frame_id>` to the matching link in `dc_description`'s URDF.
+Without it gz-sensors stamps messages with the scoped sensor name, which is not a TF
+frame, and every tf2 `MessageFilter` downstream — AMCL, both Nav2 costmaps — silently
+drops the message.
+
+## Running headless, without a GPU
+
+The rendering sensors (`gpu_lidar` and both `rgbd_camera`s) **do** work with no GPU and
+no X server, which is how CI and the dev containers run. gz-sim's `ogre2` backend falls
+back to headless rendering on its own:
+
+```
+[Wrn] [Ogre2RenderEngine.cc:551] Unable to open display: . Trying to run in headless mode.
+```
+
+No extra packages, base image, or `<render_engine>` override is needed. What it costs is
+speed, and the cost is large enough to plan around:
+
+| Configuration | Real-time factor |
+|---|---|
+| Bare world, no robot | ~0.27 |
+| Full demo: world + robot + both RGBD cameras + Nav2 | ~0.20 |
+| World with the 240 pallet/bag/QR-code props removed | ~1.09 |
+
+(measured on 8 CPUs under software rendering; a full 60-waypoint pass of the QR-code
+demo took ~63 minutes of wall clock for ~8 minutes of simulated time.)
+
+The dominant cost is the **number of model instances**, not their meshes or collision
+geometry — 317 instances of 27 distinct models. Removing their collision geometry
+entirely only doubles the rate; removing the instances is what buys the 4x. See
+[#52](https://github.com/Minipada/ros2_data_collection/issues/52) if that matters for
+your use.
+
+One trap worth knowing, since it costs about 150x: gz-sim does **not** propagate a
+wrapper `<model>`'s `<static>` into an `<include>`d nested model. `qrcodes.world` wraps
+each prop in a `<static>1</static>` model, so any prop whose own `model.sdf` does not
+also declare `<static>` is simulated as a free rigid body. `models/europallet`,
+`models/europallet_10` and `models/bag` each declare it for exactly this reason — keep
+that in mind when adding props.
+
+Two smaller sharp edges in the same family:
+
+- A `gpu_lidar` `<range><min>` of `0` is fatal, not merely odd: gz-rendering feeds it to
+  Ogre as the ray frustum's near clip and Ogre throws
+  `InvalidParametersException: Near clip distance must be greater than zero`, which
+  aborts `gz sim`. Use a small positive value.
+- Two `<collision>` blocks with the same name inside one `<link>` is illegal SDF. Gazebo
+  Classic tolerated it; gz-sim rejects the entire spawn with
+  `Error Code 2: Msg: collision with name[collision] already exists`, and the robot
+  simply never appears in the world.

--- a/dc_simulation/config/warehouse_bridge.yaml
+++ b/dc_simulation/config/warehouse_bridge.yaml
@@ -50,37 +50,46 @@
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "left_camera/image_raw"
+# The two RGBD cameras. gz-sim derives its topic names from the sensor's
+# <topic> ("left_camera" -> /left_camera/image, /left_camera/depth_image,
+# /left_camera/camera_info), but the ROS side has to keep the names the Classic
+# libgazebo_ros_camera.so plugins published under -- <camera_name>/image_raw,
+# <camera_name>/camera_info and <camera_name>/depth/image_raw, with camera_name
+# = {left,right}_intel_realsense_r200_depth. dc_demos' qrcodes_*.yaml
+# cam_topic entries, the qrcodes.rviz displays and the demo docs all name those
+# topics, so renaming them here instead would break every consumer (#279).
+
+- ros_topic_name: "left_intel_realsense_r200_depth/image_raw"
   gz_topic_name: "/left_camera/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "left_camera/camera_info"
+- ros_topic_name: "left_intel_realsense_r200_depth/camera_info"
   gz_topic_name: "/left_camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "left_camera/depth/image_raw"
+- ros_topic_name: "left_intel_realsense_r200_depth/depth/image_raw"
   gz_topic_name: "/left_camera/depth_image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "right_camera/image_raw"
+- ros_topic_name: "right_intel_realsense_r200_depth/image_raw"
   gz_topic_name: "/right_camera/image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "right_camera/camera_info"
+- ros_topic_name: "right_intel_realsense_r200_depth/camera_info"
   gz_topic_name: "/right_camera/camera_info"
   ros_type_name: "sensor_msgs/msg/CameraInfo"
   gz_type_name: "gz.msgs.CameraInfo"
   direction: GZ_TO_ROS
 
-- ros_topic_name: "right_camera/depth/image_raw"
+- ros_topic_name: "right_intel_realsense_r200_depth/depth/image_raw"
   gz_topic_name: "/right_camera/depth_image"
   ros_type_name: "sensor_msgs/msg/Image"
   gz_type_name: "gz.msgs.Image"

--- a/dc_simulation/config/warehouse_bridge.yaml
+++ b/dc_simulation/config/warehouse_bridge.yaml
@@ -44,8 +44,13 @@
   gz_type_name: "gz.msgs.LaserScan"
   direction: GZ_TO_ROS
 
+# JointStatePublisher's <topic> in waffle.model overrides gz-sim's default
+# /world/<world>/model/<model>/joint_state. gz advertises that default name anyway but
+# never publishes on it, so bridging it produced a permanently silent /joint_states
+# (#279/#324). Bridging the plugin's own topic also drops this file's only dependency
+# on the world and model names, which renaming either used to break silently.
 - ros_topic_name: "joint_states"
-  gz_topic_name: "/world/warehouse/model/turtlebot3_waffle/joint_state"
+  gz_topic_name: "/joint_states"
   ros_type_name: "sensor_msgs/msg/JointState"
   gz_type_name: "gz.msgs.Model"
   direction: GZ_TO_ROS

--- a/dc_simulation/launch/warehouse.launch.py
+++ b/dc_simulation/launch/warehouse.launch.py
@@ -2,7 +2,11 @@ import os
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.actions import (
+    AppendEnvironmentVariable,
+    DeclareLaunchArgument,
+    IncludeLaunchDescription,
+)
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PythonExpression
 from launch_ros.actions import Node
@@ -11,6 +15,10 @@ from launch_ros.actions import Node
 def generate_launch_description():
     sim_dir = get_package_share_directory("dc_simulation")
     ros_gz_sim_dir = get_package_share_directory("ros_gz_sim")
+    # waffle.model's visuals are the TurtleBot3 meshes, which no longer ship in
+    # a Jazzy package of their own (turtlebot3_gazebo has no Jazzy release);
+    # nav2_minimal_tb3_sim is where they live now, under model://turtlebot3_model.
+    tb3_models_dir = os.path.join(get_package_share_directory("nav2_minimal_tb3_sim"), "models")
 
     # Launch configuration variables specific to simulation
     headless = LaunchConfiguration("headless")
@@ -20,6 +28,9 @@ def generate_launch_description():
     x_pose = LaunchConfiguration("x_pose")
     y_pose = LaunchConfiguration("y_pose")
     z_pose = LaunchConfiguration("z_pose")
+    roll = LaunchConfiguration("roll")
+    pitch = LaunchConfiguration("pitch")
+    yaw = LaunchConfiguration("yaw")
 
     declare_simulator_cmd = DeclareLaunchArgument(
         "headless",
@@ -54,6 +65,15 @@ def generate_launch_description():
     declare_z_pose_cmd = DeclareLaunchArgument(
         "z_pose", default_value="0.01", description="Initial robot z pose"
     )
+    declare_roll_cmd = DeclareLaunchArgument(
+        "roll", default_value="0.00", description="Initial robot roll"
+    )
+    declare_pitch_cmd = DeclareLaunchArgument(
+        "pitch", default_value="0.00", description="Initial robot pitch"
+    )
+    declare_yaw_cmd = DeclareLaunchArgument(
+        "yaw", default_value="0.00", description="Initial robot yaw"
+    )
 
     # gz-sim itself (server, with GUI unless headless)
     gz_sim_cmd = IncludeLaunchDescription(
@@ -81,6 +101,12 @@ def generate_launch_description():
             y_pose,
             "-z",
             z_pose,
+            "-R",
+            roll,
+            "-P",
+            pitch,
+            "-Y",
+            yaw,
         ],
     )
 
@@ -90,11 +116,21 @@ def generate_launch_description():
         package="ros_gz_bridge",
         executable="parameter_bridge",
         output="screen",
-        parameters=[{"config_file": os.path.join(sim_dir, "config", "warehouse_bridge.yaml")}],
+        parameters=[
+            {
+                "config_file": os.path.join(sim_dir, "config", "warehouse_bridge.yaml"),
+                # The bridge is the node that publishes /clock, so it has to run
+                # on the wall clock itself; everything downstream of it does not.
+                "use_sim_time": False,
+            }
+        ],
     )
+
+    set_tb3_model_path_cmd = AppendEnvironmentVariable("GZ_SIM_RESOURCE_PATH", tb3_models_dir)
 
     ld = LaunchDescription()
 
+    ld.add_action(set_tb3_model_path_cmd)
     ld.add_action(declare_simulator_cmd)
     ld.add_action(declare_world_cmd)
     ld.add_action(declare_robot_name_cmd)
@@ -102,6 +138,9 @@ def generate_launch_description():
     ld.add_action(declare_x_pose_cmd)
     ld.add_action(declare_y_pose_cmd)
     ld.add_action(declare_z_pose_cmd)
+    ld.add_action(declare_roll_cmd)
+    ld.add_action(declare_pitch_cmd)
+    ld.add_action(declare_yaw_cmd)
 
     ld.add_action(gz_sim_cmd)
     ld.add_action(spawn_robot_cmd)

--- a/dc_simulation/models/bag/model.sdf
+++ b/dc_simulation/models/bag/model.sdf
@@ -93,6 +93,11 @@
         </surface>
       </collision>
     </link>
-    <static>0</static>
+    <!-- Warehouse scenery: never moves, and gz-sim does not propagate the
+         <static> of the wrapper <model> in qrcodes.world down into this
+         included nested model, so without this every instance is simulated as
+         a free rigid body. At 176 pallets and bags that alone took the world
+         from ~0.27 to ~0.007 real-time factor (#279, feeds #52). -->
+    <static>1</static>
   </model>
 </sdf>

--- a/dc_simulation/models/europallet/model.sdf
+++ b/dc_simulation/models/europallet/model.sdf
@@ -1,6 +1,12 @@
 <?xml version='1.0' ?>
 <sdf version="1.7">
   <model name="europallet">
+    <!-- Warehouse scenery: never moves, and gz-sim does not propagate the
+         <static> of the wrapper <model> in qrcodes.world down into this
+         included nested model, so without this every instance is simulated as
+         a free rigid body. At 176 pallets and bags that alone took the world
+         from ~0.27 to ~0.007 real-time factor (#279, feeds #52). -->
+    <static>1</static>
     <!-- <pose>-0 -0 0 0 -0 0</pose> -->
     <link name="link">
       <collision name="collision">

--- a/dc_simulation/models/europallet_10/model.sdf
+++ b/dc_simulation/models/europallet_10/model.sdf
@@ -1,6 +1,12 @@
 <?xml version='1.0' ?>
 <sdf version="1.7">
   <model name="europallet_10">
+    <!-- Warehouse scenery: never moves, and gz-sim does not propagate the
+         <static> of the wrapper <model> in qrcodes.world down into this
+         included nested model, so without this every instance is simulated as
+         a free rigid body. At 176 pallets and bags that alone took the world
+         from ~0.27 to ~0.007 real-time factor (#279, feeds #52). -->
+    <static>1</static>
     <pose>0 0 0.61 0 0 0</pose>
 
     <link name="link">

--- a/dc_simulation/package.xml
+++ b/dc_simulation/package.xml
@@ -8,6 +8,10 @@
   <license>MPL-2.0</license>
 
   <exec_depend>dc_description</exec_depend>
+  <!-- Ships the TurtleBot3 meshes worlds/waffle.model's visuals reference
+       (model://turtlebot3_model). turtlebot3_gazebo, which used to provide
+       them, has no Jazzy release. -->
+  <exec_depend>nav2_minimal_tb3_sim</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>rclpy</exec_depend>

--- a/dc_simulation/package.xml
+++ b/dc_simulation/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>dc_simulation</name>
   <version>0.1.0</version>
   <description>Warehouse simulation.</description>

--- a/dc_simulation/worlds/waffle.model
+++ b/dc_simulation/worlds/waffle.model
@@ -33,7 +33,7 @@
         <pose>-0.064 0 0 0 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://turtlebot3_common/meshes/waffle_base.dae</uri>
+            <uri>model://turtlebot3_model/meshes/waffle_base.dae</uri>
             <scale>0.001 0.001 0.001</scale>
           </mesh>
         </geometry>
@@ -45,6 +45,11 @@
         <always_on>true</always_on>
         <update_rate>200</update_rate>
         <topic>imu</topic>
+        <!-- Without gz_frame_id, gz-sensors stamps messages with the scoped
+             sensor name ("turtlebot3_waffle/imu_link/tb3_imu"), which is not a
+             TF frame, and every tf2 MessageFilter downstream drops the message.
+             The name has to match the link in dc_description's URDF. -->
+        <gz_frame_id>imu_link</gz_frame_id>
         <imu>
           <angular_velocity>
             <x>
@@ -118,7 +123,7 @@
         <pose>-0.064 0 0.121 0 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://turtlebot3_common/meshes/lds.dae</uri>
+            <uri>model://turtlebot3_model/meshes/lds.dae</uri>
             <scale>0.001 0.001 0.001</scale>
           </mesh>
         </geometry>
@@ -130,6 +135,10 @@
         <pose>-0.064 0 0.15 0 0 0</pose>
         <update_rate>5</update_rate>
         <topic>scan</topic>
+        <!-- AMCL and both costmaps' obstacle_layer run the LaserScan through a
+             tf2 MessageFilter; the scan frame must be the URDF's base_scan link
+             or every scan is silently discarded. -->
+        <gz_frame_id>base_scan</gz_frame_id>
         <lidar>
           <scan>
             <horizontal>
@@ -140,7 +149,12 @@
             </horizontal>
           </scan>
           <range>
-            <min>0.00000</min>
+            <!-- Not 0: gz-rendering feeds this straight to Ogre as the GPU-ray
+                 frustum's near clip distance, and Ogre throws
+                 "Near clip distance must be greater than zero", which aborts
+                 gz sim outright. Same value nav2_minimal_tb3_sim's gz_waffle
+                 uses (#279). -->
+            <min>0.00001</min>
             <max>20.0</max>
             <resolution>0.015000</resolution>
           </range>
@@ -204,7 +218,7 @@
         <pose>0.0 0.144 0.023 0 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://turtlebot3_common/meshes/tire.dae</uri>
+            <uri>model://turtlebot3_model/meshes/tire.dae</uri>
             <scale>0.001 0.001 0.001</scale>
           </mesh>
         </geometry>
@@ -262,7 +276,7 @@
         <pose>0.0 -0.144 0.023 0 0 0</pose>
         <geometry>
           <mesh>
-            <uri>model://turtlebot3_common/meshes/tire.dae</uri>
+            <uri>model://turtlebot3_model/meshes/tire.dae</uri>
             <scale>0.001 0.001 0.001</scale>
           </mesh>
         </geometry>
@@ -366,6 +380,7 @@
         <update_rate>5</update_rate>
         <pose>0.064 -0.047 0.107 0 0 1.57</pose>
         <topic>left_camera</topic>
+        <gz_frame_id>camera_left_depth_optical_frame</gz_frame_id>
         <camera name="left_realsense_depth_camera">
           <image>
             <width>1280</width>
@@ -378,15 +393,6 @@
           </clip>
         </camera>
       </sensor>
-
-      <collision name="collision">
-        <pose>0 0.047 -0.005 0 0 0</pose>
-        <geometry>
-          <box>
-            <size>0.008 0.130 0.022</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
 
     <link name="right_camera_link">
@@ -418,6 +424,7 @@
         <update_rate>5</update_rate>
         <pose>0.064 -0.047 0.107 0 0 -1.57</pose>
         <topic>right_camera</topic>
+        <gz_frame_id>camera_right_depth_optical_frame</gz_frame_id>
         <camera name="right_realsense_depth_camera">
           <image>
             <width>1280</width>
@@ -430,15 +437,6 @@
           </clip>
         </camera>
       </sensor>
-
-      <collision name="collision">
-        <pose>0 0.047 -0.005 0 0 0</pose>
-        <geometry>
-          <box>
-            <size>0.008 0.130 0.022</size>
-          </box>
-        </geometry>
-      </collision>
     </link>
 
     <joint name="base_joint" type="fixed">
@@ -473,6 +471,16 @@
     <joint name='caster_back_left_joint' type='ball'>
       <parent>base_link</parent>
       <child>caster_back_left_link</child>
+    </joint>
+
+    <!-- imu_link carried no joint at all (pre-existing, inherited from the
+         Gazebo Classic model): under gz-sim's DART physics that made it a
+         free-falling body detached from the robot. Attached here at the same
+         offset dc_description's URDF uses. -->
+    <joint name="imu_joint" type="fixed">
+      <parent>base_link</parent>
+      <child>imu_link</child>
+      <pose>0.0 0 0.068 0 0 0</pose>
     </joint>
 
     <joint name="lidar_joint" type="fixed">

--- a/doc/src/dc/demos/memory_uptime_stdout.md
+++ b/doc/src/dc/demos/memory_uptime_stdout.md
@@ -16,7 +16,7 @@ ros2 launch dc_demos group_memory_uptime_stdout.launch.py
 [component_container_isolated-1] [{"memory":{"used":71.82553863525391},"date":1677673417.869207,"uptime":{"time":96906},"run_id":"221"}]
 ```
 
-This launchfile is a wrapper of [dc_bringup/launch/bringup.launch.py](https://github.com/Minipada/ros2_data_collection/blob/humble/dc_bringup/launch/dc_bringup.launch.py) which loads a [custom yaml configuration](https://github.com/Minipada/ros2_data_collection/blob/humble/dc_demos/params/group_memory_uptime_stdout.yaml)
+This launchfile is a wrapper of [dc_bringup/launch/bringup.launch.py](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_bringup/launch/dc_bringup.launch.py) which loads a [custom yaml configuration](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_demos/params/group_memory_uptime_stdout.yaml)
 
 ```admonish info
 Note that here the group node is started. It is one parameter in the launchfile to enable it. In the [uptime demo](./uptime_stdout.md), it is disabled by default because it is not used.

--- a/doc/src/dc/demos/qrcodes_minio_pgsql.md
+++ b/doc/src/dc/demos/qrcodes_minio_pgsql.md
@@ -2,18 +2,20 @@
 
 In this example, we add a robot and start collecting robot data to PostgreSQL, and maps and scanned QR codes to RustFS as image files.
 
-You will also need 2 terminal windows, to:
+You will also need 3 terminal windows, to:
 
-1. Run the Nav2 turtlebot3 launchfile: it starts localization, navigation and RViz
+1. Run the simulation + Nav2 launchfile: it starts gz-sim, localization, navigation and RViz
 2. Run DC
+3. Drive the robot past the QR codes
 
-Since RViz is pretty verbose, using 3 terminal windows will help reading the JSON printed on the terminal window.
+Keeping them separate helps reading the JSON printed on the DC terminal, which
+RViz and gz-sim would otherwise drown out.
 
-| Terminal | Description                                     |
-| -------- | ----------------------------------------------- |
-| RViz     | Start it independently because of its verbosity |
-| Nav2     | Localization and navigation                     |
-| DC       | Data collection                                 |
+| Terminal | Description                                        |
+| -------- | -------------------------------------------------- |
+| Nav2     | gz-sim, localization, navigation and RViz          |
+| DC       | Data collection                                     |
+| Run      | Waypoint follower driving past every QR-coded pallet |
 
 ## Setup RustFS and PostgreSQL
 
@@ -31,47 +33,41 @@ Vector's `postgres` sink maps each top-level key of a Record's JSON payload onto
 
 ## Setup the ROS environment
 
-In each, terminal, source your environment and setup turtlebot configuration:
+In each terminal, source your environment:
 
 ```bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source install/setup.bash
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/aws_robomaker_small_warehouse_world/models/
-export TURTLEBOT3_MODEL=waffle
 ```
 
-## Start RVIZ
-
-```bash
-ros2 run rviz2 rviz2 -d ${PWD}/install/dc_simulation/share/dc_simulation/rviz/qrcodes.rviz
-```
+Nothing else has to be exported. `dc_simulation`'s environment hook puts its own
+`models/` and `worlds/` on `GZ_SIM_RESOURCE_PATH`, and `warehouse.launch.py` adds
+`nav2_minimal_tb3_sim`'s models (where the TurtleBot3 meshes live now — the
+Gazebo Classic `turtlebot3_gazebo` package has no Jazzy release).
 
 ## Start Navigation
 
-Then, start the Turtlebot launchfile with custom parameters to start the QRcode world:
+`dc_demos`' own launch file brings up gz-sim with the QR-code warehouse world,
+spawns `dc_simulation`'s TurtleBot3-Waffle with its `ros_gz_bridge`, and starts
+Nav2 (`map_server` + AMCL + planners) against `dc_simulation/maps/qrcodes.yaml`.
+It also starts DC, which this demo drives separately, so turn that off here:
 
 ```bash
-ros2 launch nav2_bringup tb3_simulation_launch.py \
+ros2 launch dc_demos tb3_qrcodes.launch.py \
     headless:=False \
-    x_pose:="-16.679400" \
-    y_pose:="-15.300200" \
-    z_pose:="0.01" \
-    roll:="0.00" \
-    pitch:="0.00" \
-    yaw:="1.570796" \
-    robot_sdf:="${PWD}/install/dc_simulation/share/dc_simulation/worlds/waffle.model" \
-    map:="${PWD}/install/dc_simulation/share/dc_simulation/maps/qrcodes.yaml" \
-    world:="${PWD}/install/dc_simulation/share/dc_simulation/worlds/qrcodes.world" \
-    nav2_params_file:="${PWD}/install/dc_simulation/share/dc_demos/params/qrcodes_nav.yaml" \
-    dc_params_file:="${PWD}/install/dc_simulation/share/dc_demos/params/qrcodes_minio_pgsql.yaml" \
-    rviz_config_file:="${PWD}/install/dc_simulation/share/dc_simulation/rviz/qrcodes.rviz" \
-    use_rviz:=False
+    use_dc:=False
 ```
 
-RViz and Gazebo will start: you should now see the robot in Gazebo, and the map on RViz.
+gz-sim and RViz will start: you should see the robot in the warehouse, and the
+map in RViz. AMCL sets the demo's initial pose itself (`set_initial_pose` in
+`qrcodes_nav.yaml`), so there is no need to click "2D Pose Estimate" — wait until
+the laser scan lines up with the map before starting the run below.
 
-Set the robot position using the "2D Pose Estimate" button.
+```admonish warning
+The warehouse world is heavy: 317 model instances, most of them the QR-coded
+pallets themselves. Expect a slow start and a real-time factor well under 1 on a
+machine without a GPU. See [#52](https://github.com/Minipada/ros2_data_collection/issues/52).
+```
 
 ## Start DC
 
@@ -82,6 +78,16 @@ ros2 launch dc_demos tb3_qrcodes_minio_pgsql.launch.py
 ```
 
 With this, all data will be transmitted
+
+## Drive the robot past the QR codes
+
+In a fourth terminal, run the waypoint follower. It sends the robot down each
+aisle, stopping in front of every QR-coded pallet so both cameras can read them,
+and exits once the pass is complete:
+
+```bash
+ros2 run dc_demos qrcodes_waypoint_follower
+```
 
 ## Understanding the configuration
 

--- a/doc/src/dc/demos/tb3_aws_influxdb.md
+++ b/doc/src/dc/demos/tb3_aws_influxdb.md
@@ -59,45 +59,42 @@ cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_influxdb_si
 `dc_params_file`'s `custom_config_files` (see below) points at this path.
 
 ### Setup simulation environment
-In the terminal 1, source your environment, setup turtlebot configuration:
+In the terminal 1, source your environment:
 
 ```bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source install/setup.bash
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
-export GAZEBO_RESOURCE_PATH=${PWD}/src/aws-robomaker-small-warehouse-world/
-export TURTLEBOT3_MODEL=waffle
-source /usr/share/gazebo/setup.bash
 ```
 
-Verify the gazebo world can be loaded properly:
-
-```bash
-gazebo /opt/ros/humble/share/aws_robomaker_small_warehouse_world/worlds/no_roof_small_warehouse/no_roof_small_warehouse.world
-```
-
-Gazebo will start with the warehouse environment. You can close it now.
+Nothing else has to be exported. `dc_simulation` puts its own models and worlds on
+`GZ_SIM_RESOURCE_PATH` through its environment hook.
 
 ```admonish info
-
-I believe requiring the source along with those export are needed because of [this issue](https://github.com/aws-robotics/aws-robomaker-small-warehouse-world/issues/22)
+This demo used to run `aws_robomaker_small_warehouse_world` under Gazebo Classic. That
+package has no Jazzy release — its own jazzy branch still hard-depends on `gazebo_ros`,
+which was never published for Jazzy. The warehouse now comes from `dc_simulation`
+instead, which vendors the same AWS RoboMaker props (shelves, clutter, trash cans) into
+a gz-sim world of its own.
 ```
 
 ## Terminal 1: Start Navigation
 
-Then, in the same terminal (1), start the Turtlebot launchfile:
+Then, in the same terminal (1), start the simulation and Nav2. DC comes up separately in
+terminal 2, so turn it off here:
 
 ```bash
-ros2 launch nav2_bringup tb3_simulation_launch.py \
-    world:=/opt/ros/humble/share/aws_robomaker_small_warehouse_world/worlds/no_roof_small_warehouse/no_roof_small_warehouse.world \
-    map:=/opt/ros/humble/share/aws_robomaker_small_warehouse_world/maps/005/map.yaml \
+ros2 launch dc_demos tb3_qrcodes.launch.py \
     headless:=False \
-    x_pose:=3.45 \
-    y_pose:=2.15 \
-    yaw:=3.14
+    use_dc:=False
 ```
 
-RViz and Gazebo will start: now you see the robot in Gazebo, and the map on RViz.
+RViz and gz-sim will start: now you see the robot in the warehouse, and the map on RViz.
+AMCL sets the initial pose itself, so there is no need to click "2D Pose Estimate".
+
+```admonish warning
+The warehouse world is heavy — 317 model instances. Expect a slow start and a real-time
+factor well under 1 without a GPU; see `dc_simulation/README.md` for measured numbers.
+```
 
 ![RViz](../../images/demos-tb3_aws_minio_pgsql-rviz-1.png)
 ![Gazebo](../../images/demos-tb3_aws_minio_pgsql-gz-1.png)

--- a/doc/src/dc/demos/tb3_aws_minio_pgsql.md
+++ b/doc/src/dc/demos/tb3_aws_minio_pgsql.md
@@ -47,45 +47,42 @@ The default yaml configuration file does not need change as it also uses default
 ```
 
 ### Setup simulation environment
-In the terminal 1, source your environment, setup turtlebot configuration:
+In the terminal 1, source your environment:
 
 ```bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source install/setup.bash
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
-export GAZEBO_RESOURCE_PATH=${PWD}/src/aws-robomaker-small-warehouse-world/
-export TURTLEBOT3_MODEL=waffle
-source /usr/share/gazebo/setup.bash
 ```
 
-Verify the gazebo world can be loaded properly:
-
-```bash
-gazebo /opt/ros/humble/share/aws_robomaker_small_warehouse_world/worlds/small_warehouse/small_warehouse.world
-```
-
-Gazebo will start with the warehouse environment. You can close it now.
+Nothing else has to be exported. `dc_simulation` puts its own models and worlds on
+`GZ_SIM_RESOURCE_PATH` through its environment hook.
 
 ```admonish info
-
-I believe requiring the source along with those export are needed because of [this issue](https://github.com/aws-robotics/aws-robomaker-small-warehouse-world/issues/22)
+This demo used to run `aws_robomaker_small_warehouse_world` under Gazebo Classic. That
+package has no Jazzy release — its own jazzy branch still hard-depends on `gazebo_ros`,
+which was never published for Jazzy. The warehouse now comes from `dc_simulation`
+instead, which vendors the same AWS RoboMaker props (shelves, clutter, trash cans) into
+a gz-sim world of its own.
 ```
 
 ## Terminal 1: Start Navigation
 
-Then, in the same terminal (1), start the Turtlebot launchfile:
+Then, in the same terminal (1), start the simulation and Nav2. DC comes up separately in
+terminal 2, so turn it off here:
 
 ```bash
-ros2 launch nav2_bringup tb3_simulation_launch.py \
-    world:=/opt/ros/humble/share/aws_robomaker_small_warehouse_world/worlds/no_roof_small_warehouse/no_roof_small_warehouse.world \
-    map:=/opt/ros/humble/share/aws_robomaker_small_warehouse_world/maps/005/map.yaml \
+ros2 launch dc_demos tb3_qrcodes.launch.py \
     headless:=False \
-    x_pose:=3.45 \
-    y_pose:=2.15 \
-    yaw:=3.14
+    use_dc:=False
 ```
 
-RViz and Gazebo will start: now you see the robot in Gazebo, and the map on RViz.
+RViz and gz-sim will start: now you see the robot in the warehouse, and the map on RViz.
+AMCL sets the initial pose itself, so there is no need to click "2D Pose Estimate".
+
+```admonish warning
+The warehouse world is heavy — 317 model instances. Expect a slow start and a real-time
+factor well under 1 without a GPU; see `dc_simulation/README.md` for measured numbers.
+```
 
 ![RViz](../../images/demos-tb3_aws_minio_pgsql-rviz-1.png)
 ![Gazebo](../../images/demos-tb3_aws_minio_pgsql-gz-1.png)

--- a/doc/src/dc/demos/tb3_stdout.md
+++ b/doc/src/dc/demos/tb3_stdout.md
@@ -14,11 +14,14 @@ Since RViz is pretty verbose, using 2 terminal windows will help reading the JSO
 In each, terminal, source your environment and setup turtlebot configuration:
 
 ```bash
-source /opt/ros/humble/setup.bash
+source /opt/ros/jazzy/setup.bash
 source install/setup.bash
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH:/opt/ros/humble/share/turtlebot3_gazebo/models
-export TURTLEBOT3_MODEL=waffle
 ```
+
+Nothing else has to be exported. Nav2's own `nav2_minimal_tb3_sim` ships the world, the
+robot and its `ros_gz_bridge` config, and puts them on `GZ_SIM_RESOURCE_PATH` itself —
+the Gazebo Classic `GAZEBO_MODEL_PATH` and `TURTLEBOT3_MODEL` variables are gone along
+with Classic.
 
 ## Start Navigation
 

--- a/doc/src/dc/demos/uptime_stdout.md
+++ b/doc/src/dc/demos/uptime_stdout.md
@@ -17,7 +17,7 @@ At the end, the data is displayed:
 [component_container_isolated-1] [{"date":1677668926.700422,"time":92415,"id":"be781e5ffb1e7ee4f817fe7b63e92c32","robot_name":"C3PO","run_id":"218"}]
 ```
 
-This launchfile is a wrapper of [dc_bringup/launch/bringup.launch.py](https://github.com/Minipada/ros2_data_collection/blob/humble/dc_bringup/launch/dc_bringup.launch.py) which loads a [custom yaml configuration](https://github.com/Minipada/ros2_data_collection/blob/humble/dc_demos/params/uptime_stdout.yaml)
+This launchfile is a wrapper of [dc_bringup/launch/bringup.launch.py](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_bringup/launch/dc_bringup.launch.py) which loads a [custom yaml configuration](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_demos/params/uptime_stdout.yaml)
 
 ## Configuration
 ### Measurement
@@ -54,7 +54,7 @@ measurement_server:
 
 **uptime.polling_interval (Optional)**: Interval to which data is collected in milliseconds
 
-**uptime.enable_validator (Optional)**: Will validate the data against a JSON schema. This file is located in the [dc_measurements package](https://github.com/Minipada/ros2_data_collection/tree/humble/dc_measurements/plugins/measurements/json). You can provide your own using the `json_schema_path` parameter, which we will explore later on
+**uptime.enable_validator (Optional)**: Will validate the data against a JSON schema. This file is located in the [dc_measurements package](https://github.com/Minipada/ros2_data_collection/tree/jazzy/dc_measurements/plugins/measurements/json). You can provide your own using the `json_schema_path` parameter, which we will explore later on
 
 **uptime.debug (Optional)**: More verbose output
 

--- a/progress.txt
+++ b/progress.txt
@@ -4640,3 +4640,188 @@ pre-existing `E231` on `2_Robot.py:88`, fixed in passing), `black`/`isort`/`code
 Pre-existing, unrelated failures left alone: `pycln` and the two `poetry-requirements` hooks
 are broken in this environment. `black` reformatted `tools/e2e/scripts/verify_zero_loss.py`
 again as a whole-repo side effect — reverted before committing, same as every prior entry.
+
+## #279: dc_demos' Nav2 QR-codes waypoint-follower demo — ported onto #268's gz-sim port
+
+**Read**: the issue, #268 (its parent port) and #51/#52 (the two pre-existing bugs #279's
+checklist asks to re-check), `dc_demos/launch/tb3_qrcodes{,_minio_pgsql}.launch.py`,
+`dc_demos/dc_demos/qrcodes_waypoint_follower.py`, `dc_demos/params/qrcodes_{nav,stdout,
+minio_pgsql}.yaml`, `dc_simulation/{launch/warehouse.launch.py,config/warehouse_bridge.yaml,
+worlds/{qrcodes.world,waffle.model},maps/qrcodes.yaml,models/**}`,
+`dc_description/urdf/turtlebot3_waffle_qrcodes.xacro`, and on the Jazzy side
+`nav2_bringup`'s `tb3_simulation_launch.py` / `bringup_launch.py` / `localization_launch.py` /
+`navigation_launch.py` / `params/nav2_params.yaml`, `nav2_minimal_tb3_sim`'s
+`spawn_tb3.launch.py` + `gz_waffle.sdf.xacro` + `turtlebot3_waffle_bridge.yaml`, and
+`opennav_docking`'s `utils.hpp`.
+
+### 1. The launch path: `tb3_simulation_launch.py` -> `warehouse.launch.py` + `bringup_launch.py`
+
+Answering the issue's first question: Jazzy's `nav2_bringup/tb3_simulation_launch.py` *is*
+gz-sim-based, but it is a **different** gz-sim integration from #268's. It xacro-expands
+`nav2_minimal_tb3_sim`'s own world, spawns *its* `gz_waffle.sdf.xacro`, and starts *its*
+`turtlebot3_waffle_bridge.yaml` — a robot with one camera, nav2's topic names, and no
+camera bridged at all. The demo passed `world:=qrcodes.world` but, per the issue, never
+forwarded the `robot_sdf` it declared, so on this branch it was driving nav2's waffle
+around the QR-code world with none of #268's sensors/DiffDrive/bridge reaching ROS.
+
+`tb3_qrcodes.launch.py` now includes `dc_simulation/launch/warehouse.launch.py` (world,
+`robot_sdf`, `robot_name`, full spawn pose, `headless`, gated on `use_simulator`) for the
+simulator half and `nav2_bringup/launch/bringup_launch.py` + `rviz_launch.py` for Nav2 and
+RViz. That fixes the `robot_sdf` pass-through by construction rather than by adding one
+more dict entry. `use_robot_state_pub` used to be documented "should always be false"
+because it governed *nav2's* robot_state_publisher; it now gates this file's own (which
+publishes `dc_description`'s two-camera URDF) and defaults True.
+
+`warehouse.launch.py` gained `roll`/`pitch`/`yaw` spawn arguments (`-R`/`-P`/`-Y` to
+`ros_gz_sim create`) — the demo spawns at yaw 1.570796 and had no way to say so — plus an
+explicit `use_sim_time: False` on the bridge (it is the node that *publishes* `/clock`) and
+`nav2_minimal_tb3_sim`'s `models/` on `GZ_SIM_RESOURCE_PATH`.
+
+### 2. Five bugs that stopped the demo dead, each found by running it
+
+- **gz sim aborted on startup.** `waffle.model`'s lidar had `<range><min>0.00000`.
+  gz-rendering hands that straight to Ogre as the GPU-ray frustum's near clip, and Ogre
+  throws `InvalidParametersException: Near clip distance must be greater than zero`, which
+  kills the server. Now `0.00001`, the value `nav2_minimal_tb3_sim`'s `gz_waffle` uses.
+- **Every sensor message was undeliverable.** None of the ported sensors set
+  `<gz_frame_id>`, so gz-sensors stamped them with the scoped sensor name
+  (`turtlebot3_waffle/base_scan/hls_lfcd_lds`), which is not a TF frame — AMCL and both
+  costmaps' `obstacle_layer` run `/scan` through a tf2 `MessageFilter` and would have
+  dropped all of it. Added `base_scan`, `imu_link` and
+  `camera_{left,right}_depth_optical_frame`, all names taken from the URDF.
+- **map_server never loaded the map.** `qrcodes_nav.yaml` set
+  `map_server.yaml_filename: "qrcodes.yaml"`. `localization_launch.py` supplies the real
+  path from the `map` launch argument as a *wildcard*-scoped extra parameter, and a
+  node-name-scoped entry wins over a wildcard one regardless of layering order — so the
+  relative name is what map_server actually got, it resolved against the process CWD, and
+  `lifecycle_manager_localization` aborted the whole bringup. Verified both ways in a
+  container: with the key present it fails; with `""` map_server activates *with no map*;
+  only with the key absent does the launch argument reach it.
+- **docking_server crashed and took the navigation bringup with it.** Jazzy's
+  `navigation_launch.py` adds `route_server`, `velocity_smoother`, `collision_monitor` and
+  `docking_server` to `lifecycle_nodes`. `opennav_docking` throws
+  `InvalidParameterValueException` on `docks` at construction if no dock is declared —
+  nav2's own `nav2_params.yaml` leaves `docks` commented out and hits this too. Added a
+  `docking_server` block with `dock_plugins` and the placeholder dock
+  `nav2_multirobot_params_1.yaml` spells out.
+- **The camera topics did not exist under the names every consumer uses.** #268's bridge
+  config documents its intent as "the same ROS topic names the Classic plugins used", but
+  the cameras were bridged as `left_camera/image_raw` while `qrcodes_{stdout,minio_pgsql}.yaml`,
+  `qrcodes.rviz` and the demo docs all name `/{left,right}_intel_realsense_r200_depth/…`.
+  Renamed in `warehouse_bridge.yaml` (the ROS side only) so nothing downstream changes.
+
+### 3. `qrcodes_nav.yaml` ported from its Humble shape to Jazzy
+
+`recoveries_server` -> `behavior_server` (the old block reached no node at all, so every
+recovery silently ran on nav2's defaults) with `nav2_behaviors::`-style plugin names and
+the split `local_`/`global_costmap_topic` keys; `progress_checker_plugin` ->
+`progress_checker_plugins`; `smoother_server`'s flat plugin config -> `smoother_plugins` +
+a `simple_smoother` block; `nav2_navfn_planner/NavfnPlanner` -> `::`; the Humble
+`plugin_lib_names` list dropped (it names BT node libraries that no longer exist, and
+bt_navigator throws on a missing one instead of skipping it) in favour of `navigators`;
+`velocity_smoother` and `collision_monitor` blocks added for the new
+`controller_server -> cmd_vel_nav -> velocity_smoother -> cmd_vel_smoothed ->
+collision_monitor -> cmd_vel` chain, with the smoother's limits matched to DWB's; and the
+dead Foxy-era `*_rclcpp_node` / `*_client` blocks removed.
+
+### 4. `qrcodes_waypoint_follower`
+
+The result handling sat inside `while rclpy.ok():`, which re-entered with the task already
+complete and reprinted the result forever instead of exiting. It now runs the pass once,
+shuts down, and returns non-zero if the pass did not succeed. Added the `#!/usr/bin/env
+python3` it never had (without it the installed program cannot exec) and a CMake `RENAME`
+so the AC's `ros2 run dc_demos qrcodes_waypoint_follower` — no `.py` — is the real name.
+
+### 5. The world was ~150x too slow to simulate, and it was not the meshes
+
+The first end-to-end attempt ran at **0.0074 real-time factor** — 7 physics steps per second
+of a 1 ms step — which makes a 60-waypoint pass a ~30-hour proposition. Measured, rather
+than guessed, by bisecting the world in a container: dropping the 240 pallet/bag/QR-code
+prop instances took it to 1.09; removing their collision geometry only reached 0.017;
+`SceneBroadcaster` was not involved (0.0077 without it).
+
+The cause is that gz-sim does **not** propagate the `<static>1</static>` of the wrapper
+`<model>` in `qrcodes.world` into the `<include>`d nested model. `models/europallet`
+and `models/europallet_10` declared no `<static>` at all and `models/bag` declared
+`<static>0</static>`, so 176 pieces of warehouse scenery were simulated as free rigid
+bodies. Declaring them static in their own `model.sdf` — which `models/qrcode_*` already
+did — takes the bare world from 0.0074 to **0.265** and the full demo (gz-sim + both RGBD
+cameras + Nav2) to **~0.20** on 8 CPUs with software rendering.
+
+### Verified for real, by running the demo end to end
+
+In a container from `localhost/dc-workspace:latest` with this worktree bind-mounted over
+`/root/ws/src/ros2_data_collection` (`colcon build --packages-select dc_simulation
+dc_description dc_demos dc_services`), gz-sim headless on llvmpipe:
+
+- `ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False` brings up
+  gz-sim, the ported robot, Nav2 and DC with **no errors and no dead processes**. Both
+  lifecycle managers report "Managed nodes are active" — localization (`map_server`,
+  `amcl`) and all ten navigation nodes including Jazzy's new `route_server`,
+  `velocity_smoother`, `collision_monitor` and `docking_server`.
+- `/scan` arrives as `frame_id: base_scan`, the cameras as
+  `/{left,right}_intel_realsense_r200_depth/image_raw` at 5 Hz with
+  `frame_id: camera_{left,right}_depth_optical_frame`, and `/tf` carries the full
+  `map -> odom -> base_footprint -> …` tree. AMCL activates against `qrcodes.pgm` and
+  publishes `/amcl_pose` at the demo's initial pose (-23.911, -13.888).
+- **`ros2 run dc_demos qrcodes_waypoint_follower` completed the whole pass**:
+  nav2's own waypoint_follower logged "Completed all 60 waypoints requested", the script
+  printed "Goal succeeded!" and exited 0, ending at (-11.840, 15.354) — the last row-3
+  waypoint (-11.85, 15.45) within its 0.1 m goal tolerance. **Zero** aborted or failed
+  goals and **zero** recovery behaviours over the entire run. 483 s of simulated time in
+  4010 s of wall clock (RTF 0.198, ~63 min).
+
+**Verified**: `pre-commit` — `flake8`, `black`, `isort`, `codespell`, `xmllint`, the yaml
+checks, the ROS package-metadata checks and the doc build all clean on every changed file.
+Pre-existing, unrelated failures left alone: `pycln` and the two `poetry-requirements`
+hooks are broken in this environment. `black` reformatted
+`tools/e2e/scripts/verify_zero_loss.py` again as a whole-repo side effect — reverted before
+committing, same as every prior entry.
+
+### #51 and #52, re-checked as the issue asks
+
+**#52 (slow) — measured and largely attributed, still open.** The nested-`<static>` finding
+above is the dominant term and is fixed here: the world alone went 0.0074 -> 0.265 RTF, a
+36x improvement, for a three-line change. What remains is per-entity cost, not collision
+cost: with everything static, dropping the 240 prop instances still buys another 4x
+(0.265 -> 1.09), so the 317 model instances themselves are now the ceiling. #52's own
+checklist (time-to-first-Record, documenting an expected startup time) is untouched and it
+stays open; the numbers here should save it the bisection.
+
+**#51 (misalignment / detection fails) — root cause identified for this branch, still
+open.** #51's first listed suspect was "the robot description actually used by the spawned
+robot (see #279)", and that is exactly what was wrong: the demo was spawning
+`nav2_minimal_tb3_sim`'s single-camera `gz_waffle` with nav2's own bridge, which bridges no
+camera at all, so `/{left,right}_intel_realsense_r200_depth/image_raw` did not exist on
+this branch and no image ever reached a Camera measurement. Both topics now exist and
+publish. Detection itself is *not* yet demonstrated, and one blocker is now visible with
+the pipeline up (see below), so #51 keeps its "several consecutive runs" acceptance
+criterion and stays open, with a much narrower search space.
+
+### Left open deliberately
+
+- **`dc_measurements`' Camera plugin receives nothing from a topic that is demonstrably
+  publishing.** With DC enabled, `measurement_server` subscribes to
+  `/right_intel_realsense_r200_depth/image_raw` (confirmed: it is the topic's only
+  subscriber, RELIABLE on both ends), the bridge publishes it at a steady 5 Hz sim rate
+  (confirmed by `ros2 topic echo`: stamps 85.0, 85.2, 85.4, 85.6…), and yet
+  `camera.cpp`'s `cameraCb` never fires — `collect()` keeps finding `last_data_.data`
+  empty and logs "Message empty from measurement right_camera" indefinitely. This is
+  independent of the topic *rename* (the params already named these topics) and sits in
+  `dc_measurements`, not in the demo's launch path; it is the next thing #51 should look
+  at.
+- **`dc_services` needed `pydantic`, `cv_bridge` and `opencv` declared.** `draw_image` died
+  on `ModuleNotFoundError: No module named 'pydantic'` in the workspace image, and every
+  Camera measurement with `draw_det_barcodes: true` then blocked on "Waiting for draw image
+  service to appear...". `pydantic` was only ever in `requirements.txt`/`pyproject.toml`,
+  which the image does not install — it resolves dependencies through rosdep. Declared all
+  three in `dc_services/package.xml`; `python3-pydantic` resolves to Noble's 1.10.14, which
+  satisfies the `^1.10.4` pin, and `draw_image` then starts and initialises its service.
+- **`dc_demos/params/tb3_simulation_*.yaml`** still name `/intel_realsense_r200_depth/image_raw`,
+  which nav2's own bridge config does not bridge at all. Those demos run nav2's sandbox
+  world, not the warehouse, so they are outside #279; noting it because the same class of
+  break is now fixed on the qrcodes side.
+- The two cameras sit at the same point in `waffle.model` (both links carry
+  `<pose>0.069 -0.047 0.407 …</pose>`) while the URDF places them at y = ±0.12 — a
+  pre-existing mismatch between what renders the images and what publishes the frames, and
+  a candidate for #51's alignment symptom. Not touched here.

--- a/progress.txt
+++ b/progress.txt
@@ -4940,3 +4940,69 @@ image; `/left_intel_realsense_r200_depth/image_raw` confirmed live from
 exists. `pre-commit` clean on all changed files bar the environment's pre-existing
 `pycln`/`poetry-requirements` breakage and the `verify_zero_loss.py` black side effect,
 reverted as always.
+
+## A daily simulation job in CI (#279 follow-on)
+
+The simulation and demo layer had no CI coverage at all, which is why every bug above
+survived: `colcon build` compiles `dc_simulation` and `dc_demos` but none of the bugs
+live in compiled code — they are SDF, launch files, bridge configs and nav params. Those
+two packages contribute zero of the workspace's gtests. And the E2E harness contains no
+reference to gz-sim, the warehouse or any demo (`grep -rln` over `tools/e2e/` returns
+nothing): it feeds the pipeline a synthetic `workload_generator.py` precisely so its
+zero-loss proof does not depend on a simulator. A demo whose robot never spawned passed
+CI for two weeks.
+
+**`tools/sim/scripts/run.sh`** drives the check in four stages against the workspace
+image, each selectable via `DC_SIM_STAGES`:
+
+- `lint` — seconds, no simulator. Every launch file in `dc_demos`/`dc_simulation`/
+  `dc_bringup` loads under `--show-args` *and* every path-shaped default it advertises
+  exists; `gz sdf -k` validates every world and model; every `cam_topic` the qrcodes
+  params name is present in the bridge config.
+- `sim` — `warehouse.launch.py` headless: the robot appears in `gz model --list`, all
+  seven bridged topics carry data, `/scan` is in-range and non-degenerate, both camera
+  frames are non-black, and a `Twist` on `/cmd_vel` actually moves the robot.
+- `nav` — `tb3_qrcodes.launch.py`: both lifecycle managers reach "Managed nodes are
+  active", `/map` is served, and AMCL broadcasts `map -> odom`.
+- `waypoints` — the real follower, asserting *progress* (`DC_SIM_WAYPOINTS`, default 6)
+  rather than completion, plus zero aborted or failed Nav2 goals. The full 60-waypoint
+  pass is an hour-plus, so it stays a manual `workflow_dispatch` with `waypoints=60`.
+
+**`.github/workflows/sim.yaml`** runs all four daily at 03:17 UTC (off the hour — GitHub
+queues heavily at :00) with a `workflow_dispatch` for the full pass. It builds its own
+workspace image against its own cache ref, because a scheduled run has no upstream job to
+depend on, and sharing `ci.yaml`'s cache would overwrite the coverage-instrumented
+workspace layer with an uninstrumented one every morning. The `lint` stage is *also*
+wired into `ci.yaml`'s existing `colcon-test` job, since it costs seconds and covers the
+dead-path and invalid-SDF classes on every PR rather than a day later.
+
+**Verified — including that the checks fail when they should**, which matters more than
+that they pass:
+
+- `lint` against a clean tree: all pass. With #324's duplicate `<collision>` deliberately
+  reintroduced into `waffle.model`: `FAIL … Error Code 2: Msg: collision with
+  name[collision] already exists`, and the world still passes. With
+  `models/europallet` moved aside: `FAIL qrcodes.world … Unable to find
+  uri[model://europallet]`, and the model still passes.
+- `sim`: robot spawned in 15 s, all 16 topic assertions pass, `/cmd_vel` moved the robot
+  1.94 m.
+- `nav`: `/map` 1100x1100 @ 0.05 m/px, `map->odom` broadcast, both managers active in 45 s.
+- `waypoints`: reached waypoint 3/60 in 270 s with zero navigation failures; whole run
+  exits 0.
+- Bad input rejected up front: `DC_SIM_WAYPOINTS=abc` and `DC_SIM_STAGES="lint bogus"`
+  both fail immediately with a readable message rather than a bash arithmetic error
+  twenty minutes in.
+
+Two bugs in my own harness, found by running it rather than reading it: `gz sdf -k`
+exits 0 even when it reports an error (so the return code says nothing, and the real
+signal is the `Error Code N:` lines), and it resolves `model://` through `SDF_PATH` — not
+the `GZ_SIM_RESOURCE_PATH` the env hook sets — so without that every `<include>` reported
+"Unable to find uri" and the world check was pure noise. Separately, `set -euo pipefail`
+plus a `grep` that legitimately matches nothing killed the waypoint poll silently on its
+first iteration.
+
+**One correction to an earlier claim in this file**: the `nav` stage originally asserted
+`/amcl_pose` publishes. It does not, for a robot sitting still after bringup — AMCL emits
+it on a filter update and `update_min_d` is 0.25 m. The assertion is now `map -> odom`,
+which AMCL re-broadcasts continuously and which every costmap and the planner chain
+actually depend on.

--- a/progress.txt
+++ b/progress.txt
@@ -4968,13 +4968,22 @@ image, each selectable via `DC_SIM_STAGES`:
   rather than completion, plus zero aborted or failed Nav2 goals. The full 60-waypoint
   pass is an hour-plus, so it stays a manual `workflow_dispatch` with `waypoints=60`.
 
-**`.github/workflows/sim.yaml`** runs all four daily at 03:17 UTC (off the hour — GitHub
-queues heavily at :00) with a `workflow_dispatch` for the full pass. It builds its own
-workspace image against its own cache ref, because a scheduled run has no upstream job to
-depend on, and sharing `ci.yaml`'s cache would overwrite the coverage-instrumented
-workspace layer with an uninstrumented one every morning. The `lint` stage is *also*
-wired into `ci.yaml`'s existing `colcon-test` job, since it costs seconds and covers the
-dead-path and invalid-SDF classes on every PR rather than a day later.
+**Where each runs.** My first cut put all four stages in a daily job and only the `lint`
+stage on PRs, on the strength of the 63-minute figure measured earlier in this file —
+but that 63 minutes was the *full 60-waypoint pass*, not the check. All four stages with
+a small waypoint target take **about 13 minutes** end to end on 8 cores, which belongs in
+review, not the next morning. So:
+
+- **`ci.yaml` gained a `sim` job** (`needs: build-workspace`, pulls the same image
+  `colcon-test` and `e2e` do, runs in parallel with them) executing all four stages with
+  `DC_SIM_WAYPOINTS=3`. Roughly the length of the existing `e2e` job.
+- **`.github/workflows/sim.yaml`** is now specifically the full pass — all 60 waypoints,
+  three aisles, every QR-coded pallet — daily at 03:17 UTC (off the hour: GitHub queues
+  heavily at :00). It is the only check that exercises the demo the way the docs tell a
+  user to run it. It builds its own workspace image against its own cache ref, because a
+  scheduled run has no upstream job to depend on and sharing `ci.yaml`'s cache would
+  overwrite the coverage-instrumented workspace layer with an uninstrumented one every
+  morning.
 
 **Verified — including that the checks fail when they should**, which matters more than
 that they pass:
@@ -4987,19 +4996,31 @@ that they pass:
 - `sim`: robot spawned in 15 s, all 16 topic assertions pass, `/cmd_vel` moved the robot
   1.94 m.
 - `nav`: `/map` 1100x1100 @ 0.05 m/px, `map->odom` broadcast, both managers active in 45 s.
-- `waypoints`: reached waypoint 3/60 in 270 s with zero navigation failures; whole run
-  exits 0.
+- `waypoints`: reached waypoint 3/60 in 270 s with zero navigation failures.
+- All four stages in sequence, exactly as `ci.yaml`'s `sim` job runs them: green, exit 0,
+  ~13 minutes, no containers left behind.
 - Bad input rejected up front: `DC_SIM_WAYPOINTS=abc` and `DC_SIM_STAGES="lint bogus"`
   both fail immediately with a readable message rather than a bash arithmetic error
   twenty minutes in.
 
-Two bugs in my own harness, found by running it rather than reading it: `gz sdf -k`
-exits 0 even when it reports an error (so the return code says nothing, and the real
-signal is the `Error Code N:` lines), and it resolves `model://` through `SDF_PATH` — not
-the `GZ_SIM_RESOURCE_PATH` the env hook sets — so without that every `<include>` reported
-"Unable to find uri" and the world check was pure noise. Separately, `set -euo pipefail`
-plus a `grep` that legitimately matches nothing killed the waypoint poll silently on its
-first iteration.
+Four bugs in my own harness, every one found by running it rather than reading it:
+
+- `gz sdf -k` exits 0 even when it reports an error, so the return code says nothing and
+  the real signal is the `Error Code N:` lines;
+- it resolves `model://` through `SDF_PATH`, not the `GZ_SIM_RESOURCE_PATH` the env hook
+  sets, so without that every `<include>` reported "Unable to find uri" and the world
+  check was pure noise — a check that could only ever fail;
+- `set -euo pipefail` plus a `grep` that legitimately matches nothing killed the waypoint
+  poll silently on its first iteration;
+- and the one that mattered most: running the stages back to back in **one** container
+  hung the `nav` stage forever. The teardown between them was
+  `pkill -f "warehouse.launch"; pkill -f "gz sim"`, and `pkill -f` matches the very shell
+  running it — so the kill took out the killer and left gz sim and its bridge orphaned.
+  The second stack then joined the same ROS graph, two nodes published `/clock`, every
+  tf2 buffer began reporting "Detected jump back in time", and Nav2 never localized. This
+  is the same contamination that cost several false starts while debugging the demo
+  itself. Each stage now gets its own container, which makes teardown total; verified by
+  running all four in sequence with zero leftover containers.
 
 **One correction to an earlier claim in this file**: the `nav` stage originally asserted
 `/amcl_pose` publishes. It does not, for a robot sitting still after bringup — AMCL emits

--- a/progress.txt
+++ b/progress.txt
@@ -1819,20 +1819,25 @@ first) and pasting back the console output. Two things worth recording:
   variants, not just the 8 used in `qrcodes.world`, for consistency) — same treatment
   as the placeholder-model fixes above: a missing/misplaced asset the migration's
   stricter loader surfaced, not a gazebo_ros-specific issue.
-- **Investigated, not a bug in our content**: `[Err] [UserCommands.cc:928] Error Code
-  2: Msg: collision with name[collision] already exists` (×2, un-tagged — i.e. from the
-  server's own log stream, not the `[GUI]`-tagged one). Reproduced this deliberately
-  across four fresh container runs to isolate the trigger: **server-only** (`gz sim -s
-  -r`) loads of the exact same `qrcodes.world` — both in the original #268 verification
-  pass and again here — are consistently clean, zero `[Err]` lines. Runs **with the GUI**
-  attached (`gz sim -r`, which is what `warehouse.launch.py` uses by default and what
-  the user's own run used) consistently reproduce the same two errors, matching what the
-  user saw. Not chased further into gz-sim's own C++ (would need instrumenting
-  gz-sim itself, not this repo) — but confirmed non-fatal either way: the world loads,
-  physics runs, the robot spawns, and topics/bridge all work identically regardless of
-  whether these two lines print. Recorded here so a future session doesn't re-diagnose
-  from scratch — the fix, if one is ever wanted, is in gz-sim's `UserCommands`/GUI-attach
-  path, not in `dc_simulation`'s own SDF content.
+- **CORRECTED BY #279/#324 — the paragraph below was wrong, and is kept only so the
+  wrong conclusion is visibly retracted rather than silently replaced.** `[Err]
+  [UserCommands.cc:928] Error Code 2: Msg: collision with name[collision] already
+  exists` is *not* a GUI-attach quirk of gz-sim and it is *not* non-fatal: it is
+  `dc_simulation/worlds/waffle.model` declaring two `<collision name="collision">`
+  blocks inside each of `left_camera_link` and `right_camera_link` — a copy-paste
+  duplicate that is illegal SDF. gz-sim 8.11 rejects the whole spawn over it, so the
+  robot was never in the world at all and `gz model --list` showed only `ground_plane`,
+  `warehouse` and the props. The claim "the robot spawns, and topics/bridge all work
+  identically" was never verified against `gz model --list` or a `/cmd_vel` round trip;
+  it was inferred from the world loading. Both duplicates are removed in #279.
+  ~~Investigated, not a bug in our content: … Reproduced this deliberately across four
+  fresh container runs to isolate the trigger: server-only (`gz sim -s -r`) loads of the
+  exact same `qrcodes.world` are consistently clean, zero `[Err]` lines. Runs with the
+  GUI attached consistently reproduce the same two errors. Not chased further into
+  gz-sim's own C++ — but confirmed non-fatal either way: the world loads, physics runs,
+  the robot spawns, and topics/bridge all work identically. The fix, if one is ever
+  wanted, is in gz-sim's `UserCommands`/GUI-attach path, not in `dc_simulation`'s own
+  SDF content.~~
 
 ### #271 - tools/e2e: aws-sdk-cpp clone pulls unneeded submodules + full workspace
 layer invalidates on every source change
@@ -4798,18 +4803,75 @@ publish. Detection itself is *not* yet demonstrated, and one blocker is now visi
 the pipeline up (see below), so #51 keeps its "several consecutive runs" acceptance
 criterion and stays open, with a much narrower search space.
 
+### Correction: the "Camera plugin receives nothing" finding was wrong
+
+A first pass through this concluded that `dc_measurements`' Camera plugin never received
+images, on the strength of a "Message empty from measurement right_camera" warning
+repeating at the polling rate while the topic was demonstrably publishing. **That was a
+misdiagnosis**, and it is recorded here because the misleading log line is the trap.
+
+Reproduced away from the simulator entirely — plain `rclpy` publisher into
+`dc_bringup` + `qrcodes_stdout.yaml`, no gz-sim — then instrumented `camera.cpp` with
+temporary logging in `cameraCb` and `collect()`. The result:
+
+    DBG[right_camera] subscribed node=measurement_server resolved=/right_intel_realsense_r200_depth/image_raw
+    DBG[left_camera] cameraCb fired, 921600 bytes
+    DBG[right_camera] collect() last_data_=921600 bytes
+
+The subscription fires and `collect()` sees the image. "Message empty" is not about the
+image at all — it is `measurement.hpp` reporting that `collect()` returned an empty
+**Record**, which for a Camera with `detection_modules: ["barcode"]`,
+`save_raw_img: false` and `save_rotated_img: false` is exactly what happens on every
+frame with no barcode in view. Nothing is added to `data_json`, so `collect()` returns an
+empty message by design. Both the earlier sim run (robot parked at its spawn pose,
+nothing in front of it) and the blank synthetic frames were legitimately empty.
+
+Proven positively by publishing the demo's own QR-code texture
+(`models/qrcode_0001/meshes/qrcode_0001.png`) on both camera topics: a full Record came
+out the far end of dc_bridge/Vector —
+
+    {"camera_name":"right_camera", ...
+     "inspected":{"barcode":[{"data":"0001","type":"QRCode","top":220,"left":245,
+                              "width":210,"height":210}]},
+     "local_paths":{"inspected":"/root/dc_data/r2d2/.../right_camera/inspected/....jpg"}}
+
+— with the inspected image written to disk. The camera path works end to end: bridge ->
+Camera measurement -> ZXing decode -> draw_image service -> Record -> Vector.
+
+The one real defect here is the log line, which fires once per poll for an entirely
+normal condition and reads like a broken pipeline. It is now throttled to once per 10 s
+and reworded ("No data collected from measurement X (nothing to report, or it is not
+receiving input)").
+
+### Also fixed, from #324 and #325 (same files, same class of bug)
+
+Both issues turned out to be already fixed, or nearly so, by the work above:
+
+- **#324 — the robot never spawned at all.** The duplicate `<collision name="collision">`
+  in each camera link, removed above, is illegal SDF; gz-sim 8.11 rejects the whole spawn
+  over it. progress.txt's #268 entry had recorded this error as a harmless GUI-attach
+  quirk of gz-sim and asserted "the robot spawns" without ever checking
+  `gz model --list`; that entry is corrected in place, as #324 asks.
+  All its acceptance criteria now verified: zero `collision with name` errors in the
+  launch log, `gz model --list` contains `turtlebot3_waffle`, and a `/cmd_vel`
+  round trip moves the robot **0.679 m**.
+- **`/joint_states` was permanently silent** — found while checking #324's topic-rate
+  criterion. `waffle.model`'s JointStatePublisher sets `<topic>joint_states</topic>`,
+  overriding gz-sim's default `/world/<world>/model/<model>/joint_state`; gz advertises
+  that default anyway but never publishes on it, and the bridge was listening to exactly
+  that. Bridging `/joint_states` instead also removes this config's only dependence on
+  the world and model names. `/odom` 3.1 Hz, `/tf` 3.0 Hz, `/joint_states` 85.8 Hz,
+  `/imu` 16.3 Hz.
+- **#325 — headless rendering works, and always did once gz-sim stopped aborting.** The
+  lidar near-clip fix above is what was killing the server. In the CI container, with no
+  GPU and no X server, ogre2 falls back to headless mode by itself: `/scan` gives 360
+  beams, all finite and in range, 0.40-11.74 m; both cameras give 1280x720 rgb8 frames
+  with essentially every byte non-zero. The real cost is speed, now documented with
+  measured numbers in a new `dc_simulation/README.md`, along with the three gz-sim traps
+  this port hit (nested `<static>`, zero lidar near clip, duplicate collision names).
+
 ### Left open deliberately
 
-- **`dc_measurements`' Camera plugin receives nothing from a topic that is demonstrably
-  publishing.** With DC enabled, `measurement_server` subscribes to
-  `/right_intel_realsense_r200_depth/image_raw` (confirmed: it is the topic's only
-  subscriber, RELIABLE on both ends), the bridge publishes it at a steady 5 Hz sim rate
-  (confirmed by `ros2 topic echo`: stamps 85.0, 85.2, 85.4, 85.6…), and yet
-  `camera.cpp`'s `cameraCb` never fires — `collect()` keeps finding `last_data_.data`
-  empty and logs "Message empty from measurement right_camera" indefinitely. This is
-  independent of the topic *rename* (the params already named these topics) and sits in
-  `dc_measurements`, not in the demo's launch path; it is the next thing #51 should look
-  at.
 - **`dc_services` needed `pydantic`, `cv_bridge` and `opencv` declared.** `draw_image` died
   on `ModuleNotFoundError: No module named 'pydantic'` in the workspace image, and every
   Camera measurement with `draw_det_barcodes: true` then blocked on "Waiting for draw image
@@ -4817,6 +4879,10 @@ criterion and stays open, with a much narrower search space.
   which the image does not install — it resolves dependencies through rosdep. Declared all
   three in `dc_services/package.xml`; `python3-pydantic` resolves to Noble's 1.10.14, which
   satisfies the `^1.10.4` pin, and `draw_image` then starts and initialises its service.
+- **`dc_description`'s URDF pointed at `turtlebot3_gazebo` meshes**, the same
+  Classic-package-with-no-Jazzy-release problem `waffle.model` had, so RViz rendered a
+  robot with no geometry. Repointed at `nav2_minimal_tb3_sim`'s `turtlebot3_model` and
+  declared the dependency; all three mesh URIs now resolve.
 - **`dc_demos/params/tb3_simulation_*.yaml`** still name `/intel_realsense_r200_depth/image_raw`,
   which nav2's own bridge config does not bridge at all. Those demos run nav2's sandbox
   world, not the warehouse, so they are outside #279; noting it because the same class of

--- a/progress.txt
+++ b/progress.txt
@@ -4891,3 +4891,52 @@ Both issues turned out to be already fixed, or nearly so, by the work above:
   `<pose>0.069 -0.047 0.407 …</pose>`) while the URDF places them at y = ±0.12 — a
   pre-existing mismatch between what renders the images and what publishes the frames, and
   a candidate for #51's alignment symptom. Not touched here.
+
+## Untracked Jazzy leftovers, fixed alongside #279 (no issue of their own)
+
+Found by auditing what else the Gazebo Harmonic port left behind — none of these had an
+issue, and all are the same failure mode #279 hit: a path into a package Jazzy
+reorganised, failing silently at runtime rather than at build time.
+
+- **The three `tb3_simulation_*` launch files declared eight arguments they never read**
+  (`slam`, `map`, `world`, `headless`, `use_simulator`, `use_rviz`, `rviz_config_file`,
+  `use_namespace`). These files start DC only — Nav2 and the simulator are launched
+  separately per the demo page — but `--show-args` advertised them as if they controlled
+  something, and two of their defaults pointed at `nav2_bringup/worlds/world_only.model`
+  and `nav2_bringup/maps/turtlebot3_world.yaml`, neither of which Jazzy's `nav2_bringup`
+  still ships (the worlds moved to `nav2_minimal_tb3_sim`, the map is now
+  `tb3_sandbox.yaml`). All eight removed; the files now advertise the eleven they use.
+- **The two AWS-warehouse demos could not be fixed mechanically.** Their docs ran Gazebo
+  Classic against `aws_robomaker_small_warehouse_world`, which has no Jazzy release at
+  all, and their Camera measurement named `/intel_realsense_r200_depth/image_raw` — a
+  topic that cannot exist on Jazzy, because nav2's sandbox waffle carries a 320x240
+  **depth-only** sensor with no `<topic>` and no RGB camera. Asked which world they
+  should run on; the call was `dc_simulation`'s warehouse, which this branch has just
+  fixed and verified and which vendors the same AWS RoboMaker props. Both demos now
+  point at `tb3_qrcodes.launch.py use_dc:=False` and at
+  `/left_intel_realsense_r200_depth/image_raw`, which was measured carrying 1280x720
+  `rgb8` frames with essentially every byte non-zero. Their Camera measurement runs with
+  `draw_det_barcodes: false` and `save_raw_img: true`, so it emits a Record every poll
+  regardless of what is in view — unlike the qrcodes demo's, which only emits on a
+  detection.
+- **Docs**: `tb3_stdout.md`, `tb3_aws_minio_pgsql.md` and `tb3_aws_influxdb.md` sourced
+  `/opt/ros/humble` and exported `GAZEBO_MODEL_PATH`/`GAZEBO_RESOURCE_PATH`/
+  `TURTLEBOT3_MODEL`, none of which exist post-Classic; `uptime_stdout.md` and
+  `memory_uptime_stdout.md` linked source files on the frozen `humble` branch (all five
+  link targets verified to exist at the `jazzy` paths).
+- **`dc_services` and `dc_simulation` were still `package format="2"`.**
+
+**Not done, deliberately**: the Python pins (`requirements.txt` / `pyproject.toml`) are
+2023-era — numpy 1.24, opencv 4.7, pillow 9.4, pydantic 1.10, streamlit 1.21. pydantic
+1.x is the one that matters, and it is fine today precisely because Noble ships
+`python3-pydantic` 1.10.14, which is what `dc_services` now resolves against; moving to
+pydantic 2 means rewriting `draw_image.py`'s models. Bumping the rest means regenerating
+`poetry.lock` through a `poetry-requirements` hook that is broken in this environment.
+Left for a deliberate dependency-refresh pass.
+
+**Verified**: all five launch files load under `ros2 launch --show-args` in the workspace
+image; `/left_intel_realsense_r200_depth/image_raw` confirmed live from
+`warehouse.launch.py`; every rewritten `blob/jazzy` doc link resolves to a file that
+exists. `pre-commit` clean on all changed files bar the environment's pre-existing
+`pycln`/`poetry-requirements` breakage and the `verify_zero_loss.py` black side effect,
+reverted as always.

--- a/tools/sim/scripts/lint_launch_files.py
+++ b/tools/sim/scripts/lint_launch_files.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Static checks over every launch file and SDF in the simulation/demo layer.
+
+Neither `colcon build` nor `colcon test` looks at any of this: launch files, SDF and
+bridge configs are data, so a launch argument defaulting to a file Jazzy deleted, or a
+model with two identically-named collisions, compiles and tests perfectly while the demo
+is dead on arrival (#279, #324).
+
+Runs inside the container against the *installed* share directories, which is what a
+user's `ros2 launch` actually reads.
+"""
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+PACKAGES = ["dc_demos", "dc_simulation", "dc_bringup"]
+# Paths a launch argument may legitimately point at without the file existing yet.
+ALLOW_MISSING = ()
+
+
+class Report:
+    def __init__(self):
+        self.failures = []
+
+    def check(self, ok, name, detail=""):
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+        if not ok:
+            self.failures.append(name)
+
+    def finish(self):
+        if self.failures:
+            print(f"\nFAILED ({len(self.failures)}): {', '.join(self.failures)}")
+            return 1
+        print("\nall checks passed")
+        return 0
+
+
+def launch_files():
+    for pkg in PACKAGES:
+        share = Path(get_package_share_directory(pkg))
+        for launch in sorted((share / "launch").glob("*.launch.py")):
+            yield pkg, launch
+
+
+def check_launch_loads(report):
+    """Every launch file loads, and every path-shaped default it advertises exists.
+
+    `os.path.join` happily builds a path to a file that was deleted upstream, so the
+    only way to catch it is to resolve the advertised defaults. This is what would have
+    flagged nav2_bringup/worlds/world_only.model and maps/turtlebot3_world.yaml, both
+    gone from Jazzy's nav2_bringup.
+
+    Args:
+        report: collects pass/fail for the exit status.
+    """
+    for pkg, path in launch_files():
+        proc = subprocess.run(
+            ["ros2", "launch", pkg, path.name, "--show-args"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+        report.check(proc.returncode == 0, f"{pkg}/{path.name} loads", proc.stderr.strip()[-200:])
+        if proc.returncode != 0:
+            continue
+
+        missing = []
+        for line in proc.stdout.splitlines():
+            line = line.strip()
+            if not line.startswith("(default: '") or not line.endswith("')"):
+                continue
+            value = line[len("(default: '") : -len("')")]
+            if not value.startswith("/") or value in ALLOW_MISSING:
+                continue
+            # Only judge values that name a file; directories and expandable
+            # strftime/$HOME patterns are not ours to resolve here.
+            if any(c in value for c in "%$*") or "." not in Path(value).name:
+                continue
+            if not os.path.exists(value):
+                missing.append(value)
+        report.check(not missing, f"{pkg}/{path.name} default paths exist", "; ".join(missing))
+
+
+def check_sdf(report):
+    """gz's own parser validates every world and model dc_simulation ships.
+
+    Catches the illegal SDF that Gazebo Classic tolerated and gz-sim does not -- two
+    <collision> blocks with the same name inside one <link> made gz-sim reject the whole
+    robot spawn, so the warehouse ran for two weeks with no robot in it (#324).
+
+    Args:
+        report: collects pass/fail for the exit status.
+    """
+    share = Path(get_package_share_directory("dc_simulation"))
+    targets = sorted((share / "worlds").glob("*.world")) + sorted(
+        (share / "worlds").glob("*.model")
+    )
+    report.check(bool(targets), "found worlds/models to validate", f"{len(targets)} files")
+
+    # `gz sdf` resolves model:// through SDF_PATH, not through the GZ_SIM_RESOURCE_PATH
+    # dc_simulation's env hook sets — without it every <include> in the world reports
+    # "Unable to find uri". Feeding it the same path makes the check meaningful in both
+    # directions: it validates the structure *and* that every included model resolves.
+    env = dict(os.environ)
+    env["SDF_PATH"] = os.environ.get("GZ_SIM_RESOURCE_PATH", str(share / "models"))
+
+    for target in targets:
+        proc = subprocess.run(
+            ["gz", "sdf", "-k", str(target)],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env=env,
+        )
+        errors = sdf_errors(proc.stderr + proc.stdout)
+        report.check(not errors, f"{target.name} is valid SDF", "; ".join(errors[:3]))
+
+
+def sdf_errors(output):
+    """The structural errors in `gz sdf -k` output, and only those.
+
+    Three things make this less obvious than it looks, all verified against a model with
+    a deliberately reintroduced duplicate collision:
+
+    - it exits 0 even when it reports an error, so the return code says nothing;
+    - libsdformat's own structural errors are the `Error Code N: Msg: ...` lines, which
+      is what has to be matched;
+    - a world full of `<include><uri>model://…` produces a flood of `Tried to use
+      callback in sdf::findFile()` — the standalone parser has no resource resolver, so
+      those are noise about this tool, not about the file. `<gz_frame_id>` likewise
+      warns as "not defined in SDF" because it is a gz-sim runtime extension.
+
+    Args:
+        output: combined stdout+stderr of `gz sdf -k`.
+
+    Returns:
+        The `Error Code N: ...` lines, empty when the file is valid.
+    """
+    clean = ANSI.sub("", output)
+    return [
+        line.strip()
+        for line in clean.replace("Error Code", "\nError Code").splitlines()
+        if line.strip().startswith("Error Code")
+    ]
+
+
+def check_bridge_config(report):
+    """Every ROS topic dc_measurements' demo params subscribe to is bridged.
+
+    The qrcodes demo shipped for two weeks naming camera topics the bridge published
+    under different names, so the Camera measurements had nothing to subscribe to.
+
+    Args:
+        report: collects pass/fail for the exit status.
+    """
+    import yaml
+
+    sim = Path(get_package_share_directory("dc_simulation"))
+    bridged = set()
+    for entry in yaml.safe_load((sim / "config" / "warehouse_bridge.yaml").read_text()):
+        name = entry["ros_topic_name"]
+        bridged.add(name if name.startswith("/") else "/" + name)
+
+    demos = Path(get_package_share_directory("dc_demos"))
+    for params in sorted((demos / "params").glob("qrcodes_*.yaml")):
+        raw = yaml.safe_load(params.read_text())
+        server = raw.get("measurement_server", {}).get("ros__parameters", {})
+        wanted = {
+            v["cam_topic"] for v in server.values() if isinstance(v, dict) and "cam_topic" in v
+        }
+        missing = sorted(wanted - bridged)
+        report.check(
+            not missing,
+            f"{params.name} cam_topics are bridged",
+            "; ".join(missing),
+        )
+
+
+def main():
+    report = Report()
+    print("[lint] launch files")
+    check_launch_loads(report)
+    print("[lint] SDF")
+    check_sdf(report)
+    print("[lint] bridge config vs demo params")
+    check_bridge_config(report)
+    return report.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/sim/scripts/run.sh
+++ b/tools/sim/scripts/run.sh
@@ -16,22 +16,24 @@
 # it feeds the pipeline a synthetic workload precisely so its zero-loss proof doesn't
 # depend on a simulator.
 #
-# Slow by nature. The warehouse is 317 model instances and CI has no GPU, so the world
-# runs well under real time (see dc_simulation/README.md for measured factors). Meant to
-# run daily on a schedule, not per-push.
+# Slow by nature: the warehouse is 317 model instances and CI has no GPU, so the world
+# runs well under real time (see dc_simulation/README.md for measured factors). All four
+# stages together are about twenty minutes, which ci.yaml's `sim` job runs on every PR.
+# Only the full 60-waypoint pass is too slow for that, and that is what the daily
+# .github/workflows/sim.yaml runs.
 #
 # Env vars (all optional):
 #   DC_SIM_IMAGE            prebuilt workspace image to run (default dc-workspace:latest).
-#                           CI's nightly job sets this to the image it just built.
+#                           Both CI jobs set this to the image they built or pulled.
 #   DC_SIM_WAYPOINTS        waypoints the follower must reach before the run is
-#                           considered good (default 6). The full pass is 60 and takes
-#                           roughly an hour even on a fast machine; 6 proves planning,
-#                           control, localization and the goal-checker all work without
-#                           holding a runner for hours. Set to 60 for the full pass.
+#                           considered good (default 6). Each costs roughly a minute and
+#                           a half of wall clock. A handful proves planning, control,
+#                           localization and the goal checker all work; 60 is the full
+#                           pass through every QR-coded pallet, which the daily job runs.
 #   DC_SIM_WAYPOINT_TIMEOUT seconds to allow for that progress (default 2700).
 #   DC_SIM_STAGES           space-separated subset of: lint sim nav waypoints
 #                           (default: all four).
-#   DC_SIM_KEEP             "true" to leave the container running for inspection.
+#   DC_SIM_KEEP             "true" to leave the last stage's container up for inspection.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,7 +46,7 @@ WAYPOINTS="${DC_SIM_WAYPOINTS:-6}"
 WAYPOINT_TIMEOUT="${DC_SIM_WAYPOINT_TIMEOUT:-2700}"
 STAGES="${DC_SIM_STAGES:-lint sim nav waypoints}"
 KEEP="${DC_SIM_KEEP:-false}"
-CONTAINER="dc-sim-check-$$"
+CONTAINER=""
 
 log() { printf '\n\033[1m[sim] %s\033[0m\n' "$*"; }
 fail() { printf '\n\033[1;31m[sim] FAILED: %s\033[0m\n' "$*" >&2; exit 1; }
@@ -63,33 +65,53 @@ done
 
 cleanup() {
   local rc=$?
+  # Nothing started yet (input validation rejected something, say) — and stop_stack is
+  # defined below this trap, so it is not safe to call in that window either.
+  [ -n "$CONTAINER" ] || exit $rc
   if [ "$KEEP" = "true" ]; then
     log "DC_SIM_KEEP=true — leaving $CONTAINER running"
-    return
+    exit $rc
   fi
-  # Logs are the only artifact worth keeping; grab them before the container goes.
-  mkdir -p "$RUN_DIR"
-  podman exec "$CONTAINER" bash -lc 'cat /tmp/*.log 2>/dev/null' > "$RUN_DIR/sim.log" 2>/dev/null || true
-  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  stop_stack
   exit $rc
 }
 trap cleanup EXIT
 
-# --- container ------------------------------------------------------------------------
-log "starting $CONTAINER from $IMAGE"
-podman run -d --name "$CONTAINER" --shm-size=2g \
-  -v "$REPO_ROOT/tools/sim/scripts:/opt/sim:ro,Z" \
-  "$IMAGE" sleep infinity >/dev/null
+# --- containers -----------------------------------------------------------------------
+# One container per stage, torn down before the next starts. Tempting as it looks to
+# reuse one and `pkill` the simulator between stages, that does not work: pkill -f
+# matches the very shell running it, so the kill takes out the killer and leaves gz sim
+# and its bridge orphaned. A second stack then joins the same ROS graph, two nodes
+# publish /clock, and every tf2 buffer starts reporting "Detected jump back in time"
+# while Nav2 quietly never localizes. A container boundary makes teardown total.
+SOURCE='source /opt/ros/jazzy/setup.bash && source /root/ws/install/setup.bash'
+
+start_stack() {
+  CONTAINER="dc-sim-$$-$1"
+  log "starting $CONTAINER from $IMAGE"
+  podman run -d --name "$CONTAINER" --shm-size=2g \
+    -v "$REPO_ROOT/tools/sim/scripts:/opt/sim:ro,Z" \
+    "$IMAGE" sleep infinity >/dev/null
+}
+
+stop_stack() {
+  [ -n "$CONTAINER" ] || return 0
+  mkdir -p "$RUN_DIR"
+  podman exec "$CONTAINER" bash -lc 'cat /tmp/*.log 2>/dev/null' >> "$RUN_DIR/sim.log" 2>/dev/null || true
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  CONTAINER=""
+}
 
 # `ros2 launch` needs a writable HOME for its log directory.
-RUN="podman exec -e HOME=/root $CONTAINER bash -lc"
-EXEC_BG="podman exec -d -e HOME=/root $CONTAINER bash -lc"
-SOURCE='source /opt/ros/jazzy/setup.bash && source /root/ws/install/setup.bash'
+rin() { podman exec -e HOME=/root "$CONTAINER" bash -lc "$1"; }
+rbg() { podman exec -d -e HOME=/root "$CONTAINER" bash -lc "$1" >/dev/null; }
 
 # --- stage: static lint ---------------------------------------------------------------
 if has_stage lint; then
+  start_stack lint
   log "linting launch files, SDF and the bridge config (seconds, no simulator)"
-  $RUN "$SOURCE && python3 /opt/sim/lint_launch_files.py" || fail "static lint"
+  rin "$SOURCE && python3 /opt/sim/lint_launch_files.py" || fail "static lint"
+  stop_stack
 fi
 
 # Waits for a condition inside the container, polling until a deadline.
@@ -97,7 +119,7 @@ wait_for() {
   local desc="$1" timeout="$2" cmd="$3" waited=0
   log "waiting for $desc (up to ${timeout}s)"
   while [ "$waited" -lt "$timeout" ]; do
-    if $RUN "$cmd" >/dev/null 2>&1; then
+    if rin "$cmd" >/dev/null 2>&1; then
       log "$desc — ready after ${waited}s"
       return 0
     fi
@@ -109,8 +131,9 @@ wait_for() {
 
 # --- stage: simulation only -----------------------------------------------------------
 if has_stage sim; then
+  start_stack sim
   log "launching warehouse.launch.py headless"
-  $EXEC_BG "$SOURCE && ros2 launch dc_simulation warehouse.launch.py headless:=True > /tmp/warehouse.log 2>&1"
+  rbg "$SOURCE && ros2 launch dc_simulation warehouse.launch.py headless:=True > /tmp/warehouse.log 2>&1"
 
   # The robot appearing in the world is the single most load-bearing assertion here:
   # an illegal-SDF spawn rejection is silent apart from one [Err] line (#324).
@@ -118,30 +141,31 @@ if has_stage sim; then
     "source /opt/ros/jazzy/setup.bash && gz model --list 2>/dev/null | grep -q turtlebot3_waffle" \
     || fail "turtlebot3_waffle never appeared in gz model --list"
 
-  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py topics" || fail "topic checks"
-  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py cmd_vel" || fail "cmd_vel round trip"
+  rin "$SOURCE && python3 /opt/sim/verify_sim.py topics" || fail "topic checks"
+  rin "$SOURCE && python3 /opt/sim/verify_sim.py cmd_vel" || fail "cmd_vel round trip"
 
-  $RUN 'pkill -f "warehouse.launch" || true; sleep 5; pkill -f "gz sim" || true; sleep 5' || true
+  stop_stack
 fi
 
 # --- stage: simulation + Nav2 ---------------------------------------------------------
 if has_stage nav || has_stage waypoints; then
+  start_stack nav
   log "launching tb3_qrcodes.launch.py (simulation + Nav2, DC off)"
-  $EXEC_BG "$SOURCE && ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False use_dc:=False > /tmp/qrcodes.log 2>&1"
+  rbg "$SOURCE && ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False use_dc:=False > /tmp/qrcodes.log 2>&1"
 
   wait_for "Nav2 to activate" 1800 \
     'grep -aq "lifecycle_manager_navigation.*Managed nodes are active" /tmp/qrcodes.log' \
     || fail "nav2 never reported all managed nodes active"
-  $RUN 'grep -aq "lifecycle_manager_localization.*Managed nodes are active" /tmp/qrcodes.log' \
+  rin 'grep -aq "lifecycle_manager_localization.*Managed nodes are active" /tmp/qrcodes.log' \
     || fail "localization never reported all managed nodes active"
 
-  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py nav" || fail "nav checks"
+  rin "$SOURCE && python3 /opt/sim/verify_sim.py nav" || fail "nav checks"
 fi
 
 # --- stage: waypoint following --------------------------------------------------------
 if has_stage waypoints; then
   log "running qrcodes_waypoint_follower until it reaches waypoint $WAYPOINTS/60"
-  $EXEC_BG "$SOURCE && ros2 run dc_demos qrcodes_waypoint_follower > /tmp/waypoints.log 2>&1; echo EXIT=\$? >> /tmp/waypoints.log"
+  rbg "$SOURCE && ros2 run dc_demos qrcodes_waypoint_follower > /tmp/waypoints.log 2>&1; echo EXIT=\$? >> /tmp/waypoints.log"
 
   # Progress, not completion: the follower reaching waypoint N proves planning, control,
   # localization and the goal checker all work. Completion of all 60 is an hour-plus and
@@ -154,7 +178,7 @@ if has_stage waypoints; then
   # return digits or nothing at all.
   count_in_container() {
     local out
-    out="$(podman exec -e HOME=/root "$CONTAINER" bash -lc "$1" 2>/dev/null || true)"
+    out="$(rin "$1" 2>/dev/null || true)"
     printf '%s' "$out" | head -1 | tr -dc '0-9'
   }
 
@@ -167,8 +191,8 @@ if has_stage waypoints; then
       log "reached waypoint $reached/60 after ${waited}s"
       break
     fi
-    if $RUN 'grep -aq "^EXIT=" /tmp/waypoints.log' 2>/dev/null; then
-      if $RUN 'grep -aq "EXIT=0" /tmp/waypoints.log' 2>/dev/null; then
+    if rin 'grep -aq "^EXIT=" /tmp/waypoints.log' 2>/dev/null; then
+      if rin 'grep -aq "EXIT=0" /tmp/waypoints.log' 2>/dev/null; then
         log "follower completed the full pass"
         reached=60
         break

--- a/tools/sim/scripts/run.sh
+++ b/tools/sim/scripts/run.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+# Simulation smoke check (#279). From the repo root:
+#
+#   ./tools/sim/scripts/run.sh
+#
+# Runs the warehouse simulation headless in a container from the DC workspace image and
+# asserts it actually works: the robot spawns, every bridged topic carries usable data,
+# /cmd_vel moves the robot, Nav2 comes up and localizes, and the waypoint follower makes
+# real progress through the QR-coded aisles.
+#
+# Why this exists as its own thing: none of the simulation/demo layer is reachable by
+# `colcon build` or `colcon test`. It is SDF, launch files, bridge configs and params --
+# data, not code -- so a robot that never spawns, a lidar that aborts the server, a
+# bridge pointed at a dead topic and a nav params file full of Humble-era keys all
+# passed CI cleanly (#279, #324, #325). The E2E harness deliberately doesn't help here:
+# it feeds the pipeline a synthetic workload precisely so its zero-loss proof doesn't
+# depend on a simulator.
+#
+# Slow by nature. The warehouse is 317 model instances and CI has no GPU, so the world
+# runs well under real time (see dc_simulation/README.md for measured factors). Meant to
+# run daily on a schedule, not per-push.
+#
+# Env vars (all optional):
+#   DC_SIM_IMAGE            prebuilt workspace image to run (default dc-workspace:latest).
+#                           CI's nightly job sets this to the image it just built.
+#   DC_SIM_WAYPOINTS        waypoints the follower must reach before the run is
+#                           considered good (default 6). The full pass is 60 and takes
+#                           roughly an hour even on a fast machine; 6 proves planning,
+#                           control, localization and the goal-checker all work without
+#                           holding a runner for hours. Set to 60 for the full pass.
+#   DC_SIM_WAYPOINT_TIMEOUT seconds to allow for that progress (default 2700).
+#   DC_SIM_STAGES           space-separated subset of: lint sim nav waypoints
+#                           (default: all four).
+#   DC_SIM_KEEP             "true" to leave the container running for inspection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIM_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$(dirname "$SIM_DIR")")"
+RUN_DIR="$SIM_DIR/.run"
+
+IMAGE="${DC_SIM_IMAGE:-dc-workspace:latest}"
+WAYPOINTS="${DC_SIM_WAYPOINTS:-6}"
+WAYPOINT_TIMEOUT="${DC_SIM_WAYPOINT_TIMEOUT:-2700}"
+STAGES="${DC_SIM_STAGES:-lint sim nav waypoints}"
+KEEP="${DC_SIM_KEEP:-false}"
+CONTAINER="dc-sim-check-$$"
+
+log() { printf '\n\033[1m[sim] %s\033[0m\n' "$*"; }
+fail() { printf '\n\033[1;31m[sim] FAILED: %s\033[0m\n' "$*" >&2; exit 1; }
+has_stage() { [[ " $STAGES " == *" $1 "* ]]; }
+
+# These arrive from workflow_dispatch inputs, so a typo should say so rather than surface
+# as an arithmetic error a thousand seconds into the run.
+[[ "$WAYPOINTS" =~ ^[0-9]+$ ]] || fail "DC_SIM_WAYPOINTS must be a number, got '$WAYPOINTS'"
+[[ "$WAYPOINT_TIMEOUT" =~ ^[0-9]+$ ]] || fail "DC_SIM_WAYPOINT_TIMEOUT must be a number, got '$WAYPOINT_TIMEOUT'"
+for stage in $STAGES; do
+  case "$stage" in
+    lint | sim | nav | waypoints) ;;
+    *) fail "unknown stage '$stage' in DC_SIM_STAGES (want: lint sim nav waypoints)" ;;
+  esac
+done
+
+cleanup() {
+  local rc=$?
+  if [ "$KEEP" = "true" ]; then
+    log "DC_SIM_KEEP=true — leaving $CONTAINER running"
+    return
+  fi
+  # Logs are the only artifact worth keeping; grab them before the container goes.
+  mkdir -p "$RUN_DIR"
+  podman exec "$CONTAINER" bash -lc 'cat /tmp/*.log 2>/dev/null' > "$RUN_DIR/sim.log" 2>/dev/null || true
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  exit $rc
+}
+trap cleanup EXIT
+
+# --- container ------------------------------------------------------------------------
+log "starting $CONTAINER from $IMAGE"
+podman run -d --name "$CONTAINER" --shm-size=2g \
+  -v "$REPO_ROOT/tools/sim/scripts:/opt/sim:ro,Z" \
+  "$IMAGE" sleep infinity >/dev/null
+
+# `ros2 launch` needs a writable HOME for its log directory.
+RUN="podman exec -e HOME=/root $CONTAINER bash -lc"
+EXEC_BG="podman exec -d -e HOME=/root $CONTAINER bash -lc"
+SOURCE='source /opt/ros/jazzy/setup.bash && source /root/ws/install/setup.bash'
+
+# --- stage: static lint ---------------------------------------------------------------
+if has_stage lint; then
+  log "linting launch files, SDF and the bridge config (seconds, no simulator)"
+  $RUN "$SOURCE && python3 /opt/sim/lint_launch_files.py" || fail "static lint"
+fi
+
+# Waits for a condition inside the container, polling until a deadline.
+wait_for() {
+  local desc="$1" timeout="$2" cmd="$3" waited=0
+  log "waiting for $desc (up to ${timeout}s)"
+  while [ "$waited" -lt "$timeout" ]; do
+    if $RUN "$cmd" >/dev/null 2>&1; then
+      log "$desc — ready after ${waited}s"
+      return 0
+    fi
+    sleep 15
+    waited=$((waited + 15))
+  done
+  return 1
+}
+
+# --- stage: simulation only -----------------------------------------------------------
+if has_stage sim; then
+  log "launching warehouse.launch.py headless"
+  $EXEC_BG "$SOURCE && ros2 launch dc_simulation warehouse.launch.py headless:=True > /tmp/warehouse.log 2>&1"
+
+  # The robot appearing in the world is the single most load-bearing assertion here:
+  # an illegal-SDF spawn rejection is silent apart from one [Err] line (#324).
+  wait_for "the robot to spawn" 600 \
+    "source /opt/ros/jazzy/setup.bash && gz model --list 2>/dev/null | grep -q turtlebot3_waffle" \
+    || fail "turtlebot3_waffle never appeared in gz model --list"
+
+  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py topics" || fail "topic checks"
+  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py cmd_vel" || fail "cmd_vel round trip"
+
+  $RUN 'pkill -f "warehouse.launch" || true; sleep 5; pkill -f "gz sim" || true; sleep 5' || true
+fi
+
+# --- stage: simulation + Nav2 ---------------------------------------------------------
+if has_stage nav || has_stage waypoints; then
+  log "launching tb3_qrcodes.launch.py (simulation + Nav2, DC off)"
+  $EXEC_BG "$SOURCE && ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False use_dc:=False > /tmp/qrcodes.log 2>&1"
+
+  wait_for "Nav2 to activate" 1800 \
+    'grep -aq "lifecycle_manager_navigation.*Managed nodes are active" /tmp/qrcodes.log' \
+    || fail "nav2 never reported all managed nodes active"
+  $RUN 'grep -aq "lifecycle_manager_localization.*Managed nodes are active" /tmp/qrcodes.log' \
+    || fail "localization never reported all managed nodes active"
+
+  $RUN "$SOURCE && python3 /opt/sim/verify_sim.py nav" || fail "nav checks"
+fi
+
+# --- stage: waypoint following --------------------------------------------------------
+if has_stage waypoints; then
+  log "running qrcodes_waypoint_follower until it reaches waypoint $WAYPOINTS/60"
+  $EXEC_BG "$SOURCE && ros2 run dc_demos qrcodes_waypoint_follower > /tmp/waypoints.log 2>&1; echo EXIT=\$? >> /tmp/waypoints.log"
+
+  # Progress, not completion: the follower reaching waypoint N proves planning, control,
+  # localization and the goal checker all work. Completion of all 60 is an hour-plus and
+  # belongs in a manual run (DC_SIM_WAYPOINTS=60).
+  # Reading a number out of the container is fiddlier than it looks under
+  # `set -euo pipefail`: grep exits 1 when it matches nothing (so a bare command
+  # substitution kills the script the first time round, before the follower has logged
+  # anything), and `grep -c` prints "0" *and* exits 1 (so a `|| echo 0` fallback yields
+  # "0\n0", which every later [ ] test then chokes on). Swallow the status inside, and
+  # return digits or nothing at all.
+  count_in_container() {
+    local out
+    out="$(podman exec -e HOME=/root "$CONTAINER" bash -lc "$1" 2>/dev/null || true)"
+    printf '%s' "$out" | head -1 | tr -dc '0-9'
+  }
+
+  waited=0
+  reached=0
+  while [ "$waited" -lt "$WAYPOINT_TIMEOUT" ]; do
+    reached=$(count_in_container 'grep -ao "Executing current waypoint: [0-9]*" /tmp/waypoints.log | tail -1 | grep -o "[0-9]*$"')
+    reached="${reached:-0}"
+    if [ "$reached" -ge "$WAYPOINTS" ]; then
+      log "reached waypoint $reached/60 after ${waited}s"
+      break
+    fi
+    if $RUN 'grep -aq "^EXIT=" /tmp/waypoints.log' 2>/dev/null; then
+      if $RUN 'grep -aq "EXIT=0" /tmp/waypoints.log' 2>/dev/null; then
+        log "follower completed the full pass"
+        reached=60
+        break
+      fi
+      fail "waypoint follower exited non-zero (see $RUN_DIR/sim.log)"
+    fi
+    sleep 30
+    waited=$((waited + 30))
+  done
+  [ "$reached" -ge "$WAYPOINTS" ] || fail "only reached waypoint $reached/60 in ${WAYPOINT_TIMEOUT}s (wanted $WAYPOINTS)"
+
+  # Navigation failures don't necessarily stop progress, so assert on them separately.
+  aborted=$(count_in_container 'grep -acE "Goal was aborted|Goal failed|Failed to make progress" /tmp/qrcodes.log')
+  [ "${aborted:-0}" -eq 0 ] || fail "$aborted navigation failures in the Nav2 log"
+  log "no aborted or failed navigation goals"
+fi
+
+log "simulation check passed (stages: $STAGES)"

--- a/tools/sim/scripts/verify_sim.py
+++ b/tools/sim/scripts/verify_sim.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Assertions for the simulation smoke check (see tools/sim/scripts/run.sh).
+
+Runs inside the container, inside the running simulation's ROS graph. Every check here
+exists because a real bug got through CI without it — the whole demo layer is invisible
+to `colcon build` and `colcon test`, since it lives in SDF, launch files, bridge configs
+and params rather than in compiled code (#279).
+
+Usage:
+    verify_sim.py topics       # sensors and odometry carry usable data
+    verify_sim.py cmd_vel      # publishing a Twist actually moves the robot
+    verify_sim.py nav          # AMCL is localized against the static map
+"""
+import math
+import sys
+
+import rclpy
+from geometry_msgs.msg import Twist
+from nav_msgs.msg import OccupancyGrid, Odometry
+from rclpy.node import Node
+from rclpy.qos import QoSDurabilityPolicy, QoSHistoryPolicy, QoSProfile, QoSReliabilityPolicy
+from sensor_msgs.msg import Image, Imu, JointState, LaserScan
+from tf2_msgs.msg import TFMessage
+
+CAMERAS = [
+    "/left_intel_realsense_r200_depth/image_raw",
+    "/right_intel_realsense_r200_depth/image_raw",
+]
+
+# Generous: the warehouse world is heavy and CI runners are slow, so these bound "did it
+# ever publish" rather than any rate. See dc_simulation/README.md for measured factors.
+SETTLE_S = 120.0
+DRIVE_S = 60.0
+
+
+class Verifier(Node):
+    def __init__(self):
+        super().__init__("verify_sim")
+        self.odom = None
+        self.scan = None
+        self.imu = None
+        self.joints = None
+        self.tf_frames = set()
+        self.map = None
+        self.images = {}
+        self.create_subscription(Odometry, "/odom", self._set("odom"), 10)
+        self.create_subscription(LaserScan, "/scan", self._set("scan"), 10)
+        self.create_subscription(Imu, "/imu", self._set("imu"), 10)
+        self.create_subscription(JointState, "/joint_states", self._set("joints"), 10)
+        self.create_subscription(TFMessage, "/tf", self._on_tf, 10)
+        # map_server latches /map, so only a transient-local subscriber sees it.
+        self.create_subscription(
+            OccupancyGrid,
+            "/map",
+            self._set("map"),
+            QoSProfile(
+                depth=1,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                reliability=QoSReliabilityPolicy.RELIABLE,
+                durability=QoSDurabilityPolicy.TRANSIENT_LOCAL,
+            ),
+        )
+        for topic in CAMERAS:
+            self.create_subscription(
+                Image, topic, lambda m, t=topic: self.images.setdefault(t, m), 10
+            )
+        self.cmd_vel = self.create_publisher(Twist, "/cmd_vel", 10)
+
+    def _set(self, attr):
+        def cb(msg):
+            setattr(self, attr, msg)
+
+        return cb
+
+    def _on_tf(self, msg):
+        for tf in msg.transforms:
+            self.tf_frames.add((tf.header.frame_id, tf.child_frame_id))
+
+    def spin(self, seconds):
+        end = self.get_clock().now().nanoseconds + seconds * 1e9
+        while self.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self, timeout_sec=0.2)
+
+    def spin_until(self, predicate, seconds):
+        end = self.get_clock().now().nanoseconds + seconds * 1e9
+        while self.get_clock().now().nanoseconds < end:
+            rclpy.spin_once(self, timeout_sec=0.2)
+            if predicate():
+                return True
+        return predicate()
+
+
+class Report:
+    def __init__(self):
+        self.failures = []
+
+    def check(self, ok, name, detail=""):
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}{': ' + detail if detail else ''}")
+        if not ok:
+            self.failures.append(name)
+
+    def finish(self):
+        if self.failures:
+            print(f"\nFAILED: {', '.join(self.failures)}")
+            return 1
+        print("\nall checks passed")
+        return 0
+
+
+def check_topics(node, report):
+    """Every bridged topic carries data, and the sensor data is not degenerate.
+
+    A silent topic here is the signature of three separate bugs this caught: a sensor
+    with no <gz_frame_id> (dropped by every tf2 MessageFilter downstream), a bridge entry
+    pointed at a gz topic nothing publishes on, and a robot that never spawned at all.
+
+    Args:
+        node: the Verifier spinning in the simulation's ROS graph.
+        report: collects pass/fail for the exit status.
+    """
+    node.spin_until(
+        lambda: all(x is not None for x in (node.odom, node.scan, node.imu, node.joints))
+        and len(node.images) == len(CAMERAS)
+        and node.tf_frames,
+        SETTLE_S,
+    )
+
+    report.check(node.odom is not None, "/odom publishes")
+    report.check(node.imu is not None, "/imu publishes")
+    report.check(node.joints is not None, "/joint_states publishes")
+    report.check(bool(node.tf_frames), "/tf publishes")
+
+    if node.joints is not None:
+        names = set(node.joints.name)
+        report.check(
+            {"wheel_left_joint", "wheel_right_joint"} <= names,
+            "/joint_states carries both wheel joints",
+            ",".join(sorted(names)),
+        )
+
+    if node.odom is not None:
+        report.check(
+            node.odom.header.frame_id == "odom" and node.odom.child_frame_id == "base_footprint",
+            "/odom frames",
+            f"{node.odom.header.frame_id} -> {node.odom.child_frame_id}",
+        )
+
+    scan = node.scan
+    report.check(scan is not None, "/scan publishes")
+    if scan is not None:
+        # frame_id must be a real URDF link or AMCL and both costmaps silently drop it.
+        report.check(scan.header.frame_id == "base_scan", "/scan frame_id", scan.header.frame_id)
+        finite = [
+            r for r in scan.ranges if math.isfinite(r) and scan.range_min < r < scan.range_max
+        ]
+        report.check(
+            len(finite) > 10, "/scan has in-range returns", f"{len(finite)}/{len(scan.ranges)}"
+        )
+        # A wall of identical readings means the renderer produced nothing useful.
+        distinct = len({round(r, 2) for r in finite})
+        # round() rather than an f-string format spec: this flake8 misparses ":.2f"
+        # inside an f-string as a dict colon and reports E231.
+        spread = f", {round(min(finite), 2)}-{round(max(finite), 2)} m" if finite else ""
+        report.check(distinct > 5, "/scan is not degenerate", f"{distinct} distinct ranges{spread}")
+
+    for topic in CAMERAS:
+        msg = node.images.get(topic)
+        report.check(msg is not None, f"{topic} publishes")
+        if msg is not None:
+            report.check(
+                any(msg.data),
+                f"{topic} is not all-black",
+                f"{msg.width}x{msg.height} {msg.encoding}",
+            )
+            report.check(
+                msg.header.frame_id.startswith("camera_"),
+                f"{topic} frame_id",
+                msg.header.frame_id,
+            )
+
+
+def check_cmd_vel(node, report):
+    """A Twist on /cmd_vel reaches DiffDrive and the robot moves.
+
+    The one assertion that proves the robot is really in the world and really actuated,
+    rather than merely present in a topic list.
+
+    Args:
+        node: the Verifier spinning in the simulation's ROS graph.
+        report: collects pass/fail for the exit status.
+    """
+    if not node.spin_until(lambda: node.odom is not None, SETTLE_S):
+        report.check(False, "/odom publishes before drive")
+        return
+    start = node.odom.pose.pose.position
+
+    twist = Twist()
+    twist.linear.x = 0.2
+    end_ns = node.get_clock().now().nanoseconds + DRIVE_S * 1e9
+    while node.get_clock().now().nanoseconds < end_ns:
+        node.cmd_vel.publish(twist)
+        node.spin(0.2)
+    node.cmd_vel.publish(Twist())
+    node.spin(5)
+
+    end = node.odom.pose.pose.position
+    moved = math.hypot(end.x - start.x, end.y - start.y)
+    origin = f"({round(start.x, 2)}, {round(start.y, 2)})"
+    report.check(moved > 0.05, "/cmd_vel moves the robot", f"{round(moved, 3)} m from {origin}")
+
+
+def check_nav(node, report):
+    """Nav2 is up and localized against the static map.
+
+    Deliberately not asserting on /amcl_pose: AMCL publishes it on a filter update, and
+    with update_min_d at 0.25 m a robot sitting still after bringup never produces one.
+    map->odom is the assertion that holds for a stationary robot — AMCL re-broadcasts it
+    continuously, and its presence is what every costmap and the whole planner chain
+    actually depend on.
+
+    Args:
+        node: the Verifier spinning in the simulation's ROS graph.
+        report: collects pass/fail for the exit status.
+    """
+    ok = node.spin_until(
+        lambda: node.map is not None and ("map", "odom") in node.tf_frames, SETTLE_S
+    )
+
+    report.check(node.map is not None, "/map publishes")
+    if node.map is not None:
+        info = node.map.info
+        report.check(
+            info.width > 0 and info.height > 0,
+            "/map has real dimensions",
+            f"{info.width}x{info.height} @ {info.resolution} m/px",
+        )
+
+    report.check(
+        ("map", "odom") in node.tf_frames,
+        "AMCL broadcasts map->odom",
+        f"{len(node.tf_frames)} transforms seen",
+    )
+    report.check(ok, "Nav2 localized")
+
+
+CHECKS = {"topics": check_topics, "cmd_vel": check_cmd_vel, "nav": check_nav}
+
+
+def main():
+    if len(sys.argv) != 2 or sys.argv[1] not in CHECKS:
+        print(f"usage: {sys.argv[0]} {{{'|'.join(CHECKS)}}}", file=sys.stderr)
+        return 2
+    stage = sys.argv[1]
+    rclpy.init()
+    node = Verifier()
+    report = Report()
+    print(f"[verify_sim] {stage}")
+    try:
+        CHECKS[stage](node, report)
+    finally:
+        rclpy.shutdown()
+    return report.finish()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #279
Closes #324
Closes #325

## What was wrong

`dc_demos/launch/tb3_qrcodes.launch.py` handed the entire simulator to `nav2_bringup`'s `tb3_simulation_launch.py`. On Jazzy that launch file *is* gz-sim-based, but it is a **different** gz-sim integration from the one #268 built: it spawns `nav2_minimal_tb3_sim`'s `gz_waffle.sdf.xacro` with `nav2_minimal_tb3_sim`'s bridge config — a single-camera robot whose bridge exposes no camera at all. Combined with the `robot_sdf` pass-through gap the issue describes (declared, never forwarded), the demo was never running against the robot, sensors or bridge #268 ported.

The simulator half now comes from `dc_simulation/launch/warehouse.launch.py`, and Nav2 from `bringup_launch.py` + `rviz_launch.py`. That fixes `robot_sdf` by construction rather than by adding one more entry to a dict.

## What actually running it turned up

| Symptom | Cause | Fix |
|---|---|---|
| `gz sim` aborts on startup | lidar `<range><min>0`, which gz-rendering feeds to Ogre as a GPU-ray near clip → `InvalidParametersException` | `0.00001`, matching `nav2_minimal_tb3_sim`'s waffle |
| **robot never spawns at all** (#324) | two `<collision name="collision">` blocks in each camera link — illegal SDF that gz-sim 8.11 rejects the whole spawn over | duplicates removed |
| every scan/image undeliverable | no `<gz_frame_id>`, so messages carried scoped sensor names that are not TF frames; AMCL and both costmaps drop them through their tf2 `MessageFilter` | `base_scan`, `imu_link`, `camera_{left,right}_depth_optical_frame` |
| `/joint_states` permanently silent | `JointStatePublisher`'s `<topic>` overrides gz-sim's default, which gz advertises but never publishes on — and the bridge listened to the default | bridge `/joint_states`; also drops the config's only dependence on world/model names |
| robot has no geometry in RViz | URDF meshes pointed at `turtlebot3_gazebo`, which has no Jazzy release | repointed at `nav2_minimal_tb3_sim/models/turtlebot3_model` |
| `map_server` never loads the map, localization bringup aborts | node-scoped `yaml_filename` in `qrcodes_nav.yaml` wins over the wildcard-scoped one `localization_launch.py` derives from `map`, so the relative `"qrcodes.yaml"` resolved against the CWD | key removed |
| `docking_server` dies, navigation bringup aborts | Jazzy adds it to `lifecycle_nodes`; `opennav_docking` throws on an undeclared `docks` (nav2's own `nav2_params.yaml` hits this too) | `docking_server` block with `dock_plugins` + the placeholder dock from `nav2_multirobot_params_1.yaml` |
| camera topics exist under names nothing uses | #268's bridge renamed them despite documenting the opposite intent | back to `/{left,right}_intel_realsense_r200_depth/…`, which `qrcodes_*.yaml`, `qrcodes.rviz` and the docs all name |
| `draw_image` dies, blocking every barcode measurement | `dc_services` imports `pydantic`/`cv2`/`cv_bridge` but declared none of them; the image installs deps through rosdep, not `requirements.txt` | declared in `dc_services/package.xml` |
| **world runs at 0.0074 RTF** | gz-sim does not propagate the wrapper `<model>`'s `<static>` into an `<include>`d nested model, so 176 pallets and bags were free rigid bodies | `<static>1</static>` in their own `model.sdf` → bare world **0.0074 → 0.265** |

That last one was bisected, not guessed: dropping the 240 props entirely gives 1.09; removing only their collisions gives 0.017; `SceneBroadcaster` is not involved (0.0077 without it).

`qrcodes_nav.yaml` is also ported from its Humble shape to Jazzy — `recoveries_server` → `behavior_server` (the old block reached no node, so every recovery silently ran on defaults), `progress_checker_plugin` → `progress_checker_plugins`, the `smoother_plugins` block, `::` plugin names, the stale `plugin_lib_names` list dropped, and `velocity_smoother`/`collision_monitor` added for the new `cmd_vel_nav → cmd_vel_smoothed → cmd_vel` chain.

`qrcodes_waypoint_follower` had its result handling inside `while rclpy.ok():`, reprinting the result forever instead of exiting; it now runs the pass once and returns a meaningful exit code. It also gained the shebang it never had, and installs without `.py` so the issue's `ros2 run dc_demos qrcodes_waypoint_follower` is the real name. Its initial-pose quaternion had a norm of 1.012, which AMCL answers with "Received initialpose message is malformed. Rejecting." — so `setInitialPose` had been a no-op.

## A retraction

An earlier revision of this PR reported that `dc_measurements`' Camera plugin received nothing from a topic that was demonstrably publishing. **That was wrong.** Reproduced away from the simulator (a plain `rclpy` publisher into `dc_bringup`) and instrumented `camera.cpp`: the subscription fires and `collect()` sees the image. `"Message empty"` is `measurement.hpp` reporting an empty **Record**, which is exactly what a Camera with `detection_modules` and no image saving returns for a frame with no barcode in view — so both the parked robot and my blank synthetic frames were legitimately empty. Publishing the demo's own `qrcode_0001` texture yields a full Record:

```json
{"camera_name":"right_camera",
 "inspected":{"barcode":[{"data":"0001","type":"QRCode","top":220,"left":245,"width":210,"height":210}]},
 "local_paths":{"inspected":"/root/dc_data/r2d2/.../right_camera/inspected/....jpg"}}
```

The camera path works end to end. The only real defect was the log line, which fired once per poll for a normal condition and reads like a broken pipeline; it is now throttled to 10 s and reworded.

## Verification

Container from `localhost/dc-workspace:latest`, this worktree bind-mounted, gz-sim headless on llvmpipe with no GPU and no X server:

- `ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False` — no errors, no dead processes, both lifecycle managers report **"Managed nodes are active"** (localization plus all ten navigation nodes, including Jazzy's new `route_server`/`velocity_smoother`/`collision_monitor`/`docking_server`).
- **`ros2 run dc_demos qrcodes_waypoint_follower` completed the whole pass** — nav2 logged "Completed all 60 waypoints requested", the script printed "Goal succeeded!" and exited 0, finishing at (-11.840, 15.354) vs. the last waypoint (-11.85, 15.45), inside its 0.1 m tolerance. **Zero** failed goals, **zero** recovery behaviours, over 483 s of sim time in 4010 s wall (RTF 0.198).
- #324's criteria: no `collision with name` error, `gz model --list` contains `turtlebot3_waffle`, `/odom` 3.1 Hz + `/tf` 3.0 Hz + `/joint_states` 85.8 Hz + `/imu` 16.3 Hz, and a `/cmd_vel` round trip moves the robot **0.679 m**.
- #325's criteria: `/scan` gives 360 beams, all finite and in range, **0.40–11.74 m**; both cameras give 1280x720 `rgb8` frames with essentially every byte non-zero. The headless-rendering cost is documented with measured numbers in a new `dc_simulation/README.md`.

`pre-commit` clean on every changed file (`pycln` and the two `poetry-requirements` hooks are broken in this environment, as in previous PRs).

## #51 / #52 re-check

- **#52** — attributed and largely fixed (the nested-`<static>` bug above). What remains is per-entity cost: with everything static, dropping the 240 props still buys another 4×, so the 317 model instances are now the ceiling. #52's own checklist is untouched; it stays open with the bisection done for it.
- **#51** — its first listed suspect ("the robot description actually used by the spawned robot, see #279") was right twice over: the robot was not being spawned at all (#324), and the camera topics did not exist. Both are fixed, and barcode decoding is now proven to work end to end against the demo's own QR texture. What remains for #51 is purely whether the simulated cameras *frame* the codes from the waypoint poses — note that `waffle.model` puts both cameras at the same point (`<pose>0.069 -0.047 0.407 …</pose>` on both links) while the URDF places them at y = ±0.12.

## Untracked Jazzy leftovers, swept up here

None of the below had an issue of its own. All are the same failure mode #279 hit — a path into a package Jazzy reorganized, failing silently at runtime rather than at build time — so they are fixed here while the context is loaded.

- **The three `tb3_simulation_*` launch files declared eight arguments they never read** (`slam`, `map`, `world`, `headless`, `use_simulator`, `use_rviz`, `rviz_config_file`, `use_namespace`). These files start DC only, but `--show-args` advertised them as if they controlled something, and two defaults pointed at `nav2_bringup/worlds/world_only.model` and `nav2_bringup/maps/turtlebot3_world.yaml` — neither of which Jazzy's `nav2_bringup` still ships. Removed; they now advertise the eleven they use.
- **The two AWS-warehouse demos could not run on Jazzy at all.** Their docs drove Gazebo Classic against `aws_robomaker_small_warehouse_world` (no Jazzy release — its own jazzy branch still hard-depends on `gazebo_ros`), and their Camera measurement named a topic that cannot exist there: nav2's sandbox waffle carries a 320x240 **depth-only** sensor and no RGB camera. Both now run `dc_simulation`'s warehouse via `tb3_qrcodes.launch.py use_dc:=False` — the world this PR fixed and verified, which vendors the same AWS RoboMaker props — with `cam_topic` on `/left_intel_realsense_r200_depth/image_raw`.
- **Docs**: three pages sourced `/opt/ros/humble` and exported `GAZEBO_MODEL_PATH`/`GAZEBO_RESOURCE_PATH`/`TURTLEBOT3_MODEL`; two more linked source files on the frozen `humble` branch (all five rewritten targets verified to exist at their `jazzy` paths).
- **`dc_services` and `dc_simulation` were still `package format="2"`.**

Deliberately not done: the Python pins (`numpy` 1.24, `opencv` 4.7, `pillow` 9.4, `pydantic` 1.10, `streamlit` 1.21). `pydantic` 1.x is the one that matters and it is correct today — Noble ships `python3-pydantic` 1.10.14, which is what `dc_services` now resolves against; moving to 2.x means rewriting `draw_image.py`'s models, and bumping the rest means regenerating `poetry.lock` through a hook that is broken in this environment. That belongs in a deliberate dependency-refresh pass.

## CI: a simulation job per PR, the full pass daily

Nothing covered this layer, which is why all of the above survived. `colcon build` compiles `dc_simulation` and `dc_demos`, but every bug here lives in SDF, launch files, bridge configs or nav params — data, not code — and those two packages contribute zero of the workspace's gtests. The E2E harness has no reference to gz-sim or any demo (`grep -rln` over `tools/e2e/` returns nothing): it feeds the pipeline a synthetic workload precisely so its zero-loss proof doesn't depend on a simulator. Correctly designed, but it leaves the demo layer uncovered.

`tools/sim/scripts/run.sh` drives four selectable stages against the workspace image:

| Stage | Asserts |
|---|---|
| `lint` | every launch file loads *and* its path-shaped defaults exist; `gz sdf -k` over every world and model; every `cam_topic` the params name is bridged |
| `sim` | robot in `gz model --list`, all seven bridged topics carrying data, `/scan` in-range and non-degenerate, camera frames non-black, `/cmd_vel` moves the robot |
| `nav` | both lifecycle managers active, `/map` served, AMCL broadcasting `map -> odom` |
| `waypoints` | the real follower reaching `DC_SIM_WAYPOINTS`, zero aborted or failed goals |

All four together are **~13 minutes** on 8 cores with a small waypoint target, so they run on **every PR** as a new `sim` job in `ci.yaml` — `needs: build-workspace`, pulling the same image `colcon-test` and `e2e` do, in parallel with them. `.github/workflows/sim.yaml` is the **full 60-waypoint pass** — three aisles, every QR-coded pallet — daily at 03:17 UTC, the only check that exercises the demo the way the docs tell a user to run it. It builds its own image against its own cache ref, since a scheduled run has no upstream job and sharing `ci.yaml`'s cache would overwrite the coverage-instrumented layer every morning.

**Verified that the checks fail when they should**, which matters more than that they pass:

- reintroducing #324's duplicate `<collision>` → `FAIL … Error Code 2: collision with name[collision] already exists`, world still passes
- moving `models/europallet` aside → `FAIL qrcodes.world … Unable to find uri[model://europallet]`, model still passes
- `DC_SIM_WAYPOINTS=abc` and `DC_SIM_STAGES="lint bogus"` rejected up front rather than as a bash error twenty minutes in
- all four stages in sequence, exactly as the PR job runs them: green, exit 0, ~13 min, zero leftover containers

Four bugs in the harness itself, every one found by running it rather than reading it. `gz sdf -k` exits 0 even when it reports an error, *and* resolves `model://` through `SDF_PATH` rather than the `GZ_SIM_RESOURCE_PATH` the env hook sets — without which every `<include>` reported "Unable to find uri" and the world check could only ever fail. `set -euo pipefail` plus a `grep` that legitimately matches nothing killed the waypoint poll on its first iteration. And running the stages back to back in one container hung `nav` forever: the teardown was `pkill -f "gz sim"`, which matches the very shell running it, so the kill took out the killer and orphaned the simulator; the second stack then joined the same ROS graph, two nodes published `/clock`, and Nav2 never localized. Each stage now gets its own container.

One assertion I had to correct: `nav` originally checked `/amcl_pose`, which a stationary robot never publishes — AMCL emits it on a filter update and `update_min_d` is 0.25 m. It now asserts `map -> odom`, which AMCL re-broadcasts continuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nu4cQFKAHFTg6Y3qLXvyKa


