### PR TITLE
feat(dc_measurements): wire RecordRingBuffer into Measurement with flush-triggered release

### DIFF
--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -52,6 +52,10 @@ public:
    * @param  run_id Unique ID of the current run
    * @param  run_id Whether Run Id is enabled
    * @param  custom_keys Vector of JSON with custom keys
+   * @param  buffer_duration_sec Seconds of history to buffer instead of publishing live; 0 (the
+   * default) disables buffering and preserves normal live publishing (#287)
+   * @param  flush_topic Topic to receive the FlushEvent that releases the buffered window,
+   * tagging each released Record with the event's incident_id, then resumes live publishing
    */
   virtual void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
                          const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
@@ -68,7 +72,8 @@ public:
                          const bool& nest, const bool& flatten, const std::string& save_local_base_path,
                          const std::string& all_base_path, const std::string& all_base_path_expanded,
                          const std::string& save_local_base_path_expanded, const std::string& run_id,
-                         const bool& run_id_enabled, const std::vector<json>& custom_keys) = 0;
+                         const bool& run_id_enabled, const std::vector<json>& custom_keys,
+                         const double& buffer_duration_sec, const std::string& flush_topic) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -3,6 +3,7 @@ project(dc_measurements)
 
 set(dependencies
   cv_bridge
+  dc_common
   dc_core
   dc_interfaces
   dc_util
@@ -290,6 +291,7 @@ install(DIRECTORY plugins/measurements/json
 
 set(tests
   test_measurement_bool_equal
+  test_measurement_buffering
   test_measurement_camera
   test_measurement_cmd_vel
   test_measurement_diagnostics

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -14,10 +14,12 @@
 #include <utility>
 #include <vector>
 
+#include "dc_common/record_ring_buffer.hpp"
 #include "dc_core/condition.hpp"
 #include "dc_core/condition_set.hpp"
 #include "dc_core/measurement.hpp"
 #include "dc_interfaces/msg/condition.hpp"
+#include "dc_interfaces/msg/flush_event.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
@@ -402,20 +404,29 @@ public:
     }
   }
 
+  // Applies the same enrichment publish() applies before publishing (validation, nesting/
+  // flattening, run_id, tags, measurement name/plugin, custom keys) without publishing --
+  // shared by publish() and bufferSample() so a Record released later from the ring buffer
+  // looks identical to one published live, modulo the incident_id onFlushEvent() adds (#287).
+  void enrichMsg(dc_interfaces::msg::StringStamped& msg)
+  {
+    // TODO pass the json, not the msg
+    validateJSON(msg);
+    nestedSample(msg);
+    flattenSample(msg);
+    addRunId(msg);
+    addTags(msg);
+    addMeasurementName(msg);
+    addMeasurementPluginName(msg);
+    addCustomKeys(msg);
+  }
+
   void publish(dc_interfaces::msg::StringStamped msg)
   {
     auto msg_copy = msg;
     if (!msg.data.empty() && msg.data != "null")
     {
-      // TODO pass the json, not the msg
-      validateJSON(msg);
-      nestedSample(msg);
-      flattenSample(msg);
-      addRunId(msg);
-      addTags(msg);
-      addMeasurementName(msg);
-      addMeasurementPluginName(msg);
-      addCustomKeys(msg);
+      enrichMsg(msg);
     }
     if (!msg.data.empty() && msg.data != "null")
     {
@@ -514,8 +525,64 @@ public:
     dc_interfaces::msg::StringStamped msg = collect();
     if (enabled_)
     {
-      publish(msg);
+      if (buffering_active_)
+      {
+        bufferSample(msg);
+      }
+      else
+      {
+        publish(msg);
+      }
     }
+  }
+
+  // While buffering is active, collectAndPublish() calls this instead of publish(): the sample
+  // is enriched exactly as a live Record would be, then pushed into ring_buffer_ instead of
+  // being published, and the buffer is evicted down to buffer_duration_sec_ relative to now (#287).
+  void bufferSample(dc_interfaces::msg::StringStamped msg)
+  {
+    if (msg.data.empty() || msg.data == "null")
+    {
+      return;
+    }
+    enrichMsg(msg);
+    auto now = std::chrono::system_clock::now();
+    ring_buffer_->push(msg.data, now);
+    ring_buffer_->evict(now);
+  }
+
+  // Releases the buffered window as Records tagged with the FlushEvent's incident_id, then
+  // turns buffering off for good -- re-arming and cooldown are separate follow-up slices, kept
+  // out of this one intentionally (#287).
+  void onFlushEvent(const dc_interfaces::msg::FlushEvent& event)
+  {
+    if (!buffering_active_ || !ring_buffer_)
+    {
+      return;
+    }
+
+    for (const auto& entry : ring_buffer_->window())
+    {
+      dc_interfaces::msg::StringStamped out;
+      out.group_key = group_key_;
+      out.header.stamp =
+          rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(entry.stamp.time_since_epoch()).count());
+      try
+      {
+        json data_json = json::parse(entry.json);
+        data_json["incident_id"] = event.incident_id;
+        out.data = data_json.dump(-1, ' ', true);
+      }
+      catch (json::parse_error& e)
+      {
+        RCLCPP_ERROR_STREAM(logger_, "Error parsing buffered Record JSON on FlushEvent release: " << entry.json);
+        continue;
+      }
+      data_pub_->publish(out);
+    }
+
+    buffering_active_ = false;
+    ring_buffer_.reset();
   }
 
   virtual dc_interfaces::msg::StringStamped collect() = 0;
@@ -534,7 +601,8 @@ public:
                  const std::vector<std::string>& remote_prefixes, const bool& nested, const bool& flatten,
                  const std::string& save_local_base_path, const std::string& all_base_path,
                  const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
-                 const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_keys) override
+                 const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_keys,
+                 const double& buffer_duration_sec, const std::string& flush_topic) override
   {
     node_ = parent;
     auto node = node_.lock();
@@ -587,6 +655,18 @@ public:
     collect_timer_ = node->create_wall_timer(
         std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); }, client_cb_group_);
 
