### PR TITLE
feat(dc_measurements): add IncidentReleaser state machine with post-roll, cooldown and auto re-arm

### DIFF
--- a/dc_common/include/dc_common/record_ring_buffer.hpp
+++ b/dc_common/include/dc_common/record_ring_buffer.hpp
@@ -74,6 +74,17 @@ public:
     }
   }
 
+  /**
+   * @brief Drop every entry regardless of age.
+   *
+   * For the caller that has just consumed the whole window and must not see those entries again --
+   * dc_measurements::IncidentReleaser after releasing one incident's pre-roll (#288).
+   */
+  void clear()
+  {
+    entries_.clear();
+  }
+
   /// Current contents, oldest first. Does not evict -- call evict() first if that's wanted.
   std::vector<StampedRecord> window() const
   {

--- a/dc_common/test/record_ring_buffer_test.cpp
+++ b/dc_common/test/record_ring_buffer_test.cpp
@@ -140,3 +140,19 @@ TEST(RecordRingBuffer, RepeatedEvictCallsConverge)
 
   EXPECT_TRUE(buf.empty());
 }
+
+TEST(RecordRingBuffer, ClearDropsEveryEntryRegardlessOfAge)
+{
+  RecordRingBuffer buf(std::chrono::seconds(10));
+  buf.push(R"({"n":"a"})", at(0));
+  buf.push(R"({"n":"b"})", at(1));
+
+  buf.clear();  // a consumer that has just released the whole window must not see it again.
+
+  EXPECT_TRUE(buf.empty());
+  EXPECT_EQ(buf.size(), 0u);
+  EXPECT_TRUE(buf.window().empty());
+
+  buf.push(R"({"n":"c"})", at(2));  // and the buffer is still usable afterwards.
+  EXPECT_EQ(json_of(buf.window()), std::vector<std::string>({ R"({"n":"c"})" }));
+}

