### PR TITLE
fix(demos): aim the QR-code demo's cameras at the codes it stops in front of

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,7 +213,8 @@ jobs:
           files: coverage/cpp.info
           flags: cpp-jazzy
 
-  # The simulation and demo layer is structurally invisible to the two jobs above:
+  # The simulation and demo layer is structurally invisible to the workspace build above
+  # and the e2e harness below:
   # `colcon build` compiles dc_simulation and dc_demos, but their content is SDF, launch
   # files, bridge configs and nav params -- data, not code -- and neither package has a
   # single gtest. The e2e harness deliberately feeds the pipeline a synthetic workload so
@@ -221,16 +222,18 @@ jobs:
   # never spawned passing CI for two weeks (#324), next to a lidar that aborted the
   # server and a nav params file still full of Humble-era keys (#279, #325).
   #
-  # All four stages run here rather than only nightly: together they are roughly the
+  # All five stages run here rather than only nightly: together they are roughly the
   # length of the e2e job, and a broken demo is worth catching in review rather than the
   # next morning. Only the *full* 60-waypoint pass is too slow for a PR, and that is what
   # .github/workflows/sim.yaml runs daily.
   sim:
     needs: build-workspace
     runs-on: ubuntu-latest
-    # Roughly 20 minutes when green on a 4-core runner; the headroom is for a contended
-    # runner, since the world already runs well under real time without a GPU.
-    timeout-minutes: 90
+    # The world already runs well under real time without a GPU, and `detect` puts two
+    # 1280x720 RGBD streams and a barcode decoder on top of the same three waypoints, so
+    # this is generous on purpose: better a slow green than a job that fails on the clock
+    # and says nothing about the demo.
+    timeout-minutes: 120
     permissions:
       contents: read
       packages: read
@@ -250,10 +253,16 @@ jobs:
       - name: Simulation smoke check
         env:
           DC_SIM_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
-          # Three waypoints is enough to prove planning, control, localization and the
-          # goal checker all work end to end -- each one costs about a minute and a half
-          # of wall clock here, and the daily job covers the full pass.
+          # Three waypoints is enough to prove planning, control, localization, the goal
+          # checker and QR-code detection all work end to end. The daily job covers the
+          # full 60-station pass; this one only has to catch a demo that broke.
           DC_SIM_WAYPOINTS: "3"
+          # run.sh's default is 2700 s, sized for the stages before `detect` existed.
+          # Driving the same waypoints with the DC pipeline up is appreciably slower --
+          # the controller runs on sim time and gz-sim advances it whether or not a
+          # CPU-starved ROS graph keeps up, so the robot really does move more slowly in
+          # *simulated* time. Give it the job's headroom rather than have it give up.
+          DC_SIM_WAYPOINT_TIMEOUT: "4200"
         run: ./tools/sim/scripts/run.sh
 
       - name: Upload simulation logs (on failure)

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -26,7 +26,7 @@ on:
         required: false
         default: "60"
       stages:
-        description: "Subset of: lint sim nav waypoints"
+        description: "Subset of: lint sim nav waypoints detect"
         required: false
         default: "lint sim nav waypoints"
 
@@ -86,6 +86,14 @@ jobs:
           # The follower needs the whole pass to finish inside this; run.sh gives up on
           # it rather than waiting for the job timeout, so the failure names the stage.
           DC_SIM_WAYPOINT_TIMEOUT: "14400"
+          # No `detect` by default: this job's measured 63-minute envelope was taken
+          # with the DC pipeline off, and running two 1280x720 RGBD streams through
+          # ZXing alongside 60 navigation goals is exactly the kind of extra load that
+          # turns a 4-hour budget into a timeout. Detection is guarded per-PR instead
+          # (ci.yaml's sim job, three waypoints), and by the geometric check in the
+          # `lint` stage, which covers all 60 stations analytically on every run.
+          # Pass "lint sim nav waypoints detect" by hand to exercise it over the full
+          # pass.
           DC_SIM_STAGES: ${{ inputs.stages || 'lint sim nav waypoints' }}
         run: ./tools/sim/scripts/run.sh
 