+    buffer_duration_sec_ = buffer_duration_sec;
+    buffering_active_ = buffer_duration_sec_ > 0.0;
+    flush_topic_ = flush_topic.empty() ? std::string("/dc/flush") : flush_topic;
+    if (buffering_active_)
+    {
+      ring_buffer_ =
+          std::make_shared<dc_common::RecordRingBuffer>(std::chrono::duration_cast<std::chrono::system_clock::duration>(
+              std::chrono::duration<double>(buffer_duration_sec_)));
+      flush_sub_ = node->create_subscription<dc_interfaces::msg::FlushEvent>(
+          flush_topic_, 10, std::bind(&Measurement::onFlushEvent, this, std::placeholders::_1));
+    }
+
     RCLCPP_INFO(logger_, "Done configuring %s", measurement_name_.c_str());
 
     if (json_schema_path_.empty())
@@ -618,6 +698,8 @@ public:
   void cleanup() override
   {
     data_pub_.reset();
+    flush_sub_.reset();
+    ring_buffer_.reset();
     onCleanup();
   }
 
@@ -703,6 +785,15 @@ protected:
 
   // Tags
   std::vector<std::string> tags_;
+
+  // Buffering: pre-event circular-buffer capture (#287). While buffering_active_, samples go
+  // into ring_buffer_ instead of being published; a FlushEvent on flush_topic_ releases the
+  // buffered window and turns buffering off for the lifetime of this Measurement instance.
+  double buffer_duration_sec_{ 0.0 };
+  bool buffering_active_{ false };
+  std::string flush_topic_;
+  std::shared_ptr<dc_common::RecordRingBuffer> ring_buffer_;
+  rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr flush_sub_;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -125,6 +125,8 @@ protected:
   std::vector<std::vector<std::string>> measurement_remote_prefixes_;
   std::vector<bool> measurement_nested_;
   std::vector<bool> measurement_flatten_;
