### PR TITLE
feat(dc_common): add RecordRingBuffer and FileScratchRing utilities

### DIFF
--- a/dc_common/CMakeLists.txt
+++ b/dc_common/CMakeLists.txt
@@ -1,13 +1,40 @@
 cmake_minimum_required(VERSION 3.5)
 project(dc_common)
 
-find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake REQUIRED)
 
-ament_package(
-  CONFIG_EXTRAS "dc_common-extras.cmake"
-)
+# dc_common defines dc_package(); it can't find_package() itself the way every other dc_*
+# package does, so it pulls the macro in directly here to apply the same standard project
+# setup (C++17, warnings, ...) to its own build.
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/dc_package.cmake)
+dc_package()
 
 install(
   DIRECTORY cmake
   DESTINATION share/${PROJECT_NAME}
+)
+
+# RecordRingBuffer / FileScratchRing (#285): header-only, ROS-free utilities, same shape as
+# dc_core's condition_set.hpp -- no compiled library needed, just the headers on the include
+# path.
+install(
+  DIRECTORY include/
+  DESTINATION include/
+)
+ament_export_include_directories(include)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+
+  foreach(test record_ring_buffer_test file_scratch_ring_test)
+    ament_add_gtest(${PROJECT_NAME}_${test} test/${test}.cpp)
+    target_include_directories(${PROJECT_NAME}_${test} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:include>
+    )
+  endforeach()
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "dc_common-extras.cmake"
 )

--- a/dc_common/include/dc_common/file_scratch_ring.hpp
+++ b/dc_common/include/dc_common/file_scratch_ring.hpp
@@ -1,0 +1,117 @@
+#ifndef DC_COMMON_FILE_SCRATCH_RING_HPP_
+#define DC_COMMON_FILE_SCRATCH_RING_HPP_
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace dc_common
+{
+
+/**
+ * @brief One staged File held by a FileScratchRing: its path inside the scratch directory plus
+ * the timestamp it was staged with.
+ */
+struct ScratchedFile
+{
+  std::filesystem::path path;
+  std::chrono::system_clock::time_point stamp;
+};
+
+/**
+ * @class dc_common::FileScratchRing
+ * @brief Disk-backed bounded time-window buffer of Files -- the FileScratchRing analogue of
+ * RecordRingBuffer, with no ROS dependency.
+ *
+ * stage() copies a produced File into a private scratch directory (created on construction if
+ * missing) under a collision-free name and records it with a timestamp; evict() deletes staged
+ * copies older than the configured window, from disk and from window(). window() reports the
+ * current contents as an ordered list of (path, timestamp), oldest first. Same push/evict/read
+ * shape as RecordRingBuffer, and the same "evict is caller-driven, not push-driven" contract: the
+ * window is relative to a caller-supplied "now", not to the last stage() call.
+ *
+ * Part of pre-event circular-buffer capture (#282) -- exercised purely against a tmp directory in
+ * tests, same as RecordRingBuffer against an injected clock.
+ */
+class FileScratchRing
+{
+public:
+  FileScratchRing(std::filesystem::path scratch_dir, std::chrono::system_clock::duration window)
+    : scratch_dir_(std::move(scratch_dir)), window_(window)
+  {
+    std::filesystem::create_directories(scratch_dir_);
+  }
+
+  /**
+   * @brief Copy `source_path` into the scratch directory under a unique staged name and record it
+   * with `stamp`. Returns the staged path.
+   *
+   * Throws std::filesystem::filesystem_error if the copy fails (source missing, disk full, ...).
+   */
+  std::filesystem::path stage(const std::filesystem::path& source_path, std::chrono::system_clock::time_point stamp)
+  {
+    const auto epoch_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(stamp.time_since_epoch()).count();
+    const auto staged_name =
+        std::to_string(epoch_ns) + "_" + std::to_string(next_id_++) + "_" + source_path.filename().string();
+    const auto staged_path = scratch_dir_ / staged_name;
+
+    std::filesystem::copy_file(source_path, staged_path, std::filesystem::copy_options::overwrite_existing);
+
+    const auto pos = std::upper_bound(entries_.begin(), entries_.end(), stamp,
+                                      [](const std::chrono::system_clock::time_point& s, const ScratchedFile& e) {
+                                        return s < e.stamp;
+                                      });
+    entries_.insert(pos, ScratchedFile{ staged_path, stamp });
+    return staged_path;
+  }
+
+  /**
+   * @brief Delete every staged File older than the configured window relative to `now` (inclusive
+   * boundary, same as RecordRingBuffer::evict()), from disk and from window().
+   *
+   * A staged File already missing from disk (e.g. removed out of band) is still dropped from the
+   * window without throwing -- replay-tolerant, mirroring dc_bridge's retention sweep.
+   */
+  void evict(std::chrono::system_clock::time_point now)
+  {
+    while (!entries_.empty() && (now - entries_.front().stamp) > window_)
+    {
+      std::error_code ec;
+      std::filesystem::remove(entries_.front().path, ec);
+      entries_.pop_front();
+    }
+  }
+
+  /// Current contents, oldest first. Does not evict -- call evict() first if that's wanted.
+  std::vector<ScratchedFile> window() const
+  {
+    return std::vector<ScratchedFile>(entries_.begin(), entries_.end());
+  }
+
+  std::size_t size() const
+  {
+    return entries_.size();
+  }
+
+  bool empty() const
+  {
+    return entries_.empty();
+  }
+
+private:
+  std::filesystem::path scratch_dir_;
+  std::chrono::system_clock::duration window_;
+  std::deque<ScratchedFile> entries_;
+  std::uint64_t next_id_{ 0 };
+};
+
+}  // namespace dc_common
+
+#endif  // DC_COMMON_FILE_SCRATCH_RING_HPP_