--- a/dc_demos/dc_demos/qrcodes_waypoint_follower.py
+++ b/dc_demos/dc_demos/qrcodes_waypoint_follower.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Follow waypoints using the ROS 2 Navigation Stack (Nav2)."""
+import math
 import sys
 
 import rclpy
@@ -7,6 +8,53 @@ from geometry_msgs.msg import Point, Pose, PoseStamped, Quaternion
 from nav2_simple_commander.robot_navigator import BasicNavigator, TaskResult
 from rclpy.duration import Duration
 from std_msgs.msg import Header
+
+# Set the robot's goal poses.
+#
+# Every number here is measured against dc_simulation/worlds/qrcodes.world and
+# dc_simulation/maps/qrcodes.{pgm,yaml}; the map frame is the world frame shifted
+# by (-7.300, +1.425) m (#51). In the map frame the four QR-coded pallet faces
+# stand at x = -18.608, -16.298, -14.804 and -12.498, and each row of codes runs
+# along y from -10.475 in steps of 1.3 m with a 2.5 m gap after the tenth.
+#
+# ROWS_X therefore stands the robot ~0.97 m off the codes in the two open aisles
+# and mid-way between the two walls of the closed one. It used to read
+# [-19.6, -15.6, -11.85]: 0.65 m off the codes in aisle 3 and 0.05 m off centre
+# in aisle 2, which left the 60-degree lens no room for the goal tolerance. See
+# qrcodes_nav.yaml's general_goal_checker for the arithmetic, and
+# tools/sim/scripts/lint_launch_files.py for the check that holds it.
+ROWS_X = [-19.6, -15.55, -11.5]
+# Exactly +/- 90 degrees, so the cameras look square at the pallet faces. These
+# used to be (z=0.7071068967, w=0.7248122258) and (z=-0.7023745033,
+# w=0.7118075984) -- norms 1.0126 and 1.0000, i.e. headings of 88.6 and -89.2
+# degrees rather than +/-90. The same transcription error in the initial pose
+# below was fixed in #279; these sixty were missed.
+ROW_YAW = [math.pi / 2, -math.pi / 2]  # Going up and down
+SPACE_PALLETS = 1.3
+SPACE_ROWS = 2.5 - SPACE_PALLETS  # since we count SPACE_PALLETS in the calculation
+PALLET_PER_ROW = 10
+ROWS_COUNT = 2
+# Centre of the first pallet in the map frame; was -10.45, 25 mm off.
+ROWS_Y0 = -10.475
+
+
+def camera_stations():
+    """The pose the robot takes in front of each QR-coded pallet, in the map frame.
+
+    One entry per pallet, in visiting order: up aisle 1, down aisle 2, up aisle 3.
+
+    Returns:
+        A list of (x, y, yaw) tuples, metres and radians in the map frame.
+    """
+    stations = []
+    for row, (row_x, yaw) in enumerate(zip(ROWS_X, [ROW_YAW[0], ROW_YAW[1], ROW_YAW[0]])):
+        indices = range(ROWS_COUNT * PALLET_PER_ROW)
+        # The middle row is driven the other way, so the robot does not have to
+        # cross the whole warehouse between aisles.
+        for index in reversed(indices) if row == 1 else indices:
+            offset = SPACE_PALLETS * index + SPACE_ROWS * (index // PALLET_PER_ROW)
+            stations.append((row_x, ROWS_Y0 + offset, yaw))
+    return stations
 
 
 def main():
@@ -20,9 +68,12 @@ def main():
     initial_pose = PoseStamped()
     initial_pose.header.frame_id = "map"
     initial_pose.header.stamp = navigator.get_clock().now().to_msg()
-    initial_pose.pose.position.x = -23.910843605740368
-    initial_pose.pose.position.y = -13.887905581663327
-    # yaw 1.570796, the same pose qrcodes_nav.yaml's amcl initial_pose.* carries.
+    # tb3_qrcodes.launch.py's spawn pose in the map frame; the same value
+    # qrcodes_nav.yaml's amcl initial_pose.* carries. See #51 for the 69 mm
+    # correction and for where the map/world offset comes from.
+    initial_pose.pose.position.x = -23.9794
+    initial_pose.pose.position.y = -13.8752
+    # yaw 1.570796, as in the launch file and the params.
     # The value transcribed here used to be (z=0.7071068967, w=0.7248122258),
     # whose norm is 1.012 -- AMCL answers a non-unit quaternion with "Received
     # initialpose message is malformed. Rejecting.", so this call did nothing and
@@ -33,67 +84,16 @@ def main():
     # Wait for navigation to fully activate. Use this line if autostart is set to true.
     navigator.waitUntilNav2Active()
 
-    # Set the robot's goal poses
-    rows_x = [-19.6, -15.6, -11.85]
-    z_orientation = [0.7071068967259818, -0.7023745033057341]  # Going up and down
-    w_orientation = [0.7248122257854975, 0.7118075983761505]  # Going up and down
-    space_pallets = 1.3
-    space_rows = 2.5 - space_pallets  # since we count the space_pallets in calculation
-    pallet_per_row = 10
-    rows_count = 2
-    rows_y0 = -10.45
-
-    row_1 = [
+    goal_poses = [
         PoseStamped(
             header=Header(frame_id="map", stamp=navigator.get_clock().now().to_msg()),
             pose=Pose(
-                position=Point(
-                    x=rows_x[0],
-                    y=rows_y0
-                    + space_pallets * index_pall
-                    + space_rows * (index_pall // pallet_per_row),
-                    z=0.0,
-                ),
-                orientation=Quaternion(x=0.0, y=0.0, z=z_orientation[0], w=w_orientation[0]),
+                position=Point(x=station_x, y=station_y, z=0.0),
+                orientation=Quaternion(x=0.0, y=0.0, z=math.sin(yaw / 2.0), w=math.cos(yaw / 2.0)),
             ),
         )
-        for index_pall in range(0, rows_count * pallet_per_row)
+        for station_x, station_y, yaw in camera_stations()
     ]
-
-    row_2 = [
-        PoseStamped(
-            header=Header(frame_id="map", stamp=navigator.get_clock().now().to_msg()),
-            pose=Pose(
-                position=Point(
-                    x=rows_x[1],
-                    y=rows_y0
-                    + (space_pallets) * index_pall
-                    + space_rows * (index_pall // pallet_per_row),
-                    z=0.0,
-                ),
-                orientation=Quaternion(x=0.0, y=0.0, z=z_orientation[1], w=w_orientation[1]),
-            ),
-        )
-        for index_pall in list(reversed(range(0, rows_count * pallet_per_row)))
-    ]
-
-    row_3 = [
-        PoseStamped(
-            header=Header(frame_id="map", stamp=navigator.get_clock().now().to_msg()),
-            pose=Pose(
-                position=Point(
-                    x=rows_x[2],
-                    y=rows_y0
-                    + space_pallets * index_pall
-                    + space_rows * (index_pall // pallet_per_row),
-                    z=0.0,
-                ),
-                orientation=Quaternion(x=0.0, y=0.0, z=z_orientation[0], w=w_orientation[0]),
-            ),
-        )
-        for index_pall in range(0, rows_count * pallet_per_row)
-    ]
-    goal_poses = row_1 + row_2 + row_3
 
     nav_start = navigator.get_clock().now()
     navigator.followWaypoints(goal_poses)

--- a/dc_demos/params/qrcodes_nav.yaml
+++ b/dc_demos/params/qrcodes_nav.yaml
@@ -39,9 +39,12 @@ amcl:
     z_short: 0.05
     scan_topic: scan
     set_initial_pose: True
-    # Obtained after setting pose on RVIZ and checking /amcl_pose topic
-    initial_pose.x: -23.910843605740368
-    initial_pose.y: -13.887905581663327
+    # The spawn pose tb3_qrcodes.launch.py uses, (-16.6794, -15.3002) in the
+    # world frame, carried into the map frame by its (-7.300, +1.425) offset.
+    # It used to be (-23.910844, -13.887906), "obtained after setting pose on
+    # RVIZ and checking /amcl_pose", which is 69 mm out in x (#51).
+    initial_pose.x: -23.9794
+    initial_pose.y: -13.8752
     initial_pose.z: 0.0
     initial_pose.yaw: 1.570796
 
@@ -92,11 +95,29 @@ controller_server:
     #  xy_goal_tolerance: 0.25
     #  yaw_goal_tolerance: 0.25
     #  stateful: True
+    # This demo's goals are camera stations, not just places to be, so the
+    # tolerance has to fit what the lens can still read from there (#51).
+    #
+    # The cameras are 60-degree-FOV, so at a standoff d the frame is
+    # +/- d*tan(30) wide, and a code is readable while
+    #
+    #     |lateral error| + d*tan(|yaw error|) + 0.181 <= d*tan(30)
+    #
+    # where 0.181 m is half the rendered width of a QR symbol on a pallet. The
+    # tightest station is aisle 2, where the pallet rows are 1.49 m apart and the
+    # robot can only ever be d = 0.73 m off either wall:
+    #
+    #     0.1 + 0.73*tan(0.1) + 0.181 = 0.354 <= 0.73*tan(30) = 0.422   OK
+    #     0.1 + 0.73*tan(0.2) + 0.181 = 0.429 <= 0.422                  false
+    #
+    # Hence 0.1 rad, not the 0.2 this carried. Yaw is the expensive term because
+    # it scales with the standoff, and a diff-drive robot turning on the spot
+    # settles well inside 0.1 rad; xy stays at 0.1 m, which costs nothing.
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"
       xy_goal_tolerance: 0.1
-      yaw_goal_tolerance: 0.2
+      yaw_goal_tolerance: 0.1
     # DWB parameters
     FollowPath:
       plugin: "dwb_core::DWBLocalPlanner"

--- a/dc_demos/params/qrcodes_nav.yaml
+++ b/dc_demos/params/qrcodes_nav.yaml
@@ -98,7 +98,7 @@ controller_server:
     # This demo's goals are camera stations, not just places to be, so the
     # tolerance has to fit what the lens can still read from there (#51).
     #
-    # The cameras are 60-degree-FOV, so at a standoff d the frame is
+    # The cameras are 60-degree FOV, so at a standoff d the frame is
     # +/- d*tan(30) wide, and a code is readable while
     #
     #     |lateral error| + d*tan(|yaw error|) + 0.181 <= d*tan(30)
@@ -112,7 +112,14 @@ controller_server:
     #
     # Hence 0.1 rad, not the 0.2 this carried. Yaw is the expensive term because
     # it scales with the standoff, and a diff-drive robot turning on the spot
-    # settles well inside 0.1 rad; xy stays at 0.1 m, which costs nothing.
+    # settles well inside 0.1 rad -- measured at no cost in navigation time (see
+    # progress.txt); xy stays at 0.1 m, which costs nothing.
+    #
+    # Worth knowing that this budget is not the whole error: the goal checker
+    # compares AMCL's *estimate* of the pose against the goal, so localization
+    # error lands on top of whatever is set here and appears nowhere above. That
+    # is the argument for a wider lens, which was tried and reverted for breaking
+    # decoding -- see dc_simulation/README.md.
     general_goal_checker:
       stateful: True
       plugin: "nav2_controller::SimpleGoalChecker"

--- a/dc_description/urdf/turtlebot3_waffle_qrcodes.xacro
+++ b/dc_description/urdf/turtlebot3_waffle_qrcodes.xacro
@@ -2,19 +2,43 @@
 <robot name="turtlebot3_waffle"
   xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:property name="ground_base_distance" value="1.300"/>
+  <!-- base_link sits 10 mm above base_footprint (see base_joint below). This used
+       to be a "ground_base_distance" of 1.300 m, borrowed from a much taller
+       robot: every camera offset below is expressed relative to the ground and
+       then rebased onto base_link, so a 1.3 m error put both cameras 0.6 m
+       underground in TF (#51). -->
+  <xacro:property name="base_link_z" value="0.010"/>
 
-  <xacro:property name="base_link_x" value="0.0"/>
-  <xacro:property name="base_link_y" value="0.0"/>
-  <xacro:property name="base_link_z" value="${ground_base_distance}"/>
+  <!-- Optical centre of each inspection camera, measured from base_footprint.
+       These must match the two rgbd_camera sensors in
+       dc_simulation/worlds/waffle.model: the SDF is what renders the images, this
+       URDF is what publishes camera_{left,right}_depth_optical_frame, and until
+       #51 the two described different cameras: pointing different ways, at
+       different heights, in different places. -->
+  <xacro:property name="camera_x" value="0.0"/>
+  <xacro:property name="camera_y" value="0.02"/>
+  <xacro:property name="camera_z" value="0.539"/>
 
-  <xacro:property name="camera_right_x" value="${0.0 - base_link_x}"/>
-  <xacro:property name="camera_right_y" value="${-0.12 - base_link_y}"/>
-  <xacro:property name="camera_right_z" value="${0.665 - base_link_z}"/>
+  <!-- realsense2_description's sensor_d455 macro does not put the optical origin
+       (camera_*_link) on the frame it is attached to: it offsets it by this much
+       in its own bottom-screw axes. Undo that below so the optical origin lands
+       on camera_{x,y,z} exactly. -->
+  <xacro:property name="d455_offset_x" value="0.01115"/>
+  <xacro:property name="d455_offset_y" value="0.0475"/>
+  <xacro:property name="d455_offset_z" value="0.0145"/>
 
-  <xacro:property name="camera_left_x" value="${0.0 - base_link_x}"/>
-  <xacro:property name="camera_left_y" value="${0.12 - base_link_y}"/>
-  <xacro:property name="camera_left_z" value="${0.690 - base_link_z}"/>
+  <!-- The sensor_d455 macro is instantiated with a further +pi/2 yaw, so a frame
+       joint of 0 makes a camera look along +Y (the robot's left) and one of pi
+       makes it look along -Y (its right). Both frame joints used to carry -pi/2,
+       which the macro's +pi/2 cancelled: in TF, both cameras looked straight
+       ahead while the simulated pair looked sideways (#51). -->
+  <xacro:property name="camera_left_x" value="${camera_x + d455_offset_y}"/>
+  <xacro:property name="camera_left_y" value="${camera_y - d455_offset_x}"/>
+  <xacro:property name="camera_left_z" value="${camera_z - base_link_z - d455_offset_z}"/>
+
+  <xacro:property name="camera_right_x" value="${camera_x - d455_offset_y}"/>
+  <xacro:property name="camera_right_y" value="${-camera_y + d455_offset_x}"/>
+  <xacro:property name="camera_right_z" value="${camera_z - base_link_z - d455_offset_z}"/>
 
 
   <!-- Init colour -->
@@ -237,7 +261,7 @@
   <joint name="camera_right_frame_joint" type="fixed">
     <parent link="base_link"/>
     <child link="camera_right_frame_link"/>
-    <origin xyz="${camera_right_x} ${camera_right_y} ${camera_right_z}" rpy="0 0 ${-pi/2}"/>
+    <origin xyz="${camera_right_x} ${camera_right_y} ${camera_right_z}" rpy="0 0 ${pi}"/>
   </joint>
 
   <xacro:arg name="use_nominal_extrinsics" default="true"/>
@@ -251,7 +275,7 @@
   <joint name="camera_left_frame_joint" type="fixed">
     <parent link="base_link"/>
     <child link="camera_left_frame_link"/>
-    <origin xyz="${camera_left_x} ${camera_left_y} ${camera_left_z}" rpy="0 0 ${-pi/2}"/>
+    <origin xyz="${camera_left_x} ${camera_left_y} ${camera_left_z}" rpy="0 0 0"/>
   </joint>
 
   <xacro:arg name="use_nominal_extrinsics" default="true"/>

--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -78,3 +78,37 @@ Two smaller sharp edges in the same family:
   Classic tolerated it; gz-sim rejects the entire spawn with
   `Error Code 2: Msg: collision with name[collision] already exists`, and the robot
   simply never appears in the world.
+- A `<sensor>`'s `<pose>` is relative to its parent `<link>`, so a link pose and a sensor
+  pose **add**. Writing the mounting point in both is the mistake behind
+  [#51](https://github.com/Minipada/ros2_data_collection/issues/51): it put both cameras
+  at twice their intended offset, and nothing complains, because a camera pointed 8
+  degrees off still renders a perfectly good picture of the wrong thing.
+
+## Camera geometry, and why the demo cares about millimetres
+
+The QR-code demo is an inspection run: the robot stops in front of a pallet so that a
+camera can read the code on it. That only works if the code lands inside the frame, and
+the aisles leave very little room to be wrong in. The numbers, all measured by rendering
+a code from a known pose and reading back the bounding box ZXing reports:
+
+| Quantity | Value |
+|---|---|
+| Camera optical centres (from `base_footprint`) | `(0, ±0.02, 0.539)` m, looking ±Y |
+| Horizontal FOV | 1.047 rad — sdformat's default, no `<horizontal_fov>` is declared |
+| Frame at standoff *d* | ±*d*·tan(30°) wide, ±*d*·tan(18°) tall |
+| QR symbol as rendered | 0.362 × 0.292 m, centred 0.539 m above the floor |
+| Standoffs the demo drives | 0.97 m (aisle 1), 0.73 m (aisle 2), 0.98 m (aisle 3) |
+
+Aisle 2 is the binding case: its two pallet rows are 1.49 m apart, so the robot can never
+be more than ~0.73 m off either wall. A code stays readable while
+
+```
+|lateral error| + d·tan(|yaw error|) + 0.181 <= d·tan(30°)
+```
+
+which at *d* = 0.73 m leaves about 0.24 m for the goal tolerance to spend, and yaw is the
+expensive half because it scales with the standoff. `dc_demos`' `qrcodes_nav.yaml`
+therefore stops at 0.1 m / 0.1 rad, not the 0.2 rad it used to, and
+`tools/sim/scripts/lint_launch_files.py` re-derives the whole inequality from the world,
+the robot model, the waypoints and the nav params on every run, so the four cannot drift
+apart again without CI saying so. The measured worst-case margin is 55 mm.

--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -94,7 +94,7 @@ a code from a known pose and reading back the bounding box ZXing reports:
 | Quantity | Value |
 |---|---|
 | Camera optical centres (from `base_footprint`) | `(0, ±0.02, 0.539)` m, looking ±Y |
-| Horizontal FOV | 1.047 rad — sdformat's default, no `<horizontal_fov>` is declared |
+| Horizontal FOV | 1.047 rad (60°) — declared, see below |
 | Frame at standoff *d* | ±*d*·tan(30°) wide, ±*d*·tan(18°) tall |
 | QR symbol as rendered | 0.362 × 0.292 m, centred 0.539 m above the floor |
 | Standoffs the demo drives | 0.97 m (aisle 1), 0.73 m (aisle 2), 0.98 m (aisle 3) |
@@ -106,9 +106,32 @@ be more than ~0.73 m off either wall. A code stays readable while
 |lateral error| + d·tan(|yaw error|) + 0.181 <= d·tan(30°)
 ```
 
-which at *d* = 0.73 m leaves about 0.24 m for the goal tolerance to spend, and yaw is the
-expensive half because it scales with the standoff. `dc_demos`' `qrcodes_nav.yaml`
-therefore stops at 0.1 m / 0.1 rad, not the 0.2 rad it used to, and
-`tools/sim/scripts/lint_launch_files.py` re-derives the whole inequality from the world,
-the robot model, the waypoints and the nav params on every run, so the four cannot drift
-apart again without CI saying so. The measured worst-case margin is 55 mm.
+`tools/sim/scripts/lint_launch_files.py` re-derives that inequality — and its vertical
+twin — from the world, the robot model, the waypoints and the nav params on every run, so
+the four cannot drift apart again without CI saying so. The worst case over the goal
+tolerance is **55 mm**.
+
+### Why the field of view is 60°, and why widening it did not work
+
+Neither camera used to declare `<horizontal_fov>`, so both inherited sdformat's fallback
+of 1.047 rad. Both declare it now. The value is unchanged, so nothing renders
+differently; what changed is that the number is visible and the lint reads it rather than
+assuming it — the check and the simulator can no longer disagree about the one number the
+whole inequality turns on.
+
+60° is narrower than the real cameras this robot is named for. The SDF sensors are named
+for an **R200** (~77° colour, ~70° depth); `dc_description` instantiates a **D455**
+(~90° colour, ~87° depth) via `realsense2_description`. Nothing upstream helps: that
+package is URDF and meshes only, with no gz sensor definition and no `horizontal_fov`
+anywhere, for any model. The only gz camera sensors in the ROS install are nav2's own
+`gz_waffle` (1.047) and the TB4's OAK-D (1.25).
+
+Widening to the R200's 77° was tried, because 55 mm of margin is thinner than it looks —
+the goal checker compares AMCL's *estimate* against the goal, so localization error lands
+on top of the tolerance and never appears in that budget. It takes the worst case from
+55 mm to 134 mm. **It was reverted anyway**: at 77° the code at aisle 1 station 9 stops
+decoding at a pose Nav2 is allowed to stop in, one the 60° lens reads without trouble.
+That is not a resolution effect — the same view rendered at 1920×1080 also fails, while
+simply upscaling the 1280×720 frame 1.5× decodes it — so something about the wider view
+defeats ZXing's detector rather than starving it of pixels. Until that is understood, the
+lens that is measured good at every station wins over the one that is more realistic.

--- a/dc_simulation/worlds/qrcodes.world
+++ b/dc_simulation/worlds/qrcodes.world
@@ -30,8 +30,11 @@
     <!--
       Gazebo Classic resolved "model://ground_plane" and "model://sun"
       against its bundled model database; gz-sim ships neither as a
-      resolvable model:// uri (see #268), so they're defined inline instead
-      -- the standard gz-sim convention (e.g. its own example worlds).
+      resolvable model:// uri (see #268), so they're defined inline instead,
+      the standard gz-sim convention (e.g. its own example worlds).
+      (A literal double hyphen is illegal inside an XML comment and makes the
+      world unreadable to every strict XML parser; libsdformat's TinyXML2 is the
+      lenient exception, which is why this went unnoticed.)
     -->
     <model name="ground_plane">
       <static>true</static>

--- a/dc_simulation/worlds/waffle.model
+++ b/dc_simulation/worlds/waffle.model
@@ -351,9 +351,29 @@
       </collision>
     </link>
 
+    <!--
+      Both inspection cameras sit on the robot's centre line, back to back on a
+      mast at the height of the QR codes, one looking left and one looking right
+      (#51). Their optical centres are 20 mm either side of that line, which is
+      as close as two camera bodies can be mounted; anything larger eats into the
+      standoff, and the aisles have none to spare.
+
+      The link pose used to be "0.069 -0.047 0.407" with the sensor pose
+      "0.064 -0.047 0.107 0 0 1.57" inside it. An SDF sensor pose is relative to
+      its parent link, so those add: both cameras ended up at the same point,
+      133 mm ahead of base_footprint and 94 mm to the right of it. The waypoint
+      follower aims base_footprint at each pallet, so that 133 mm put the code
+      130 to 140 mm off the image centre before the robot had made any navigation
+      error at all, and at the 0.6 to 0.9 m standoff the demo drives, that is most
+      of the margin a 60-degree lens has. See dc_simulation/README.md for the
+      measured geometry and the arithmetic.
+    -->
     <link name="left_camera_link">
       <inertial>
-        <pose>0.069 -0.047 1.107 0 0 0</pose>
+        <!-- Was <pose>0.069 -0.047 1.107 0 0 0</pose>: a 35 g mass hung 1.1 m
+             above its own link, another artefact of the same absolute-vs-relative
+             mix-up. The camera body's centre of mass is the link origin. -->
+        <pose>0 0 0 0 0 0</pose>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0.000</ixy>
@@ -365,7 +385,7 @@
         <mass>0.035</mass>
       </inertial>
       <collision name="collision">
-        <pose>0 0.047 -0.005 0 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.008 0.130 0.022</size>
@@ -373,12 +393,12 @@
         </geometry>
       </collision>
 
-      <pose>0.069 -0.047 0.407 0 0 0</pose>
+      <pose>0 0.02 0.539 0 0 0</pose>
 
       <sensor name="left_intel_realsense_r200_depth" type="rgbd_camera">
         <always_on>1</always_on>
         <update_rate>5</update_rate>
-        <pose>0.064 -0.047 0.107 0 0 1.57</pose>
+        <pose>0 0 0 0 0 1.5707963</pose>
         <topic>left_camera</topic>
         <gz_frame_id>camera_left_depth_optical_frame</gz_frame_id>
         <camera name="left_realsense_depth_camera">
@@ -397,7 +417,7 @@
 
     <link name="right_camera_link">
       <inertial>
-        <pose>0.069 -0.047 1.107 0 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <inertia>
           <ixx>0.001</ixx>
           <ixy>0.000</ixy>
@@ -409,7 +429,7 @@
         <mass>0.035</mass>
       </inertial>
       <collision name="collision">
-        <pose>0 0.047 -0.005 0 0 0</pose>
+        <pose>0 0 0 0 0 0</pose>
         <geometry>
           <box>
             <size>0.008 0.130 0.022</size>
@@ -417,12 +437,12 @@
         </geometry>
       </collision>
 
-      <pose>0.069 -0.047 0.407 0 0 0</pose>
+      <pose>0 -0.02 0.539 0 0 0</pose>
 
       <sensor name="right_intel_realsense_r200_depth" type="rgbd_camera">
         <always_on>1</always_on>
         <update_rate>5</update_rate>
-        <pose>0.064 -0.047 0.107 0 0 -1.57</pose>
+        <pose>0 0 0 0 0 -1.5707963</pose>
         <topic>right_camera</topic>
         <gz_frame_id>camera_right_depth_optical_frame</gz_frame_id>
         <camera name="right_realsense_depth_camera">

--- a/dc_simulation/worlds/waffle.model
+++ b/dc_simulation/worlds/waffle.model
@@ -402,6 +402,26 @@
         <topic>left_camera</topic>
         <gz_frame_id>camera_left_depth_optical_frame</gz_frame_id>
         <camera name="left_realsense_depth_camera">
+          <!-- Declared rather than inherited. The value is sdformat's own fallback,
+               so this changes nothing about what renders; what it changes is that
+               the number is visible, and that
+               tools/sim/scripts/lint_launch_files.py reads it instead of assuming
+               it. nav2's own gz_waffle declares the same 1.047, and the TB4's OAK-D
+               declares 1.25.
+
+               Widening it was tried and reverted (#51). 60 degrees is narrower than
+               the real cameras this robot is named for: an R200 is about 77 degrees
+               in colour, the D455 dc_description instantiates about 90. Widening to
+               77 does buy framing margin, 55 mm to 134 mm at the tightest station.
+               It costs more than it buys: at 77 degrees the code at aisle 1
+               station 9 stops decoding at a pose Nav2 is allowed to stop in, and it
+               is not a resolution problem, because rendering the same view at
+               1920x1080 fails too while merely upscaling the 1280x720 frame decodes
+               fine. Something about the wider view defeats ZXing's detector here.
+               The narrower lens is measured good at every station and the wider one
+               is not, so measurement wins over realism until someone works out why.
+               See dc_simulation/README.md. -->
+          <horizontal_fov>1.047</horizontal_fov>
           <image>
             <width>1280</width>
             <height>720</height>
@@ -446,6 +466,26 @@
         <topic>right_camera</topic>
         <gz_frame_id>camera_right_depth_optical_frame</gz_frame_id>
         <camera name="right_realsense_depth_camera">
+          <!-- Declared rather than inherited. The value is sdformat's own fallback,
+               so this changes nothing about what renders; what it changes is that
+               the number is visible, and that
+               tools/sim/scripts/lint_launch_files.py reads it instead of assuming
+               it. nav2's own gz_waffle declares the same 1.047, and the TB4's OAK-D
+               declares 1.25.
+
+               Widening it was tried and reverted (#51). 60 degrees is narrower than
+               the real cameras this robot is named for: an R200 is about 77 degrees
+               in colour, the D455 dc_description instantiates about 90. Widening to
+               77 does buy framing margin, 55 mm to 134 mm at the tightest station.
+               It costs more than it buys: at 77 degrees the code at aisle 1
+               station 9 stops decoding at a pose Nav2 is allowed to stop in, and it
+               is not a resolution problem, because rendering the same view at
+               1920x1080 fails too while merely upscaling the 1280x720 frame decodes
+               fine. Something about the wider view defeats ZXing's detector here.
+               The narrower lens is measured good at every station and the wider one
+               is not, so measurement wins over realism until someone works out why.
+               See dc_simulation/README.md. -->
+          <horizontal_fov>1.047</horizontal_fov>
           <image>
             <width>1280</width>
             <height>720</height>

--- a/doc/src/dc/demos/qrcodes_minio_pgsql.md
+++ b/doc/src/dc/demos/qrcodes_minio_pgsql.md
@@ -89,6 +89,22 @@ and exits once the pass is complete:
 ros2 run dc_demos qrcodes_waypoint_follower
 ```
 
+```admonish info
+The waypoints are camera stations, not just places to be, and the aisles are narrow
+enough that the difference matters: a code is only readable while
+
+    |lateral error| + standoff * tan(|yaw error|) + 0.181 <= standoff * tan(30°)
+
+where 0.181 m is half a rendered QR symbol and 30° is half the cameras' field of view.
+The tightest station has a 0.73 m standoff, which is why `qrcodes_nav.yaml` stops the
+robot within 0.1 m and 0.1 rad rather than Nav2's more usual tolerances. If you move the
+waypoints, the pallets or the cameras, re-run `./tools/sim/scripts/run.sh` — its `lint`
+stage re-derives that inequality from the world, the robot model, the waypoints and the
+nav params, and its `detect` stage checks that codes really do come back. See
+[dc_simulation's README](https://github.com/Minipada/ros2_data_collection/blob/jazzy/dc_simulation/README.md)
+for the measured geometry.
+```
+
 ## Understanding the configuration
 
 ```admonish info

--- a/progress.txt
+++ b/progress.txt
@@ -5273,6 +5273,10 @@ exactly. That number is now in the waypoint follower's header comment and in the
   stations instead of reimplementing them.
 - `qrcodes_nav.yaml`: `yaw_goal_tolerance` 0.2 -> 0.1, with the inequality above written
   out next to it. `xy_goal_tolerance` stays at 0.1: it is the cheap half.
+- `waffle.model` again: both cameras now **declare** `<horizontal_fov>1.047</horizontal_fov>`
+  rather than inheriting it. Same value, so nothing renders differently; the point is that
+  the lint reads it instead of assuming it. Widening it was tried and reverted -- see the
+  section below.
 - The AMCL seed pose, in both `qrcodes_nav.yaml` and the follower, was
   (-23.910844, -13.887906) and commented "obtained after setting pose on RVIZ and
   checking /amcl_pose" -- a hand-placed estimate, 69 mm out in x from where the launch
@@ -5401,3 +5405,66 @@ reason the daily job keeps DC off.
 file unreadable to every strict XML parser; libsdformat's TinyXML2 is the lenient
 exception, which is why it survived. `check_qr_alignment` parses `waffle.model` with
 ElementTree and tripped over the same thing in a comment of its own.
+
+### The field of view: investigated, widened, measured, reverted
+
+The fix above leaves a 55 mm worst-case margin, and 55 mm is thinner than it looks: the
+goal checker compares AMCL's *estimate* of the pose against the goal, so localization
+error lands on top of the tolerance and none of it appears in that budget. The only lever
+that widens the budget without moving pallets is the lens.
+
+**Neither camera declared `<horizontal_fov>`**, so both inherited sdformat's fallback of
+1.047 rad. That was never a decision, and 60 degrees is narrower than any camera on the
+market -- including both cameras this robot claims to be. Checked rather than assumed:
+
+- R200 (what the SDF sensors are named for): ~77 degrees colour, ~70 degrees depth/IR.
+- D455 (what `dc_description` instantiates, via `realsense2_description`'s `sensor_d455`
+  macro): ~90 degrees colour, ~87 degrees depth. Worth knowing for realism that Intel has
+  since exited the depth-camera market entirely, so neither is purchasable new; the D400
+  series was the de-facto standard for short-range RGB-D in robotics until then.
+
+**Nothing to reuse.** `realsense2_description` on Jazzy is URDF and meshes only -- no gz
+sensor definition for any model, and `grep -r horizontal_fov` over the whole package
+returns nothing. The only gz camera sensors in the entire ROS install are nav2's own:
+`nav2_minimal_tb3_sim`'s `gz_waffle` (its realsense, 1.047) and
+`nav2_minimal_tb4_description`'s OAK-D (1.25). So declaring it is done by hand, but
+declaring it *is* the neighbouring convention.
+
+**77 degrees was chosen and implemented** -- the R200's colour FOV, which is the stream
+this demo reads (`image_raw`), and self-consistent with the name the model carries. Not
+the D455's 87 that a first pass suggested, because `intel_realsense_r200` is not a label
+on the sensor, it is the **ROS topic name** across every demo params file, the bridge
+config, the RViz config and the docs, deliberately preserved through the Classic-to-gz
+port. It took the worst-case margin from 55 mm to 134 mm and flipped the binding axis from
+horizontal to vertical.
+
+**Then it was reverted, on the evidence.** Re-running the all-station sweep at 77 degrees
+turned up a miss the 60-degree configuration does not have: aisle 1, station 9, the `wB`
+corner -- `dx -0.043, dy -0.090, dyaw -0.1`, which sits exactly on the tolerance circle
+and is therefore a pose Nav2 is allowed to stop in. The code is fully in frame,
+unobstructed, about 300x240 px, and ZXing returns nothing.
+
+Three measurements pinned it down:
+
+- **Not framing.** The rendered image shows the whole symbol with clear margin on every
+  side.
+- **Not resolution.** Rendering the same view at 1920x1080 (about 450 px of code) fails
+  too, while merely upscaling the 1280x720 frame 1.5x with cubic interpolation -- which
+  adds no information at all -- decodes it.
+- **It is the lens.** The same pose, same container, same everything, re-rendered at
+  1.047: `OK QRCode '0002' box=225,196 409x330`.
+
+So something about the wider view defeats ZXing's detector rather than starving it of
+pixels, and the wider lens trades a deterministic geometric margin for a stochastic decode
+one -- a much worse property for a demo whose acceptance criterion is "detection succeeds
+on every QR code". The narrower lens is measured good at all 180 station/pose cases, all
+72 envelope-boundary cases and a 20-station live pass; the wider one is not. Measurement
+wins over realism until someone works out why.
+
+What survives from the exercise, and is worth keeping: **the value is now declared** rather
+than silently inherited, and `check_qr_alignment` **reads** it out of `waffle.model`
+instead of assuming sdformat's default. The check and the simulator can no longer disagree
+about the one number the whole inequality turns on -- which would have been the same class
+of bug as #51 itself. The old constant survives only as the documented fallback for a model
+that stops declaring one. The 77-degree experiment is written up in `waffle.model` and
+`dc_simulation/README.md` so nobody repeats it without knowing how it ends.

--- a/progress.txt
+++ b/progress.txt
@@ -5176,3 +5176,228 @@ more than that once buildah's own layer commit is added on top) — two local at
 both failed with "no space left on device" after the full ~20-minute compile. All
 verification after that point was via real CI runs, which is slower per round-trip but
 was the only environment with enough disk to actually exercise the design.
+
+## #51: robot misaligned with the QR codes, detection fails
+
+**Read**: the issue, #279 (its blocker, which closed and named the suspects to check in
+order), `dc_demos/dc_demos/qrcodes_waypoint_follower.py`, `dc_demos/params/qrcodes_nav.yaml`,
+`dc_demos/params/qrcodes_stdout.yaml`, `dc_demos/launch/tb3_qrcodes.launch.py`,
+`dc_simulation/{worlds/{qrcodes.world,waffle.model},maps/qrcodes.{pgm,yaml},models/qrcode_*}`,
+`dc_description/urdf/turtlebot3_waffle_qrcodes.xacro`,
+`dc_measurements/plugins/{measurements/camera.cpp,conditions/moving.cpp}`,
+`dc_measurements/include/dc_measurements/measurement.hpp`, and `tools/sim/scripts/*`.
+
+### The symptom, reproduced away from Nav2
+
+Nav2's goal checker is allowed to stop the robot anywhere within `xy_goal_tolerance` and
+`yaw_goal_tolerance` of a waypoint. So rather than run the demo and hope to catch a bad
+stop, the robot was teleported (`gz service /world/warehouse/set_pose`) to a grid of poses
+across that whole envelope and a frame taken from each camera at each one, then decoded
+with the same call `dc_measurements`' Camera plugin makes (`ZXing::ReadBarcodes` with
+default options, in a 20-line C++ tool linked against the same libraries).
+
+135 poses -- three aisles x (dx, dy) in {-0.1, 0, 0.1} x dyaw in {-0.2, ..., 0.2}:
+
+| Aisle | Poses whose facing camera decoded the code |
+|---|---|
+| 1 (open, west side) | 38/45 |
+| 2 (between two pallet rows) | **18/45** |
+| 3 (open, east side) | 32/45 |
+
+Every failure is the same one: the code runs off the edge of the frame. In aisle 2 the
+right camera missed even at `dx=-0.1, dy=0, dyaw=0` -- a pose Nav2 considers a perfect
+arrival.
+
+### Root cause: three errors that all push the code the same way
+
+Measured from the renders, a QR symbol on a pallet is 0.362 x 0.292 m and
+its centre sits 0.539 m above the floor. The cameras have no `<horizontal_fov>`, so they
+get sdformat's default 1.047 rad; at a standoff *d* the frame is +/- *d*·tan(30°) wide.
+A code is readable while
+
+    |lateral error| + d·tan(|yaw error|) + 0.181 <= d·tan(30°)
+
+**1. The cameras were not where anything thought they were (the "description" term).**
+`waffle.model` had `<pose>0.069 -0.047 0.407</pose>` on each camera link *and*
+`<pose>0.064 -0.047 0.107 0 0 ±1.57</pose>` on the sensor inside it. An SDF `<sensor>`
+pose is relative to its parent link, so those add: both cameras sat at the same point,
+133 mm ahead of `base_footprint` and 94 mm to the right of it. The waypoints aim
+`base_footprint` at the pallet, so that 133 mm put the code 130-140 mm off the image
+centre before any navigation error at all. Measured on the renders: 176 px of a 240 px
+margin in aisle 1, all of it on one side.
+
+`dc_description`'s URDF disagreed with all of it, in every axis. Its
+`ground_base_distance` was **1.300 m**, borrowed from a much taller robot, and every
+camera offset is expressed from the ground and rebased onto `base_link`, so both cameras
+were 0.6 m *underground* in TF. Both frame joints also carried `rpy="0 0 -pi/2"`, which
+the `sensor_d455` macro's own `+pi/2` cancels, so in TF both cameras looked straight
+ahead while the simulated pair looked sideways. None of this reaches the barcode
+decoder -- `camera.cpp` never touches TF -- but it is what RViz draws and what any
+downstream consumer of `camera_*_depth_optical_frame` would believe.
+
+**2. The waypoints were not square to the wall, or centred on the pallets (the "world
+layout" term).** `z_orientation`/`w_orientation` were `(0.7071068967, 0.7248122258)` and
+`(-0.7023745033, 0.7118075984)`: norms 1.0126 and 1.0000, i.e. headings of 88.6° and
+-89.2° rather than ±90°. #279 found and fixed exactly this transcription error in the
+*initial* pose ten lines above, and left the sixty goal poses alone. `rows_y0` was
+-10.45 against pallet centres at -10.475. And `rows_x` stood the robot 0.65 m off the
+codes in aisle 3 (where the aisle is wide open and there was no reason to be that close)
+and 0.05 m off centre in aisle 2 (where it is not).
+
+**3. The tolerance was never sized against the lens (the "tolerance" term).**
+`yaw_goal_tolerance: 0.2` is 11.5°, which at a 0.73 m standoff slides the code 0.15 m
+across the frame -- on its own, more than the margin aisle 2 has.
+
+The map/world relation needed to say any of this is not written down anywhere, so it was
+measured: the four pallet blocks sit at map x -18.100/-16.800/-14.300/-13.000 in
+`qrcodes.pgm` against world -10.8/-9.5/-7.0/-5.7, and the first pallet row at map y
+-10.475 against world -11.9, giving **x_map = x_world - 7.300, y_map = y_world + 1.425**
+exactly. That number is now in the waypoint follower's header comment and in the lint.
+
+### The fix
+
+- `waffle.model`: both cameras onto the robot's centre line, back to back at
+  (0, ±0.02, 0.539) looking ±Y, sensor poses zeroed so the link pose *is* the mounting
+  point. The 1.107 m inertial pose and the +0.047 m collision offset in the same links,
+  both artefacts of the same absolute-vs-relative mix-up, went with them.
+- `turtlebot3_waffle_qrcodes.xacro`: `base_link_z` 1.300 -> 0.010, camera offsets
+  rewritten from the same (0, ±0.02, 0.539), the `sensor_d455` macro's internal
+  (0.01115, 0.0475, 0.0145) offset undone so `camera_*_link` lands exactly there, and
+  the frame joints changed to 0 / pi so the left camera looks left and the right right.
+  Verified by walking the expanded URDF: both optical origins at (0, ±0.02, 0.539) with
+  optical +Z along base ±Y, matching the SDF sensor for sensor.
+- `qrcodes_waypoint_follower.py`: exact ±90° quaternions, `rows_y0` -10.475,
+  `rows_x` [-19.6, -15.55, -11.5] (0.97 m from camera to code in both open aisles,
+  0.73 m either side in the closed one, which is the most its 1.49 m allows). The three near-identical row comprehensions collapsed into one
+  `camera_stations()` returning (x, y, yaw) tuples, so the lint below can import the
+  stations instead of reimplementing them.
+- `qrcodes_nav.yaml`: `yaw_goal_tolerance` 0.2 -> 0.1, with the inequality above written
+  out next to it. `xy_goal_tolerance` stays at 0.1: it is the cheap half.
+- The AMCL seed pose, in both `qrcodes_nav.yaml` and the follower, was
+  (-23.910844, -13.887906) and commented "obtained after setting pose on RVIZ and
+  checking /amcl_pose" -- a hand-placed estimate, 69 mm out in x from where the launch
+  file actually spawns the robot. Now the spawn pose carried through the offset exactly,
+  (-23.9794, -13.8752), which also gives the lint a way to check the offset constant
+  against numbers the demo already states (`check_map_offset`): the launch file gives the
+  spawn pose in the world frame and the params give the same spot in the map frame, so
+  the two must differ by exactly WORLD_TO_MAP.
+
+### Verified
+
+**The static check first, because it is the one that has to fail.** A new
+`check_qr_alignment` in `tools/sim/scripts/lint_launch_files.py` re-derives the whole
+inequality from the four files that have to agree -- camera mounting out of
+`waffle.model`, stations out of `qrcodes_waypoint_follower`, pallet faces out of
+`qrcodes.world`, tolerances out of `qrcodes_nav.yaml` -- and reports the worst-case
+margin over the tolerance circle in closed form (`d*k - r*hypot(k, 1)` with
+`k = tan(hfov/2) - tan(yaw_tol)`; the naive version that subtracts the full xy tolerance
+from the standoff *and* adds it laterally is 47 mm pessimistic).
+
+    as shipped                    PASS   worst margin  0.055 m
+    pre-fix camera mounting only  FAIL   worst margin -0.113 m
+    pre-fix waypoint rows only    FAIL   worst margin -0.017 m
+    pre-fix yaw tolerance only    FAIL   worst margin -0.016 m
+
+Each of the three fixes is individually load-bearing, and the check catches each on its
+own.
+
+**Then the renders, on the boundary of the envelope**, which is where the worst case
+actually lives: 8 directions around the `xy_goal_tolerance` circle x dyaw in
+{-0.1, 0, +0.1}, per aisle. **72/72 decode**, against 88/135 for the same geometry
+before the fix.
+
+**Then the demo itself**, `tb3_qrcodes.launch.py headless:=True use_rviz:=False
+use_dc:=True` -- the real thing, Nav2 driving and the DC pipeline running -- with
+`ros2 run dc_demos qrcodes_waypoint_follower`. Through the whole of aisle 1, 20 stations:
+
+    20 Records carrying a decoded barcode, one per station
+    10 x "0002" and 10 x "0004", exactly the two codes that wall carries
+    0 aborted or failed goals, 0 recovery behaviours
+
+The pass was stopped after aisle 1 rather than run to 60. This machine was at load 26 on
+8 cores with the user's own tooling taking ~3 of them, the run held a real-time factor of
+0.11, and 60 stations at ~62 s of simulated time each would have been most of a day. The
+remaining two aisles are covered instead by the all-station sweep below, which exercises
+the same geometry at every one of the 60 stations in a fraction of the time.
+
+**And every station, since one live pass could not reach them all.** The same teleport
+harness, over all 60 camera stations, three poses each: the nominal pose and the two
+worst points on the tolerance circle (the closed-form worst offset, `0.1*k/hypot(k,1)`
+across the aisle and `0.1/hypot(k,1)` along it, paired with `dyaw = +/-0.1` so each
+camera gets the combination that pushes its code towards the edge rather than away).
+
+    180/180 (station, pose) cases decode on every camera that faces a coded pallet
+    aisle 1: 0002, 0004      aisle 2: 0001, 0003, 0005, 0007      aisle 3: 0006, 0008
+
+All eight codes the world carries, from every station the demo stops at, anywhere Nav2
+is allowed to leave the robot.
+
+**Regression guard.** `tools/sim/scripts/run.sh` gained a `detect` stage: a modifier on
+`waypoints` that brings the DC pipeline up with the demo and asserts that codes really
+come back, via a new `verify_sim.py record` that reads the Measurement topics. It reads
+the topics rather than grepping the launch log on purpose -- the log also carries each
+Measurement's JSON *schema*, which contains the word "barcode" without any code ever
+having been seen, and a check that counts those can never fail.
+
+The stage was exercised by running `tools/sim/scripts/run.sh` itself, the way CI calls it,
+against an image built from this branch. **The first run failed, which is the point**:
+that image was missing `python3-pydantic`, so `dc_services`' `draw_image` never started,
+every Camera measurement sat in "Waiting for draw image service to appear...", and no
+Record was ever published. Zero codes over two stations, and the stage said so and exited
+non-zero -- while every other stage in the same run passed, the robot spawned, Nav2
+localized, and both goals succeeded with no navigation failures. That is exactly the
+shape of #51: a demo that looks healthy from every angle except the one that matters.
+(The real workspace image resolves that dependency through rosdep; `dc_services`'
+`package.xml` has declared it since #279. It was the throwaway image that was short.)
+
+With the dependency in place the stage goes green, reading the codes aisle 1 carries at
+the stations it stops at:
+
+    /dc/measurement/right_camera pose=(-19.655, -10.534, 1.169) format=QRCode code=0002
+    /dc/measurement/right_camera pose=(-19.637,  -9.435, 1.536) format=QRCode code=0002
+
+**It also caught a false positive, which changed the check.** One of those two reads was
+the string `51`, decoded before the robot reached the first pallet. ZXing's default
+`ReaderOptions` try every symbology, 1-D ones included, and warehouse shelving obliges.
+So the recorder now logs the barcode's `type` alongside its payload and the stage counts
+`format=QRCode` reads only -- a check that accepts "some barcode, any barcode" would pass
+on scenery. The false positive itself is *not* fixed here: `detection_modules:
+["barcode"]` means all symbologies on purpose, and narrowing that is a product decision
+for the Camera plugin, not something to slip into #51. Worth its own issue.
+
+That first run also showed up a race in the assertion as first written: it read the code
+count once, immediately after the waypoint loop breaks -- and that loop breaks the instant
+nav2 reports it is working on the next waypoint, a second or two before the measurement at
+the station behind it has polled, decoded and published. It now polls for up to 180 s and
+breaks as soon as the count is reached, which can only turn a flaky failure into a pass,
+never the reverse.
+
+It goes into `ci.yaml`'s per-PR `sim` job (three waypoints) and is deliberately **not**
+in `sim.yaml`'s daily default. That job's 63-minute envelope was measured with DC off,
+its budget is already 4 hours inside a 5-hour job, and running two 1280x720 RGBD streams
+through ZXing alongside 60 navigation goals is the kind of load that turns that into a
+timeout. The daily job still gets the geometric check, which covers all 60 stations
+analytically; `detect` is one `workflow_dispatch` input away when it is wanted.
+
+### One thing that is *not* a regression, and one that is worth knowing
+
+The tighter `yaw_goal_tolerance` costs no measurable navigation time. Measured by
+flipping it live, mid-pass, with `ros2 param set` so nothing else changed. The seven
+goals after the initial approach, at 0.1 rad, took 66, 67, 73, 75, 72, 64 and 59 s of
+*simulated* time each; the two after the flip, at 0.2 rad, took 62 and 62 s. A diff-drive robot rotating on the spot settles well inside 0.1 rad, as
+expected.
+
+What *is* slow is the pass with DC running: ~62 s of simulated time per 1.3 m hop here
+against the ~8 s/waypoint (483 s for 60) #279 measured with `use_dc:=False`. Real-time
+factor was 0.11 against #279's 0.198, on a machine at load 26 with 8 cores. The
+controller runs on `use_sim_time`, and gz-sim advances simulated time whether or not
+ROS keeps up, so a starved `controller_server` really does make the robot slower *in
+simulated time*, not merely in wall clock. Worth having on the record for #52, and the
+reason the daily job keeps DC off.
+
+### Also fixed, found by the tooling above
+
+`qrcodes.world` had a literal `--` inside an XML comment, which is illegal and makes the
+file unreadable to every strict XML parser; libsdformat's TinyXML2 is the lenient
+exception, which is why it survived. `check_qr_alignment` parses `waffle.model` with
+ElementTree and tripped over the same thing in a comment of its own.

--- a/tools/sim/scripts/lint_launch_files.py
+++ b/tools/sim/scripts/lint_launch_files.py
@@ -199,8 +199,10 @@ CODE_HALF_H = 0.146  # half its rendered height, m
 # four pallet blocks sit at map x -18.100/-16.800/-14.300/-13.000 against world
 # -10.8/-9.5/-7.0/-5.7, and the first pallet row at map y -10.475 against world -11.9.
 WORLD_TO_MAP = (-7.300, 1.425)
-# sdformat's default when a <camera> declares no <horizontal_fov>, which neither of
-# waffle.model's does.
+# sdformat's fallback when a <camera> declares no <horizontal_fov>. Both of
+# waffle.model's do declare one, and read_camera_poses() reads it -- this is only the
+# floor for a model that stopped saying, and 60 degrees is narrower than any real
+# camera, so a silent fall back to it should be visible in the margin.
 DEFAULT_HFOV = 1.047
 
 
@@ -212,7 +214,7 @@ def read_camera_poses():
     both cameras 133 mm ahead of the point the waypoints aim at.
 
     Returns:
-        {"left": (x, y, z, yaw), "right": ...}, metres and radians.
+        {"left": (x, y, z, yaw, hfov), "right": ...}, metres and radians.
     """
     import xml.etree.ElementTree as ElementTree
 
