### PR TITLE
feat(dc_triggers): add Trigger plugin base, EdgeTrigger, and broadcast node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ are already recorded there rather than in code comments.
 | `dc_core` | Headers for plugins core to the DC stack |
 | `dc_common` | Common support functionality used throughout the DC stack |
 | `dc_measurements` | Collect data with Measurement plugins |
+| `dc_triggers` | Trigger plugins and the broadcast node publishing FlushEvents |
 | `dc_group` | Group node — merges Records from several Measurements by time proximity |
 | `dc_services` | Collect uptime data |
 | `dc_lifecycle_manager` | Controller/manager for the DC system's lifecycle nodes |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,7 +10,16 @@ _Avoid_: metric, sensor log, sample
 
 **Condition**:
 A boolean predicate on robot state that gates whether a Measurement's Records are collected.
-_Avoid_: trigger, filter
+_Avoid_: filter (as a synonym for Condition; "Trigger" is now a distinct DC concept, see below)
+
+**Trigger**:
+A plugin that fires a one-shot signal (a FlushEvent) on the false→true rising edge of a
+Condition composition, distinct from Condition's continuous gating. Used to release a
+Measurement's pre-event buffer around an incident (e.g. an emergency brake).
+
+**FlushEvent**:
+The message a Trigger broadcast node publishes when its Trigger fires, carrying a fresh
+`incident_id` that downstream Measurements adopt for that one event.
 
 **Group**:
 A merge of Records from several Measurements into one Record, based on time proximity.

--- a/dc_core/include/dc_core/trigger.hpp
+++ b/dc_core/include/dc_core/trigger.hpp
@@ -1,0 +1,73 @@
+#ifndef DC_CORE_TRIGGER_HPP_
+#define DC_CORE_TRIGGER_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dc_core/condition.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+namespace dc_core
+{
+/**
+ * @class dc_core::Trigger
+ * @brief Abstract plugin base for Triggers, distinct from Condition: a Condition gates whether a
+ * Measurement's Records are collected, while a Trigger fires a one-shot signal (see
+ * dc_interfaces::msg::FlushEvent) that a Trigger broadcast node publishes for downstream
+ * Measurements to react to. Lifecycle methods mirror dc_core::Condition's exactly, so both plugin
+ * families stay familiar to write and to load.
+ */
+class Trigger
+{
+public:
+  using Ptr = std::shared_ptr<Trigger>;
+
+  /**
+   * @brief Virtual destructor
+   */
+  virtual ~Trigger()
+  {
+  }
+
+  /**
+   * @param  parent pointer to user's node
+   * @param  name The name of this trigger
+   * @param  conditions Every Condition plugin loaded by the parent node, keyed by name, for this
+   * Trigger to compose via if_all/if_any/if_none
+   * @param  if_all_conditions Fire only once every named Condition is active
+   * @param  if_any_conditions Fire once any named Condition is active
+   * @param  if_none_conditions Fire only once no named Condition is active
+   */
+  virtual void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
+                         const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
+                         const std::vector<std::string>& if_all_conditions,
+                         const std::vector<std::string>& if_any_conditions,
+                         const std::vector<std::string>& if_none_conditions) = 0;
+
+  /**
+   * @brief Method to cleanup resources used on shutdown.
+   */
+  virtual void cleanup() = 0;
+
+  /**
+   * @brief Method to activate Trigger and any threads involved in execution.
+   */
+  virtual void activate() = 0;
+
+  /**
+   * @brief Method to deactivate Trigger and any threads involved in execution.
+   */
+  virtual void deactivate() = 0;
+
+  /**
+   * @brief Evaluate the composed Condition state now. Called on a poll cadence by the owning
+   * node; returns true at most once per firing (e.g. EdgeTrigger returns true exactly once per
+   * false->true rising edge, not on every poll while the composed result stays true).
+   */
+  virtual bool checkFired() = 0;
+};
+}  // namespace dc_core
+
+#endif  // DC_CORE_TRIGGER_HPP_