--- a/dc_common/include/dc_common/record_ring_buffer.hpp
+++ b/dc_common/include/dc_common/record_ring_buffer.hpp
@@ -1,0 +1,100 @@
+#ifndef DC_COMMON_RECORD_RING_BUFFER_HPP_
+#define DC_COMMON_RECORD_RING_BUFFER_HPP_
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <deque>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dc_common
+{
+
+/**
+ * @brief One stamped Record held by a RecordRingBuffer: its JSON payload plus the timestamp it
+ * was pushed with.
+ */
+struct StampedRecord
+{
+  std::string json;
+  std::chrono::system_clock::time_point stamp;
+};
+
+/**
+ * @class dc_common::RecordRingBuffer
+ * @brief In-memory bounded time-window buffer of stamped Record JSON strings, with no ROS
+ * dependency.
+ *
+ * push() inserts a Record in ascending-stamp order (so out-of-order pushes still leave window()
+ * in time order) but never evicts on its own; evict() drops entries older than the configured
+ * window relative to a caller-supplied "now". Keeping the two separate means the window is always
+ * relative to wall-clock "now", not to whenever the last push happened -- important for a buffer
+ * that may sit idle between pushes yet still needs to age out.
+ *
+ * Part of pre-event circular-buffer capture (#282): a Trigger plugin keeps pushing Records into
+ * one of these as they're produced and, on trigger, reads window() to get "the last N seconds of
+ * data" regardless of when the trigger itself fires.
+ */
+class RecordRingBuffer
+{
+public:
+  /**
+   * @param window Entries older than this age (relative to the `now` passed to evict()) are
+   * eligible for eviction. Age exactly equal to `window` is kept -- see evict().
+   */
+  explicit RecordRingBuffer(std::chrono::system_clock::duration window) : window_(window)
+  {
+  }
+
+  /**
+   * @brief Insert one stamped Record, maintaining ascending-stamp order.
+   *
+   * Does not evict; call evict() to enforce the configured time window.
+   */
+  void push(std::string json, std::chrono::system_clock::time_point stamp)
+  {
+    const auto pos = std::upper_bound(entries_.begin(), entries_.end(), stamp,
+                                      [](const std::chrono::system_clock::time_point& s, const StampedRecord& e) {
+                                        return s < e.stamp;
+                                      });
+    entries_.insert(pos, StampedRecord{ std::move(json), stamp });
+  }
+
+  /**
+   * @brief Drop every entry older than the configured window relative to `now`. An entry exactly
+   * `window` old is kept (inclusive boundary).
+   */
+  void evict(std::chrono::system_clock::time_point now)
+  {
+    while (!entries_.empty() && (now - entries_.front().stamp) > window_)
+    {
+      entries_.pop_front();
+    }
+  }
+
+  /// Current contents, oldest first. Does not evict -- call evict() first if that's wanted.
+  std::vector<StampedRecord> window() const
+  {
+    return std::vector<StampedRecord>(entries_.begin(), entries_.end());
+  }
+
+  std::size_t size() const
+  {
+    return entries_.size();
+  }
+
+  bool empty() const
+  {
+    return entries_.empty();
+  }
+
+private:
+  std::chrono::system_clock::duration window_;
+  std::deque<StampedRecord> entries_;
+};
+
+}  // namespace dc_common
+
+#endif  // DC_COMMON_RECORD_RING_BUFFER_HPP_