@@ -224,13 +226,18 @@ def read_camera_poses():
         # The link's own <pose>, not <inertial>'s or <collision>'s: find() only looks at
         # direct children, which is the whole point of using it here.
         base = [float(v) for v in link.find("pose").text.split()]
-        rel = [float(v) for v in link.find("sensor").find("pose").text.split()]
+        sensor = link.find("sensor")
+        rel = [float(v) for v in sensor.find("pose").text.split()]
+        # Read the lens rather than assume it: the whole check turns on the frame being
+        # the width the simulator actually renders.
+        fov = sensor.find("camera").find("horizontal_fov")
         # Both poses are yaw-only in this model, so composing them is an addition.
         poses[side] = (
             base[0] + rel[0],
             base[1] + rel[1],
             base[2] + rel[2],
             base[5] + rel[5],
+            DEFAULT_HFOV if fov is None else float(fov.text),
         )
     return poses
 
@@ -336,15 +343,14 @@ def check_qr_alignment(report):
     xy_tol, yaw_tol = read_goal_tolerance()
     report.check(bool(planes), "found QR-coded pallet faces", f"{len(planes)} faces")
 
-    half_w_angle = DEFAULT_HFOV / 2.0
-    # 1280x720, so the vertical half-angle follows from the horizontal one.
-    half_h_angle = math.atan(math.tan(half_w_angle) * 720.0 / 1280.0)
-
     worst = None
     unseen = []
     for station_x, station_y, yaw in camera_stations():
         seen = False