--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -54,26 +54,29 @@ public:
    * @param  custom_keys Vector of JSON with custom keys
    * @param  buffer_duration_sec Seconds of history to buffer instead of publishing live; 0 (the
    * default) disables buffering and preserves normal live publishing (#287)
+   * @param  post_roll_duration_sec Seconds to keep publishing live after a flush, still tagged
+   * with the same incident_id; 0 (the default) means pre-roll only (#288)
+   * @param  cooldown_sec Seconds to ignore further FlushEvents once post-roll ends, before
+   * buffering re-arms itself; 0 (the default) re-arms immediately (#288)
    * @param  flush_topic Topic to receive the FlushEvent that releases the buffered window,
-   * tagging each released Record with the event's incident_id, then resumes live publishing
+   * tagging each released Record with the event's incident_id
    */
-  virtual void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
-                         const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
-                         std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin,
-                         const std::string& group_key, const std::string& topic_output, const int& polling_interval,
-                         const bool& debug, const bool& enable_validator, const std::string& json_schema_path,
-                         const std::vector<std::string>& tags, const bool& init_collect,
-                         const int& init_max_measurements, const bool& include_measurement_name,
-                         const bool& include_measurement_plugin, const int& condition_max_measurements,
-                         const std::vector<std::string>& if_all_conditions,
-                         const std::vector<std::string>& if_any_conditions,
-                         const std::vector<std::string>& if_none_conditions, const std::string& gate_condition,
-                         const std::vector<std::string>& remote_keys, const std::vector<std::string>& remote_prefixes,
-                         const bool& nest, const bool& flatten, const std::string& save_local_base_path,
-                         const std::string& all_base_path, const std::string& all_base_path_expanded,
-                         const std::string& save_local_base_path_expanded, const std::string& run_id,
-                         const bool& run_id_enabled, const std::vector<json>& custom_keys,
-                         const double& buffer_duration_sec, const std::string& flush_topic) = 0;
+  virtual void
+  configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
+            const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
+            std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin, const std::string& group_key,
+            const std::string& topic_output, const int& polling_interval, const bool& debug,
+            const bool& enable_validator, const std::string& json_schema_path, const std::vector<std::string>& tags,
+            const bool& init_collect, const int& init_max_measurements, const bool& include_measurement_name,
+            const bool& include_measurement_plugin, const int& condition_max_measurements,
+            const std::vector<std::string>& if_all_conditions, const std::vector<std::string>& if_any_conditions,
+            const std::vector<std::string>& if_none_conditions, const std::string& gate_condition,
+            const std::vector<std::string>& remote_keys, const std::vector<std::string>& remote_prefixes,
+            const bool& nest, const bool& flatten, const std::string& save_local_base_path,
+            const std::string& all_base_path, const std::string& all_base_path_expanded,
+            const std::string& save_local_base_path_expanded, const std::string& run_id, const bool& run_id_enabled,
+            const std::vector<json>& custom_keys, const double& buffer_duration_sec,
+            const double& post_roll_duration_sec, const double& cooldown_sec, const std::string& flush_topic) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -290,6 +290,7 @@ install(DIRECTORY plugins/measurements/json
 )
 
 set(tests
+  test_incident_releaser
   test_measurement_bool_equal
   test_measurement_buffering
   test_measurement_camera

--- a/dc_measurements/include/dc_measurements/incident_releaser.hpp
+++ b/dc_measurements/include/dc_measurements/incident_releaser.hpp
@@ -1,0 +1,236 @@
+#ifndef DC_MEASUREMENTS__INCIDENT_RELEASER_HPP_
+#define DC_MEASUREMENTS__INCIDENT_RELEASER_HPP_
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <utility>
+
+#include "dc_common/record_ring_buffer.hpp"
+
+namespace dc_measurements
+{
+
+/// The four phases of one incident-capture cycle, see IncidentReleaser.
+enum class IncidentState : int8_t
+{
+  Buffering = 0,
+  Flushing = 1,
+  PostRoll = 2,
+  Cooldown = 3,
+};
+
+inline const char* toString(const IncidentState& state)
+{
+  switch (state)
+  {
+    case IncidentState::Buffering:
+      return "Buffering";
+    case IncidentState::Flushing:
+      return "Flushing";
+    case IncidentState::PostRoll:
+      return "PostRoll";
+    case IncidentState::Cooldown:
+      return "Cooldown";
+  }
+  return "Unknown";
+}
+
+/// Seconds as a double (how the ROS parameters express durations) to a system_clock duration.
+inline std::chrono::system_clock::duration durationFromSeconds(const double& seconds)
+{
+  return std::chrono::duration_cast<std::chrono::system_clock::duration>(std::chrono::duration<double>(seconds));
+}
+
+/**
+ * @class dc_measurements::IncidentReleaser
+ * @brief Per-Measurement incident-capture state machine over a RecordRingBuffer, with no ROS
+ * dependency (#288).
+ *
+ * One cycle:
+ *
+ *   Buffering --onFlush--> Flushing --> PostRoll --> Cooldown --> Buffering
+ *
+ * - **Buffering** (the initial state): every offered sample goes into the ring buffer, nothing is
+ *   published. This is the only state in which a FlushEvent is acted upon (see isArmed()).
+ * - **Flushing**: the buffered window is released, oldest first, each Record tagged with the
+ *   incident_id the FlushEvent carried. Release is currently immediate, so this state is entered
+ *   and left within onFlush(); it exists as a distinct state because rate-limited release (the
+ *   `max release rate` knob of #282) drains the window across several tick()s instead.
+ * - **PostRoll**: samples are published live for `post_roll` after the flush, still tagged with
+ *   the same incident_id, so the aftermath of the incident is captured too. A zero `post_roll`
+ *   (the default) skips the phase entirely -- pre-roll only.
+ * - **Cooldown**: further FlushEvents are ignored for `cooldown` after post-roll ends, so a
+ *   flapping Trigger can't produce a flood of overlapping incidents. Samples are buffered again
+ *   during this phase, so the next incident still gets a full pre-roll window rather than one
+ *   with a `post_roll + cooldown`-sized hole at its start.
+ *
+ * After cooldown the machine re-arms itself back to Buffering with no manual intervention -- a
+ * second incident is captured like the first.
+ *
+ * Time is supplied by the caller on every entry point rather than read from a clock, and Records
+ * go out through a caller-supplied callback rather than a publisher, which is what lets the whole
+ * cycle be tested with a fake clock and no ROS node.
+ */
+class IncidentReleaser
+{
+public:
+  using Duration = std::chrono::system_clock::duration;
+  using TimePoint = std::chrono::system_clock::time_point;
+
+  /**
+   * @brief Emit one Record: its (already enriched) JSON payload, the timestamp it was collected
+   * at, and the incident_id of the cycle releasing it.
+   */
+  using PublishFn =
+      std::function<void(const std::string& record_json, const TimePoint& stamp, const std::string& incident_id)>;
+
+  /**
+   * @param buffer_window How much history to keep buffered while armed (`buffer_duration_sec`).
+   * @param post_roll How long to keep publishing live after a flush (`post_roll_duration_sec`);
+   * zero or less means pre-roll only.
+   * @param cooldown How long to ignore FlushEvents once post-roll ends (`cooldown_sec`); zero or
+   * less re-arms immediately.
+   * @param publish Called for every released and every post-roll Record.
+   */
+  IncidentReleaser(const Duration& buffer_window, const Duration& post_roll, const Duration& cooldown, PublishFn publish)
+    : post_roll_(post_roll), cooldown_(cooldown), publish_(std::move(publish)), buffer_(buffer_window)
+  {
+  }
+
+  /**
+   * @brief Hand one freshly collected sample to the machine.
+   *
+   * Buffered while Buffering or in Cooldown, published live (tagged with the current incident_id)
+   * during PostRoll. Drives time-based transitions first, so a sample collected after the
+   * post-roll deadline is buffered rather than published even if nothing else called tick().
+   */
+  void offer(const std::string& record_json, const TimePoint& now)
+  {
+    tick(now);
+
+    if (state_ == IncidentState::PostRoll)
+    {
+      publish_(record_json, now, incident_id_);
+      return;
+    }
+
+    buffer_.push(record_json, now);
+    buffer_.evict(now);
+  }
+
+  /**
+   * @brief A FlushEvent arrived: release the buffered window under `incident_id` and start the
+   * post-roll/cooldown phases.
+   *
+   * Ignored unless armed -- an event arriving during flushing, post-roll, or cooldown belongs to
+   * the incident already being captured (or to a flapping Trigger) and starts no new cycle.
+   */
+  void onFlush(const std::string& incident_id, const TimePoint& now)
+  {
+    tick(now);
+
+    if (!isArmed())
+    {
+      return;
+    }
+
+    state_ = IncidentState::Flushing;
+    incident_id_ = incident_id;
+
+    buffer_.evict(now);
+    for (const auto& entry : buffer_.window())
+    {
+      publish_(entry.json, entry.stamp, incident_id_);
+    }
+    // Released entries are gone for good: the next incident gets its own window, not this one
+    // replayed a second time.
+    buffer_.clear();
+
+    if (post_roll_ > Duration::zero())
+    {
+      state_ = IncidentState::PostRoll;
+      phase_deadline_ = now + post_roll_;
+      return;
+    }
+    enterCooldown(now);
+  }
+
+  /**
+   * @brief Advance the time-based transitions (post-roll expiry, cooldown expiry) to `now`.
+   *
+   * Safe and cheap to call at any rate; offer() and onFlush() call it themselves, so a
+   * Measurement driving both from its polling timer needs no separate tick.
+   */
+  void tick(const TimePoint& now)
+  {
+    if (state_ == IncidentState::PostRoll && now >= phase_deadline_)
+    {
+      // Cooldown runs from when post-roll actually ended, not from whenever this tick noticed it,
+      // so the total suppression is `post_roll + cooldown` however coarsely tick() is called.
+      enterCooldown(phase_deadline_);
+    }
+    if (state_ == IncidentState::Cooldown && now >= phase_deadline_)
+    {
+      enterBuffering();
+    }
+  }
+
+  /// Whether a FlushEvent would start a new capture cycle right now.
+  bool isArmed() const
+  {
+    return state_ == IncidentState::Buffering;
+  }
+
+  IncidentState state() const
+  {
+    return state_;
+  }
+
+  /// The incident_id of the cycle in progress; empty while armed.
+  const std::string& incidentId() const
+  {
+    return incident_id_;
+  }
+
+  /// How many samples are currently buffered, awaiting a flush.
+  std::size_t bufferedCount() const
+  {
+    return buffer_.size();
+  }
+
+private:
+  // `from` is taken by value on purpose: tick() passes phase_deadline_ itself, and the assignment
+  // below would otherwise change the value `from` refers to mid-function.
+  void enterCooldown(TimePoint from)
+  {
+    state_ = IncidentState::Cooldown;
+    phase_deadline_ = from + cooldown_;
+    if (from >= phase_deadline_)
+    {
+      // Nothing to suppress: re-arm without waiting for another tick().
+      enterBuffering();
+    }
+  }
+
+  void enterBuffering()
+  {
+    state_ = IncidentState::Buffering;
+    incident_id_.clear();
+  }
+
+  Duration post_roll_;
+  Duration cooldown_;
+  PublishFn publish_;
+
+  dc_common::RecordRingBuffer buffer_;
+  IncidentState state_{ IncidentState::Buffering };
+  std::string incident_id_;
+  // End of the phase in progress; only meaningful in PostRoll and Cooldown.
+  TimePoint phase_deadline_;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__INCIDENT_RELEASER_HPP_

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -14,13 +14,13 @@
 #include <utility>
 #include <vector>
 
-#include "dc_common/record_ring_buffer.hpp"
 #include "dc_core/condition.hpp"
 #include "dc_core/condition_set.hpp"
 #include "dc_core/measurement.hpp"
 #include "dc_interfaces/msg/condition.hpp"
 #include "dc_interfaces/msg/flush_event.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/incident_releaser.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/create_timer_ros.h"
@@ -525,9 +525,9 @@ public:
     dc_interfaces::msg::StringStamped msg = collect();
     if (enabled_)
     {
-      if (buffering_active_)
+      if (releaser_)
       {
-        bufferSample(msg);
+        offerSample(msg);
       }
       else
       {
@@ -536,53 +536,55 @@ public:
     }
   }
 
-  // While buffering is active, collectAndPublish() calls this instead of publish(): the sample
-  // is enriched exactly as a live Record would be, then pushed into ring_buffer_ instead of
-  // being published, and the buffer is evicted down to buffer_duration_sec_ relative to now (#287).
-  void bufferSample(dc_interfaces::msg::StringStamped msg)
+  // With incident capture configured, collectAndPublish() calls this instead of publish(): the
+  // sample is enriched exactly as a live Record would be, then handed to the IncidentReleaser,
+  // which buffers it or (during post-roll) publishes it live through publishIncidentRecord() (#288).
+  void offerSample(dc_interfaces::msg::StringStamped msg)
   {
     if (msg.data.empty() || msg.data == "null")
     {
       return;
     }
     enrichMsg(msg);
-    auto now = std::chrono::system_clock::now();
-    ring_buffer_->push(msg.data, now);
-    ring_buffer_->evict(now);
+    releaser_->offer(msg.data, std::chrono::system_clock::now());
   }
 
-  // Releases the buffered window as Records tagged with the FlushEvent's incident_id, then
-  // turns buffering off for good -- re-arming and cooldown are separate follow-up slices, kept
-  // out of this one intentionally (#287).
+  // Emits one Record belonging to an incident -- either released from the pre-roll buffer (stamped
+  // with when it was collected, not when it was released) or collected live during post-roll.
+  // Publishes straight through data_pub_, bypassing publish()'s gate/counter logic: a Record
+  // captured for an incident was already unconditionally collected and isn't re-filtered on the
+  // way out.
+  void publishIncidentRecord(const std::string& record_json, const std::chrono::system_clock::time_point& stamp,
+                             const std::string& incident_id)
+  {
+    dc_interfaces::msg::StringStamped out;
+    out.group_key = group_key_;
+    out.header.stamp =
+        rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp.time_since_epoch()).count());
+    try
+    {
+      json data_json = json::parse(record_json);
+      data_json["incident_id"] = incident_id;
+      out.data = data_json.dump(-1, ' ', true);
+    }
+    catch (json::parse_error& e)
+    {
+      RCLCPP_ERROR_STREAM(logger_,
+                          "Error parsing Record JSON while releasing incident " << incident_id << ": " << record_json);
+      return;
+    }
+    data_pub_->publish(out);
+  }
+
+  // A Trigger fired somewhere in the system: hand the event to the state machine, which releases
+  // the buffered window under this incident_id when armed and ignores the event otherwise (#288).
   void onFlushEvent(const dc_interfaces::msg::FlushEvent& event)
   {
-    if (!buffering_active_ || !ring_buffer_)
+    if (!releaser_)
     {
       return;
     }
-
-    for (const auto& entry : ring_buffer_->window())
-    {
-      dc_interfaces::msg::StringStamped out;
-      out.group_key = group_key_;
-      out.header.stamp =
-          rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(entry.stamp.time_since_epoch()).count());
-      try
-      {
-        json data_json = json::parse(entry.json);
-        data_json["incident_id"] = event.incident_id;
-        out.data = data_json.dump(-1, ' ', true);
-      }
-      catch (json::parse_error& e)
-      {
-        RCLCPP_ERROR_STREAM(logger_, "Error parsing buffered Record JSON on FlushEvent release: " << entry.json);
-        continue;
-      }
-      data_pub_->publish(out);
-    }
-
-    buffering_active_ = false;
-    ring_buffer_.reset();
+    releaser_->onFlush(event.incident_id, std::chrono::system_clock::now());
   }
 
   virtual dc_interfaces::msg::StringStamped collect() = 0;
@@ -602,7 +604,8 @@ public:
                  const std::string& save_local_base_path, const std::string& all_base_path,
                  const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
                  const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_keys,
-                 const double& buffer_duration_sec, const std::string& flush_topic) override
+                 const double& buffer_duration_sec, const double& post_roll_duration_sec, const double& cooldown_sec,
+                 const std::string& flush_topic) override
   {
     node_ = parent;
     auto node = node_.lock();
@@ -656,13 +659,16 @@ public:
         std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); }, client_cb_group_);
 
     buffer_duration_sec_ = buffer_duration_sec;