--- a/dc_common/package.xml
+++ b/dc_common/package.xml
@@ -7,11 +7,13 @@
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>
 
-    <buildtool_depend>ament_cmake_core</buildtool_depend>
+    <buildtool_depend>ament_cmake</buildtool_depend>
 
     <build_depend>ament_cmake_python</build_depend>
 
     <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+
+    <test_depend>ament_cmake_gtest</test_depend>
 
     <export>
         <build_type>ament_cmake</build_type>

--- a/dc_common/test/file_scratch_ring_test.cpp
+++ b/dc_common/test/file_scratch_ring_test.cpp
@@ -1,0 +1,193 @@
+// Unit tests for dc_common::FileScratchRing (#285, part of #282's pre-event circular-buffer
+// capture). No node, no rclcpp::init(): exercised purely against a tmp-dir fixture (RAII
+// cleanup per test), following the pattern used in dc_bridge/test/retention_test.cpp.
+
+#include "dc_common/file_scratch_ring.hpp"
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using dc_common::FileScratchRing;
+using dc_common::ScratchedFile;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+struct Fixture
+{
+  std::filesystem::path tmp;
+  std::filesystem::path sources;
+  std::filesystem::path scratch;
+
+  Fixture()
+  {
+    tmp = std::filesystem::temp_directory_path() /
+          ("dc_file_scratch_ring_test_" + std::to_string(::getpid()) + "_" + std::to_string(counter_++));
+    sources = tmp / "sources";
+    scratch = tmp / "scratch";
+    std::filesystem::create_directories(sources);
+  }
+  ~Fixture()
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(tmp, ec);
+  }
+
+  std::filesystem::path write_source(const std::string& name, const std::string& contents = "x")
+  {
+    auto p = sources / name;
+    std::ofstream(p, std::ios::binary) << contents;
+    return p;
+  }
+
+  static std::atomic<int> counter_;
+};
+std::atomic<int> Fixture::counter_{ 0 };
+
+std::vector<std::filesystem::path> paths_of(const std::vector<ScratchedFile>& entries)
+{
+  std::vector<std::filesystem::path> out;
+  out.reserve(entries.size());
+  for (const auto& e : entries)
+  {
+    out.push_back(e.path);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST(FileScratchRing, ConstructorCreatesTheScratchDirectory)
+{
+  Fixture fx;
+  ASSERT_FALSE(std::filesystem::exists(fx.scratch));
+
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(60));
+
+  EXPECT_TRUE(std::filesystem::exists(fx.scratch));
+  EXPECT_TRUE(std::filesystem::is_directory(fx.scratch));
+}
+
+TEST(FileScratchRing, StageCopiesTheFileAndLeavesTheSourceInPlace)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(60));
+  auto source = fx.write_source("img.jpg", "hello");
+
+  auto staged = ring.stage(source, at(0));
+
+  EXPECT_TRUE(std::filesystem::exists(source));  // stage() copies, it doesn't move.
+  ASSERT_TRUE(std::filesystem::exists(staged));
+  EXPECT_NE(staged, source);
+  std::ifstream in(staged, std::ios::binary);
+  std::string contents((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  EXPECT_EQ(contents, "hello");
+}
+
+TEST(FileScratchRing, StagingTheSameSourceTwiceProducesDistinctStagedPaths)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(60));
+  auto source = fx.write_source("img.jpg");
+
+  auto first = ring.stage(source, at(0));
+  auto second = ring.stage(source, at(1));
+
+  EXPECT_NE(first, second);
+  EXPECT_TRUE(std::filesystem::exists(first));
+  EXPECT_TRUE(std::filesystem::exists(second));
+  EXPECT_EQ(ring.size(), 2u);
+}
+
+TEST(FileScratchRing, WindowReturnsEntriesInTimeOrderRegardlessOfStageOrder)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(60));
+  auto middle = ring.stage(fx.write_source("middle.jpg"), at(5));
+  auto first = ring.stage(fx.write_source("first.jpg"), at(1));
+  auto last = ring.stage(fx.write_source("last.jpg"), at(9));
+
+  EXPECT_EQ(paths_of(ring.window()), std::vector<std::filesystem::path>({ first, middle, last }));
+}
+
+TEST(FileScratchRing, EvictDeletesEntriesStrictlyOlderThanWindowFromDiskAndWindow)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto old_path = ring.stage(fx.write_source("old.jpg"), at(0));
+  auto new_path = ring.stage(fx.write_source("new.jpg"), at(5));
+
+  ring.evict(at(11));  // "old" is 11s old (>10s window); "new" is 6s old (<=10s window).
+
+  EXPECT_EQ(ring.size(), 1u);
+  EXPECT_FALSE(std::filesystem::exists(old_path));
+  EXPECT_TRUE(std::filesystem::exists(new_path));
+  EXPECT_EQ(paths_of(ring.window()), std::vector<std::filesystem::path>({ new_path }));
+}
+
+TEST(FileScratchRing, EvictBoundaryAgeEqualToWindowIsKept)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto staged = ring.stage(fx.write_source("boundary.jpg"), at(0));
+
+  ring.evict(at(10));  // age == window exactly: inclusive boundary, must survive.
+
+  EXPECT_EQ(ring.size(), 1u);
+  EXPECT_TRUE(std::filesystem::exists(staged));
+}
+
+TEST(FileScratchRing, EvictBoundaryOneTickPastWindowIsDropped)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto staged = ring.stage(fx.write_source("boundary.jpg"), at(0));
+
+  ring.evict(at(11));  // age > window by the smallest margin used here: must be dropped.
+
+  EXPECT_TRUE(ring.empty());
+  EXPECT_FALSE(std::filesystem::exists(staged));
+}
+
+TEST(FileScratchRing, EvictOnEmptyRingIsANoop)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  ring.evict(at(1000));
+  EXPECT_TRUE(ring.empty());
+}
+
+TEST(FileScratchRing, EvictToleratesAStagedFileAlreadyMissingFromDisk)
+{
+  // Simulates something else on the system removing a staged copy out of band: the ring must
+  // still converge cleanly on the next evict rather than throwing or getting stuck.
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto staged = ring.stage(fx.write_source("gone.jpg"), at(0));
+  std::filesystem::remove(staged);
+
+  ring.evict(at(11));
+
+  EXPECT_TRUE(ring.empty());
+}
+
+TEST(FileScratchRing, StageThrowsWhenSourceFileDoesNotExist)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+
+  EXPECT_THROW(ring.stage(fx.sources / "does_not_exist.jpg", at(0)), std::filesystem::filesystem_error);
+  EXPECT_TRUE(ring.empty());
+}