-        for side, (cx, cy, cz, cyaw) in cameras.items():
+        for side, (cx, cy, cz, cyaw, hfov) in cameras.items():
+            half_w_angle = hfov / 2.0
+            # 1280x720, so the vertical half-angle follows from the horizontal one.
+            half_h_angle = math.atan(math.tan(half_w_angle) * 720.0 / 1280.0)
             # Camera position and viewing direction in the map frame.
             wx = station_x + cx * math.cos(yaw) - cy * math.sin(yaw)
             wy = station_y + cx * math.sin(yaw) + cy * math.cos(yaw)

--- a/tools/sim/scripts/lint_launch_files.py
+++ b/tools/sim/scripts/lint_launch_files.py
@@ -182,6 +182,226 @@ def check_bridge_config(report):
         )
 
 
+# --- QR-code alignment ------------------------------------------------------------------
+#
+# The demo's waypoints are camera stations: the robot stops there so that a camera can
+# read the QR code on the pallet in front of it. Nothing in the repo used to relate the
+# two, so the stations drifted out of the cameras' field of view and stayed there for
+# years (#51) -- a failure invisible to every other check, because the robot navigates
+# perfectly and the cameras publish perfectly good pictures of the wrong thing.
+#
+# The numbers below are measured, not assumed: rendering a code from a known pose and
+# reading back the bounding box ZXing reports for it gives
+CODE_CENTRE_Z = 0.539  # height of the symbol's centre above the floor, m
+CODE_HALF_W = 0.181  # half the symbol's rendered width, m
+CODE_HALF_H = 0.146  # half its rendered height, m
+# The map frame is the world frame shifted by this much. Measured off qrcodes.pgm: the
+# four pallet blocks sit at map x -18.100/-16.800/-14.300/-13.000 against world
+# -10.8/-9.5/-7.0/-5.7, and the first pallet row at map y -10.475 against world -11.9.
+WORLD_TO_MAP = (-7.300, 1.425)
+# sdformat's default when a <camera> declares no <horizontal_fov>, which neither of
+# waffle.model's does.
+DEFAULT_HFOV = 1.047
+
+
+def read_camera_poses():
+    """Where waffle.model's two inspection cameras sit, relative to base_footprint.
+
+    An SDF <sensor> pose is relative to its parent <link>, so both have to be composed --
+    the bug this check exists for was exactly that composition being overlooked, leaving
+    both cameras 133 mm ahead of the point the waypoints aim at.
+
+    Returns:
+        {"left": (x, y, z, yaw), "right": ...}, metres and radians.
+    """
+    import xml.etree.ElementTree as ElementTree
+
+    share = Path(get_package_share_directory("dc_simulation"))
+    model = ElementTree.parse(share / "worlds" / "waffle.model").getroot().find("model")
+    poses = {}
+    for side in ("left", "right"):
+        link = model.find(f'link[@name="{side}_camera_link"]')
+        # The link's own <pose>, not <inertial>'s or <collision>'s: find() only looks at
+        # direct children, which is the whole point of using it here.
+        base = [float(v) for v in link.find("pose").text.split()]
+        rel = [float(v) for v in link.find("sensor").find("pose").text.split()]
+        # Both poses are yaw-only in this model, so composing them is an addition.
+        poses[side] = (
+            base[0] + rel[0],
+            base[1] + rel[1],
+            base[2] + rel[2],
+            base[5] + rel[5],
+        )
+    return poses
+
+
+def read_code_planes():
+    """The QR-coded pallet faces in qrcodes.world, as (map x, facing, {y}).
+
+    Returns:
+        A list of (plane_x, normal_x, ys): the face's x in the map frame, the direction
+        its codes look along x (+1 or -1), and the set of y values it carries.
+    """
+    share = Path(get_package_share_directory("dc_simulation"))
+    world = re.sub(r"<!--.*?-->", "", (share / "worlds" / "qrcodes.world").read_text(), flags=re.S)
+    planes = {}
+    for _, body in re.findall(r'<model name="([^"]+)">(.*?)</model>', world, re.S):
+        uri = re.search(r"<uri>model://(qrcode_[^<]+)</uri>", body)
+        pose = re.search(r"<pose>([^<]+)</pose>", body)
+        if not uri or not pose:
+            continue
+        values = [float(v) for v in pose.group(1).split()]
+        plane_x = round(values[0] + WORLD_TO_MAP[0], 4)
+        # yaw 0 means the code looks along +x, pi means -x.
+        normal = 1 if abs(values[5]) < 1.0 else -1
+        planes.setdefault((plane_x, normal), set()).add(round(values[1] + WORLD_TO_MAP[1], 4))
+    return [(x, n, ys) for (x, n), ys in sorted(planes.items())]
+
+
+def read_goal_tolerance():
+    """The controller's active goal checker tolerances, as (xy, yaw)."""
+    import yaml
+
+    params = Path(get_package_share_directory("dc_demos")) / "params" / "qrcodes_nav.yaml"
+    controller = yaml.safe_load(params.read_text())["controller_server"]["ros__parameters"]
+    checker = controller[controller["goal_checker_plugins"][0]]
+    return checker["xy_goal_tolerance"], checker["yaw_goal_tolerance"]
+
+
+def check_map_offset(report):
+    """WORLD_TO_MAP still describes the world and map the demo actually loads.
+
+    Every number in check_qr_alignment is expressed in the map frame, so a wrong offset
+    would make the whole check agree with itself and with nothing else. The demo states
+    the same relation twice from opposite ends -- tb3_qrcodes.launch.py spawns the robot
+    at a world pose, and qrcodes_nav.yaml hands AMCL the map pose of that same spot --
+    so the two have to differ by exactly WORLD_TO_MAP.
+
+    Args:
+        report: collects pass/fail for the exit status.
+    """
+    import math
+
+    import yaml
+
+    launch = (
+        Path(get_package_share_directory("dc_demos")) / "launch" / "tb3_qrcodes.launch.py"
+    ).read_text()
+    spawn = {}
+    for axis in ("x", "y"):
+        match = re.search(rf'"{axis}_pose", default="(-?[\d.]+)"', launch)
+        if match:
+            spawn[axis] = float(match.group(1))
+
+    params = Path(get_package_share_directory("dc_demos")) / "params" / "qrcodes_nav.yaml"
+    amcl = yaml.safe_load(params.read_text())["amcl"]["ros__parameters"]
+
+    report.check(len(spawn) == 2, "found the demo's spawn pose", str(spawn))
+    if len(spawn) != 2:
+        return
+    error = math.hypot(
+        spawn["x"] + WORLD_TO_MAP[0] - amcl["initial_pose.x"],
+        spawn["y"] + WORLD_TO_MAP[1] - amcl["initial_pose.y"],
+    )
+    report.check(
+        error < 0.05,
+        "map/world offset matches the demo's own spawn and initial poses",
+        f"{round(error, 4)} m apart",
+    )
+
+
+def check_qr_alignment(report):
+    """Every camera station keeps its QR code in frame across the whole goal tolerance.
+
+    This is the check that was missing when #51 was filed. It relates the four things
+    that have to agree and never did -- the camera's mounting in waffle.model, the
+    stations in qrcodes_waypoint_follower.py, the pallet layout in qrcodes.world and the
+    goal tolerance in qrcodes_nav.yaml -- and fails if a code can leave the frame at a
+    pose Nav2 is allowed to stop at.
+
+    Worst case is on the boundary of the tolerance circle, where shortening the standoff
+    and sliding the code sideways trade off against each other; the closed form for that
+    minimum is below. Yaw is the expensive term at these standoffs because it costs
+    d*tan(yaw), so it grows with the very distance that buys the margin.
+
+    Args:
+        report: collects pass/fail for the exit status.
+    """
+    import math
+
+    from dc_demos.qrcodes_waypoint_follower import camera_stations
+
+    cameras = read_camera_poses()
+    planes = read_code_planes()
+    xy_tol, yaw_tol = read_goal_tolerance()
+    report.check(bool(planes), "found QR-coded pallet faces", f"{len(planes)} faces")
+
+    half_w_angle = DEFAULT_HFOV / 2.0
+    # 1280x720, so the vertical half-angle follows from the horizontal one.
+    half_h_angle = math.atan(math.tan(half_w_angle) * 720.0 / 1280.0)
+
+    worst = None
+    unseen = []
+    for station_x, station_y, yaw in camera_stations():
+        seen = False
+        for side, (cx, cy, cz, cyaw) in cameras.items():
+            # Camera position and viewing direction in the map frame.
+            wx = station_x + cx * math.cos(yaw) - cy * math.sin(yaw)
+            wy = station_y + cx * math.sin(yaw) + cy * math.cos(yaw)
+            look = yaw + cyaw
+            look_x = math.cos(look)
+            if abs(look_x) < 0.9:  # not looking across the aisle at all
+                continue
+            for plane_x, normal, ys in planes:
+                standoff = (plane_x - wx) * look_x
+                # In front of this camera, facing it, and near enough to be its pallet.
+                if standoff <= 0 or standoff > 1.5 or normal * look_x > 0:
+                    continue
+                target_y = min(ys, key=lambda y: abs(y - station_y))
+                if abs(target_y - station_y) > 0.5:
+                    continue
+                seen = True
+                # Worst case over the goal tolerance. The position error is a vector of
+                # length up to xy_tol: its component across the aisle shortens the
+                # standoff (a smaller frame), its component along the aisle slides the
+                # code towards the edge, and the two trade off around the circle. With
+                # slack = tan(hfov/2) - tan(yaw_tol), the horizontal budget at offset
+                # angle phi is (d - r*cos phi)*slack - r*|sin phi|, whose minimum over
+                # phi is d*slack - r*hypot(slack, 1). Vertically only the standoff
+                # matters, so the worst case there is simply the nearest it may stop.
+                slack = math.tan(half_w_angle) - math.tan(yaw_tol)
+                margin_w = (
+                    standoff * slack
+                    - xy_tol * math.hypot(slack, 1.0)
+                    - abs(target_y - wy)
+                    - CODE_HALF_W
+                )
+                margin_h = (
+                    (standoff - xy_tol) * math.tan(half_h_angle)
+                    - abs(CODE_CENTRE_Z - cz)
+                    - CODE_HALF_H
+                )
+                margin = min(margin_w, margin_h)
+                if worst is None or margin < worst[0]:
+                    worst = (margin, side, station_x, station_y, round(standoff, 3))
+        if not seen:
+            unseen.append((station_x, station_y))
+
+    report.check(
+        not unseen,
+        "every camera station faces a QR-coded pallet",
+        f"{len(unseen)} do not, first at {unseen[0]}" if unseen else "",
+    )
+    if worst is not None:
+        margin, side, at_x, at_y, standoff = worst
+        report.check(
+            margin > 0,
+            "QR codes stay in frame across the goal tolerance",
+            f"worst margin {round(margin, 3)} m ({side} camera at ({at_x}, {at_y}), "
+            f"standoff {standoff} m, tolerance {xy_tol} m / {yaw_tol} rad)",
+        )
+
+
 def main():
     report = Report()
     print("[lint] launch files")