-    buffering_active_ = buffer_duration_sec_ > 0.0;
+    post_roll_duration_sec_ = post_roll_duration_sec;
+    cooldown_sec_ = cooldown_sec;
     flush_topic_ = flush_topic.empty() ? std::string("/dc/flush") : flush_topic;
-    if (buffering_active_)
+    if (buffer_duration_sec_ > 0.0)
     {
-      ring_buffer_ =
-          std::make_shared<dc_common::RecordRingBuffer>(std::chrono::duration_cast<std::chrono::system_clock::duration>(
-              std::chrono::duration<double>(buffer_duration_sec_)));
+      releaser_ = std::make_shared<IncidentReleaser>(
+          durationFromSeconds(buffer_duration_sec_), durationFromSeconds(post_roll_duration_sec_),
+          durationFromSeconds(cooldown_sec_),
+          [this](const std::string& record_json, const std::chrono::system_clock::time_point& stamp,
+                 const std::string& incident_id) { publishIncidentRecord(record_json, stamp, incident_id); });
       flush_sub_ = node->create_subscription<dc_interfaces::msg::FlushEvent>(
           flush_topic_, 10, std::bind(&Measurement::onFlushEvent, this, std::placeholders::_1));
     }
@@ -699,7 +705,7 @@ public:
   {
     data_pub_.reset();
     flush_sub_.reset();
-    ring_buffer_.reset();
+    releaser_.reset();
     onCleanup();
   }
 
@@ -786,13 +792,15 @@ protected:
   // Tags
   std::vector<std::string> tags_;
 
-  // Buffering: pre-event circular-buffer capture (#287). While buffering_active_, samples go
-  // into ring_buffer_ instead of being published; a FlushEvent on flush_topic_ releases the
-  // buffered window and turns buffering off for the lifetime of this Measurement instance.
+  // Incident capture: pre-event circular-buffer capture (#287) driven by the IncidentReleaser
+  // state machine (#288). releaser_ is only created when buffer_duration_sec_ > 0; while it
+  // exists, collected samples go to it instead of publish(), and a FlushEvent on flush_topic_
+  // starts one buffer-release / post-roll / cooldown / re-arm cycle.
   double buffer_duration_sec_{ 0.0 };
-  bool buffering_active_{ false };
+  double post_roll_duration_sec_{ 0.0 };
+  double cooldown_sec_{ 0.0 };
   std::string flush_topic_;
-  std::shared_ptr<dc_common::RecordRingBuffer> ring_buffer_;
+  std::shared_ptr<IncidentReleaser> releaser_;
   rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr flush_sub_;
 };
 

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -126,6 +126,8 @@ protected:
   std::vector<bool> measurement_nested_;
   std::vector<bool> measurement_flatten_;
   std::vector<double> measurement_buffer_duration_sec_;
+  std::vector<double> measurement_post_roll_duration_sec_;
+  std::vector<double> measurement_cooldown_sec_;
   std::vector<std::string> measurement_flush_topic_;
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -154,6 +154,8 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   measurement_nested_.resize(measurement_ids_.size());
   measurement_flatten_.resize(measurement_ids_.size());
   measurement_buffer_duration_sec_.resize(measurement_ids_.size());
+  measurement_post_roll_duration_sec_.resize(measurement_ids_.size());
+  measurement_cooldown_sec_.resize(measurement_ids_.size());
   measurement_flush_topic_.resize(measurement_ids_.size());
 
   measurement_if_all_conditions_.resize(measurement_ids_.size());
@@ -239,6 +241,9 @@ bool MeasurementServer::loadMeasurementPlugins()
     measurement_flatten_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "flatten", false);
     measurement_buffer_duration_sec_[i] =
         dc_util::get_double_type_param(node, measurement_ids_[i], "buffer_duration_sec", 0.0);
+    measurement_post_roll_duration_sec_[i] =
+        dc_util::get_double_type_param(node, measurement_ids_[i], "post_roll_duration_sec", 0.0);
+    measurement_cooldown_sec_[i] = dc_util::get_double_type_param(node, measurement_ids_[i], "cooldown_sec", 0.0);
     measurement_flush_topic_[i] =
         dc_util::get_str_type_param(node, measurement_ids_[i], "flush_topic", std::string("/dc/flush"));
 
@@ -274,8 +279,10 @@ bool MeasurementServer::loadMeasurementPlugins()
               << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
               << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
               << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