+  std::vector<double> measurement_buffer_duration_sec_;
+  std::vector<std::string> measurement_flush_topic_;
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;
   std::string all_base_path_;

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>cv_bridge</depend>
+  <depend>dc_common</depend>
   <depend>dc_core</depend>
   <depend>dc_interfaces</depend>
   <depend>dc_lifecycle_manager</depend>

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -153,6 +153,8 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   measurement_remote_prefixes_.resize(measurement_ids_.size());
   measurement_nested_.resize(measurement_ids_.size());
   measurement_flatten_.resize(measurement_ids_.size());
+  measurement_buffer_duration_sec_.resize(measurement_ids_.size());
+  measurement_flush_topic_.resize(measurement_ids_.size());
 
   measurement_if_all_conditions_.resize(measurement_ids_.size());
   measurement_if_any_conditions_.resize(measurement_ids_.size());
@@ -235,6 +237,10 @@ bool MeasurementServer::loadMeasurementPlugins()
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "remote_prefixes", std::vector<std::string>());
     measurement_nested_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "nested", false);
     measurement_flatten_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "flatten", false);
+    measurement_buffer_duration_sec_[i] =
+        dc_util::get_double_type_param(node, measurement_ids_[i], "buffer_duration_sec", 0.0);
+    measurement_flush_topic_[i] =
+        dc_util::get_str_type_param(node, measurement_ids_[i], "flush_topic", std::string("/dc/flush"));
 
     measurement_if_all_conditions_[i] =
         dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_all_conditions", std::vector<std::string>());