@@ -190,6 +410,9 @@ def main():
     check_sdf(report)
     print("[lint] bridge config vs demo params")
     check_bridge_config(report)
+    print("[lint] QR-code alignment")
+    check_map_offset(report)
+    check_qr_alignment(report)
     return report.finish()
 
 

--- a/tools/sim/scripts/run.sh
+++ b/tools/sim/scripts/run.sh
@@ -17,22 +17,28 @@
 # depend on a simulator.
 #
 # Slow by nature: the warehouse is 317 model instances and CI has no GPU, so the world
-# runs well under real time (see dc_simulation/README.md for measured factors). All four
-# stages together are about twenty minutes, which ci.yaml's `sim` job runs on every PR.
-# Only the full 60-waypoint pass is too slow for that, and that is what the daily
-# .github/workflows/sim.yaml runs.
+# runs well under real time (see dc_simulation/README.md for measured factors), and
+# `detect` slows it further by running the DC pipeline alongside. ci.yaml's `sim` job runs
+# every stage on each PR with a handful of waypoints; only the full 60-waypoint pass is
+# too slow for that, and that is what the daily .github/workflows/sim.yaml runs.
 #
 # Env vars (all optional):
 #   DC_SIM_IMAGE            prebuilt workspace image to run (default dc-workspace:latest).
 #                           Both CI jobs set this to the image they built or pulled.
 #   DC_SIM_WAYPOINTS        waypoints the follower must reach before the run is