-              << ", Gate condition: " << measurement_gate_condition_[i] << ", Buffer duration sec: "
-              << measurement_buffer_duration_sec_[i] << ", Flush topic: " << measurement_flush_topic_[i]);
+              << ", Gate condition: " << measurement_gate_condition_[i]
+              << ", Buffer duration sec: " << measurement_buffer_duration_sec_[i] << ", Post roll duration sec: "
+              << measurement_post_roll_duration_sec_[i] << ", Cooldown sec: " << measurement_cooldown_sec_[i]
+              << ", Flush topic: " << measurement_flush_topic_[i]);
 
       measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(measurement_types_[i]));
       measurements_.back()->configure(
@@ -288,7 +295,8 @@ bool MeasurementServer::loadMeasurementPlugins()
           measurement_gate_condition_[i], measurement_remote_keys_[i], measurement_remote_prefixes_[i],
           measurement_nested_[i], measurement_flatten_[i], save_local_base_path_, all_base_path_,
           all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_keys_,
-          measurement_buffer_duration_sec_[i], measurement_flush_topic_[i]);
+          measurement_buffer_duration_sec_[i], measurement_post_roll_duration_sec_[i], measurement_cooldown_sec_[i],
+          measurement_flush_topic_[i]);
     }
     catch (const pluginlib::PluginlibException& ex)
     {

--- a/dc_measurements/test/test_incident_releaser.cpp
+++ b/dc_measurements/test/test_incident_releaser.cpp
@@ -1,0 +1,271 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "dc_measurements/incident_releaser.hpp"
+
+using dc_measurements::IncidentReleaser;
+using dc_measurements::IncidentState;
+using dc_measurements::toString;
+
+// One captured emission, standing in for a ROS publish: what went out, stamped with what, under
+// which incident.
+struct Published
+{
+  std::string json;
+  IncidentReleaser::TimePoint stamp;
+  std::string incident_id;
+};
+
+class IncidentReleaserTest : public ::testing::Test
+{
+protected:
+  // Fake clock: every entry point takes the time from the test, so nothing here reads a real one.
+  // Starting well past the epoch keeps `base_ - something` valid.
+  IncidentReleaser::TimePoint base_{ std::chrono::system_clock::time_point() + std::chrono::hours(24) };
+
+  IncidentReleaser::TimePoint at(const double& seconds) const
+  {
+    return base_ + dc_measurements::durationFromSeconds(seconds);
+  }
+
+  std::vector<Published> published_;
+
+  IncidentReleaser::PublishFn capture()
+  {
+    return [this](const std::string& json, const IncidentReleaser::TimePoint& stamp, const std::string& incident_id) {
+      published_.push_back(Published{ json, stamp, incident_id });
+    };
+  }
+
+  // buffer 10s, post-roll/cooldown per test.
+  IncidentReleaser makeReleaser(const double& post_roll_sec, const double& cooldown_sec)
+  {
+    return IncidentReleaser(std::chrono::seconds(10), dc_measurements::durationFromSeconds(post_roll_sec),
+                            dc_measurements::durationFromSeconds(cooldown_sec), capture());
+  }
+
+  std::vector<std::string> publishedJson() const
+  {
+    std::vector<std::string> out;
+    for (const auto& entry : published_)
+    {
+      out.push_back(entry.json);
+    }
+    return out;
+  }
+};
+
+TEST_F(IncidentReleaserTest, StartsArmedAndBufferingPublishesNothing)
+{
+  auto releaser = makeReleaser(0.0, 0.0);
+
+  releaser.offer("{\"a\":1}", at(0.0));
+  releaser.offer("{\"a\":2}", at(1.0));
+  releaser.tick(at(2.0));
+
+  EXPECT_TRUE(releaser.isArmed());
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering);
+  EXPECT_EQ(releaser.bufferedCount(), 2u);
+  EXPECT_TRUE(published_.empty());
+  EXPECT_TRUE(releaser.incidentId().empty());
+}
+
+TEST_F(IncidentReleaserTest, FlushReleasesBufferedWindowOldestFirstWithOriginalStamps)
+{
+  auto releaser = makeReleaser(0.0, 0.0);
+
+  releaser.offer("{\"a\":1}", at(0.0));
+  releaser.offer("{\"a\":2}", at(1.0));
+  releaser.offer("{\"a\":3}", at(2.0));
+
+  releaser.onFlush("incident-1", at(3.0));
+
+  ASSERT_EQ(published_.size(), 3u);
+  EXPECT_EQ(publishedJson(), (std::vector<std::string>{ "{\"a\":1}", "{\"a\":2}", "{\"a\":3}" }));
+  EXPECT_EQ(published_[0].stamp, at(0.0));
+  EXPECT_EQ(published_[1].stamp, at(1.0));
+  EXPECT_EQ(published_[2].stamp, at(2.0));
+  for (const auto& entry : published_)
+  {
+    EXPECT_EQ(entry.incident_id, "incident-1");
+  }
+  // The released window is consumed, not replayed on the next incident.
+  EXPECT_EQ(releaser.bufferedCount(), 0u);
+}
+
+TEST_F(IncidentReleaserTest, SamplesOlderThanBufferWindowAreNotReleased)
+{
+  auto releaser = makeReleaser(0.0, 0.0);
+
+  releaser.offer("{\"a\":\"stale\"}", at(0.0));
+  releaser.offer("{\"a\":\"fresh\"}", at(20.0));
+
+  releaser.onFlush("incident-1", at(21.0));
+
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(published_[0].json, "{\"a\":\"fresh\"}");
+}
+
+// Acceptance criterion: post-roll transition and duration.
+TEST_F(IncidentReleaserTest, PostRollPublishesLiveUnderTheSameIncidentIdForItsDuration)
+{
+  auto releaser = makeReleaser(5.0, 0.0);
+
+  releaser.offer("{\"a\":\"pre\"}", at(0.0));
+  releaser.onFlush("incident-1", at(1.0));
+
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.state(), IncidentState::PostRoll) << "state is " << toString(releaser.state());
+  EXPECT_FALSE(releaser.isArmed());
+  EXPECT_EQ(releaser.incidentId(), "incident-1");
+
+  // Within post-roll: published live, right away, still tagged with the incident.
+  releaser.offer("{\"a\":\"post-1\"}", at(2.0));
+  releaser.offer("{\"a\":\"post-2\"}", at(5.9));
+  ASSERT_EQ(published_.size(), 3u);
+  EXPECT_EQ(published_[1].json, "{\"a\":\"post-1\"}");
+  EXPECT_EQ(published_[1].stamp, at(2.0));
+  EXPECT_EQ(published_[1].incident_id, "incident-1");
+  EXPECT_EQ(published_[2].incident_id, "incident-1");
+  EXPECT_EQ(releaser.bufferedCount(), 0u);
+
+  // Post-roll ends 5s after the flush (at 6.0): this sample is buffered, not published, and with
+  // no cooldown configured the machine is armed again.
+  releaser.offer("{\"a\":\"after\"}", at(6.1));
+  EXPECT_EQ(published_.size(), 3u);
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering) << "state is " << toString(releaser.state());
+  EXPECT_TRUE(releaser.isArmed());
+  EXPECT_EQ(releaser.bufferedCount(), 1u);
+  EXPECT_TRUE(releaser.incidentId().empty());
+}
+
+// Acceptance criterion: cooldown suppresses a second flush during the window.
+TEST_F(IncidentReleaserTest, CooldownIgnoresASecondFlushWithinItsWindow)
+{
+  auto releaser = makeReleaser(2.0, 5.0);
+
+  releaser.offer("{\"a\":\"pre\"}", at(0.0));
+  releaser.onFlush("incident-1", at(1.0));
+  ASSERT_EQ(published_.size(), 1u);
+
+  // Still in post-roll: a second FlushEvent belongs to the incident already being captured.
+  releaser.onFlush("incident-2", at(2.0));
+  EXPECT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.state(), IncidentState::PostRoll);
+  EXPECT_EQ(releaser.incidentId(), "incident-1");
+
+  // Post-roll ended at 3.0, cooldown runs to 8.0: samples buffer again but flushes stay ignored.
+  releaser.offer("{\"a\":\"during-cooldown\"}", at(4.0));
+  EXPECT_EQ(releaser.state(), IncidentState::Cooldown);
+  EXPECT_FALSE(releaser.isArmed());
+  EXPECT_EQ(releaser.bufferedCount(), 1u);
+
+  releaser.onFlush("incident-3", at(7.9));
+  EXPECT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.state(), IncidentState::Cooldown);
+}
+
+// Acceptance criterion: auto re-arm after cooldown.
+TEST_F(IncidentReleaserTest, ReArmsItselfAfterCooldownAndCapturesTheNextIncident)
+{
+  auto releaser = makeReleaser(2.0, 5.0);
+
+  releaser.onFlush("incident-1", at(1.0));
+  // Post-roll ends at 3.0, cooldown at 8.0.
+  releaser.offer("{\"a\":\"during-cooldown\"}", at(4.0));
+  ASSERT_FALSE(releaser.isArmed());
+
+  releaser.tick(at(8.0));
+  EXPECT_TRUE(releaser.isArmed()) << "still in " << toString(releaser.state()) << " after cooldown";
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering);
+  EXPECT_TRUE(releaser.incidentId().empty());
+
+  // The window buffered during cooldown is the next incident's pre-roll -- no hole at its start.
+  releaser.offer("{\"a\":\"after-rearm\"}", at(9.0));
+  EXPECT_EQ(releaser.bufferedCount(), 2u);
+
+  releaser.onFlush("incident-2", at(10.0));
+  ASSERT_EQ(published_.size(), 2u);
+  EXPECT_EQ(published_[0].json, "{\"a\":\"during-cooldown\"}");
+  EXPECT_EQ(published_[0].incident_id, "incident-2");
+  EXPECT_EQ(published_[1].json, "{\"a\":\"after-rearm\"}");
+  EXPECT_EQ(published_[1].incident_id, "incident-2");
+}
+
+// A FlushEvent arriving exactly when cooldown expires is honored: the window is inclusive of its
+// own end, so an armed machine never silently drops the event that re-armed it.
+TEST_F(IncidentReleaserTest, FlushAtTheCooldownDeadlineIsHonored)
+{
+  auto releaser = makeReleaser(2.0, 5.0);
+
+  releaser.onFlush("incident-1", at(0.0));
+  releaser.offer("{\"a\":\"buffered\"}", at(4.0));
+  // Post-roll ended at 2.0, cooldown ends exactly at 7.0.
+  releaser.onFlush("incident-2", at(7.0));
+
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(published_[0].incident_id, "incident-2");
+}
+
+// Default configuration (both durations 0): pre-roll only, and back to buffering right away rather
+// than publishing live from then on.
+TEST_F(IncidentReleaserTest, ZeroPostRollAndCooldownReArmImmediatelyAfterRelease)
+{
+  auto releaser = makeReleaser(0.0, 0.0);
+
+  releaser.offer("{\"a\":\"pre\"}", at(0.0));
+  releaser.onFlush("incident-1", at(1.0));
+
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering);
+  EXPECT_TRUE(releaser.isArmed());
+
+  // Samples after the release go back into the buffer instead of being published live.
+  releaser.offer("{\"a\":\"next\"}", at(2.0));
+  EXPECT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.bufferedCount(), 1u);
+
+  // ... and a second incident is captured immediately, with its own id.
+  releaser.onFlush("incident-2", at(3.0));
+  ASSERT_EQ(published_.size(), 2u);
+  EXPECT_EQ(published_[1].json, "{\"a\":\"next\"}");
+  EXPECT_EQ(published_[1].incident_id, "incident-2");
+}
+
+// Cooldown with no post-roll still suppresses, measured from the flush itself.
+TEST_F(IncidentReleaserTest, ZeroPostRollStillEntersCooldownWhenOneIsConfigured)
+{
+  auto releaser = makeReleaser(0.0, 5.0);
+
+  releaser.onFlush("incident-1", at(0.0));
+  EXPECT_EQ(releaser.state(), IncidentState::Cooldown);
+  EXPECT_FALSE(releaser.isArmed());
+
+  releaser.tick(at(4.9));
+  EXPECT_FALSE(releaser.isArmed());
+  releaser.tick(at(5.0));
+  EXPECT_TRUE(releaser.isArmed());
+}
+
+// Nothing buffered yet is not an error: the incident's post-roll is captured all the same.
+TEST_F(IncidentReleaserTest, FlushWithAnEmptyBufferStillRunsPostRoll)
+{
+  auto releaser = makeReleaser(3.0, 0.0);
+
+  releaser.onFlush("incident-1", at(0.0));
+  EXPECT_TRUE(published_.empty());
+  EXPECT_EQ(releaser.state(), IncidentState::PostRoll);
+
+  releaser.offer("{\"a\":\"post\"}", at(1.0));
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(published_[0].incident_id, "incident-1");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -1,7 +1,9 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <functional>
 #include <nlohmann/json.hpp>
+#include <string>
 
 #include "dc_interfaces/msg/flush_event.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
@@ -53,6 +55,28 @@ protected:
     received_.push_back(msg.data);
   }
 