--- a/dc_interfaces/CMakeLists.txt
+++ b/dc_interfaces/CMakeLists.txt
@@ -17,6 +17,7 @@ endforeach()
 rosidl_generate_interfaces(
   ${PROJECT_NAME}
   "msg/Condition.msg"
+  "msg/FlushEvent.msg"
   "srv/DrawImage.srv"
   "srv/SaveImage.srv"
   "msg/StringStamped.msg"

--- a/dc_interfaces/msg/FlushEvent.msg
+++ b/dc_interfaces/msg/FlushEvent.msg
@@ -1,0 +1,2 @@
+string incident_id
+builtin_interfaces/Time stamp

--- a/dc_triggers/CMakeLists.txt
+++ b/dc_triggers/CMakeLists.txt
@@ -1,0 +1,125 @@
+cmake_minimum_required(VERSION 3.8)
+project(dc_triggers)
+
+set(dependencies
+  dc_core
+  dc_interfaces
+  dc_util
+  lifecycle_msgs
+  nav2_util
+  pluginlib
+  rclcpp_components
+  rclcpp_lifecycle
+  std_msgs
+)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
+foreach(Dependency IN ITEMS ${dependencies})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+find_package(PkgConfig REQUIRED)
+pkg_search_module(UUID REQUIRED uuid)
+
+dc_package()
+
+set(library_name trigger_broadcast_node_core)
+set(executable_name trigger_broadcast_node)
+
+include_directories(
+  include
+  ${UUID_INCLUDE_DIRS}
+)
+
+# Trigger plugins
+add_library(dc_edge_trigger SHARED plugins/edge_trigger.cpp)
+list(APPEND dc_trigger_plugin_libs dc_edge_trigger)
+
+foreach(trigger_plugin ${dc_trigger_plugin_libs})
+  ament_target_dependencies(${trigger_plugin} ${dependencies})
+  target_compile_definitions(${trigger_plugin} PRIVATE BT_PLUGIN_EXPORT)
+endforeach()
+
+pluginlib_export_plugin_description_file(dc_core trigger_plugin.xml)
+
+# Library
+add_library(${library_name} SHARED
+  src/trigger_broadcast_node.cpp
+)
+
+target_link_libraries(
+  ${library_name}
+  ${UUID_LIBRARIES}
+)
+
+ament_target_dependencies(${library_name}
+  ${dependencies}
+)
+
+# Executable
+add_executable(${executable_name}
+  src/main.cpp
+)
+
+target_link_libraries(
+  ${executable_name}
+  ${library_name}
+)
+
+ament_target_dependencies(${executable_name}
+  ${dependencies}
+)
+
+rclcpp_components_register_nodes(${library_name} "trigger_broadcast_node::TriggerBroadcastNode")
+
+install(TARGETS ${library_name}
+                ${dc_trigger_plugin_libs}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(TARGETS ${executable_name}
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+
+install(DIRECTORY include/
+  DESTINATION include/
+)
+
+install(FILES trigger_plugin.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(dc_measurements REQUIRED)
+  find_package(nav_msgs REQUIRED)
+
+  # test_trigger_edge_trigger.cpp drives a real TriggerBroadcastNode end to end (lifecycle-node
+  # integration test, matching dc_measurements' test_measurement_*.cpp style) and needs
+  # dc_measurements' Moving condition plugin -- an existing self-subscribing Condition -- to
+  # toggle deterministically without a bespoke test-only plugin.
+  ament_add_gtest(${PROJECT_NAME}_test_edge_trigger test/test_trigger_edge_trigger.cpp)
+  target_include_directories(${PROJECT_NAME}_test_edge_trigger PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  ament_target_dependencies(${PROJECT_NAME}_test_edge_trigger
+    ${dependencies}
+    dc_measurements
+    nav_msgs
+  )
+  target_link_libraries(
+    ${PROJECT_NAME}_test_edge_trigger
+    ${library_name}
+  )
+endif()
+
+ament_export_include_directories(include)
+ament_export_libraries(${library_name}
+  ${dc_trigger_plugin_libs}
+)
+ament_export_dependencies(${dependencies})
+ament_package()

--- a/dc_triggers/include/dc_triggers/plugins/edge_trigger.hpp
+++ b/dc_triggers/include/dc_triggers/plugins/edge_trigger.hpp
@@ -1,0 +1,33 @@
+#ifndef DC_TRIGGERS__PLUGINS__EDGE_TRIGGER_HPP_
+#define DC_TRIGGERS__PLUGINS__EDGE_TRIGGER_HPP_
+
+#include "dc_triggers/trigger.hpp"
+
+namespace dc_triggers
+{
+
+/**
+ * @class dc_triggers::EdgeTrigger
+ * @brief Fires exactly once on the false->true rising edge of its ConditionSet's composed result.
+ * No bespoke rule-evaluation logic of its own -- if_all/if_any/if_none composition is entirely
+ * delegated to dc_core::ConditionSet, the same evaluator dc_measurements::Measurement uses for
+ * live gating (#284), so the two mechanisms can't silently diverge in how they interpret the same
+ * rule syntax.
+ */
+class EdgeTrigger : public dc_triggers::Trigger
+{
+public:
+  EdgeTrigger();
+  ~EdgeTrigger() override;
+
+  bool checkFired() override;
+
+private:
+  // Whether the composed ConditionSet was satisfied on the previous checkFired() call, so a
+  // sustained true only fires once, on the transition into it.
+  bool previously_satisfied_{ false };
+};
+
+}  // namespace dc_triggers
+
+#endif  // DC_TRIGGERS__PLUGINS__EDGE_TRIGGER_HPP_

--- a/dc_triggers/include/dc_triggers/trigger.hpp
+++ b/dc_triggers/include/dc_triggers/trigger.hpp
@@ -1,0 +1,123 @@
+#ifndef DC_TRIGGERS__TRIGGER_HPP_
+#define DC_TRIGGERS__TRIGGER_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dc_core/condition.hpp"
+#include "dc_core/condition_set.hpp"
+#include "dc_core/trigger.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace dc_triggers
+{
+
+/**
+ * @class dc_triggers::Trigger
+ * @brief Common plugin plumbing shared by every concrete Trigger, the way dc_conditions::Condition
+ * is shared by every concrete Condition: owns the node handle, the Condition map the Trigger was
+ * configured with, and the ConditionSet composing them, leaving checkFired() as the one thing a
+ * concrete Trigger (e.g. EdgeTrigger) has to implement.
+ */
+class Trigger : public dc_core::Trigger
+{
+public:
+  Trigger()
+  {
+  }
+
+  ~Trigger() override = default;
+
+  // an opportunity for derived classes to do something on configuration, if they choose
+  virtual void onConfigure()
+  {
+  }
+
+  // an opportunity for derived classes to do something on cleanup, if they choose
+  virtual void onCleanup()
+  {
+  }
+
+  std::shared_ptr<rclcpp_lifecycle::LifecycleNode> getNode()
+  {
+    auto node = node_.lock();
+    if (!node)
+    {
+      throw std::runtime_error{ "Failed to lock node" };
+    }
+    return node;
+  }
+
+  void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
+                 const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
+                 const std::vector<std::string>& if_all_conditions, const std::vector<std::string>& if_any_conditions,
+                 const std::vector<std::string>& if_none_conditions) override
+  {
+    node_ = parent;
+    auto node = node_.lock();
+
+    logger_ = node->get_logger();
+
+    RCLCPP_INFO(logger_, "Configuring %s", name.c_str());
+
+    trigger_name_ = name;
+    conditions_ = conditions;
+    condition_set_ = dc_core::ConditionSet(if_all_conditions, if_any_conditions, if_none_conditions);
+
+    RCLCPP_INFO(logger_, "Done configuring %s", trigger_name_.c_str());
+
+    onConfigure();
+  }
+
+  void cleanup() override
+  {
+    onCleanup();
+  }
+
+  void activate() override
+  {
+    RCLCPP_INFO(logger_, "Activating trigger %s", trigger_name_.c_str());
+    enabled_ = true;
+  }
+
+  void deactivate() override
+  {
+    enabled_ = false;
+  }
+
+protected:
+  // Current state of one of the configured Conditions. A name that is not a configured Condition
+  // reads as false rather than dereferencing a null plugin -- mirrors
+  // dc_measurements::Measurement::getConditionState().
+  bool getConditionState(const std::string& condition_name)
+  {
+    auto condition_it = conditions_.find(condition_name);
+    if (condition_it == conditions_.end() || !condition_it->second)
+    {
+      RCLCPP_ERROR_STREAM(logger_, "Trigger " << trigger_name_ << ": '" << condition_name
+                                              << "' is not a configured condition; treating it as false.");
+      return false;
+    }
+    // Triggers have no data sample of their own to hand a Condition the way a Measurement does --
+    // only Conditions that maintain their own state (e.g. subscribing to a topic directly, such
+    // as Moving) are meaningful composed into a Trigger.
+    return condition_it->second->getState(dc_interfaces::msg::StringStamped());
+  }
+
+  rclcpp_lifecycle::LifecycleNode::WeakPtr node_;
+
+  std::string trigger_name_;
+  bool enabled_{ false };
+
+  std::map<std::string, std::shared_ptr<dc_core::Condition>> conditions_;
+  dc_core::ConditionSet condition_set_;
+
+  rclcpp::Logger logger_{ rclcpp::get_logger("dc_triggers") };
+};
+
+}  // namespace dc_triggers
+
+#endif  // DC_TRIGGERS__TRIGGER_HPP_

--- a/dc_triggers/include/dc_triggers/trigger_broadcast_node.hpp
+++ b/dc_triggers/include/dc_triggers/trigger_broadcast_node.hpp
@@ -1,0 +1,78 @@
+#ifndef DC_TRIGGERS__TRIGGER_BROADCAST_NODE_HPP_
+#define DC_TRIGGERS__TRIGGER_BROADCAST_NODE_HPP_
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dc_core/condition.hpp"
+#include "dc_core/trigger.hpp"
+#include "dc_interfaces/msg/flush_event.hpp"
+#include "nav2_util/lifecycle_node.hpp"
+#include "pluginlib/class_loader.hpp"
+
+namespace trigger_broadcast_node
+{
+
+/**
+ * @class trigger_broadcast_node::TriggerBroadcastNode
+ * @brief Loads the Condition plugins a Trigger composes plus one Trigger plugin, polls the
+ * Trigger on a timer, and publishes a dc_interfaces::msg::FlushEvent -- minting a fresh
+ * incident_id -- each time it fires. Mirrors measurement_server::MeasurementServer's plugin
+ * loading, scaled down to the single Trigger this node hosts.
+ */
+class TriggerBroadcastNode : public nav2_util::LifecycleNode
+{
+public:
+  explicit TriggerBroadcastNode(const rclcpp::NodeOptions& options = rclcpp::NodeOptions());
+  ~TriggerBroadcastNode() override;
+
+  /**
+   * @brief Loads every Condition plugin named in the condition_plugins parameter.
+   * @return bool if successfully loaded the plugins
+   */
+  bool loadConditionPlugins();
+
+  /**
+   * @brief Loads the configured Trigger plugin.
+   * @return bool if successfully loaded the plugin
+   */
+  bool loadTriggerPlugin();
+
+protected:
+  nav2_util::CallbackReturn on_configure(const rclcpp_lifecycle::State& state) override;
+  nav2_util::CallbackReturn on_activate(const rclcpp_lifecycle::State& state) override;
+  nav2_util::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& state) override;
+  nav2_util::CallbackReturn on_cleanup(const rclcpp_lifecycle::State& state) override;
+  nav2_util::CallbackReturn on_shutdown(const rclcpp_lifecycle::State& state) override;
+
+  // Polls the Trigger plugin; on a fire, mints an incident_id and publishes a FlushEvent.
+  void checkTrigger();
+  std::string mintIncidentId();
+
+  // Conditions, loaded the same way measurement_server does.
+  std::map<std::string, std::shared_ptr<dc_core::Condition>> conditions_;
+  std::vector<std::string> condition_ids_;
+  std::vector<std::string> condition_types_;
+  pluginlib::ClassLoader<dc_core::Condition> condition_plugin_loader_;
+
+  // The single Trigger this node hosts.
+  const std::string trigger_id_{ "trigger" };
+  std::string trigger_type_;
+  std::vector<std::string> trigger_if_all_conditions_;
+  std::vector<std::string> trigger_if_any_conditions_;
+  std::vector<std::string> trigger_if_none_conditions_;
+  std::string trigger_topic_;
+  int trigger_polling_interval_;
+  pluginlib::ClassLoader<dc_core::Trigger> trigger_plugin_loader_;
+  pluginlib::UniquePtr<dc_core::Trigger> trigger_;
+
+  rclcpp_lifecycle::LifecyclePublisher<dc_interfaces::msg::FlushEvent>::SharedPtr flush_pub_;
+  rclcpp::TimerBase::SharedPtr check_timer_;
+  rclcpp::CallbackGroup::SharedPtr client_cb_group_;
+};
+
+}  // namespace trigger_broadcast_node
+
+#endif  // DC_TRIGGERS__TRIGGER_BROADCAST_NODE_HPP_

--- a/dc_triggers/package.xml
+++ b/dc_triggers/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>dc_triggers</name>
+  <version>0.1.0</version>
+  <description>Trigger plugins and the broadcast node that publishes FlushEvents when one fires</description>
+  <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
+  <license>MPL-2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>dc_core</depend>
+  <depend>dc_interfaces</depend>
+  <depend>dc_util</depend>
+  <depend>lifecycle_msgs</depend>
+  <depend>nav2_util</depend>
+  <depend>pkg-config</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp_components</depend>
+  <depend>rclcpp_lifecycle</depend>
+  <depend>std_msgs</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>dc_measurements</test_depend>
+  <test_depend>nav_msgs</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <dc_core plugin="${prefix}/trigger_plugin.xml" />
+  </export>
+</package>

--- a/dc_triggers/plugins/edge_trigger.cpp
+++ b/dc_triggers/plugins/edge_trigger.cpp
@@ -1,0 +1,38 @@
+#include "dc_triggers/plugins/edge_trigger.hpp"
+
+namespace dc_triggers
+{
+
+EdgeTrigger::EdgeTrigger() : dc_triggers::Trigger()
+{
+}
+
+EdgeTrigger::~EdgeTrigger() = default;
+
+bool EdgeTrigger::checkFired()
+{
+  if (!enabled_)
+  {
+    return false;
+  }
+
+  const bool satisfied = condition_set_.isSatisfied(
+      dc_core::ConditionStateLookup{ [this](const std::string& condition_name) {
+        return getConditionState(condition_name);
+      } });
+
+  const bool fired = satisfied && !previously_satisfied_;
+  previously_satisfied_ = satisfied;
+
+  if (fired)
+  {
+    RCLCPP_INFO(logger_, "Trigger %s fired", trigger_name_.c_str());
+  }
+
+  return fired;
+}
+
+}  // namespace dc_triggers
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_triggers::EdgeTrigger, dc_core::Trigger)

--- a/dc_triggers/src/main.cpp
+++ b/dc_triggers/src/main.cpp
@@ -1,0 +1,17 @@
+#include <memory>
+
+#include "dc_triggers/trigger_broadcast_node.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::executors::MultiThreadedExecutor executor;
+  auto node = std::make_shared<trigger_broadcast_node::TriggerBroadcastNode>();
+
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
+  rclcpp::shutdown();
+
+  return 0;
+}

--- a/dc_triggers/src/trigger_broadcast_node.cpp
+++ b/dc_triggers/src/trigger_broadcast_node.cpp
@@ -1,0 +1,191 @@
+#include "dc_triggers/trigger_broadcast_node.hpp"
+
+#include <uuid/uuid.h>
+
+#include "dc_util/node_utils.hpp"
+
+namespace trigger_broadcast_node
+{
+
+TriggerBroadcastNode::TriggerBroadcastNode(const rclcpp::NodeOptions& options)
+  : nav2_util::LifecycleNode("trigger_broadcast_node", "", options)
+  , condition_plugin_loader_("dc_core", "dc_core::Condition")
+  , trigger_plugin_loader_("dc_core", "dc_core::Trigger")
+{
+  condition_ids_ = dc_util::get_str_array_param(this, "condition_plugins", std::vector<std::string>());
+}
+
+TriggerBroadcastNode::~TriggerBroadcastNode()
+{
+  trigger_.reset();
+}
+
+bool TriggerBroadcastNode::loadConditionPlugins()
+{
+  auto node = shared_from_this();
+  condition_types_.resize(condition_ids_.size());
+
+  for (size_t i = 0; i != condition_ids_.size(); i++)
+  {
+    condition_types_[i] = dc_util::get_str_type_param(node, condition_ids_[i], "plugin");
+    try
+    {
+      RCLCPP_INFO(get_logger(), "Creating condition plugin %s: Type %s", condition_ids_[i].c_str(),
+                  condition_types_[i].c_str());
+      conditions_[condition_ids_[i]] = condition_plugin_loader_.createUniqueInstance(condition_types_[i]);
+      conditions_[condition_ids_[i]]->configure(node, condition_ids_[i]);
+    }
+    catch (const pluginlib::PluginlibException& ex)
+    {
+      RCLCPP_FATAL(get_logger(),
+                   "Failed to create condition %s of type %s."
+                   " Exception: %s",
+                   condition_ids_[i].c_str(), condition_types_[i].c_str(), ex.what());
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool TriggerBroadcastNode::loadTriggerPlugin()
+{
+  auto node = shared_from_this();
+
+  trigger_type_ = dc_util::get_str_type_param(node, trigger_id_, "plugin");
+  trigger_if_all_conditions_ =
+      dc_util::get_str_array_type_param(node, trigger_id_, "if_all_conditions", std::vector<std::string>());
+  trigger_if_any_conditions_ =
+      dc_util::get_str_array_type_param(node, trigger_id_, "if_any_conditions", std::vector<std::string>());
+  trigger_if_none_conditions_ =
+      dc_util::get_str_array_type_param(node, trigger_id_, "if_none_conditions", std::vector<std::string>());
+  trigger_topic_ = dc_util::get_str_type_param(node, trigger_id_, "topic", std::string("/dc/flush"));
+  trigger_polling_interval_ = dc_util::get_int_type_param(node, trigger_id_, "polling_interval", 100);
+
+  try
+  {
+    RCLCPP_INFO_STREAM(get_logger(), "Creating trigger plugin "
+                                          << trigger_id_ << ": Type " << trigger_type_ << ", Topic: " << trigger_topic_
+                                          << ", Polling interval: " << trigger_polling_interval_);
+
+    trigger_ = trigger_plugin_loader_.createUniqueInstance(trigger_type_);
+    trigger_->configure(node, trigger_id_, conditions_, trigger_if_all_conditions_, trigger_if_any_conditions_,
+                        trigger_if_none_conditions_);
+  }
+  catch (const pluginlib::PluginlibException& ex)
+  {
+    RCLCPP_FATAL(get_logger(),
+                 "Failed to create trigger %s of type %s."
+                 " Exception: %s",
+                 trigger_id_.c_str(), trigger_type_.c_str(), ex.what());
+    return false;
+  }
+
+  return true;
+}
+
+std::string TriggerBroadcastNode::mintIncidentId()
+{
+  uuid_t uuid_obj;
+  char uuid_str[37];
+  uuid_generate(uuid_obj);
+  uuid_unparse(uuid_obj, uuid_str);
+  return std::string(uuid_str);
+}
+
+void TriggerBroadcastNode::checkTrigger()
+{
+  if (!trigger_ || !trigger_->checkFired())
+  {
+    return;
+  }
+
+  dc_interfaces::msg::FlushEvent msg;
+  msg.incident_id = mintIncidentId();
+  msg.stamp = get_clock()->now();
+
+  RCLCPP_INFO_STREAM(get_logger(), "Trigger '" << trigger_id_ << "' fired, incident_id=" << msg.incident_id);
+
+  flush_pub_->publish(msg);
+}
+
+nav2_util::CallbackReturn TriggerBroadcastNode::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(get_logger(), "Configuring");
+  auto node = shared_from_this();
+
+  if (!loadConditionPlugins())
+  {
+    return nav2_util::CallbackReturn::FAILURE;
+  }
+
+  if (!loadTriggerPlugin())
+  {
+    return nav2_util::CallbackReturn::FAILURE;
+  }
+
+  flush_pub_ = node->create_publisher<dc_interfaces::msg::FlushEvent>(trigger_topic_, rclcpp::QoS(10));
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn TriggerBroadcastNode::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(get_logger(), "Activating");
+  auto node = shared_from_this();
+
+  flush_pub_->on_activate();
+  trigger_->activate();
+
+  client_cb_group_ = node->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  check_timer_ = node->create_wall_timer(
+      std::chrono::milliseconds(trigger_polling_interval_), [this] { checkTrigger(); }, client_cb_group_);
+
+  createBond();
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn TriggerBroadcastNode::on_deactivate(const rclcpp_lifecycle::State& /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Deactivating");
+
+  check_timer_.reset();
+  trigger_->deactivate();
+  flush_pub_->on_deactivate();
+
+  destroyBond();
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn TriggerBroadcastNode::on_cleanup(const rclcpp_lifecycle::State& /*state*/)
+{
+  RCLCPP_INFO(get_logger(), "Cleaning up");
+
+  if (trigger_)
+  {
+    trigger_->cleanup();
+    trigger_.reset();
+  }
+  for (auto& condition : conditions_)
+  {
+    condition.second->cleanup();
+  }
+  conditions_.clear();
+  flush_pub_.reset();
+
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+nav2_util::CallbackReturn TriggerBroadcastNode::on_shutdown(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(get_logger(), "Shutting down");
+  return nav2_util::CallbackReturn::SUCCESS;
+}
+
+}  // namespace trigger_broadcast_node
+
+#include "rclcpp_components/register_node_macro.hpp"
+
+RCLCPP_COMPONENTS_REGISTER_NODE(trigger_broadcast_node::TriggerBroadcastNode)

--- a/dc_triggers/test/test_trigger_edge_trigger.cpp
+++ b/dc_triggers/test/test_trigger_edge_trigger.cpp
@@ -139,7 +139,10 @@ TEST_F(TriggerEdgeTriggerTest, SecondRisingEdgeFiresAgainWithDistinctIncidentId)
   spinFor(polling_interval_ * 3);
   EXPECT_EQ(flush_count_, 1);
 
-  // Move again: a second rising edge fires a second, distinct incident.
+  // Move again: the two below-threshold messages above left moving_count_ at -1, so it takes
+  // two above-threshold messages (not one) to cross +count_hysteresis_ and re-fire the rising
+  // edge -- the counter is symmetric, unlike gate_condition's one-shot latch.
+  publishOdom(1.0);
   publishOdom(1.0);
   while (flush_count_ == 1)
   {

--- a/dc_triggers/test/test_trigger_edge_trigger.cpp
+++ b/dc_triggers/test/test_trigger_edge_trigger.cpp
@@ -1,0 +1,163 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <set>
+
+#include "dc_interfaces/msg/flush_event.hpp"
+#include "dc_triggers/trigger_broadcast_node.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+
+class TriggerEdgeTriggerTest : public ::testing::Test
+{
+protected:
+  TriggerEdgeTriggerTest()
+  {
+    SetUp();
+  }
+
+  ~TriggerEdgeTriggerTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    // condition_plugins is read by the constructor itself, so it must be supplied as a parameter
+    // override rather than via tb_node_->declare_parameter afterwards.
+    auto options = rclcpp::NodeOptions().parameter_overrides(
+        { rclcpp::Parameter("condition_plugins", std::vector<std::string>{ "moving" }) });
+    tb_node_ = std::make_shared<trigger_broadcast_node::TriggerBroadcastNode>(options);
+
+    sub_flush_ = tb_node_->create_subscription<dc_interfaces::msg::FlushEvent>(
+        "/dc/flush", rclcpp::SystemDefaultsQoS(),
+        std::bind(&TriggerEdgeTriggerTest::flushEventCallback, this, std::placeholders::_1));
+    odom_pub_ = tb_node_->create_publisher<nav_msgs::msg::Odometry>("/odom", rclcpp::QoS(10));
+
+    tb_node_->declare_parameter("moving.plugin", std::string("dc_conditions/Moving"));
+    tb_node_->declare_parameter("moving.odom_topic", std::string("/odom"));
+    // A single Odometry message flips the Condition, keeping the test deterministic and fast.
+    tb_node_->declare_parameter("moving.count_hysteresis", 1);
+
+    tb_node_->declare_parameter("trigger.plugin", std::string("dc_triggers/EdgeTrigger"));
+    tb_node_->declare_parameter("trigger.if_all_conditions", std::vector<std::string>{ "moving" });
+    tb_node_->declare_parameter("trigger.topic", std::string("/dc/flush"));
+    tb_node_->declare_parameter("trigger.polling_interval", polling_interval_);
+  }
+
+  void TearDown() override
+  {
+    tb_node_->deactivate();
+    tb_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    tb_node_->configure();
+    tb_node_->activate();
+  }
+
+  void flushEventCallback(const dc_interfaces::msg::FlushEvent& msg)
+  {
+    flush_count_++;
+    incident_ids_.insert(msg.incident_id);
+  }
+
+  void publishOdom(double linear_x)
+  {
+    nav_msgs::msg::Odometry msg;
+    msg.twist.twist.linear.x = linear_x;
+    odom_pub_->publish(msg);
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(tb_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<trigger_broadcast_node::TriggerBroadcastNode> tb_node_;
+  rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr sub_flush_;
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  int polling_interval_{ 20 };
+
+public:
+  int flush_count_{ 0 };
+  std::set<std::string> incident_ids_;
+};
+
+// Acceptance criterion: the underlying Condition never becoming true never fires the Trigger.
+TEST_F(TriggerEdgeTriggerTest, ConditionNeverBecomingTrueNeverFires)
+{
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_EQ(flush_count_, 0);
+}
+
+// Acceptance criterion: exactly one FlushEvent per false->true rising edge, not on sustained true.
+TEST_F(TriggerEdgeTriggerTest, FiresOnceOnRisingEdgeNotOnSustainedTrue)
+{
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 3);
+  EXPECT_EQ(flush_count_, 0);
+
+  // Arm the Condition: one Odometry message above the speed threshold flips Moving to active.
+  publishOdom(1.0);
+  while (flush_count_ == 0)
+  {
+    rclcpp::spin_some(tb_node_->get_node_base_interface());
+  }
+  EXPECT_EQ(flush_count_, 1);
+
+  // The Condition stays active (sustained true) for several more poll cycles -- no extra fire.
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(flush_count_, 1);
+}
+
+// Acceptance criterion: a second rising edge (after the Condition falls and rises again) fires
+// again, each firing carrying a distinct incident_id.
+TEST_F(TriggerEdgeTriggerTest, SecondRisingEdgeFiresAgainWithDistinctIncidentId)
+{
+  startLifecycleNode();
+
+  publishOdom(1.0);
+  while (flush_count_ == 0)
+  {
+    rclcpp::spin_some(tb_node_->get_node_base_interface());
+  }
+  EXPECT_EQ(flush_count_, 1);
+
+  // Stop moving: two below-threshold messages flip Moving back to inactive.
+  publishOdom(0.0);
+  publishOdom(0.0);
+  spinFor(polling_interval_ * 3);
+  EXPECT_EQ(flush_count_, 1);
+
+  // Move again: a second rising edge fires a second, distinct incident.
+  publishOdom(1.0);
+  while (flush_count_ == 1)
+  {
+    rclcpp::spin_some(tb_node_->get_node_base_interface());
+  }
+  EXPECT_EQ(flush_count_, 2);
+  EXPECT_EQ(incident_ids_.size(), 2u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_triggers/trigger_plugin.xml
+++ b/dc_triggers/trigger_plugin.xml
@@ -1,0 +1,9 @@
+<class_libraries>
+    <library path="dc_edge_trigger">
+        <class name="dc_triggers/EdgeTrigger" type="dc_triggers::EdgeTrigger" base_class_type="dc_core::Trigger">
+            <description>
+                dc_trigger_edge_trigger
+            </description>
+        </class>
+    </library>
+</class_libraries>

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -58,6 +58,8 @@
   - [Moving](./dc/conditions/moving.md)
   - [Same as previous](./dc/conditions/same_as_previous.md)
   - [String match](./dc/conditions/string_match.md)
+- [Triggers](./dc/triggers.md)
+  - [Edge trigger](./dc/triggers/edge_trigger.md)
 - [Data validation](./dc/data_validation.md)
 - [Groups](./dc/groups.md)
 - [Raw topic collection](./dc/raw_topics.md)

--- a/doc/src/dc/introduction.md
+++ b/doc/src/dc/introduction.md
@@ -67,7 +67,7 @@ DC uses a modular approach, based on [pluginlib](https://index.ros.org/p/pluginl
 * **Customizable validation**: validate Records using existing or customized JSON schemas
 * **Easy to extend**: add new Measurements by writing a plugin; add new Destinations with configuration alone
 * **Flexible data collection conditions**: collect data based on conditions such as whether the robot is moving or if a field is equal to a value
-* **Trigger-based data collection**: collect data when a defined set of combination of all, any, or no condition are met
+* **Condition-based data collection**: collect data when a defined set of combination of all, any, or no condition are met
 * **Customizable record collection**: configure the number of records to collect at the start and when a condition is activated.
 * **Data inspection**: inspect data from camera input including barcode and QR codes
 * **Fast and efficient**: high performance, using an external Shipper for delivery, and designed to minimize code duplication and reduce human errors

--- a/doc/src/dc/triggers.md
+++ b/doc/src/dc/triggers.md
@@ -1,0 +1,49 @@
+# Triggers
+
+## Description
+
+A **Trigger** is distinct from a **Condition**: a Condition gates whether a Measurement's
+Records are collected right now, while a Trigger fires a one-shot signal that downstream
+Measurements react to — e.g. releasing a pre-event buffer of recent data (later slices of
+[#282](https://github.com/Minipada/ros2_data_collection/issues/282) wire that reaction up;
+this package only builds the signal itself).
+
+The `trigger_broadcast_node` loads the Condition plugins named in `condition_plugins` (the
+same Condition plugins Measurements use — see [Conditions](./conditions.md)) plus one
+Trigger plugin, polls the Trigger on a timer, and publishes a
+`dc_interfaces/msg/FlushEvent` on a configurable topic (`/dc/flush` by default) each time
+it fires. The node mints a fresh `incident_id` (a UUID) for every firing; nothing else
+generates one — every subscriber shares one ID per incident.
+
+```admonish note title="Only self-updating Conditions are meaningful here"
+A Measurement passes its own freshly-collected Record to each Condition it consults, so
+plugins like `BoolEqual` read a field out of that Record. A Trigger has no Record of its
+own: it only makes sense to compose Conditions that maintain their own state from a
+subscription, such as [Moving](./conditions/moving.md).
+```
+
+## Available plugins
+
+| Name                              | Description                                                              |
+| ---------------------------------- | -------------------------------------------------------------------------- |
+| [Edge trigger](./triggers/edge_trigger.md) | Fires once on the false→true rising edge of an `if_all`/`if_any`/`if_none` Condition composition |
+
+## Node parameters
+
+| Parameter name     | Description                                | Type(s)     | Default          |
+| ------------------- | --------------------------------------------- | ----------- | ---------------- |
+| condition_plugins   | Name of the condition plugins to load       | list\[str\] | N/A (mandatory)  |
+
+## Plugin parameters
+
+Every Trigger plugin loaded by this node is namespaced under `trigger` and shares these
+parameters:
+
+| Parameter name              | Description                                                     | Type(s)     | Default        |
+| ---------------------------- | -------------------------------------------------------------------- | ----------- | -------------- |
+| trigger.plugin               | Name of the trigger plugin to load                                | str         | N/A (mandatory) |
+| trigger.if_all_conditions    | Fire only once every named Condition is active                    | list\[str\] | []             |
+| trigger.if_any_conditions    | Fire once any named Condition is active                           | list\[str\] | []             |
+| trigger.if_none_conditions   | Fire only once no named Condition is active                       | list\[str\] | []             |
+| trigger.topic                | Topic `FlushEvent` messages are published on                      | str         | "/dc/flush"    |
+| trigger.polling_interval     | Interval in milliseconds at which the composed Condition state is checked | int | 100            |

--- a/doc/src/dc/triggers/edge_trigger.md
+++ b/doc/src/dc/triggers/edge_trigger.md
@@ -1,0 +1,15 @@
+# Edge trigger
+
+## Description
+
+Composes the Condition plugins named in `if_all_conditions`/`if_any_conditions`/
+`if_none_conditions` — the exact same rules Measurements already use — and fires exactly
+once on the false→true rising edge of the composed result. A sustained `true` fires only
+once; the Trigger stays quiet until the composed result falls back to `false` and rises
+again. No rule-evaluation logic of its own: composition is entirely delegated to the same
+`ConditionSet` evaluator `dc_measurements::Measurement` uses for live gating.
+
+## Parameters
+
+See [Node parameters](../triggers.md#node-parameters) — `EdgeTrigger` has no parameters
+of its own beyond the shared `trigger.*` ones every Trigger plugin reads.

--- a/progress.txt
+++ b/progress.txt
@@ -5884,7 +5884,18 @@ Measurement collects; a Trigger fires a one-shot signal on a rising edge.
   attempt failed for an environment reason, not a code one: each `podman run --rm`
   invocation is a fresh container, so `build/`/`install/` from the build step didn't
   survive into a separate test-step invocation ("Has this package been built before?").
-  Re-running build and test in one combined container invocation was in flight when this
-  entry was written; its result -- particularly whether the three
-  `test_trigger_edge_trigger` cases pass as designed -- still needs to be confirmed and
-  logged in a follow-up, the same kind of gap #285's entry closed out formally later.
+  Re-running build and test in one combined container invocation surfaced one real bug --
+  in the test, not the production code: `SecondRisingEdgeFiresAgainWithDistinctIncidentId`
+  published a single above-threshold Odometry message to re-arm `Moving` after it had
+  fallen back to inactive, copying the one-shot-latch assumption from
+  `test_measurement_gate_condition.cpp`. `Moving`'s hysteresis counter isn't a latch
+  though -- it's symmetric: the two below-threshold messages that flipped it back to
+  inactive left `moving_count_` at -1, so one more above-threshold message only reached 0,
+  one short of crossing `+count_hysteresis_` again. The test hung waiting for a second
+  `FlushEvent` that could never arrive, caught by `colcon test`'s 60s per-test timeout.
+  Fixed by publishing two above-threshold messages instead of one. Re-run after the fix:
+  `colcon test --packages-select dc_core dc_triggers` -- **66 tests, 0 errors, 0
+  failures** (`dc_core`'s existing 61 `ConditionSet` tests unaffected; all 3
+  `test_trigger_edge_trigger` cases passing, 0.80s). Confirmed via `gh pr view --json body`
+  and `gh pr edit` that PR #342's description reflects these results rather than the
+  in-flight state it was opened with.

--- a/progress.txt
+++ b/progress.txt
@@ -5794,3 +5794,97 @@ on the PR.
   as prior sessions. A real `colcon build --packages-select dc_common --cmake-args
   -DBUILD_TESTING=ON` + `colcon test` on a Jazzy workspace (CI, or a machine with more
   disk) is still needed to close the loop formally.
+
+## #286 - Add dc_triggers package: Trigger plugin base, EdgeTrigger, and broadcast node
+
+First implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), unblocked by #284's `ConditionSet` evaluator. Introduces a **Trigger** concept
+distinct from Condition (CONTEXT.md's Condition entry warned to avoid "trigger" as a
+synonym for it -- it now names something real): a Condition continuously gates whether a
+Measurement collects; a Trigger fires a one-shot signal on a rising edge.
+
+- `dc_core/include/dc_core/trigger.hpp`: `dc_core::Trigger`, an abstract plugin base with
+  the same four lifecycle methods as `dc_core::Condition` (`configure`/`cleanup`/
+  `activate`/`deactivate`), plus one more: `checkFired()`, polled by the owning node,
+  returning true at most once per firing. `configure()` takes the parent node, this
+  Trigger's name, the Condition plugin map the owning node already loaded (mirroring how
+  `dc_core::Measurement::configure()` receives it), and the `if_all`/`if_any`/`if_none`
+  name lists to compose them with.
+- `dc_triggers` (new package): `dc_triggers::Trigger` (`include/dc_triggers/trigger.hpp`)
+  is the common plugin plumbing every concrete Trigger shares -- node handle, the
+  Condition map, and a `dc_core::ConditionSet` built from the three name lists -- exactly
+  the role `dc_conditions::Condition` plays for Condition plugins. It exposes
+  `getConditionState(name)`, which looks a Condition up and calls its `getState()` with a
+  **default-constructed** `dc_interfaces::msg::StringStamped` -- a Trigger has no Record
+  of its own to hand a Condition the way a Measurement does, so only Conditions that
+  maintain their own state via a subscription (e.g. `Moving`) are meaningful composed
+  into a Trigger; msg-dependent Conditions (`BoolEqual` and friends) would always read
+  against an empty message here. Documented on `dc_triggers/trigger.hpp` and in
+  `doc/src/dc/triggers.md`, not silently swallowed.
+- `dc_triggers::EdgeTrigger` (`plugins/edge_trigger.cpp`): the one concrete Trigger this
+  slice ships. `checkFired()` evaluates `condition_set_.isSatisfied()` and fires
+  (`satisfied && !previously_satisfied_`) exactly on the false->true transition -- a
+  sustained `true` across repeated polls fires only once, matching the acceptance
+  criterion verbatim. No rule-evaluation logic of its own: composition is entirely
+  `dc_core::ConditionSet`, the same evaluator `dc_measurements::Measurement` uses for live
+  gating, so the two mechanisms can't diverge in how they read the same if_all/if_any/
+  if_none syntax.
+- `dc_interfaces/msg/FlushEvent.msg`: `string incident_id` + `builtin_interfaces/Time
+  stamp`, registered in `dc_interfaces/CMakeLists.txt`.
+- `trigger_broadcast_node::TriggerBroadcastNode` (`include/dc_triggers/
+  trigger_broadcast_node.hpp`, `src/trigger_broadcast_node.cpp`): a `nav2_util::LifecycleNode`
+  mirroring `measurement_server::MeasurementServer`'s plugin-loading shape, scaled down to
+  the single Trigger this node hosts. `condition_plugins` (a top-level string-array
+  parameter, read in the constructor like `MeasurementServer::measurement_plugins`) names
+  the Condition plugins to load; each is configured via `<condition_id>.plugin` exactly as
+  today. The one Trigger is namespaced `trigger.*`: `trigger.plugin` (mandatory),
+  `trigger.if_all_conditions`/`if_any_conditions`/`if_none_conditions` (default empty),
+  `trigger.topic` (default `/dc/flush`), `trigger.polling_interval` (default 100 ms, the
+  cadence `checkTrigger()` is invoked on via a wall timer created in `on_activate()`).
+  Each `checkTrigger()` tick calls `trigger_->checkFired()`; on a fire, mints a UUID via
+  the same `<uuid/uuid.h>` `uuid_generate()` call `MeasurementServer::setRunId()` already
+  uses for `run_id`, stamps a `FlushEvent`, and publishes -- the node is the *only* minter
+  of `incident_id`, matching the acceptance criterion that Measurements adopt it rather
+  than generating their own (Measurement-side adoption is out of scope here; deferred to
+  a later #282 slice).
+- `dc_triggers/trigger_plugin.xml` exports `dc_triggers/EdgeTrigger` as a `dc_core::Trigger`,
+  installed and pluginlib-registered the same way `dc_measurements/condition_plugin.xml`
+  and `measurement_plugin.xml` are.
+- **Tests**: `dc_triggers/test/test_trigger_edge_trigger.cpp`, an `ament_add_gtest`
+  lifecycle-node integration test in the `test_measurement_*.cpp` style (spin up a real
+  `TriggerBroadcastNode`, subscribe to its `/dc/flush` output, drive state through ROS
+  messages, assert on what's received) rather than a Trigger-only unit test, since
+  `EdgeTrigger`'s own logic is thin wiring around the already-unit-tested `ConditionSet`
+  evaluator (per #282's testing decisions). Reuses `dc_measurements`' `Moving` Condition
+  (self-subscribing to `/odom`) to toggle state deterministically, the same fixture
+  `dc_measurements/test/test_measurement_gate_condition.cpp` already established for
+  exactly this reason -- declared a `test_depend` on `dc_measurements` for it. Three
+  cases: the Condition never becoming true never fires; a rising edge fires exactly once
+  and a sustained true afterward fires no more; and a second rising edge (after the
+  Condition falls and rises again) fires again with a *distinct* `incident_id`
+  (`std::set` dedup on all received `incident_id`s, asserted to grow to 2).
+- **Docs**: `doc/src/dc/triggers.md` (+ `doc/src/dc/triggers/edge_trigger.md`), wired into
+  `doc/src/SUMMARY.md` between Conditions and Data validation, documenting both node-level
+  (`condition_plugins`) and plugin-level (`trigger.*`) parameters per the acceptance
+  criterion. `CONTEXT.md` gains **Trigger** and **FlushEvent** glossary entries per #282's
+  "Further Notes" instruction, and Condition's existing entry is reworded -- it used to
+  list "trigger" as a term to avoid entirely; now it avoids "filter" specifically, since
+  "Trigger" is a real, distinct concept. `doc/src/dc/introduction.md`'s pre-existing
+  "Trigger-based data collection" bullet was actually describing if_all/if_any/if_none
+  Condition gating (predating this issue) and would now read as describing the wrong
+  feature; reworded to "Condition-based data collection" without touching its content.
+  `CLAUDE.md`'s package table gains a `dc_triggers` row.
+- **Verified**: `podman run` against the `localhost/dc-workspace` Jazzy image (the same one
+  #284/#285 used), bind-mounting this worktree over `/root/ws/src/ros2_data_collection`:
+  `colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements
+  dc_triggers --cmake-args -DBUILD_TESTING=ON` succeeded end to end (10min 55s; dc_triggers
+  itself 36.9s) with zero warnings under the `-Wall -Wextra -Wpedantic -Werror -Wdeprecated`
+  `dc_package()` flags, confirming the new `dc_core::Trigger`/`dc_triggers` headers and
+  plugin sources compile clean and pluginlib registration resolves. A first `colcon test`
+  attempt failed for an environment reason, not a code one: each `podman run --rm`
+  invocation is a fresh container, so `build/`/`install/` from the build step didn't
+  survive into a separate test-step invocation ("Has this package been built before?").
+  Re-running build and test in one combined container invocation was in flight when this
+  entry was written; its result -- particularly whether the three
+  `test_trigger_edge_trigger` cases pass as designed -- still needs to be confirmed and
+  logged in a follow-up, the same kind of gap #285's entry closed out formally later.


### PR DESCRIPTION
## Summary

First implementation slice of #282 (pre-event circular-buffer capture via a new Trigger
plugin), unblocked by #284's `ConditionSet` evaluator.

- `dc_core::Trigger`: abstract plugin base with lifecycle methods matching `Condition`
  (`configure`/`cleanup`/`activate`/`deactivate`), plus `checkFired()`.
- New `dc_triggers` package: `dc_triggers::Trigger` (common plugin plumbing, mirroring
  `dc_conditions::Condition`) and `dc_triggers::EdgeTrigger`, which composes Condition
  plugins via `if_all`/`if_any`/`if_none` using the shared `ConditionSet` evaluator and
  fires exactly once on the false→true rising edge.
- New `dc_interfaces::msg::FlushEvent` (`incident_id` string + `stamp`).
- `trigger_broadcast_node`: loads one Trigger plugin plus its Condition plugins via
  `pluginlib::ClassLoader`, polls the Trigger on a timer, and publishes `FlushEvent` on a
  configurable topic (default `/dc/flush`), minting a fresh `incident_id` per firing.
- Docs: `doc/src/dc/triggers.md` + `triggers/edge_trigger.md`, wired into `SUMMARY.md`;
  `CONTEXT.md` gains **Trigger**/**FlushEvent** glossary entries; a pre-existing
  "Trigger-based data collection" bullet in `introduction.md` (which actually described
  Condition-based gating) reworded to avoid colliding with the new term.

## Verification

`colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements
dc_triggers --cmake-args -DBUILD_TESTING=ON` against the Jazzy workspace image succeeded
end to end with zero warnings under `-Wall -Wextra -Wpedantic -Werror -Wdeprecated`.

`colcon test --packages-select dc_core dc_triggers`: **66 tests, 0 errors, 0 failures** —
`dc_core`'s existing 61 `ConditionSet` tests unaffected, plus the 3 new
`test_trigger_edge_trigger` lifecycle-node integration cases (no-fire when the Condition
never activates; a single fire on the rising edge with no re-fire while it stays true;
and a second rising edge firing again with a distinct `incident_id`), all passing.

## Test plan

- [x] `colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements dc_triggers --cmake-args -DBUILD_TESTING=ON`
- [x] `colcon test --packages-select dc_core dc_triggers` — 66 tests, 0 errors, 0 failures

Closes #286

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XckY5hSLpnHrtztTHwcqqW