-#                           considered good (default 6). Each costs roughly a minute and
-#                           a half of wall clock. A handful proves planning, control,
-#                           localization and the goal checker all work; 60 is the full
-#                           pass through every QR-coded pallet, which the daily job runs.
+#                           considered good (default 6). A handful proves planning,
+#                           control, localization, the goal checker and -- with `detect`
+#                           -- QR-code reading all work; 60 is the full pass through every
+#                           QR-coded pallet, which the daily job runs.
 #   DC_SIM_WAYPOINT_TIMEOUT seconds to allow for that progress (default 2700).
-#   DC_SIM_STAGES           space-separated subset of: lint sim nav waypoints
-#                           (default: all four).
+#   DC_SIM_STAGES           space-separated subset of: lint sim nav waypoints detect
+#                           (default: all five). `detect` is a modifier on
+#                           `waypoints`: it brings the DC pipeline up with the
+#                           demo and additionally asserts that a QR code was
+#                           actually read at the stations the robot visited,
+#                           which is the only check that fails when the cameras
+#                           and the waypoints drift apart (#51). It costs one
+#                           extra process, not an extra run.
 #   DC_SIM_KEEP             "true" to leave the last stage's container up for inspection.
 set -euo pipefail
 
@@ -44,7 +50,7 @@ RUN_DIR="$SIM_DIR/.run"
 IMAGE="${DC_SIM_IMAGE:-dc-workspace:latest}"
 WAYPOINTS="${DC_SIM_WAYPOINTS:-6}"
 WAYPOINT_TIMEOUT="${DC_SIM_WAYPOINT_TIMEOUT:-2700}"
