### PR TITLE
fix(simulation): declare qrcodes.world's ambient light, verify #61 doesn't reproduce

### DIFF
--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -165,3 +165,31 @@ That is not a resolution effect — the same view rendered at 1920×1080 also fa
 simply upscaling the 1280×720 frame 1.5× decodes it — so something about the wider view
 defeats ZXing's detector rather than starving it of pixels. Until that is understood, the
 lens that is measured good at every station wins over the one that is more realistic.
+
+## Lighting: verified stable on gz-sim, #61
+
+[#61](https://github.com/Minipada/ros2_data_collection/issues/61) was filed against
+Gazebo Classic (OGRE 1.x): the world rendered too dark intermittently, which broke QR
+detection. #268 replaced the renderer wholesale (OGRE 1.x → gz-sim/gz-rendering OGRE2),
+so this was re-scoped as a verification task rather than a known bug — either the old
+symptom is gone under the new renderer, or it presents differently and needs its own fix.
+
+**It does not reproduce.** Five independent cold starts of the full `tb3_qrcodes.launch.py`
+pipeline — two on GitHub-hosted CI runners (commits `41e24d0`, 6/6 stations decoded, and
+`2b03c78`, 5/6), three run locally against the same CI-built image (2/3, 2/3, and 3/4,
+the last against the world file this section documents) — each read a QR code at every
+station bar the one-station gap `tools/sim/scripts/run.sh`'s own `detect` stage already
+treats as expected (the goal-reached and camera-poll events race by design; see the
+script's own comment). No run produced a degenerate (all-black or otherwise all-uniform)
+camera frame.
+
+That is consistent with the world having no source of *intermittent* lighting to begin
+with: `qrcodes.world`'s `<scene>` carries a fixed `<ambient>`/`<background>` (now declared
+explicitly rather than left to sdformat's fallback — the same reasoning already applied to
+`<horizontal_fov>` above), a single `directional` sun at a fixed `<direction>`, no sky/
+time-of-day element and no light-flicker plugin. Nothing in the file varies frame to frame
+or run to run. Gazebo Classic's OGRE1 backend is a different renderer with its own
+initialization quirks; whatever produced the original symptom does not carry over.
+
+**Closed with this evidence** rather than left open per the issue's own acceptance
+criteria — reopen if a dark frame turns up again, with the run's log attached.

--- a/dc_simulation/worlds/qrcodes.world
+++ b/dc_simulation/worlds/qrcodes.world
@@ -77,7 +77,23 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
+    <!--
+      #61 was filed against Gazebo Classic (OGRE 1.x), where the world rendered too dark
+      intermittently -- and, tellingly, with no <ambient> declared here even then, so the
+      renderer's own fallback was silently doing the work. Declaring it is the same fix
+      already applied to <horizontal_fov> and robot_sdf elsewhere in this port: state the
+      value sdformat would otherwise supply invisibly, so it cannot drift out from under
+      the demo unnoticed. The value is unchanged -- sdformat 1.10's own default -- so this
+      does not alter what gets rendered.
+      Re-verified on gz-sim/ogre2 for #61: five independent cold starts (two on GitHub-
+      hosted CI runners, three local, the last against this exact file), each reading a
+      QR code at every station it stopped at bar the harness's own documented goal-
+      reached/camera-poll race, with no degenerate (all-black) camera frame in any run.
+      The old symptom does not reproduce under the ported renderer.
+    -->
     <scene>
+      <ambient>0.4 0.4 0.4 1</ambient>
+      <background>0.7 0.7 0.7 1</background>
       <shadows>false</shadows>
     </scene>
 

--- a/progress.txt
+++ b/progress.txt
@@ -5567,3 +5567,53 @@ admonition is reworded from "expect a slow start" to the concrete breakdown: bri
 under a minute, first Record several minutes out, full 60-waypoint pass over an hour --
 so a user reads what "slow" actually means before they start the demo, not after they
 give up waiting.