+  void publishFlush(const std::string& incident_id)
+  {
+    dc_interfaces::msg::FlushEvent flush_msg;
+    flush_msg.incident_id = incident_id;
+    flush_pub_->publish(flush_msg);
+  }
+
+  // How many received Records carry this incident_id.
+  int countTaggedWith(const std::string& incident_id) const
+  {
+    int count = 0;
+    for (const auto& data : received_)
+    {
+      json data_json = json::parse(data);
+      if (data_json.contains("incident_id") && data_json["incident_id"] == incident_id)
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+
   void spinFor(int milliseconds)
   {
     std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
@@ -62,6 +86,23 @@ protected:
     {
       rclcpp::spin_some(ms_node_->get_node_base_interface());
     }
+  }
+
+  // Spin until `done` holds, giving up after `timeout_ms` -- a bounded wait, so a behavior
+  // regression fails the test loudly instead of hanging until the suite times out.
+  bool spinUntil(const std::function<bool()>& done, int timeout_ms)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (!done())
+    {
+      if ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time))
+              .count() >= timeout_ms)
+      {
+        return false;
+      }
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+    return true;
   }
 
   std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
@@ -105,8 +146,10 @@ TEST_F(MeasurementBufferingTest, BuffersSamplesSilentlyUntilFlush)
 }
 
 // Acceptance criterion: on a FlushEvent, exactly the buffered window is published, each Record