-STAGES="${DC_SIM_STAGES:-lint sim nav waypoints}"
+STAGES="${DC_SIM_STAGES:-lint sim nav waypoints detect}"
 KEEP="${DC_SIM_KEEP:-false}"
 CONTAINER=""
 
@@ -58,8 +64,8 @@ has_stage() { [[ " $STAGES " == *" $1 "* ]]; }
 [[ "$WAYPOINT_TIMEOUT" =~ ^[0-9]+$ ]] || fail "DC_SIM_WAYPOINT_TIMEOUT must be a number, got '$WAYPOINT_TIMEOUT'"
 for stage in $STAGES; do
   case "$stage" in
-    lint | sim | nav | waypoints) ;;
-    *) fail "unknown stage '$stage' in DC_SIM_STAGES (want: lint sim nav waypoints)" ;;
+    lint | sim | nav | waypoints | detect) ;;
+    *) fail "unknown stage '$stage' in DC_SIM_STAGES (want: lint sim nav waypoints detect)" ;;
   esac
 done
 
@@ -148,10 +154,13 @@ if has_stage sim; then
 fi
 
 # --- stage: simulation + Nav2 ---------------------------------------------------------
-if has_stage nav || has_stage waypoints; then
+if has_stage nav || has_stage waypoints || has_stage detect; then
   start_stack nav
-  log "launching tb3_qrcodes.launch.py (simulation + Nav2, DC off)"
-  rbg "$SOURCE && ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False use_dc:=False > /tmp/qrcodes.log 2>&1"
+  # `detect` needs the measurement/bridge half of the demo running; the other stages do
+  # not, and leaving it out keeps them cheaper on a runner with no GPU.
+  if has_stage detect; then USE_DC=True; else USE_DC=False; fi
+  log "launching tb3_qrcodes.launch.py (simulation + Nav2, DC $USE_DC)"
+  rbg "$SOURCE && ros2 launch dc_demos tb3_qrcodes.launch.py headless:=True use_rviz:=False use_dc:=$USE_DC > /tmp/qrcodes.log 2>&1"
 
   wait_for "Nav2 to activate" 1800 \
     'grep -aq "lifecycle_manager_navigation.*Managed nodes are active" /tmp/qrcodes.log' \
@@ -163,7 +172,11 @@ if has_stage nav || has_stage waypoints; then
 fi
 
 # --- stage: waypoint following --------------------------------------------------------
-if has_stage waypoints; then
+if has_stage waypoints || has_stage detect; then
+  if has_stage detect; then
+    log "recording every QR code the demo reads"
+    rbg "$SOURCE && python3 /opt/sim/verify_sim.py record > /tmp/codes.log 2>&1"
+  fi
   log "running qrcodes_waypoint_follower until it reaches waypoint $WAYPOINTS/60"
   rbg "$SOURCE && ros2 run dc_demos qrcodes_waypoint_follower > /tmp/waypoints.log 2>&1; echo EXIT=\$? >> /tmp/waypoints.log"
 
@@ -208,6 +221,46 @@ if has_stage waypoints; then
   aborted=$(count_in_container 'grep -acE "Goal was aborted|Goal failed|Failed to make progress" /tmp/qrcodes.log')
   [ "${aborted:-0}" -eq 0 ] || fail "$aborted navigation failures in the Nav2 log"
   log "no aborted or failed navigation goals"
+fi
+
+# --- stage: QR-code detection ---------------------------------------------------------
+# Navigating the aisles perfectly while reading nothing is exactly the failure #51
+# describes, and every other stage here passes while it happens: the robot spawns, the
+# cameras publish, Nav2 reaches every goal. Only counting decoded codes catches it.
+if has_stage detect; then
+  log "checking the demo actually read the codes it drove up to"
+
+  # One station is one stop in front of one pallet, and the Camera measurements report
+  # once per stop (condition_max_measurements: 1 against the `moving` condition), so the
+  # count tracks the stations visited. Asserting on `reached - 1` rather than `reached`
+  # leaves room for the station the robot is standing at when the poll loop above breaks
+  # out, and for the first goal, which it drives to from the spawn pose across the
+  # warehouse rather than from a pallet.
+  want=$((reached - 1))
+  [ "$want" -ge 1 ] || want=1
+
+  # Poll rather than read once. The loop above breaks the instant nav2 reports it is
+  # working on the next waypoint, which is a second or two before the Camera measurement
+  # at the station behind it has polled, decoded and published — reading the count there
+  # and then would be a race, not an assertion.
+  #
+  # Count QRCode reads specifically. Two things make a looser count worthless: ZXing's
+  # default options try every symbology, and a run of this check duly read a "51" off the
+  # warehouse shelving before reaching the first pallet; and if the recorder died on
+  # import, its traceback would read as a pile of successful detections.
+  reads=0
+  waited=0
+  while [ "$waited" -lt 180 ]; do
+    reads=$(count_in_container 'grep -ac "format=QRCode" /tmp/codes.log')
+    reads="${reads:-0}"
+    [ "$reads" -ge "$want" ] && break
+    sleep 15
+    waited=$((waited + 15))
+  done
+
+  codes=$(rin 'grep -a "format=QRCode" /tmp/codes.log | grep -ao "code=[0-9]*" | sort -u | tr "\n" " "' 2>/dev/null || true)
+  log "$reads QR codes read over $reached stations: ${codes:-none}"
+  [ "$reads" -ge "$want" ] || fail "only $reads QR codes read, wanted at least $want (see $RUN_DIR/sim.log)"
 fi
 
 log "simulation check passed (stages: $STAGES)"

--- a/tools/sim/scripts/verify_sim.py
+++ b/tools/sim/scripts/verify_sim.py
@@ -10,7 +10,9 @@ Usage:
     verify_sim.py topics       # sensors and odometry carry usable data
     verify_sim.py cmd_vel      # publishing a Twist actually moves the robot
     verify_sim.py nav          # AMCL is localized against the static map