+
+## #61 - QR-codes demo world renders too dark intermittently, re-verified on gz-sim
+
+Filed against Gazebo Classic (OGRE 1.x); #268 replaced the renderer wholesale with
+gz-sim/gz-rendering OGRE2 and rewrote `qrcodes.world` for SDF 1.10 in the process, so #61
+was re-scoped from a known bug to a verification task: confirm lighting is stable and
+barcode detection holds across repeated cold starts under the new renderer, and either
+close it on that evidence or characterise and fix whatever remains. #61's own blocker,
+#279 (porting the Nav2 demo off Classic), closed before this session, so the task was
+unblocked.
+
+**Evidence gathered**: five independent cold starts of `tb3_qrcodes.launch.py`'s full
+pipeline (gz-sim + Nav2 + DC), each starting from a freshly-started container/runner --
+
+- Two on GitHub-hosted CI runners, via the `sim` job `c80b376`/`8bcb071` wired up to run
+  by default (including its `detect` stage) on every PR: commit `41e24d0` read 6/6
+  QR codes over 6 stations reached; commit `2b03c78` (this branch's parent) read 5/6.
+- Three run locally against the same CI-built workspace image
+  (`ghcr.io/minipada/ros2_data_collection/dc-workspace:2b03c781e...`, pulled after
+  `podman image prune -f` freed space -- the box was at 92% disk usage and the first pull
+  attempt failed with "no space left on device"): 2/3, 2/3, and 3/4 stations, the last run
+  against the world-file change this entry documents, with `dc_simulation/{worlds,launch,
+  config}` and `dc_demos/{launch,params}` bind-mounted over the image's install paths so
+  the run actually exercised current source rather than the image's baked-in copies (a
+  first attempt without the `config` mount silently used a stale bridge config with the
+  pre-rename ROS topic names, which is why `left_intel_realsense_r200_depth/image_raw`
+  turned up missing at first).
+
+Every run's misses are all within the one-station gap `run.sh`'s own `detect` stage
+already treats as expected -- it asserts `reached - 1`, not `reached`, specifically
+because the goal-reached and camera-poll events race (see the script's own comment) --
+and no run produced a degenerate (all-black or otherwise uniform) camera frame. The old
+symptom does not reproduce under the ported renderer.
+
+**Fixed anyway, for the same reason `<horizontal_fov>` was made explicit**:
+`qrcodes.world`'s `<scene>` declared no `<ambient>`, silently relying on sdformat's own
+fallback (`0.4 0.4 0.4 1`, confirmed from `sdformat14`'s `scene.sdf` schema). Nothing
+in the file makes that value vary run to run -- no sky/time-of-day element, no light-
+flicker plugin, and the one `directional` sun has a fixed `<direction>` -- so it was
+never a plausible source of *intermittent* darkness, but leaving a load-bearing constant
+to an implicit fallback is exactly the class of bug #51 and the FOV fix both already
+called out in this file. `<ambient>0.4 0.4 0.4 1</ambient>` and
+`<background>0.7 0.7 0.7 1</background>` are now declared in `<scene>` at their
+unchanged (sdformat-default) values, with a comment recording the #61 investigation and
+its cold-start count. `lint_launch_files.py` (SDF validity, bridge config, QR alignment)
+passes unchanged against the edit.
+
+**Documented**: `dc_simulation/README.md` carries a new "Lighting: verified stable on
+gz-sim, #61" section with the cold-start count and the reasoning above. Closed with this
+evidence per the issue's own acceptance criteria, rather than left open.


### PR DESCRIPTION
## Summary

- #61 was filed against Gazebo Classic (OGRE 1.x): the QR-codes demo world rendered too
  dark intermittently, breaking barcode detection. #268 replaced the renderer wholesale
  with gz-sim/gz-rendering OGRE2, which re-scoped #61 to a verification task rather than
  a known bug.
- Five independent cold starts of the full `tb3_qrcodes.launch.py` pipeline — two on
  GitHub-hosted CI runners (`sim` job, commits `41e24d0` and `2b03c78`) and three local,
  the last against the exact world-file change in this PR — each read a QR code at every
  station bar the one-station goal-reached/camera-poll race `tools/sim/scripts/run.sh`'s
  own `detect` stage already tolerates by design. No run produced a degenerate
  (all-black) camera frame. **The old symptom does not reproduce under the ported
  renderer.**
- `qrcodes.world`'s `<scene>` declared no `<ambient>`/`<background>`, silently relying on
  sdformat's own fallback. Declared both explicitly at their unchanged values — the same
  fix already applied to `<horizontal_fov>` in #61's neighbouring history — so a
  load-bearing lighting constant can't silently drift again.
- Documented the verification evidence in `dc_simulation/README.md` and `progress.txt`.

## Test plan

- [x] `tools/sim/scripts/lint_launch_files.py` (SDF validity, bridge config, QR
      alignment) passes unchanged against the edited world file
- [x] Five cold starts of the full demo pipeline (2 CI + 3 local) each read QR codes at
      every station reached, no degenerate camera frames
- [x] `pre-commit` passes on the changed files (`dc_simulation/README.md`,
      `dc_simulation/worlds/qrcodes.world`, `progress.txt`)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Y3hrK8ZFnd3esARBGDT3G