-// tagged with the event's incident_id, and live publishing resumes immediately afterward.
-TEST_F(MeasurementBufferingTest, FlushEventReleasesBufferedWindowThenResumesLivePublishing)
+// tagged with the event's incident_id. With post_roll_duration_sec left at its default 0 this is
+// pre-roll only -- the Measurement returns to buffering instead of publishing live from then on
+// (the #287 behavior this replaces resumed live publishing for good).
+TEST_F(MeasurementBufferingTest, FlushEventReleasesBufferedWindowThenReturnsToBuffering)
 {
   ms_node_->declare_parameter("dummy.buffer_duration_sec", 10.0);
   ms_node_->declare_parameter("dummy.flush_topic", std::string("/dc/flush"));
@@ -117,36 +160,69 @@ TEST_F(MeasurementBufferingTest, FlushEventReleasesBufferedWindowThenResumesLive
   spinFor(polling_interval_ * 3);
   ASSERT_TRUE(received_.empty());
 
-  dc_interfaces::msg::FlushEvent flush_msg;
-  flush_msg.incident_id = "incident-42";
-  flush_pub_->publish(flush_msg);
-
-  while (received_.empty())
-  {
-    rclcpp::spin_some(ms_node_->get_node_base_interface());
-  }
+  publishFlush("incident-42");
+  ASSERT_TRUE(spinUntil([this] { return !received_.empty(); }, 1000));
+  // Let the whole released window be delivered.
+  spinFor(polling_interval_ * 2);
 
   // Every Record released from the buffer carries the incident_id from the FlushEvent.
-  int count_after_flush = static_cast<int>(received_.size());
-  for (const auto& data : received_)
-  {
-    json data_json = json::parse(data);
-    ASSERT_TRUE(data_json.contains("incident_id"));
-    EXPECT_EQ(data_json["incident_id"], "incident-42");
-  }
+  int released = static_cast<int>(received_.size());
+  EXPECT_EQ(countTaggedWith("incident-42"), released);
 
-  // Live publishing resumes: subsequent ticks publish without buffering, so more Records arrive
-  // without needing another FlushEvent.
-  while (static_cast<int>(received_.size()) <= count_after_flush)
-  {
-    rclcpp::spin_some(ms_node_->get_node_base_interface());
-  }
-  EXPECT_GT(static_cast<int>(received_.size()), count_after_flush);
+  // Pre-roll only: no further Records once the window is out, since buffering resumed.
+  spinFor(polling_interval_ * 5);
+  EXPECT_EQ(static_cast<int>(received_.size()), released);
+}
 
-  // Records published live after the flush must not carry incident_id -- that only tags the
-  // released buffered window.
-  json last_json = json::parse(received_.back());
-  EXPECT_FALSE(last_json.contains("incident_id"));
+// Acceptance criterion: the end-to-end cycle on a real Measurement -- buffer, flush, post-roll
+// live publish, cooldown (a second FlushEvent ignored), re-armed and buffering again.
+TEST_F(MeasurementBufferingTest, FullIncidentCycleBuffersFlushesPostRollsCoolsDownThenReArms)
+{
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", 10.0);
+  ms_node_->declare_parameter("dummy.post_roll_duration_sec", 0.6);
+  ms_node_->declare_parameter("dummy.cooldown_sec", 0.6);
+
+  startLifecycleNode();
+
+  // Buffering: samples accumulate silently.
+  spinFor(polling_interval_ * 3);
+  ASSERT_TRUE(received_.empty());
+
+  // Flushing: the buffered window comes out tagged with the incident.
+  publishFlush("incident-1");
+  ASSERT_TRUE(spinUntil([this] { return !received_.empty(); }, 1000));
+
+  // PostRoll: 200ms in, the released window has certainly all been delivered, so any Record that
+  // shows up in the *next* 200ms was published live rather than released from the buffer.
+  spinFor(200);
+  int after_release = static_cast<int>(received_.size());
+  spinFor(200);
+  EXPECT_GT(static_cast<int>(received_.size()), after_release) << "post-roll should publish live";
+  // Released and post-roll Records alike belong to the same incident.
+  EXPECT_EQ(countTaggedWith("incident-1"), static_cast<int>(received_.size()));
+
+  // Cooldown: post-roll ends 600ms after the flush and cooldown runs 600ms past that. A further
+  // FlushEvent inside either phase belongs to the incident already being captured and must be
+  // ignored entirely -- once while still post-rolling, once during cooldown proper.
+  publishFlush("ignored-during-post-roll");
+  spinFor(400);
+  publishFlush("ignored-during-cooldown");
+  spinFor(400);
+  EXPECT_EQ(countTaggedWith("ignored-during-post-roll"), 0) << "a FlushEvent during post-roll is ignored";
+  EXPECT_EQ(countTaggedWith("ignored-during-cooldown"), 0) << "a FlushEvent during cooldown is ignored";
+
+  // Back to Buffering: nothing more is published once post-roll is over.
+  spinFor(600);
+  int at_rearm = static_cast<int>(received_.size());
+  spinFor(polling_interval_ * 4);
+  EXPECT_EQ(static_cast<int>(received_.size()), at_rearm) << "buffering again, so nothing is published";
+
+  // Re-armed: a fresh incident is captured with no manual intervention, and the samples buffered
+  // during cooldown are its pre-roll.
+  publishFlush("incident-3");
+  EXPECT_TRUE(spinUntil([this] { return countTaggedWith("incident-3") > 0; }, 1000))
+      << "the Measurement should have re-armed itself after cooldown";
+  EXPECT_EQ(countTaggedWith("incident-1"), at_rearm);
 }
 
 int main(int argc, char** argv)

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -77,16 +77,35 @@ Each measurement is collected through a node and has these configuration paramet
 | **include_measurement_name**   | Include measurement name in the JSON data                                                    | bool        | false                                |
 | **include_measurement_plugin** | Include measurement plugin name in the JSON data                                             | bool        | false                                |
 | **buffer_duration_sec**        | Seconds of history to buffer instead of publishing live; 0 disables buffering and preserves normal live publishing | float | 0 |
-| **flush_topic**                | Topic to receive the `FlushEvent` (see [Triggers](./triggers.md)) that releases the buffered window, tagging each Record with the event's `incident_id`, then resumes live publishing | str | "/dc/flush" |
+| **post_roll_duration_sec**     | Seconds to keep publishing live after a flush, still tagged with the same `incident_id`; 0 means pre-roll only | float | 0 |
+| **cooldown_sec**               | Seconds to ignore further `FlushEvent`s once post-roll ends, before buffering re-arms itself; 0 re-arms immediately | float | 0 |
+| **flush_topic**                | Topic to receive the `FlushEvent` (see [Triggers](./triggers.md)) that releases the buffered window, tagging each Record with the event's `incident_id` | str | "/dc/flush" |
 
-```admonish info title="buffer_duration_sec and flush_topic: pre-event circular-buffer capture"
+```admonish info title="buffer_duration_sec and friends: pre-event circular-buffer capture"
 When `buffer_duration_sec` is set above 0, this Measurement stops publishing live: each
 collected sample is instead pushed into an in-memory ring buffer covering the last
-`buffer_duration_sec` seconds. On receiving a `FlushEvent` on `flush_topic` (published by a
-`dc_triggers` broadcast node when its Trigger fires), the whole buffered window is published
-at once, each Record tagged with the event's `incident_id`, and the Measurement then resumes
-live publishing for good — buffering does not re-arm. Post-roll capture, cooldown, and
-rate-limiting are not part of this behavior yet.
+`buffer_duration_sec` seconds. A `FlushEvent` on `flush_topic` (published by a `dc_triggers`
+broadcast node when its Trigger fires) then drives one incident-capture cycle:
+
+1. **Buffering** — the default, armed state: samples accumulate in the ring buffer and nothing
+   is published. Only in this state does a `FlushEvent` start a cycle.
+2. **Flushing** — the whole buffered window is published at once, oldest first, each Record
+   tagged with the event's `incident_id` and stamped with when it was *collected*, not when it
+   was released. The window is consumed, so the next incident releases its own history rather
+   than replaying this one.
+3. **PostRoll** — for `post_roll_duration_sec` after the flush, samples are published live as
+   they are collected, still tagged with the same `incident_id`, so the aftermath of the
+   incident is captured too. Left at its default 0, this phase is skipped entirely: pre-roll
+   only.
+4. **Cooldown** — for `cooldown_sec` after post-roll ends, further `FlushEvent`s are ignored, so
+   a flapping Trigger cannot produce a flood of overlapping incidents. Samples are buffered
+   again during this phase, so the next incident still gets a full pre-roll window.
+
+The Measurement then re-arms itself back to **Buffering** with no manual intervention — a
+second incident is captured exactly like the first. With both `post_roll_duration_sec` and
+`cooldown_sec` left at 0, a flush releases the pre-roll window and the Measurement is armed
+again immediately. Rate-limited release of the buffered window is not implemented yet: the
+whole window goes out in one burst.
 ```
 
 ```admonish info title="gate_condition vs. if_all/if_any/if_none_conditions"

--- a/progress.txt
+++ b/progress.txt
@@ -6013,3 +6013,140 @@ Measurement buffer its recent history in memory and release it, tagged with an
   session notes, reverted again here to keep this diff scoped; `poetry-requirements` failed
   on the same pre-existing local environment gap (no `poetry` module) noted in every prior
   session, unrelated to this change.
+
+## #288 - Add IncidentReleaser state machine: post-roll capture, cooldown, and auto re-arm
+
+Third implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), on top of #285's `RecordRingBuffer`/`FileScratchRing`, #286's `dc_triggers`, and
+#287's basic flush-and-resume wiring. Turns #287's one-shot "release the window, then
+publish live for good" into the full per-Measurement state machine #282 specified.
+
+- **New `dc_measurements/include/dc_measurements/incident_releaser.hpp`**: header-only,
+  ROS-free `dc_measurements::IncidentReleaser` plus an `IncidentState` enum
+  (`Buffering`/`Flushing`/`PostRoll`/`Cooldown`), a `toString(IncidentState)` helper, and a
+  `durationFromSeconds(double)` helper converting the ROS parameters' seconds-as-double into
+  `std::chrono::system_clock::duration`. One cycle:
+  - **Buffering** (initial, armed): `offer()`ed samples go into an owned
+    `dc_common::RecordRingBuffer` (`push` + `evict` relative to the caller-supplied now);
+    nothing is published. The only state in which `onFlush()` does anything.
+  - **Flushing**: releases `buffer_.window()` oldest-first through the `PublishFn`, each
+    Record tagged with the FlushEvent's `incident_id` and stamped with when it was
+    *collected*, then `buffer_.clear()`s so the next incident releases its own history
+    rather than replaying this one. Release is immediate today, so the state is entered and
+    left inside `onFlush()`; it stays a distinct state because #282's `max release rate`
+    knob will drain the window across several `tick()`s instead (deliberately not built in
+    this slice -- the issue's acceptance criteria don't include rate limiting).
+  - **PostRoll**: for `post_roll` after the flush, `offer()`ed samples are published live as
+    collected, still under the same `incident_id`. Zero (the default) skips the phase.
+  - **Cooldown**: for `cooldown` after post-roll *ends* (not after the flush), `onFlush()` is
+    ignored. Samples keep buffering during this phase, so the next incident still gets a full
+    pre-roll window instead of one with a `post_roll + cooldown`-sized hole at its start.
+  - Then `enterBuffering()` re-arms automatically, clearing `incident_id_`.
+  - Interface is the small one #288 asked for: `offer(json, now)`, `onFlush(incident_id,
+    now)`, `tick(now)`, `isArmed()`, plus `state()`/`incidentId()`/`bufferedCount()` for
+    assertions. Time is a parameter on every entry point rather than read from a clock, and
+    Records go out through a caller-supplied `PublishFn` rather than a publisher -- that is
+    what makes the whole cycle testable with a fake clock and no ROS node. `offer()` and
+    `onFlush()` both call `tick(now)` first, so a Measurement driving them from its polling
+    timer and flush subscription needs no separate tick timer, and a sample collected after
+    the post-roll deadline is buffered rather than published even at a coarse polling rate.
+  - Cooldown is measured from `phase_deadline_` (when post-roll actually ended), not from
+    whenever the tick noticed the expiry, so total suppression is `post_roll + cooldown`
+    however coarsely `tick()` gets called.
+- **`dc_common/include/dc_common/record_ring_buffer.hpp`**: new `clear()` (drop every entry
+  regardless of age), needed so a released window is not released a second time. New test
+  case `ClearDropsEveryEntryRegardlessOfAge` covers it, including that the buffer is still
+  usable afterwards.
+- **`dc_measurements/include/dc_measurements/measurement.hpp`**: `buffering_active_` and the
+  raw `ring_buffer_` are replaced by a single `std::shared_ptr<IncidentReleaser> releaser_`,
+  created in `configure()` only when `buffer_duration_sec_ > 0` and reset in `cleanup()`.
+  - `collectAndPublish()` branches on `releaser_` instead of `buffering_active_`.
+  - `bufferSample()` renamed to `offerSample()` (it no longer only buffers -- during
+    post-roll the same call publishes): enriches via the existing `enrichMsg()`, then
+    `releaser_->offer(msg.data, system_clock::now())`.
+  - New `publishIncidentRecord(record_json, stamp, incident_id)` is the `PublishFn` the
+    releaser is constructed with -- it is #287's release loop body, now shared by pre-roll
+    release and post-roll live publishing: sets `group_key`, converts the buffered
+    `system_clock` stamp to `header.stamp`, injects `incident_id` into the JSON, and
+    publishes straight through `data_pub_`, bypassing `publish()`'s gate/counter logic (a
+    Record captured for an incident was already unconditionally collected and is not
+    re-filtered on the way out).
+  - `onFlushEvent()` is now two lines: no-op without a `releaser_`, otherwise forward
+    `event.incident_id` to `releaser_->onFlush()`. All the "is this event actionable"
+    reasoning moved into the state machine.
+- **New parameters** `post_roll_duration_sec` (double, default 0.0) and `cooldown_sec`
+  (double, default 0.0), read in `loadMeasurementPlugins()` via the existing
+  `dc_util::get_double_type_param`, resized/logged alongside `buffer_duration_sec`/
+  `flush_topic`, and threaded through `dc_core::Measurement::configure()`. Unlike #287 (which
+  appended its two parameters at the very end of the signature), these two were inserted
+  *after* `buffer_duration_sec` and before `flush_topic` so all four buffering parameters
+  read in a sensible order -- safe because `dc_measurements::Measurement` remains the only
+  implementor of the interface and `MeasurementServer` its only caller (re-verified by grep).
+- **Behavior change vs #287, intentional**: a flush no longer latches buffering off forever.
+  With both new parameters at their default 0 a flush releases the pre-roll window and the
+  Measurement is armed again immediately, rather than resuming live publishing for good --
+  #282's user story 21 ("the system doesn't keep continuously shipping data indefinitely
+  after one incident") and 7 (auto re-arm). `buffer_duration_sec` unset/zero is still exactly
+  today's live-publishing behavior; `ZeroBufferDurationPublishesLiveAsBefore` still covers
+  that, unchanged. #287's `FlushEventReleasesBufferedWindowThenResumesLivePublishing` was
+  renamed to `...ThenReturnsToBuffering` and its second half inverted accordingly (it now
+  asserts *no* further Records arrive after the released window).
+- **Tests**:
+  - New `dc_measurements/test/test_incident_releaser.cpp` (registered first in
+    `CMakeLists.txt`'s `tests` list), 10 cases, fake clock (`base_` = epoch + 24h, `at(sec)`
+    helper) and a `Published{json, stamp, incident_id}` capture vector standing in for a ROS
+    publisher: armed-and-silent start; release ordering with original stamps; window eviction;
+    post-roll transition, live tagging and duration; cooldown ignoring a second flush both
+    during post-roll and during cooldown proper; auto re-arm after cooldown *including* the
+    window buffered during cooldown becoming the next incident's pre-roll; a flush landing
+    exactly on the cooldown deadline being honored; both-zero defaults re-arming immediately;
+    zero post-roll still entering a configured cooldown; and a flush with an empty buffer
+    still running post-roll.
+  - New lifecycle case `FullIncidentCycleBuffersFlushesPostRollsCoolsDownThenReArms` in
+    `test_measurement_buffering.cpp` -- the issue's end-to-end criterion on a real
+    Measurement (`post_roll_duration_sec` 0.6, `cooldown_sec` 0.6, 50ms polling): buffers
+    silently, flushes under `incident-1`, proves post-roll *live* publishing by measuring
+    growth in a second 200ms window (by then the released burst has certainly been delivered,
+    so further growth can only be live), ignores a FlushEvent during post-roll and another
+    during cooldown, shows the Record count going flat once re-armed, then captures
+    `incident-3` off a third FlushEvent. Two new fixture helpers: `publishFlush(incident_id)`
+    and `countTaggedWith(incident_id)`, plus `spinUntil(predicate, timeout_ms)` -- a *bounded*
+    spin, so a behavior regression fails loudly instead of hanging the way #286's Moving
+    re-arm bug did.
+- **Docs**: `doc/src/dc/measurements.md` gains `post_roll_duration_sec` and `cooldown_sec`
+  rows, and its buffering admonish block was rewritten from "post-roll capture, cooldown and
+  rate-limiting are not part of this behavior yet" into a numbered walk through the four
+  phases plus the re-arm, still noting that rate-limited release is not implemented (the whole
+  window goes out in one burst).
+- **Real bug caught by the new unit tests**: `tick()` passed the *member* `phase_deadline_` by
+  const reference into `enterCooldown()`, which assigns `phase_deadline_ = from + cooldown_`
+  and then checks `from >= phase_deadline_` to handle a zero cooldown -- with `from` aliasing
+  the member it had just overwritten, that comparison was always true, so every cooldown
+  re-armed instantly. `CooldownIgnoresASecondFlushWithinItsWindow` and
+  `ReArmsItselfAfterCooldownAndCapturesTheNextIncident` failed on it; fixed by taking `from`
+  by value (with a comment saying why). Worth noting the first version of the lifecycle test
+  passed *despite* this bug, because its second FlushEvent landed during post-roll (ignored
+  either way) -- the lifecycle test was then strengthened to send one during cooldown proper
+  too, which is what makes it actually cover the criterion.
+- **Verified**: `podman run` against the `localhost/dc-workspace` Jazzy image, bind-mounting
+  this worktree over `/root/ws/src/ros2_data_collection`, same as #284-#287. `colcon build
+  --packages-select dc_common dc_core dc_interfaces dc_measurements --cmake-args
+  -DBUILD_TESTING=ON` succeeded with **zero warnings** under `-Wall -Wextra -Wpedantic
+  -Werror -Wdeprecated` (21min for `dc_measurements` -- every measurement/condition plugin
+  recompiles because they all include `measurement.hpp`), then `colcon test` +
+  `colcon test-result`: **235 tests, 0 errors, 0 failures, 0 skipped** across the four
+  packages (up from #287's 222: +10 `test_incident_releaser`, +1 lifecycle case, +1
+  `RecordRingBuffer::clear` case, +1 from the `dc_measurements` ctest count). While iterating
+  on the aliasing fix, the unit test was also compiled and run standalone (`g++ -std=c++17
+  -Wall -Wextra -Wpedantic -Werror -I dc_measurements/include -I dc_common/include ...
+  -lgtest`) inside the same image -- it needs neither ROS nor colcon, which is the point of
+  keeping `IncidentReleaser` ROS-free, and it turns a 22-minute verification loop into
+  seconds.
+- `pre-commit run --files <changed>` passed `clang-format`, `codespell`, the mdbook **doc
+  build**, `black`/`isort`/`pyupgrade`, `ros2_ws_same_versions`/`ros2_ws_set_metadata` and the
+  rest. `clang-format` left one 121-char line (the `IncidentReleaser` constructor signature)
+  and still reports the file as passing, so it was left as formatted. The only failures are
+  the two long-standing local-environment ones: `poetry-requirements` (no `poetry` module on
+  this host) and `pycln`/`flake8` on the pre-existing violation in
+  `tools/e2e/scripts/verify_zero_loss.py`, which the hooks reformat repo-wide and which was
+  reverted again here to keep this diff scoped, exactly as in the #285/#286/#287 sessions.


### PR DESCRIPTION
Closes #288

Third implementation slice of #282 (pre-event circular-buffer capture): extends #287's
one-shot flush-and-resume into the full `IncidentReleaser` state machine, owned per
Measurement.

## What changed

**New `dc_measurements::IncidentReleaser`** (`incident_releaser.hpp`, header-only, no ROS
dependency) drives one incident-capture cycle over a `dc_common::RecordRingBuffer`:

```
Buffering --onFlush--> Flushing --> PostRoll --> Cooldown --> Buffering
```

- **Buffering** (initial, armed): samples go into the ring buffer, nothing is published. The
  only state in which a `FlushEvent` starts a cycle.
- **Flushing**: releases the buffered window oldest-first, each Record tagged with the event's
  `incident_id` and stamped with when it was *collected*, then consumes the window so the next
  incident does not replay it. Immediate today; kept as its own state because rate-limited
  release (#282's `max release rate`) will drain it across several `tick()`s.
- **PostRoll**: for `post_roll_duration_sec`, samples are published live as collected, still
  tagged with the same `incident_id`. Default 0 skips the phase — pre-roll only.
- **Cooldown**: for `cooldown_sec` after post-roll ends, further `FlushEvent`s are ignored.
  Samples keep buffering, so the next incident still gets a full pre-roll window.

Then it re-arms itself back to Buffering with no manual intervention.

The interface is the small one the issue asked for — `offer(json, now)`, `onFlush(incident_id,
now)`, `tick(now)`, `isArmed()`, plus `state()`/`incidentId()`/`bufferedCount()` for
assertions. Time comes in as an argument on every entry point and Records go out through a
caller-supplied `PublishFn`, which is what lets the whole cycle be tested with a fake clock and
no ROS node.

**New parameters**: `post_roll_duration_sec` (float, default 0) and `cooldown_sec` (float,
default 0), read by `MeasurementServer` alongside `buffer_duration_sec`/`flush_topic` and passed
through `dc_core::Measurement::configure()`.

**Behavior change vs #287**: a flush no longer turns buffering off for good. With both new
parameters at their default 0, a flush releases the pre-roll window and the Measurement is armed
again immediately instead of publishing live from then on — user story 21 of #282 ("the system
doesn't keep continuously shipping data indefinitely after one incident"). `buffer_duration_sec`
unset/zero is still exactly today's live-publishing behavior, regression-tested as before.

**`dc_common::RecordRingBuffer::clear()`**: needed so a released window is not released twice.

## Tests

- `dc_measurements/test/test_incident_releaser.cpp` — 10 new unit tests, fake clock, captured
  "what was published" callback, no ROS: release ordering/stamps/eviction, post-roll transition
  and duration, cooldown suppressing a second flush, auto re-arm after cooldown (including the
  window buffered *during* cooldown becoming the next incident's pre-roll), flush exactly at the
  cooldown deadline, both-zero defaults, and a flush with an empty buffer.
- `dc_measurements/test/test_measurement_buffering.cpp` — new
  `FullIncidentCycleBuffersFlushesPostRollsCoolsDownThenReArms` lifecycle test on a real
  Measurement (buffer → flush → post-roll live publish → second `FlushEvent` ignored → re-armed
  and buffering → third `FlushEvent` captured under a new `incident_id`), and
  `FlushEventReleasesBufferedWindowThenResumesLivePublishing` updated to
  `...ThenReturnsToBuffering` to match the re-arming behavior above.
- `dc_common/test/record_ring_buffer_test.cpp` — a `clear()` case.

## Docs

`doc/src/dc/measurements.md` gains the two parameter rows and its buffering admonish block now
walks the four phases instead of saying post-roll/cooldown don't exist yet.

## Verification

`colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements --cmake-args
-DBUILD_TESTING=ON` in the Jazzy `dc-workspace` image: zero warnings under `-Wall -Wextra
-Wpedantic -Werror -Wdeprecated`. `colcon test` + `colcon test-result`: **235 tests, 0 errors,
0 failures, 0 skipped** (222 before this change).

The new unit tests caught a real bug on their first run: `tick()` passed the member
`phase_deadline_` by const reference into `enterCooldown()`, which overwrites it, so the
zero-cooldown shortcut compared the new deadline against itself and every cooldown re-armed
instantly. Fixed by taking that parameter by value. Notably the lifecycle test passed *despite*
the bug because its second `FlushEvent` landed during post-roll (ignored either way) — it now
sends one during cooldown proper as well, which is what makes it cover the criterion.

`pre-commit run --files <changed>` passes `clang-format`, `codespell`, the mdbook doc build and
the ROS metadata hooks; the only failures are the long-standing local-environment ones
(`poetry-requirements` with no `poetry` module, and `pycln`/`flake8` on the pre-existing
violation in `tools/e2e/scripts/verify_zero_loss.py`, reverted here to keep the diff scoped).

## Not covered here

Every test in this PR (and in #287) drives a single Measurement, so one `FlushEvent` fanning out
to *several* Measurements under one shared `incident_id` — user stories 4 and 22 of #282 — is
still unverified. Tracked in #345 rather than widened into this slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013MijmqvPTp3TMWMGkc6fNn