--- a/dc_common/test/record_ring_buffer_test.cpp
+++ b/dc_common/test/record_ring_buffer_test.cpp
@@ -1,0 +1,142 @@
+// Unit tests for dc_common::RecordRingBuffer (#285, part of #282's pre-event circular-buffer
+// capture). No node, no rclcpp::init(): the buffer is exercised purely against explicit
+// std::chrono::system_clock::time_point values standing in for an injected/fake clock -- push()
+// and evict() both take the timestamp/"now" as a parameter rather than reading a real clock.
+
+#include "dc_common/record_ring_buffer.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <vector>
+
+using dc_common::RecordRingBuffer;
+using dc_common::StampedRecord;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+std::vector<std::string> json_of(const std::vector<StampedRecord>& entries)
+{
+  std::vector<std::string> out;
+  out.reserve(entries.size());
+  for (const auto& e : entries)
+  {
+    out.push_back(e.json);
+  }
+  return out;
+}
+
+}  // namespace
+
+TEST(RecordRingBuffer, StartsEmpty)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  EXPECT_TRUE(buf.empty());
+  EXPECT_EQ(buf.size(), 0u);
+  EXPECT_TRUE(buf.window().empty());
+}
+
+TEST(RecordRingBuffer, PushDoesNotEvictOnItsOwn)
+{
+  // The window is relative to a caller-supplied "now", not to the last push -- pushing a Record
+  // far in the future of an earlier one must not silently drop the earlier one.
+  RecordRingBuffer buf(std::chrono::seconds(1));
+  buf.push(R"({"n":1})", at(0));
+  buf.push(R"({"n":2})", at(100));
+
+  EXPECT_EQ(buf.size(), 2u);
+  EXPECT_EQ(json_of(buf.window()), std::vector<std::string>({ R"({"n":1})", R"({"n":2})" }));
+}
+
+TEST(RecordRingBuffer, WindowReturnsEntriesInTimeOrderRegardlessOfPushOrder)
+{
+  RecordRingBuffer buf(std::chrono::seconds(100));
+  buf.push(R"({"n":"middle"})", at(5));
+  buf.push(R"({"n":"first"})", at(1));
+  buf.push(R"({"n":"last"})", at(9));
+
+  EXPECT_EQ(json_of(buf.window()),
+            std::vector<std::string>({ R"({"n":"first"})", R"({"n":"middle"})", R"({"n":"last"})" }));
+}
+
+TEST(RecordRingBuffer, EvictDropsEntriesStrictlyOlderThanWindow)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.push(R"({"n":"old"})", at(0));
+  buf.push(R"({"n":"new"})", at(5));
+
+  buf.evict(at(11));  // "old" is 11s old (>10s window); "new" is 6s old (<=10s window).
+
+  EXPECT_EQ(buf.size(), 1u);
+  EXPECT_EQ(json_of(buf.window()), std::vector<std::string>({ R"({"n":"new"})" }));
+}
+
+TEST(RecordRingBuffer, EvictBoundaryAgeEqualToWindowIsKept)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.push(R"({"n":"boundary"})", at(0));
+
+  buf.evict(at(10));  // age == window exactly: inclusive boundary, must survive.
+
+  EXPECT_EQ(buf.size(), 1u);
+}
+
+TEST(RecordRingBuffer, EvictBoundaryOneTickPastWindowIsDropped)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.push(R"({"n":"boundary"})", at(0));
+
+  buf.evict(at(11));  // age > window by the smallest margin used here: must be dropped.
+
+  EXPECT_TRUE(buf.empty());
+}
+
+TEST(RecordRingBuffer, EvictOnEmptyBufferIsANoop)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.evict(at(1000));
+  EXPECT_TRUE(buf.empty());
+}
+
+TEST(RecordRingBuffer, EvictLeavesNewerEntriesAfterDroppingOlderOnes)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.push(R"({"n":"a"})", at(0));
+  buf.push(R"({"n":"b"})", at(3));
+  buf.push(R"({"n":"c"})", at(6));
+  buf.push(R"({"n":"d"})", at(9));
+
+  buf.evict(at(15));  // window is (5, 15]: only entries with stamp > 5 survive -- b(3) and a(0) drop, c(6)/d(9) stay.
+
+  EXPECT_EQ(json_of(buf.window()), std::vector<std::string>({ R"({"n":"c"})", R"({"n":"d"})" }));
+}
+
+TEST(RecordRingBuffer, WindowDoesNotMutateOrEvict)
+{
+  RecordRingBuffer buf(std::chrono::seconds(1));
+  buf.push(R"({"n":"a"})", at(0));
+
+  auto first_read = buf.window();
+  auto second_read = buf.window();
+
+  EXPECT_EQ(first_read.size(), 1u);
+  EXPECT_EQ(second_read.size(), 1u);
+  EXPECT_EQ(buf.size(), 1u);  // reading window() twice, well past the window, still hasn't evicted.
+}
+
+TEST(RecordRingBuffer, RepeatedEvictCallsConverge)
+{
+  RecordRingBuffer buf(std::chrono::seconds(5));
+  buf.push(R"({"n":"a"})", at(0));
+
+  buf.evict(at(100));
+  buf.evict(at(200));  // calling evict again on an already-empty buffer must not throw or hang.
+
+  EXPECT_TRUE(buf.empty());
+}