@@ -248,27 +254,28 @@ bool MeasurementServer::loadMeasurementPlugins()
 
     try
     {
-      RCLCPP_INFO_STREAM(get_logger(),
-                         "Creating measurement plugin "
-                             << measurement_ids_[i].c_str() << ": Type " << measurement_types_[i].c_str()
-                             << ", Group key: " << measurement_group_key_[i] << ", Polling interval: "
-                             << measurement_polling_interval_[i] << ", Debug: " << (int)measurement_debug_[i]
-                             << ", Validator enabled: " << (int)measurement_enable_validator_[i]
-                             << ", Schema path: " << measurement_json_schema_path_[i].c_str() << ", Tags: ["
-                             << dc_util::join(measurement_tags_[i], ",")
-                             << "], Init collect: " << (int)measurement_init_collect_[i]
-                             << ", Init Max measurement: " << measurement_init_max_measurements_[i]
-                             << ", Include measurement name: " << measurement_include_measurement_name_[i]
-                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-                             << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
-                             << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i]) << ", Nest: "
-                             << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
-                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-                             << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
-                             << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
-                             << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
-                             << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
-                             << ", Gate condition: " << measurement_gate_condition_[i]);
+      RCLCPP_INFO_STREAM(
+          get_logger(),
+          "Creating measurement plugin "
+              << measurement_ids_[i].c_str() << ": Type " << measurement_types_[i].c_str()
+              << ", Group key: " << measurement_group_key_[i]
+              << ", Polling interval: " << measurement_polling_interval_[i] << ", Debug: " << (int)measurement_debug_[i]
+              << ", Validator enabled: " << (int)measurement_enable_validator_[i]
+              << ", Schema path: " << measurement_json_schema_path_[i].c_str() << ", Tags: ["
+              << dc_util::join(measurement_tags_[i], ",") << "], Init collect: " << (int)measurement_init_collect_[i]
+              << ", Init Max measurement: " << measurement_init_max_measurements_[i]
+              << ", Include measurement name: " << measurement_include_measurement_name_[i]
+              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
+              << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
+              << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i])
+              << ", Nest: " << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
+              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
+              << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
+              << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
+              << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
+              << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
+              << ", Gate condition: " << measurement_gate_condition_[i] << ", Buffer duration sec: "
+              << measurement_buffer_duration_sec_[i] << ", Flush topic: " << measurement_flush_topic_[i]);
 
       measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(measurement_types_[i]));
       measurements_.back()->configure(
@@ -280,7 +287,8 @@ bool MeasurementServer::loadMeasurementPlugins()
           measurement_if_all_conditions_[i], measurement_if_any_conditions_[i], measurement_if_none_conditions_[i],
           measurement_gate_condition_[i], measurement_remote_keys_[i], measurement_remote_prefixes_[i],
           measurement_nested_[i], measurement_flatten_[i], save_local_base_path_, all_base_path_,
-          all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_keys_);
+          all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_keys_,
+          measurement_buffer_duration_sec_[i], measurement_flush_topic_[i]);
     }
     catch (const pluginlib::PluginlibException& ex)
     {

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -1,0 +1,165 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <nlohmann/json.hpp>
+
+#include "dc_interfaces/msg/flush_event.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+
+using json = nlohmann::json;
+
+class MeasurementBufferingTest : public ::testing::Test
+{
+protected:
+  MeasurementBufferingTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementBufferingTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "dummy" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementBufferingTest::dummyDataCallback, this, std::placeholders::_1));
+    flush_pub_ = ms_node_->create_publisher<dc_interfaces::msg::FlushEvent>("/dc/flush", rclcpp::QoS(10));
+
+    ms_node_->declare_parameter("dummy.plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter("dummy.topic_output", std::string("/dc/measurement/dummy"));
+    ms_node_->declare_parameter("dummy.record", std::string("{\"message\": \"hello\"}"));
+    ms_node_->declare_parameter("dummy.polling_interval", polling_interval_);
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    received_.push_back(msg.data);
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<dc_interfaces::msg::FlushEvent>::SharedPtr flush_pub_;
+  int polling_interval_{ 50 };
+
+public:
+  std::vector<std::string> received_;
+};
+
+// Acceptance criterion: buffer_duration_sec unset/zero preserves today's behavior exactly --
+// live publishing on every tick, no buffering.
+TEST_F(MeasurementBufferingTest, ZeroBufferDurationPublishesLiveAsBefore)
+{
+  ms_node_->declare_parameter("dummy.init_collect", true);
+
+  startLifecycleNode();
+
+  while (received_.empty())
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_FALSE(received_.empty());
+  json data_json = json::parse(received_.front());
+  EXPECT_FALSE(data_json.contains("incident_id"));
+}
+
+// Acceptance criterion: while buffering is armed, samples are buffered silently -- nothing is
+// published even after several polling ticks.
+TEST_F(MeasurementBufferingTest, BuffersSamplesSilentlyUntilFlush)
+{
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", 10.0);
+
+  startLifecycleNode();
+
+  spinFor(polling_interval_ * 5);
+
+  EXPECT_TRUE(received_.empty());
+}
+
+// Acceptance criterion: on a FlushEvent, exactly the buffered window is published, each Record
+// tagged with the event's incident_id, and live publishing resumes immediately afterward.
+TEST_F(MeasurementBufferingTest, FlushEventReleasesBufferedWindowThenResumesLivePublishing)
+{
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", 10.0);
+  ms_node_->declare_parameter("dummy.flush_topic", std::string("/dc/flush"));
+
+  startLifecycleNode();
+
+  // Let a few samples accumulate in the ring buffer, silently.
+  spinFor(polling_interval_ * 3);
+  ASSERT_TRUE(received_.empty());
+
+  dc_interfaces::msg::FlushEvent flush_msg;
+  flush_msg.incident_id = "incident-42";
+  flush_pub_->publish(flush_msg);
+
+  while (received_.empty())
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  // Every Record released from the buffer carries the incident_id from the FlushEvent.
+  int count_after_flush = static_cast<int>(received_.size());
+  for (const auto& data : received_)
+  {
+    json data_json = json::parse(data);
+    ASSERT_TRUE(data_json.contains("incident_id"));
+    EXPECT_EQ(data_json["incident_id"], "incident-42");
+  }
+
+  // Live publishing resumes: subsequent ticks publish without buffering, so more Records arrive
+  // without needing another FlushEvent.
+  while (static_cast<int>(received_.size()) <= count_after_flush)
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+  EXPECT_GT(static_cast<int>(received_.size()), count_after_flush);
+
+  // Records published live after the flush must not carry incident_id -- that only tags the
+  // released buffered window.
+  json last_json = json::parse(received_.back());
+  EXPECT_FALSE(last_json.contains("incident_id"));
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -76,6 +76,18 @@ Each measurement is collected through a node and has these configuration paramet
 | **gate_condition**             | Name of a Condition that must become true once before any collection is published; then latches open permanently and is never consulted again | str | N/A (optional) |
 | **include_measurement_name**   | Include measurement name in the JSON data                                                    | bool        | false                                |
 | **include_measurement_plugin** | Include measurement plugin name in the JSON data                                             | bool        | false                                |
+| **buffer_duration_sec**        | Seconds of history to buffer instead of publishing live; 0 disables buffering and preserves normal live publishing | float | 0 |
+| **flush_topic**                | Topic to receive the `FlushEvent` (see [Triggers](./triggers.md)) that releases the buffered window, tagging each Record with the event's `incident_id`, then resumes live publishing | str | "/dc/flush" |
+
+```admonish info title="buffer_duration_sec and flush_topic: pre-event circular-buffer capture"
+When `buffer_duration_sec` is set above 0, this Measurement stops publishing live: each
+collected sample is instead pushed into an in-memory ring buffer covering the last
+`buffer_duration_sec` seconds. On receiving a `FlushEvent` on `flush_topic` (published by a
+`dc_triggers` broadcast node when its Trigger fires), the whole buffered window is published
+at once, each Record tagged with the event's `incident_id`, and the Measurement then resumes
+live publishing for good — buffering does not re-arm. Post-roll capture, cooldown, and
+rate-limiting are not part of this behavior yet.
+```
 
 ```admonish info title="gate_condition vs. if_all/if_any/if_none_conditions"
 `gate_condition` is a one-shot arming latch, not a per-collection gate: it names a single

--- a/progress.txt
+++ b/progress.txt
@@ -5899,3 +5899,117 @@ Measurement collects; a Trigger fires a one-shot signal on a rising edge.
   `test_trigger_edge_trigger` cases passing, 0.80s). Confirmed via `gh pr view --json body`
   and `gh pr edit` that PR #342's description reflects these results rather than the
   in-flight state it was opened with.
+
+## #287 - Wire RecordRingBuffer into Measurement with basic flush-triggered release
+
+Second implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), following #285's `RecordRingBuffer`/`FileScratchRing` and #286's `dc_triggers`
+package. Wires `dc_common::RecordRingBuffer` into `dc_measurements::Measurement`: an
+opt-in `buffer_duration_sec` parameter and a subscription to a configurable flush topic
+(default `/dc/flush`, consuming the `FlushEvent` #286 already ships) that together let a
+Measurement buffer its recent history in memory and release it, tagged with an
+`incident_id`, when a Trigger fires elsewhere in the system.
+
+- `dc_core/include/dc_core/measurement.hpp`: `dc_core::Measurement::configure()` gains two
+  trailing parameters, `buffer_duration_sec` (double) and `flush_topic` (string), appended
+  after the existing `custom_keys` parameter to minimize churn in the already-long
+  positional signature. `dc_measurements::Measurement` is the only class implementing this
+  interface, so the change is contained to that one override.
+- `dc_measurements/include/dc_measurements/measurement.hpp`: the substantive change.
+  - New members: `buffer_duration_sec_`, `buffering_active_` (true once
+    `buffer_duration_sec_ > 0`, latched false forever once a `FlushEvent` releases the
+    window), `flush_topic_`, `ring_buffer_` (`dc_common::RecordRingBuffer`), and
+    `flush_sub_` (subscription to `flush_topic_`).
+  - `configure()` sets these from the two new parameters; when `buffering_active_` starts
+    true, it constructs `ring_buffer_` with `buffer_duration_sec_` converted to a
+    `std::chrono::system_clock::duration` and subscribes `onFlushEvent()` to
+    `flush_topic_` (defaulting to `/dc/flush` if passed empty, mirroring how
+    `topic_output_` defaults when empty). `cleanup()` additionally resets `flush_sub_` and
+    `ring_buffer_` alongside the existing `data_pub_.reset()`.
+  - Extracted `enrichMsg()` from `publish()`'s existing pre-publish block (validation,
+    nesting/flattening, run_id, tags, measurement name/plugin, custom keys) with no
+    behavior change, so both `publish()` and the new `bufferSample()` apply identical
+    enrichment -- a Record released later from the buffer looks exactly like one published
+    live, modulo the `incident_id` `onFlushEvent()` adds afterward.
+  - `collectAndPublish()`: when `buffering_active_`, calls the new `bufferSample()` instead
+    of `publish()`; otherwise unchanged. `bufferSample()` enriches the sample, then
+    `ring_buffer_->push(msg.data, now)` followed by `ring_buffer_->evict(now)` to keep the
+    window bounded to `buffer_duration_sec_`. This is also what runs on activation's
+    `init_collect_` path, since that already goes through `collectAndPublish()` -- the
+    first sample buffers rather than publishing live, consistent with the rest of the
+    behavior.
+  - `onFlushEvent(FlushEvent)`: no-ops if buffering isn't active (handles a stray/duplicate
+    FlushEvent after release, or one before buffering was ever armed). Otherwise, for every
+    entry in `ring_buffer_->window()` (oldest first), parses the buffered JSON, sets
+    `incident_id` to the event's, republishes via `data_pub_->publish()` directly --
+    bypassing `publish()`'s gate/counter logic entirely, since a released buffered Record
+    was already unconditionally captured and shouldn't be re-filtered on the way out --
+    with `header.stamp` set from the entry's original buffered timestamp rather than now.
+    Then sets `buffering_active_ = false` and releases `ring_buffer_`, so every subsequent
+    `collectAndPublish()` tick takes the `publish()` branch: live publishing resumes
+    immediately and does not re-arm. Post-roll capture, cooldown, and rate-limiting are
+    explicitly out of scope for this slice per the issue, deferred to later #282 slices.
+  - New includes: `dc_common/record_ring_buffer.hpp`, `dc_interfaces/msg/flush_event.hpp`.
+- `dc_measurements/include/dc_measurements/measurement_server.hpp` +
+  `dc_measurements/src/measurement_server.cpp`: `MeasurementServer` reads
+  `<measurement_id>.buffer_duration_sec` (double, default 0.0, via the existing
+  `dc_util::get_double_type_param`) and `<measurement_id>.flush_topic` (string, default
+  `/dc/flush`) alongside every other per-measurement plugin parameter, resized/populated in
+  `loadMeasurementPlugins()` the same way as `nested`/`flatten`/etc., passed as the two new
+  trailing arguments to `configure()`, and logged in the existing per-plugin
+  `RCLCPP_INFO_STREAM` alongside the rest.
+- `dc_measurements/CMakeLists.txt` + `dc_measurements/package.xml`: added a `dc_common`
+  dependency (this package didn't need it before #287; `dc_common` is the header-only
+  package `RecordRingBuffer` lives in per #285).
+- **Regression safety for the acceptance criterion "buffer_duration_sec unset/zero
+  preserves today's behavior exactly"**: with the parameter defaulting to `0.0`,
+  `buffering_active_` is `false`, so `collectAndPublish()` takes the pre-existing
+  `publish(msg)` branch unconditionally -- verified both by inspection (no new branch is
+  reachable when the flag is false) and by the full pre-existing `dc_measurements` test
+  suite (37 other test files, none of which set the new parameters) passing unchanged, plus
+  an explicit new regression test (`ZeroBufferDurationPublishesLiveAsBefore`, see below).
+- **Tests**: new `dc_measurements/test/test_measurement_buffering.cpp` (registered in
+  `CMakeLists.txt`'s `tests` list), using the same `MeasurementServer` + `Dummy` plugin +
+  `rclcpp::spin_some` harness `test_measurement_gate_condition.cpp` established. Three
+  cases: `ZeroBufferDurationPublishesLiveAsBefore` (the regression case above, `init_collect`
+  true, expects a live Record with no `incident_id` and no buffering param set at all);
+  `BuffersSamplesSilentlyUntilFlush` (`buffer_duration_sec` 10s, several polling ticks pass
+  with nothing received on the output topic); and
+  `FlushEventReleasesBufferedWindowThenResumesLivePublishing`, the acceptance criterion's
+  lifecycle test verbatim -- samples accumulate silently, a `FlushEvent` with
+  `incident_id="incident-42"` published on `/dc/flush` causes every released Record to
+  carry that `incident_id`, and further polling ticks afterward publish additional Records
+  (live resumption) that do *not* carry `incident_id` (proving the tag only applies to the
+  released buffered window, not to subsequent live Records). Hit one real test bug during
+  verification: the initial version declared `dummy.init_collect` in the shared `SetUp()`
+  and then re-declared it with a different value inside the first test, which throws
+  ("parameter ... has already been declared") since ROS 2 parameter declaration isn't
+  idempotent across distinct values -- fixed by moving that declaration out of `SetUp()`
+  and only declaring it (or relying on the framework's own true default) per test that
+  actually needs a non-default value.
+- **Docs**: `doc/src/dc/measurements.md` gains `buffer_duration_sec` and `flush_topic` rows
+  in the Plugin parameters table plus an admonish block explaining the buffering/flush
+  behavior and linking to `triggers.md`. `CONTEXT.md`'s Trigger/FlushEvent glossary entries
+  (written during #286) already described this exact wiring ("downstream Measurements
+  adopt [incident_id] for that one event") and needed no changes.
+- **Verified**: `podman run` against the `localhost/dc-workspace` Jazzy image (same one
+  #284/#285/#286 used), bind-mounting this worktree over
+  `/root/ws/src/ros2_data_collection`. `colcon build --packages-select dc_common dc_core
+  dc_interfaces dc_measurements --cmake-args -DBUILD_TESTING=ON` succeeded end to end with
+  zero warnings under `-Wall -Wextra -Wpedantic -Werror -Wdeprecated`. `colcon test`
+  (combined build+test in one container invocation, per #286's finding that `build/`/
+  `install/` don't survive across separate `podman run --rm` invocations) initially caught
+  a real bug in the new test file (the `init_collect` double-declaration above, not
+  production code) -- caught immediately since the test failed loudly rather than hanging.
+  After the fix: **222 tests, 0 errors, 0 failures, 0 skipped** across `dc_common`,
+  `dc_core`, `dc_interfaces`, and `dc_measurements` combined (all 3 new
+  `test_measurement_buffering` cases passing, ~0.6s; the other 37 pre-existing
+  `dc_measurements` test files unaffected). `pre-commit run` on the changed files passed
+  `clang-format` (reformatted `measurement_server.cpp`'s wrapped `RCLCPP_INFO_STREAM` and a
+  couple of resize/param blocks to 120-col; no semantic change, re-verified compile+tests
+  afterward), `codespell`, XML lint, `ros2_ws_same_versions`/`ros2_ws_set_metadata`, doc
+  build; `black` incidentally reformatted the same unrelated pre-existing violation in
+  `tools/e2e/scripts/verify_zero_loss.py` already flagged and reverted in the #285/#286
+  session notes, reverted again here to keep this diff scoped; `poetry-requirements` failed
+  on the same pre-existing local environment gap (no `poetry` module) noted in every prior
+  session, unrelated to this change.


### PR DESCRIPTION
## Summary

- Adds an opt-in `buffer_duration_sec` parameter and a `flush_topic` subscription (default `/dc/flush`) to `Measurement`. While buffering is enabled, `collectAndPublish()` feeds enriched samples into a `dc_common::RecordRingBuffer` instead of publishing them live.
- On receiving a `FlushEvent`, the Measurement releases the buffered window as Records tagged with the event's `incident_id`, then resumes live publishing for good (post-roll capture, cooldown, and rate-limiting are separate follow-up slices, per the issue).
- `buffer_duration_sec` unset/zero preserves today's behavior exactly.

Second implementation slice of #282, following #285 (`RecordRingBuffer`) and #286 (`dc_triggers`/`FlushEvent`).

## Test plan

- [x] `colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements --cmake-args -DBUILD_TESTING=ON` — zero warnings under `-Wall -Wextra -Wpedantic -Werror -Wdeprecated`
- [x] `colcon test` — 222 tests, 0 errors, 0 failures, 0 skipped (all 3 new `test_measurement_buffering` cases pass; all 37 pre-existing `dc_measurements` test files unaffected)
- [x] `pre-commit run` on changed files — clang-format, codespell, XML lint, doc build all pass

Closes #287