+    verify_sim.py record       # log every QR code the demo reads, until killed
 """
+import json
 import math
 import sys
 
@@ -245,13 +247,64 @@ def check_nav(node, report):
 
 CHECKS = {"topics": check_topics, "cmd_vel": check_cmd_vel, "nav": check_nav}
 
+MEASUREMENTS = ["/dc/measurement/right_camera", "/dc/measurement/left_camera"]
+
+
+class Recorder(Node):
+    """Prints one line per QR code the demo reads, with the pose it read it from.
+
+    Deliberately reads the Measurement topics rather than grepping the launch log: the
+    log also carries each Measurement's JSON *schema*, which mentions "barcode" without
+    any code ever having been seen, and a check that counts those can never fail.
+    """
+
+    def __init__(self):
+        super().__init__("verify_sim_recorder")
+        from geometry_msgs.msg import PoseWithCovarianceStamped
+
+        from dc_interfaces.msg import StringStamped
+
+        self.pose = None
+        self.create_subscription(PoseWithCovarianceStamped, "/amcl_pose", self._on_pose, 10)
+        for topic in MEASUREMENTS:
+            self.create_subscription(
+                StringStamped, topic, lambda m, t=topic: self._on_record(t, m), 10
+            )
+
+    def _on_pose(self, msg):
+        pose = msg.pose.pose
+        yaw = 2.0 * math.atan2(pose.orientation.z, pose.orientation.w)
+        self.pose = (round(pose.position.x, 3), round(pose.position.y, 3), round(yaw, 3))
+
+    def _on_record(self, topic, msg):
+        try:
+            data = json.loads(msg.data)
+        except ValueError:
+            return
+        for barcode in data.get("inspected", {}).get("barcode", []):
+            # The format matters as much as the payload. ZXing's default options try
+            # every symbology, 1-D ones included, and warehouse scenery obliges: a run
+            # of this check read a "51" off the shelving before it reached the first
+            # pallet. Only a QRCode read means the demo saw what it came for.
+            print(
+                f"{topic} pose={self.pose} format={barcode.get('type', '?')} "
+                f"code={barcode['data']}",
+                flush=True,
+            )
+
 
 def main():
-    if len(sys.argv) != 2 or sys.argv[1] not in CHECKS:
-        print(f"usage: {sys.argv[0]} {{{'|'.join(CHECKS)}}}", file=sys.stderr)
+    if len(sys.argv) != 2 or sys.argv[1] not in list(CHECKS) + ["record"]:
+        print(f"usage: {sys.argv[0]} {{{'|'.join(list(CHECKS) + ['record'])}}}", file=sys.stderr)
         return 2
     stage = sys.argv[1]
     rclpy.init()
+    if stage == "record":
+        try:
+            rclpy.spin(Recorder())
+        except KeyboardInterrupt:
+            pass
+        return 0
     node = Verifier()
     report = Report()
     print(f"[verify_sim] {stage}")


### PR DESCRIPTION
Closes #51

The QR-code demo drives the aisles perfectly and reads nothing, because the waypoints and
the cameras were never related to each other. Three independent errors all push the code
the same way out of frame, and the goal tolerance was never sized against the lens.

## Reproducing it away from Nav2

Nav2 may stop the robot anywhere inside `xy_goal_tolerance` / `yaw_goal_tolerance`, so
rather than run the demo and hope to catch a bad stop, the robot was teleported across
that whole envelope and a frame taken from each camera at each pose, decoded with the same
call the Camera measurement makes (`ZXing::ReadBarcodes`, default options).

135 poses — three aisles × (dx, dy) ∈ {−0.1, 0, 0.1} × dyaw ∈ {−0.2 … 0.2}:

| Aisle | Poses whose facing camera decoded the code |
|---|---|
| 1 (open) | 38/45 |
| 2 (between two pallet rows) | **18/45** |
| 3 (open) | 32/45 |

Every failure is the same: the code runs off the frame edge. In aisle 2 the right camera
missed even at `dx=−0.1, dy=0, dyaw=0` — a pose Nav2 considers a perfect arrival.

## Root cause

A QR symbol renders 0.362 × 0.292 m with its centre 0.539 m above the floor, and the
cameras declare no `<horizontal_fov>` so they get sdformat's default 1.047 rad. A code is
readable while

```
|lateral error| + d·tan(|yaw error|) + 0.181 <= d·tan(30°)
```

**Description.** `waffle.model` carried a pose on each camera link *and* a pose on the
sensor inside it. An SDF `<sensor>` pose is relative to its parent link, so those add:
both cameras sat at the same point, 133 mm ahead of `base_footprint` and 94 mm to its
right. The waypoints aim `base_footprint` at the pallet, so that 133 mm alone put the code
176 px off centre with only 240 px of margin left on that side. `dc_description`'s URDF
described a different robot again — a `ground_base_distance` of 1.300 m borrowed from a
much taller machine put both cameras 0.6 m *underground* in TF, and both frame joints'
`-pi/2` was cancelled by the `sensor_d455` macro's own `+pi/2`, so in TF both looked
straight ahead while the simulated pair looked sideways.

**World layout.** The 60 goal quaternions were non-unit (norm 1.0126), i.e. headings of
88.6° and −89.2° rather than ±90° — the same transcription error #279 fixed in the
*initial* pose ten lines above and left in the goals. `rows_y0` was 25 mm off the pallet
centres, and `rows_x` stood the robot 0.65 m off the codes in a wide-open aisle and 50 mm
off centre in the one that has no room.

**Tolerance.** `yaw_goal_tolerance: 0.2` is 11.5°, which at aisle 2's 0.73 m standoff
slides the code 0.148 m across the frame — on its own more margin than that aisle has.

## The fix

- Both cameras onto the robot's centre line, back to back at `(0, ±0.02, 0.539)` looking
  ±Y, in **both** `waffle.model` and `dc_description`'s URDF, verified frame by frame so
  the two finally describe the same cameras.
- Exact ±90° quaternions, waypoint rows on the pallet centres, and standoffs of 0.97 m in
  the open aisles / dead centre in the closed one.
- `yaw_goal_tolerance` 0.2 → 0.1, with the inequality written out beside it.
  `xy_goal_tolerance` stays at 0.1.
- The AMCL seed pose, hand-placed in RViz and 69 mm out, replaced by the launch file's
  spawn pose carried through the map/world offset.
- Both cameras now **declare** `<horizontal_fov>` instead of inheriting it — same value,
  so nothing renders differently; the point is that the lint reads it rather than assumes
  it. See below for the experiment that did *not* survive.

## The field of view: investigated, widened, measured, reverted

55 mm of margin is thinner than it looks — the goal checker compares AMCL's *estimate*
against the goal, so localization error lands on top of the tolerance and never appears in
that budget. The only lever that widens it without moving pallets is the lens, and neither
camera declared one, so both inherited sdformat's fallback of 1.047 rad. 60° is narrower
than the real cameras this robot is named for: the SDF sensors say **R200** (~77° colour,
~70° depth), `dc_description` instantiates a **D455** (~90° colour, ~87° depth).

Nothing upstream helps — `realsense2_description` on Jazzy is URDF and meshes only, with
no gz sensor definition and no `horizontal_fov` anywhere, for any model. The only gz camera
sensors in the whole ROS install are nav2's own `gz_waffle` (1.047) and the TB4's OAK-D
(1.25), so declaring it by hand *is* the neighbouring convention.

So 77° was implemented — the R200's colour FOV, self-consistent with the topic names the
repo already carries. Worst case 55 mm → 134 mm. **Then it was reverted**, because
re-running the all-station sweep at 77° turned up a miss the 60° build does not have:
aisle 1, station 9, `dx −0.043, dy −0.090, dyaw −0.1` — exactly on the tolerance circle,
so a pose Nav2 is allowed to stop in. The code is fully in frame, unobstructed, ~300×240 px,
and ZXing returns nothing.

- **Not framing** — the whole symbol is visible with clear margin all round.
- **Not resolution** — the same view at 1920×1080 (~450 px of code) fails too, while merely
  upscaling the 1280×720 frame 1.5× with cubic interpolation, which adds no information,
  decodes it.
- **It is the lens** — same pose, same container, re-rendered at 1.047:
  `OK QRCode '0002' box=225,196 409x330`.

The wider lens trades a deterministic geometric margin for a stochastic decode one, which
is a much worse property for a demo whose acceptance criterion is "detection succeeds on
every QR code". What survives is the declaration itself, and `check_qr_alignment` now
*reads* the FOV from `waffle.model` rather than assuming the default — the check and the
simulator can no longer disagree about the one number the whole inequality turns on, which
would be the same class of bug as #51 itself. The experiment is written up in the model and
the README so nobody repeats it blind.

## Verification

**The static check first, because it has to fail.** `check_qr_alignment` in
`tools/sim/scripts/lint_launch_files.py` re-derives the inequality from the four files
that must agree — camera mounting, waypoints, pallet faces, goal tolerance — and reports
the worst-case margin over the tolerance circle in closed form:

```
as shipped                    PASS   worst margin  0.055 m
pre-fix camera mounting only  FAIL   worst margin -0.113 m
pre-fix waypoint rows only    FAIL   worst margin -0.017 m
pre-fix yaw tolerance only    FAIL   worst margin -0.016 m
```

Each of the three fixes is individually load-bearing, and the check catches each alone.

**Renders on the boundary of the envelope**, where the worst case lives: 8 directions
around the `xy_goal_tolerance` circle × dyaw ∈ {−0.1, 0, +0.1}, per aisle — **72/72
decode**, against 88/135 for the same geometry before.

**Every station, since one live pass can't reach them all in reasonable time.** Same
harness over all 60 camera stations × three poses each (nominal + the two worst points on
the tolerance circle): **180/180 decode on every camera facing a coded pallet**, covering
all eight codes the world carries — 0002/0004 in aisle 1, 0001/0003/0005/0007 in aisle 2,
0006/0008 in aisle 3.

**And the demo itself**, `tb3_qrcodes.launch.py … use_dc:=True` with the waypoint
follower, through the whole of aisle 1: **20 Records, one per station, 10 × "0002" and
10 × "0004"** — exactly the two codes that wall carries — with zero aborted goals and zero
recovery behaviours. Stopped after aisle 1 rather than run to 60: this box was at load 26
on 8 cores and held a real-time factor of 0.11, so 60 stations would have been most of a
day. The all-station sweep above covers the other two aisles.

## Regression guard

`run.sh` gains a `detect` stage — a modifier on `waypoints` that brings the DC pipeline up
with the demo and asserts codes really come back. It reads the Measurement topics rather
than grepping the launch log, because the log also carries each Measurement's JSON
*schema*, which mentions "barcode" without any code having been seen; a check counting
those could never fail. It runs per-PR in `ci.yaml`'s `sim` job; `sim.yaml`'s daily full
pass keeps DC off, since its 63-minute envelope was measured without it.

It was exercised by running `run.sh` the way CI calls it, and the first run *failed* —
which is the point. That image was missing `python3-pydantic`, so `draw_image` never
started, every Camera measurement blocked on it, and no Record was published: zero codes
over two stations, while every other stage passed, the robot spawned, Nav2 localized and
both goals succeeded. That is the exact shape of #51.

With the dependency in place it goes green — and then caught a *false positive*: one read
was the string `51`, decoded off the shelving before the robot reached a pallet, because
ZXing's default options try every symbology. The stage now counts `format=QRCode` reads
only; one that accepts "some barcode, any barcode" would pass on scenery. The false
positive itself is left alone — `detection_modules: ["barcode"]` means all symbologies on
purpose, and narrowing it is a product decision, not something to slip into this PR.

Also: the tighter yaw tolerance costs no measurable navigation time — flipped live
mid-pass with `ros2 param set`, goals at 0.1 rad took 59-75 s of simulated time and goals
at 0.2 rad took 62 s. And `qrcodes.world` had a literal `--` inside an XML comment, which
is illegal and makes the file unreadable to every strict XML parser; libsdformat's TinyXML2
is the lenient exception, which is why it survived.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018TJPr23iXifRzhjdxujMDT