--- a/progress.txt
+++ b/progress.txt
@@ -5728,3 +5728,69 @@ done in the same image (16 min 13 s, no warnings under the `-Werror` `dc_package
 then `colcon test --packages-select dc_measurements` -- **134 tests, 0 errors, 0 failures,
 0 skipped**, across all 37 test binaries. CI's `build-workspace` job runs the same thing
 on the PR.
+
+### #285 - Add RecordRingBuffer and FileScratchRing utilities to dc_common
+
+- Added two generic, ROS-independent bounded time-window buffers to `dc_common`, the first
+  slice of pre-event circular-buffer capture (#282; a Trigger plugin wires these into
+  Measurements in later slices — out of scope here):
+  - `dc_common::RecordRingBuffer` (`dc_common/include/dc_common/record_ring_buffer.hpp`):
+    an in-memory ring of stamped Record JSON strings (`StampedRecord{ json, stamp }`).
+    `push()` inserts in ascending-stamp order (so out-of-order pushes still leave
+    `window()` time-ordered) but never evicts on its own; `evict(now)` drops entries
+    strictly older than the configured duration relative to a caller-supplied `now`
+    (age exactly equal to the window is kept — inclusive boundary). Keeping push and
+    evict separate matters because the window has to stay accurate relative to
+    wall-clock "now" even if the buffer sits idle between pushes, not just relative to
+    the last push.
+  - `dc_common::FileScratchRing` (`dc_common/include/dc_common/file_scratch_ring.hpp`):
+    the disk-backed analogue for Files. `stage()` copies a produced File into a private
+    scratch directory (created on construction) under a collision-free
+    `<epoch_ns>_<counter>_<original filename>` name and records it with a timestamp;
+    `evict(now)` deletes staged copies past the same duration/boundary rule as
+    `RecordRingBuffer`, from disk and from the window, tolerating a staged File already
+    missing on disk (replay-safe, mirroring `dc_bridge`'s retention sweep). `window()`
+    returns the current contents as an ordered `std::vector<ScratchedFile>` (path +
+    stamp), oldest first.
+  - Both are header-only, following the same "ROS-free utility, no node needed" pattern
+    already established by `dc_core/include/dc_core/condition_set.hpp` — `dc_common` had
+    no `include/`/`src/`/`test/` tree of its own before this (just the `dc_package()`
+    CMake macro), so this is also the first time it ships actual library code.
+- `dc_common/CMakeLists.txt`: switched `find_package(ament_cmake_core)` to the full
+  `find_package(ament_cmake)` (needed for `ament_export_include_directories` and
+  `ament_cmake_gtest`), and — since `dc_common` defines `dc_package()` itself and so can't
+  `find_package(dc_common)` on itself the way every other `dc_*` package does — pulled the
+  macro in directly via `include(cmake/dc_package.cmake)` before calling it, so the package
+  gets the same standard C++17/`-Wall -Wextra -Wpedantic -Werror` setup as everything else.
+  Installs and exports `include/`, and wires a `BUILD_TESTING` block running both new
+  suites through `ament_add_gtest`. `package.xml`: `buildtool_depend` bumped from
+  `ament_cmake_core` to `ament_cmake` to match, and added `test_depend ament_cmake_gtest`.
+- **Tests**: `dc_common/test/record_ring_buffer_test.cpp` (10 cases: empty-start, push not
+  auto-evicting, out-of-order push still time-ordered on read, evict dropping only what's
+  due, both inclusive/exclusive age boundaries, evict on an empty buffer, evict leaving
+  newer entries after dropping older ones, `window()` being a non-mutating read, repeated
+  evict calls converging) and `dc_common/test/file_scratch_ring_test.cpp` (10 cases,
+  mirroring the same shape plus disk-specific ones: constructor creates the scratch dir,
+  `stage()` copies rather than moves and leaves the source untouched, staging the same
+  source twice yields distinct staged paths, evict deleting from disk as well as the
+  window, evict tolerating an already-missing staged file, `stage()` throwing
+  `std::filesystem::filesystem_error` on a missing source) — both using explicit
+  `std::chrono::system_clock::time_point` values as the injected/fake clock (same
+  parameter-passing style `dc_bridge`'s `retention::sweep()` uses for its `now`), and the
+  File test using an RAII tmp-dir `Fixture` following `dc_bridge/test/retention_test.cpp`'s
+  pattern exactly, per the issue's acceptance criteria.
+- **Verified without `colcon`** (not installed in this sandbox, same gap noted in #242/#243):
+  compiled and ran both test files directly against the real headers with a standalone
+  `g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror -Wdeprecated -fPIC` (the exact flag set
+  `dc_package()` applies) and a locally-built `googletest` v1.15.2 static lib — both
+  binaries compiled warning-free and **all 20 tests passed**. `pre-commit run` on the
+  changed files passed `clang-format` (which reformatted a couple of lambda continuation
+  lines — re-verified compile+tests afterward), `codespell`, XML lint,
+  `ros2_ws_same_versions`/`ros2_ws_set_metadata`; `black` incidentally reformatted an
+  unrelated pre-existing violation in `tools/e2e/scripts/verify_zero_loss.py` (already
+  flagged in the #338 PR history as pre-existing on `origin/jazzy`, not from this change)
+  which was reverted to keep this diff scoped; `poetry-requirements` failed on a
+  pre-existing local environment gap (no `poetry` module) unrelated to this change, same
+  as prior sessions. A real `colcon build --packages-select dc_common --cmake-args
+  -DBUILD_TESTING=ON` + `colcon test` on a Jazzy workspace (CI, or a machine with more
+  disk) is still needed to close the loop formally.


### PR DESCRIPTION
## Summary
- Adds two generic, ROS-independent bounded time-window buffers to `dc_common`, the first slice of pre-event circular-buffer capture (#282): `RecordRingBuffer` (in-memory ring of stamped Record JSON strings) and `FileScratchRing` (disk-backed analogue that stages Files into a scratch directory). Both are header-only, follow the same push/evict/window-read shape, and are exercised with an injected clock / tmp-dir fixture, no ROS node required.
- Neither utility is wired into a Measurement yet — that's later slices per the issue.
- `dc_common` previously had no `include/`/`src/`/`test/` tree; this wires up `ament_cmake_gtest` and header install/export for the package.

## Test plan
- [x] Compiled and ran both gtest suites (20 cases) directly against the headers with the repo's `-Wall -Wextra -Wpedantic -Werror` flags and a locally-built googletest — all pass, no warnings.
- [x] `pre-commit run` on changed files passes (`clang-format`, `codespell`, XML lint, ROS2 metadata checks); unrelated pre-existing `black`/`poetry-requirements` issues left untouched.
- [ ] Real `colcon build --packages-select dc_common --cmake-args -DBUILD_TESTING=ON` + `colcon test` on a Jazzy workspace (no `colcon`/ROS install available in this sandbox — see progress.txt for detail).

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AYPAqz75GtLDye1FquMCgq