### PR TITLE
feat(dc_measurements): rate-limit the IncidentReleaser buffered-window release

### DIFF
--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -58,6 +58,9 @@ public:
    * with the same incident_id; 0 (the default) means pre-roll only (#288)
    * @param  cooldown_sec Seconds to ignore further FlushEvents once post-roll ends, before
    * buffering re-arms itself; 0 (the default) re-arms immediately (#288)
+   * @param  max_flush_rate_hz Ceiling on how fast the buffered window is emitted once a flush
+   * releases it, protecting Bridge/network bandwidth; 0 (the default) releases it in one burst
+   * (#289)
    * @param  flush_topic Topic to receive the FlushEvent that releases the buffered window,
    * tagging each released Record with the event's incident_id
    */
@@ -76,7 +79,8 @@ public:
             const std::string& all_base_path, const std::string& all_base_path_expanded,
             const std::string& save_local_base_path_expanded, const std::string& run_id, const bool& run_id_enabled,
             const std::vector<json>& custom_keys, const double& buffer_duration_sec,
-            const double& post_roll_duration_sec, const double& cooldown_sec, const std::string& flush_topic) = 0;
+            const double& post_roll_duration_sec, const double& cooldown_sec, const double& max_flush_rate_hz,
+            const std::string& flush_topic) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/include/dc_measurements/incident_releaser.hpp
+++ b/dc_measurements/include/dc_measurements/incident_releaser.hpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "dc_common/record_ring_buffer.hpp"
 
@@ -55,9 +56,10 @@ inline std::chrono::system_clock::duration durationFromSeconds(const double& sec
  * - **Buffering** (the initial state): every offered sample goes into the ring buffer, nothing is
  *   published. This is the only state in which a FlushEvent is acted upon (see isArmed()).
  * - **Flushing**: the buffered window is released, oldest first, each Record tagged with the
- *   incident_id the FlushEvent carried. Release is currently immediate, so this state is entered
- *   and left within onFlush(); it exists as a distinct state because rate-limited release (the
- *   `max release rate` knob of #282) drains the window across several tick()s instead.
+ *   incident_id the FlushEvent carried. With no `max_flush_rate_hz` configured the whole window
+ *   goes out in one burst, so the state is entered and left within onFlush(); with a rate
+ *   configured the window is drained across several tick()s instead (#289), and samples collected
+ *   meanwhile go back into the ring buffer rather than being published.
  * - **PostRoll**: samples are published live for `post_roll` after the flush, still tagged with
  *   the same incident_id, so the aftermath of the incident is captured too. A zero `post_roll`
  *   (the default) skips the phase entirely -- pre-roll only.
@@ -92,19 +94,26 @@ public:
    * zero or less means pre-roll only.
    * @param cooldown How long to ignore FlushEvents once post-roll ends (`cooldown_sec`); zero or
    * less re-arms immediately.
+   * @param max_flush_rate_hz Ceiling on how fast the buffered window is emitted during Flushing
+   * (`max_flush_rate_hz`); zero or less releases the whole window in one burst.
    * @param publish Called for every released and every post-roll Record.
    */
-  IncidentReleaser(const Duration& buffer_window, const Duration& post_roll, const Duration& cooldown, PublishFn publish)
-    : post_roll_(post_roll), cooldown_(cooldown), publish_(std::move(publish)), buffer_(buffer_window)
+  IncidentReleaser(const Duration& buffer_window, const Duration& post_roll, const Duration& cooldown,
+                   const double& max_flush_rate_hz, PublishFn publish)
+    : post_roll_(post_roll)
+    , cooldown_(cooldown)
+    , release_interval_(max_flush_rate_hz > 0.0 ? durationFromSeconds(1.0 / max_flush_rate_hz) : Duration::zero())
+    , publish_(std::move(publish))
+    , buffer_(buffer_window)
   {
   }
 
   /**
    * @brief Hand one freshly collected sample to the machine.
    *
-   * Buffered while Buffering or in Cooldown, published live (tagged with the current incident_id)
-   * during PostRoll. Drives time-based transitions first, so a sample collected after the
-   * post-roll deadline is buffered rather than published even if nothing else called tick().
+   * Buffered while Buffering, Flushing or Cooldown, published live (tagged with the current
+   * incident_id) during PostRoll. Drives time-based transitions first, so a sample collected after
+   * the post-roll deadline is buffered rather than published even if nothing else called tick().
    */
   void offer(const std::string& record_json, const TimePoint& now)
   {
@@ -140,31 +149,30 @@ public:
     incident_id_ = incident_id;
 
     buffer_.evict(now);
-    for (const auto& entry : buffer_.window())
-    {
-      publish_(entry.json, entry.stamp, incident_id_);
-    }
-    // Released entries are gone for good: the next incident gets its own window, not this one
-    // replayed a second time.
+    // Released entries are gone from the buffer for good: the next incident gets its own window,
+    // not this one replayed a second time. They live in pending_ until the drain emits them.
+    pending_ = buffer_.window();
+    pending_index_ = 0;
     buffer_.clear();
 
-    if (post_roll_ > Duration::zero())
-    {
-      state_ = IncidentState::PostRoll;
-      phase_deadline_ = now + post_roll_;
-      return;
-    }
-    enterCooldown(now);
+    next_release_ = now;
+    drainRelease(now);
   }
 
   /**
-   * @brief Advance the time-based transitions (post-roll expiry, cooldown expiry) to `now`.
+   * @brief Advance the time-based transitions (rate-limited release, post-roll expiry, cooldown
+   * expiry) to `now`.
    *
    * Safe and cheap to call at any rate; offer() and onFlush() call it themselves, so a
-   * Measurement driving both from its polling timer needs no separate tick.
+   * Measurement driving both from its polling timer needs no separate tick -- though with
+   * `max_flush_rate_hz` set above the polling rate a dedicated timer keeps the drain smooth.
    */
   void tick(const TimePoint& now)
   {
+    if (state_ == IncidentState::Flushing)
+    {
+      drainRelease(now);
+    }
     if (state_ == IncidentState::PostRoll && now >= phase_deadline_)
     {
       // Cooldown runs from when post-roll actually ended, not from whenever this tick noticed it,
@@ -200,7 +208,50 @@ public:
     return buffer_.size();
   }
 
+  /// How many released Records are still queued behind the flush rate limit; 0 unless Flushing.
+  std::size_t pendingReleaseCount() const
+  {
+    return pending_.size() - pending_index_;
+  }
+
 private:
+  /**
+   * @brief Emit as many of the still-pending Records as `max_flush_rate_hz` allows by `now`, and
+   * leave Flushing once the whole window is out.
+   *
+   * The cap is on the emission rate over time, not on how many Records one call may emit: when
+   * tick() is called more coarsely than the release interval the drain catches up by emitting
+   * everything that came due since the last call, and never more than that. Without the catch-up a
+   * Measurement whose polling timer is slower than `max_flush_rate_hz` could never reach the
+   * configured rate, and the release would take as long as the buffer window itself.
+   */
+  void drainRelease(const TimePoint& now)
+  {
+    while (pending_index_ < pending_.size())
+    {
+      if (release_interval_ > Duration::zero() && now < next_release_)
+      {
+        // Still Flushing: the next tick() picks the drain up where this one left off.
+        return;
+      }
+      const auto& entry = pending_[pending_index_++];
+      publish_(entry.json, entry.stamp, incident_id_);
+      next_release_ += release_interval_;
+    }
+
+    pending_.clear();
+    pending_index_ = 0;
+    // Post-roll runs from the end of the release, not from the FlushEvent, so a rate-limited drain
+    // doesn't eat into the aftermath window it is supposed to capture.
+    if (post_roll_ > Duration::zero())
+    {
+      state_ = IncidentState::PostRoll;
+      phase_deadline_ = now + post_roll_;
+      return;
+    }
+    enterCooldown(now);
+  }
+
   // `from` is taken by value on purpose: tick() passes phase_deadline_ itself, and the assignment
   // below would otherwise change the value `from` refers to mid-function.
   void enterCooldown(TimePoint from)
@@ -222,6 +273,8 @@ private:
 
   Duration post_roll_;
   Duration cooldown_;
+  // Minimum spacing between two released Records; zero means "no limit, release in one burst".
+  Duration release_interval_;
   PublishFn publish_;
 
   dc_common::RecordRingBuffer buffer_;
@@ -229,6 +282,12 @@ private:
   std::string incident_id_;
   // End of the phase in progress; only meaningful in PostRoll and Cooldown.
   TimePoint phase_deadline_;
+  // The window being released, oldest first, and how far the drain has got through it. An index
+  // rather than a pop_front so the released Records are not shuffled down one by one.
+  std::vector<dc_common::StampedRecord> pending_;
+  std::size_t pending_index_{ 0 };
+  // When the next pending Record may go out; only meaningful in Flushing.
+  TimePoint next_release_;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -8,6 +8,7 @@
 #include <ctime>
 #include <fstream>
 #include <memory>
+#include <mutex>
 #include <nlohmann/json-schema.hpp>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -543,9 +544,13 @@ public:
   {
     if (msg.data.empty() || msg.data == "null")
     {
+      // Nothing to offer, but the phase deadlines and a rate-limited release still need driving.
+      const std::lock_guard<std::mutex> lock(releaser_mutex_);
+      releaser_->tick(std::chrono::system_clock::now());
       return;
     }
     enrichMsg(msg);
+    const std::lock_guard<std::mutex> lock(releaser_mutex_);
     releaser_->offer(msg.data, std::chrono::system_clock::now());
   }
 
@@ -584,6 +589,7 @@ public:
     {
       return;
     }
+    const std::lock_guard<std::mutex> lock(releaser_mutex_);
     releaser_->onFlush(event.incident_id, std::chrono::system_clock::now());
   }
 
@@ -605,7 +611,7 @@ public:
                  const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
                  const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_keys,
                  const double& buffer_duration_sec, const double& post_roll_duration_sec, const double& cooldown_sec,
-                 const std::string& flush_topic) override
+                 const double& max_flush_rate_hz, const std::string& flush_topic) override
   {
     node_ = parent;
     auto node = node_.lock();
@@ -661,16 +667,33 @@ public:
     buffer_duration_sec_ = buffer_duration_sec;
     post_roll_duration_sec_ = post_roll_duration_sec;
     cooldown_sec_ = cooldown_sec;
+    max_flush_rate_hz_ = max_flush_rate_hz;
     flush_topic_ = flush_topic.empty() ? std::string("/dc/flush") : flush_topic;
     if (buffer_duration_sec_ > 0.0)
     {
       releaser_ = std::make_shared<IncidentReleaser>(
           durationFromSeconds(buffer_duration_sec_), durationFromSeconds(post_roll_duration_sec_),
-          durationFromSeconds(cooldown_sec_),
+          durationFromSeconds(cooldown_sec_), max_flush_rate_hz_,
           [this](const std::string& record_json, const std::chrono::system_clock::time_point& stamp,
                  const std::string& incident_id) { publishIncidentRecord(record_json, stamp, incident_id); });
       flush_sub_ = node->create_subscription<dc_interfaces::msg::FlushEvent>(
           flush_topic_, 10, std::bind(&Measurement::onFlushEvent, this, std::placeholders::_1));
+      if (max_flush_rate_hz_ > 0.0)
+      {
+        // A rate-limited release is drained by tick(), and the polling timer alone would drain it
+        // at the polling rate -- in bursts, and never faster than collection however high
+        // max_flush_rate_hz is. This timer paces the release properly (#289).
+        release_timer_ = node->create_wall_timer(
+            durationFromSeconds(1.0 / max_flush_rate_hz_),
+            [this] {
+              const std::lock_guard<std::mutex> lock(releaser_mutex_);
+              if (releaser_)
+              {
+                releaser_->tick(std::chrono::system_clock::now());
+              }
+            },
+            client_cb_group_);
+      }
     }
 
     RCLCPP_INFO(logger_, "Done configuring %s", measurement_name_.c_str());
@@ -705,7 +728,12 @@ public:
   {
     data_pub_.reset();
     flush_sub_.reset();
-    releaser_.reset();
+    // Before the releaser it ticks, so the timer can't fire on a null one.
+    release_timer_.reset();
+    {
+      const std::lock_guard<std::mutex> lock(releaser_mutex_);
+      releaser_.reset();
+    }
     onCleanup();
   }
 
@@ -799,9 +827,15 @@ protected:
   double buffer_duration_sec_{ 0.0 };
   double post_roll_duration_sec_{ 0.0 };
   double cooldown_sec_{ 0.0 };
+  double max_flush_rate_hz_{ 0.0 };
   std::string flush_topic_;
   std::shared_ptr<IncidentReleaser> releaser_;
   rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr flush_sub_;
+  // Paces a rate-limited release; only created when max_flush_rate_hz_ > 0 (#289).
+  rclcpp::TimerBase::SharedPtr release_timer_;
+  // The releaser is reached from three concurrent paths -- the polling timer, the FlushEvent
+  // subscription and release_timer_ -- so every entry into it is serialized here.
+  std::mutex releaser_mutex_;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -128,6 +128,7 @@ protected:
   std::vector<double> measurement_buffer_duration_sec_;
   std::vector<double> measurement_post_roll_duration_sec_;
   std::vector<double> measurement_cooldown_sec_;
+  std::vector<double> measurement_max_flush_rate_hz_;
   std::vector<std::string> measurement_flush_topic_;
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -156,6 +156,7 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   measurement_buffer_duration_sec_.resize(measurement_ids_.size());
   measurement_post_roll_duration_sec_.resize(measurement_ids_.size());
   measurement_cooldown_sec_.resize(measurement_ids_.size());
+  measurement_max_flush_rate_hz_.resize(measurement_ids_.size());
   measurement_flush_topic_.resize(measurement_ids_.size());
 
   measurement_if_all_conditions_.resize(measurement_ids_.size());
@@ -244,6 +245,8 @@ bool MeasurementServer::loadMeasurementPlugins()
     measurement_post_roll_duration_sec_[i] =
         dc_util::get_double_type_param(node, measurement_ids_[i], "post_roll_duration_sec", 0.0);
     measurement_cooldown_sec_[i] = dc_util::get_double_type_param(node, measurement_ids_[i], "cooldown_sec", 0.0);
+    measurement_max_flush_rate_hz_[i] =
+        dc_util::get_double_type_param(node, measurement_ids_[i], "max_flush_rate_hz", 0.0);
     measurement_flush_topic_[i] =
         dc_util::get_str_type_param(node, measurement_ids_[i], "flush_topic", std::string("/dc/flush"));
 
@@ -259,30 +262,31 @@ bool MeasurementServer::loadMeasurementPlugins()
 
     try
     {
-      RCLCPP_INFO_STREAM(
-          get_logger(),
-          "Creating measurement plugin "
-              << measurement_ids_[i].c_str() << ": Type " << measurement_types_[i].c_str()
-              << ", Group key: " << measurement_group_key_[i]
-              << ", Polling interval: " << measurement_polling_interval_[i] << ", Debug: " << (int)measurement_debug_[i]
-              << ", Validator enabled: " << (int)measurement_enable_validator_[i]
-              << ", Schema path: " << measurement_json_schema_path_[i].c_str() << ", Tags: ["
-              << dc_util::join(measurement_tags_[i], ",") << "], Init collect: " << (int)measurement_init_collect_[i]
-              << ", Init Max measurement: " << measurement_init_max_measurements_[i]
-              << ", Include measurement name: " << measurement_include_measurement_name_[i]
-              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-              << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
-              << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i])
-              << ", Nest: " << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
-              << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-              << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
-              << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
-              << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
-              << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
-              << ", Gate condition: " << measurement_gate_condition_[i]
-              << ", Buffer duration sec: " << measurement_buffer_duration_sec_[i] << ", Post roll duration sec: "
-              << measurement_post_roll_duration_sec_[i] << ", Cooldown sec: " << measurement_cooldown_sec_[i]
-              << ", Flush topic: " << measurement_flush_topic_[i]);
+      RCLCPP_INFO_STREAM(get_logger(),
+                         "Creating measurement plugin "
+                             << measurement_ids_[i].c_str() << ": Type " << measurement_types_[i].c_str()
+                             << ", Group key: " << measurement_group_key_[i] << ", Polling interval: "
+                             << measurement_polling_interval_[i] << ", Debug: " << (int)measurement_debug_[i]
+                             << ", Validator enabled: " << (int)measurement_enable_validator_[i]
+                             << ", Schema path: " << measurement_json_schema_path_[i].c_str() << ", Tags: ["
+                             << dc_util::join(measurement_tags_[i], ",")
+                             << "], Init collect: " << (int)measurement_init_collect_[i]
+                             << ", Init Max measurement: " << measurement_init_max_measurements_[i]
+                             << ", Include measurement name: " << measurement_include_measurement_name_[i]
+                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
+                             << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
+                             << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i]) << ", Nest: "
+                             << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
+                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
+                             << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
+                             << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
+                             << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
+                             << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
+                             << ", Gate condition: " << measurement_gate_condition_[i]
+                             << ", Buffer duration sec: " << measurement_buffer_duration_sec_[i]
+                             << ", Post roll duration sec: " << measurement_post_roll_duration_sec_[i]
+                             << ", Cooldown sec: " << measurement_cooldown_sec_[i] << ", Max flush rate hz: "
+                             << measurement_max_flush_rate_hz_[i] << ", Flush topic: " << measurement_flush_topic_[i]);
 
       measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(measurement_types_[i]));
       measurements_.back()->configure(
@@ -296,7 +300,7 @@ bool MeasurementServer::loadMeasurementPlugins()
           measurement_nested_[i], measurement_flatten_[i], save_local_base_path_, all_base_path_,
           all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_keys_,
           measurement_buffer_duration_sec_[i], measurement_post_roll_duration_sec_[i], measurement_cooldown_sec_[i],
-          measurement_flush_topic_[i]);
+          measurement_max_flush_rate_hz_[i], measurement_flush_topic_[i]);
     }
     catch (const pluginlib::PluginlibException& ex)
     {

--- a/dc_measurements/test/test_incident_releaser.cpp
+++ b/dc_measurements/test/test_incident_releaser.cpp
@@ -40,11 +40,12 @@ protected:
     };
   }
 
-  // buffer 10s, post-roll/cooldown per test.
-  IncidentReleaser makeReleaser(const double& post_roll_sec, const double& cooldown_sec)
+  // buffer 10s, post-roll/cooldown/flush rate per test (0 Hz = unlimited, the default).
+  IncidentReleaser makeReleaser(const double& post_roll_sec, const double& cooldown_sec,
+                                const double& max_flush_rate_hz = 0.0)
   {
     return IncidentReleaser(std::chrono::seconds(10), dc_measurements::durationFromSeconds(post_roll_sec),
-                            dc_measurements::durationFromSeconds(cooldown_sec), capture());
+                            dc_measurements::durationFromSeconds(cooldown_sec), max_flush_rate_hz, capture());
   }
 
   std::vector<std::string> publishedJson() const
@@ -262,6 +263,162 @@ TEST_F(IncidentReleaserTest, FlushWithAnEmptyBufferStillRunsPostRoll)
   releaser.offer("{\"a\":\"post\"}", at(1.0));
   ASSERT_EQ(published_.size(), 1u);
   EXPECT_EQ(published_[0].incident_id, "incident-1");
+}
+
+// Acceptance criterion (#289): with max_flush_rate_hz set, a buffered window larger than one
+// publish interval is drained across several tick()s instead of going out in one burst.
+TEST_F(IncidentReleaserTest, MaxFlushRateSpacesTheReleasedWindowAcrossTicks)
+{
+  auto releaser = makeReleaser(0.0, 0.0, 2.0);  // 2 Hz -> one Record every 0.5s
+
+  for (int i = 0; i < 5; ++i)
+  {
+    releaser.offer("{\"a\":" + std::to_string(i) + "}", at(i));
+  }
+
+  releaser.onFlush("incident-1", at(5.0));
+  // The first Record goes out with the flush itself; the rest wait their turn.
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.state(), IncidentState::Flushing) << "state is " << toString(releaser.state());
+  EXPECT_FALSE(releaser.isArmed());
+  EXPECT_EQ(releaser.pendingReleaseCount(), 4u);
+
+  // Before the interval elapses, nothing more is emitted...
+  releaser.tick(at(5.4));
+  EXPECT_EQ(published_.size(), 1u);
+  // ... and on it, exactly one more.
+  releaser.tick(at(5.5));
+  EXPECT_EQ(published_.size(), 2u);
+
+  // A tick coarser than the interval catches up with everything that came due (6.0 and 6.5), and
+  // no more than that.
+  releaser.tick(at(6.6));
+  EXPECT_EQ(published_.size(), 4u);
+  EXPECT_EQ(releaser.state(), IncidentState::Flushing);
+
+  releaser.tick(at(7.0));
+  ASSERT_EQ(published_.size(), 5u);
+  EXPECT_EQ(releaser.pendingReleaseCount(), 0u);
+  // Window fully released: with neither post-roll nor cooldown configured, armed again.
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering) << "state is " << toString(releaser.state());
+
+  // Rate limiting changes when Records go out, not what goes out: same order, same original
+  // stamps, same incident.
+  EXPECT_EQ(publishedJson(),
+            (std::vector<std::string>{ "{\"a\":0}", "{\"a\":1}", "{\"a\":2}", "{\"a\":3}", "{\"a\":4}" }));
+  for (int i = 0; i < 5; ++i)
+  {
+    EXPECT_EQ(published_[i].stamp, at(i));
+    EXPECT_EQ(published_[i].incident_id, "incident-1");
+  }
+}
+
+// The cap holds however finely the machine is ticked: by any moment, no more Records have been
+// emitted than the configured rate allows since the flush.
+TEST_F(IncidentReleaserTest, ReleaseNeverEmitsFasterThanTheConfiguredRate)
+{
+  const double rate_hz = 4.0;
+  auto releaser = makeReleaser(0.0, 0.0, rate_hz);
+
+  for (int i = 0; i < 20; ++i)
+  {
+    releaser.offer("{\"a\":" + std::to_string(i) + "}", at(i * 0.1));
+  }
+
+  const double flush_at = 2.0;
+  releaser.onFlush("incident-1", at(flush_at));
+
+  for (double elapsed = 0.0; elapsed <= 6.0; elapsed += 0.05)
+  {
+    releaser.tick(at(flush_at + elapsed));
+    // One Record at the flush itself, then one per 1/rate_hz elapsed.
+    const std::size_t allowed = 1u + static_cast<std::size_t>(elapsed * rate_hz + 1e-9);
+    EXPECT_LE(published_.size(), allowed) << "burst detected " << elapsed << "s into the release";
+  }
+  EXPECT_EQ(published_.size(), 20u) << "the whole window should still make it out";
+}
+
+// A rate-limited release takes time; samples collected while it runs are buffered, exactly as they
+// would be in any other non-PostRoll state, so they become the next incident's pre-roll instead of
+// being published unattributed.
+TEST_F(IncidentReleaserTest, SamplesOfferedDuringARateLimitedReleaseAreBufferedAndDriveTheDrain)
+{
+  auto releaser = makeReleaser(0.0, 0.0, 1.0);  // 1 Hz
+
+  releaser.offer("{\"a\":\"pre-1\"}", at(0.0));
+  releaser.offer("{\"a\":\"pre-2\"}", at(0.5));
+  releaser.offer("{\"a\":\"pre-3\"}", at(0.9));
+
+  releaser.onFlush("incident-1", at(1.0));
+  ASSERT_EQ(published_.size(), 1u);
+  EXPECT_EQ(releaser.bufferedCount(), 0u);
+
+  // offer() ticks first, so a Measurement's polling timer drives the drain on its own: this
+  // sample is buffered and the Record due at 2.0 goes out.
+  releaser.offer("{\"a\":\"during-release\"}", at(2.0));
+  EXPECT_EQ(published_.size(), 2u);
+  EXPECT_EQ(published_[1].json, "{\"a\":\"pre-2\"}");
+  EXPECT_EQ(releaser.bufferedCount(), 1u);
+
+  releaser.tick(at(3.0));
+  ASSERT_EQ(published_.size(), 3u);
+  EXPECT_EQ(published_[2].json, "{\"a\":\"pre-3\"}");
+  EXPECT_TRUE(releaser.isArmed());
+
+  // The sample collected mid-release is the next incident's, not this one's.
+  releaser.onFlush("incident-2", at(4.0));
+  ASSERT_EQ(published_.size(), 4u);
+  EXPECT_EQ(published_[3].json, "{\"a\":\"during-release\"}");
+  EXPECT_EQ(published_[3].incident_id, "incident-2");
+}
+
+// Post-roll is the aftermath window: it starts once the release finishes, so a slow drain doesn't
+// consume it. FlushEvents arriving mid-release belong to the incident already being captured.
+TEST_F(IncidentReleaserTest, PostRollStartsWhenTheRateLimitedReleaseFinishes)
+{
+  auto releaser = makeReleaser(2.0, 0.0, 2.0);  // post-roll 2s, 2 Hz release
+
+  releaser.offer("{\"a\":\"pre-1\"}", at(0.0));
+  releaser.offer("{\"a\":\"pre-2\"}", at(0.2));
+  releaser.offer("{\"a\":\"pre-3\"}", at(0.4));
+
+  releaser.onFlush("incident-1", at(1.0));
+  EXPECT_EQ(releaser.state(), IncidentState::Flushing);
+
+  releaser.onFlush("incident-2", at(1.2));
+  EXPECT_EQ(releaser.state(), IncidentState::Flushing);
+  EXPECT_EQ(releaser.incidentId(), "incident-1");
+  EXPECT_EQ(published_.size(), 1u) << "a second FlushEvent must not restart the release";
+
+  // Last of the three goes out at 2.0; post-roll then runs to 4.0.
+  releaser.tick(at(2.0));
+  ASSERT_EQ(published_.size(), 3u);
+  EXPECT_EQ(releaser.state(), IncidentState::PostRoll) << "state is " << toString(releaser.state());
+
+  releaser.offer("{\"a\":\"post\"}", at(3.9));
+  ASSERT_EQ(published_.size(), 4u);
+  EXPECT_EQ(published_[3].json, "{\"a\":\"post\"}");
+  EXPECT_EQ(published_[3].incident_id, "incident-1");
+
+  releaser.offer("{\"a\":\"after\"}", at(4.1));
+  EXPECT_EQ(published_.size(), 4u);
+  EXPECT_TRUE(releaser.isArmed());
+}
+
+// Default configuration (no rate configured): the whole window still goes out in one burst.
+TEST_F(IncidentReleaserTest, UnlimitedFlushRateReleasesTheWholeWindowInOneBurst)
+{
+  auto releaser = makeReleaser(0.0, 0.0);
+
+  for (int i = 0; i < 5; ++i)
+  {
+    releaser.offer("{\"a\":" + std::to_string(i) + "}", at(i));
+  }
+  releaser.onFlush("incident-1", at(5.0));
+
+  EXPECT_EQ(published_.size(), 5u);
+  EXPECT_EQ(releaser.pendingReleaseCount(), 0u);
+  EXPECT_EQ(releaser.state(), IncidentState::Buffering);
 }
 
 int main(int argc, char** argv)

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -53,6 +53,19 @@ protected:
   void dummyDataCallback(const dc_interfaces::msg::StringStamped& msg)
   {
     received_.push_back(msg.data);
+    // When each Record actually landed, for the rate-limited release (#289).
+    arrivals_.push_back(std::chrono::steady_clock::now());
+  }
+
+  // Milliseconds between the first and the last Record received so far.
+  int receivedSpanMs() const
+  {
+    if (arrivals_.size() < 2)
+    {
+      return 0;
+    }
+    return static_cast<int>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(arrivals_.back() - arrivals_.front()).count());
   }
 
   void publishFlush(const std::string& incident_id)
@@ -112,6 +125,7 @@ protected:
 
 public:
   std::vector<std::string> received_;
+  std::vector<std::chrono::steady_clock::time_point> arrivals_;
 };
 
 // Acceptance criterion: buffer_duration_sec unset/zero preserves today's behavior exactly --
@@ -223,6 +237,44 @@ TEST_F(MeasurementBufferingTest, FullIncidentCycleBuffersFlushesPostRollsCoolsDo
   EXPECT_TRUE(spinUntil([this] { return countTaggedWith("incident-3") > 0; }, 1000))
       << "the Measurement should have re-armed itself after cooldown";
   EXPECT_EQ(countTaggedWith("incident-1"), at_rearm);
+}
+
+// Acceptance criterion (#289): a large buffered window is not burst-published when
+// max_flush_rate_hz is configured -- it is spread out at (at most) that rate, so a robot
+// recovering from an incident doesn't also have to absorb the whole window at once.
+TEST_F(MeasurementBufferingTest, MaxFlushRateSpreadsALargeBufferedWindowOverTime)
+{
+  const double max_flush_rate_hz = 10.0;  // one Record every 100ms
+  const int release_interval_ms = 100;
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", 10.0);
+  ms_node_->declare_parameter("dummy.max_flush_rate_hz", max_flush_rate_hz);
+
+  startLifecycleNode();
+
+  // A second of 50ms polling buffers ~20 samples -- a window far larger than one release
+  // interval, which is what makes the rate limit observable.
+  spinFor(1000);
+  ASSERT_TRUE(received_.empty());
+
+  publishFlush("incident-rate");
+  ASSERT_TRUE(spinUntil([this] { return !received_.empty(); }, 1000));
+
+  // Without the rate limit the whole window would be out by now; at 10Hz only a handful can be.
+  spinFor(300);
+  const int early = static_cast<int>(received_.size());
+  EXPECT_LE(early, 8) << "burst: " << early << " Records in the first 300ms of a 10Hz release";
+
+  // The whole window still makes it out, only spread over time.
+  ASSERT_TRUE(spinUntil([this] { return received_.size() >= 15u; }, 5000))
+      << "only " << received_.size() << " Records released";
+  EXPECT_GT(static_cast<int>(received_.size()), early);
+  EXPECT_EQ(countTaggedWith("incident-rate"), static_cast<int>(received_.size()));
+
+  // n Records at that rate cannot have arrived in less than (n-1) intervals; 70% of that leaves
+  // room for timer and delivery jitter while still failing loudly on a burst (span ~0).
+  const int spacing_count = static_cast<int>(received_.size()) - 1;
+  EXPECT_GE(receivedSpanMs(), (spacing_count * release_interval_ms * 7) / 10)
+      << spacing_count + 1 << " Records arrived within " << receivedSpanMs() << "ms";
 }
 
 int main(int argc, char** argv)

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -79,6 +79,7 @@ Each measurement is collected through a node and has these configuration paramet
 | **buffer_duration_sec**        | Seconds of history to buffer instead of publishing live; 0 disables buffering and preserves normal live publishing | float | 0 |
 | **post_roll_duration_sec**     | Seconds to keep publishing live after a flush, still tagged with the same `incident_id`; 0 means pre-roll only | float | 0 |
 | **cooldown_sec**               | Seconds to ignore further `FlushEvent`s once post-roll ends, before buffering re-arms itself; 0 re-arms immediately | float | 0 |
+| **max_flush_rate_hz**          | Ceiling on how fast the buffered window is emitted once a flush releases it; 0 releases the whole window in one burst | float | 0 |
 | **flush_topic**                | Topic to receive the `FlushEvent` (see [Triggers](./triggers.md)) that releases the buffered window, tagging each Record with the event's `incident_id` | str | "/dc/flush" |
 
 ```admonish info title="buffer_duration_sec and friends: pre-event circular-buffer capture"
@@ -89,14 +90,19 @@ broadcast node when its Trigger fires) then drives one incident-capture cycle:
 
 1. **Buffering** — the default, armed state: samples accumulate in the ring buffer and nothing
    is published. Only in this state does a `FlushEvent` start a cycle.
-2. **Flushing** — the whole buffered window is published at once, oldest first, each Record
-   tagged with the event's `incident_id` and stamped with when it was *collected*, not when it
-   was released. The window is consumed, so the next incident releases its own history rather
-   than replaying this one.
-3. **PostRoll** — for `post_roll_duration_sec` after the flush, samples are published live as
-   they are collected, still tagged with the same `incident_id`, so the aftermath of the
-   incident is captured too. Left at its default 0, this phase is skipped entirely: pre-roll
-   only.
+2. **Flushing** — the buffered window is published oldest first, each Record tagged with the
+   event's `incident_id` and stamped with when it was *collected*, not when it was released.
+   With `max_flush_rate_hz` left at 0 the whole window goes out in one burst; set above 0, it is
+   emitted at no more than that many Records per second, so a robot recovering from an incident
+   does not also have to absorb the entire window at once. The window is consumed, so the next
+   incident releases its own history rather than replaying this one. Samples collected while a
+   rate-limited release is still draining are buffered, not published, and so become part of the
+   *next* incident's pre-roll.
+3. **PostRoll** — for `post_roll_duration_sec` after the release finishes, samples are published
+   live as they are collected, still tagged with the same `incident_id`, so the aftermath of the
+   incident is captured too. It runs from the end of the release, not from the `FlushEvent`, so
+   a rate-limited release does not eat into it. Left at its default 0, this phase is skipped
+   entirely: pre-roll only.
 4. **Cooldown** — for `cooldown_sec` after post-roll ends, further `FlushEvent`s are ignored, so
    a flapping Trigger cannot produce a flood of overlapping incidents. Samples are buffered
    again during this phase, so the next incident still gets a full pre-roll window.
@@ -104,8 +110,7 @@ broadcast node when its Trigger fires) then drives one incident-capture cycle:
 The Measurement then re-arms itself back to **Buffering** with no manual intervention — a
 second incident is captured exactly like the first. With both `post_roll_duration_sec` and
 `cooldown_sec` left at 0, a flush releases the pre-roll window and the Measurement is armed
-again immediately. Rate-limited release of the buffered window is not implemented yet: the
-whole window goes out in one burst.
+again immediately.
 ```
 
 ```admonish info title="gate_condition vs. if_all/if_any/if_none_conditions"

--- a/progress.txt
+++ b/progress.txt
@@ -6150,3 +6150,94 @@ publish live for good" into the full per-Measurement state machine #282 specifie
   this host) and `pycln`/`flake8` on the pre-existing violation in
   `tools/e2e/scripts/verify_zero_loss.py`, which the hooks reformat repo-wide and which was
   reverted again here to keep this diff scoped, exactly as in the #285/#286/#287 sessions.
+
+## #289 - Rate-limit IncidentReleaser's buffered-window release
+
+Fourth implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), on top of #285's `RecordRingBuffer`, #286's `dc_triggers`, #287's flush wiring and
+#288's `IncidentReleaser` state machine. Turns #288's burst release ("the whole window goes
+out in one `onFlush()`") into a paced one, so a robot recovering from whatever triggered the
+incident doesn't also have to push its entire pre-roll window through the Bridge at once.
+
+- **New parameter `max_flush_rate_hz`** (double, default 0.0 = unlimited, today's burst
+  behavior): read in `loadMeasurementPlugins()` via the existing
+  `dc_util::get_double_type_param`, resized/logged alongside the other three buffering
+  parameters, and threaded through `dc_core::Measurement::configure()` -- inserted after
+  `cooldown_sec` and before `flush_topic`, keeping all buffering parameters in one run, the
+  same placement rule #288 used (safe: `dc_measurements::Measurement` is still the only
+  implementor and `MeasurementServer` its only caller).
+- **`dc_measurements/include/dc_measurements/incident_releaser.hpp`**: `Flushing` stops being
+  a state the machine passes straight through and becomes one it can *sit in*.
+  - The constructor takes `max_flush_rate_hz` and stores it as a `release_interval_`
+    (`1/hz`, zero meaning "no limit").
+  - `onFlush()` no longer publishes the window in a loop: it moves `buffer_.window()` into a
+    `pending_` vector (plus a `pending_index_` cursor -- an index rather than a `pop_front` so
+    released Records aren't shuffled down one by one), clears the buffer as before, sets
+    `next_release_ = now` and calls the new `drainRelease(now)`.
+  - `drainRelease()` emits every pending Record that has come due (`now >= next_release_`,
+    advancing `next_release_` by one interval each time) and returns while any remain, leaving
+    the machine in `Flushing`; once the window is out it does what `onFlush()` used to do at
+    the end -- enter `PostRoll` or `enterCooldown()`. With no rate configured the loop runs to
+    completion in one call, so the unlimited path is byte-for-byte the old behavior.
+  - `tick()` drives the drain first, then the existing post-roll/cooldown expiries.
+  - **Rate semantics, deliberate**: the cap is on the emission rate *over time*, not on how
+    many Records a single `tick()` may emit. A coarse tick catches up on everything that came
+    due since the last one and no more. The alternative (at most one Record per tick) would
+    cap the drain at the caller's tick rate, which for a Measurement is its polling rate --
+    `max_flush_rate_hz` above the polling rate would then do nothing at all and every release
+    would take as long as the buffer window itself.
+  - **Post-roll now runs from the end of the release**, not from the `FlushEvent`, so a slow
+    drain doesn't eat the aftermath window it exists to capture. Samples collected *during* a
+    rate-limited release are buffered (as in every non-`PostRoll` state), so they become the
+    next incident's pre-roll rather than going out unattributed -- the safe choice over
+    appending them to `pending_`, which would never drain if collection outpaced the
+    configured rate.
+  - New `pendingReleaseCount()` accessor beside `bufferedCount()` for assertions.
+- **`dc_measurements/include/dc_measurements/measurement.hpp`**:
+  - When `max_flush_rate_hz > 0`, `configure()` creates a `release_timer_` wall timer at the
+    release interval whose callback just `tick()`s the releaser. Without it the drain would
+    only advance on the polling timer -- in bursts of `polling_interval / release_interval`
+    Records, and never faster than collection.
+  - `offerSample()` now `tick()`s the releaser even when the collected sample is empty/`null`,
+    so an idle or failing `collect()` can't stall a release in progress.
+  - New `releaser_mutex_` serializes the three paths that now reach the state machine
+    concurrently (polling timer, FlushEvent subscription, release timer -- `client_cb_group_`
+    is Reentrant). `cleanup()` resets `release_timer_` before the releaser and takes the lock
+    to reset it; the timer callback null-checks `releaser_` as well.
+- **Tests**:
+  - `test_incident_releaser.cpp` (10 -> 15 cases; `makeReleaser()` gained a defaulted
+    `max_flush_rate_hz` argument so the existing 10 are untouched): the acceptance criterion
+    (5 buffered Records at 2Hz -- one out with the flush, nothing before the interval elapses,
+    exactly one on it, a coarse tick catching up exactly the two that came due, same order and
+    original stamps throughout); a property check ticking every 50ms for 6s over a 20-Record
+    window at 4Hz asserting the count never exceeds `1 + elapsed * rate`; samples offered
+    mid-release being buffered and becoming the *next* incident's window while their `offer()`
+    drives the drain; post-roll starting when the release finishes and a `FlushEvent`
+    mid-release being ignored; and the default (no rate) still releasing in one burst.
+  - `test_measurement_buffering.cpp`: new `MaxFlushRateSpreadsALargeBufferedWindowOverTime` --
+    ~20 samples buffered at 50ms polling, released at 10Hz; asserts at most 8 Records in the
+    first 300ms (a burst would deliver all 20), that the whole window still comes out, that
+    every Record carries the incident_id, and -- via a new `arrivals_` vector of receive
+    timestamps and a `receivedSpanMs()` helper -- that n Records span at least 70% of
+    `(n-1) * 100ms`, which is the "did not burst" assertion proper (a burst spans ~0ms).
+- **Docs**: `doc/src/dc/measurements.md` gains a `max_flush_rate_hz` row; the Flushing and
+  PostRoll steps of the buffering admonish block now describe the paced release, where
+  mid-release samples go, and post-roll's new anchor; the "rate-limited release is not
+  implemented yet" sentence is gone.
+- **Verified**: `podman run` against `localhost/dc-workspace` (Jazzy) with this worktree
+  bind-mounted over `/root/ws/src/ros2_data_collection`, as in #284-#288. `colcon build
+  --packages-select dc_common dc_core dc_interfaces dc_measurements --cmake-args
+  -DBUILD_TESTING=ON` succeeded with zero warnings under `-Wall -Wextra -Wpedantic -Werror
+  -Wdeprecated`, then `colcon test` + `colcon test-result --all`: **241 tests, 0 errors, 0
+  failures, 0 skipped** (up from #288's 235: +5 `test_incident_releaser` cases, +1 lifecycle
+  case). The unit test was also compiled and run standalone (`g++ -std=c++17 -Wall -Wextra
+  -Wpedantic -Werror -I dc_measurements/include -I dc_common/include ... -lgtest`) inside the
+  same image -- seconds instead of the 12-minute colcon loop, which is the payoff of keeping
+  `IncidentReleaser` ROS-free.
+- `pre-commit run --files <changed>` passed `clang-format` (it reflowed the
+  `RCLCPP_INFO_STREAM` in `measurement_server.cpp` and one `EXPECT_EQ` in the new unit test;
+  both left as formatted), `codespell`, the mdbook doc build, XML lint,
+  `ros2_ws_same_versions`/`ros2_ws_set_metadata` and the rest. The only failures are the two
+  long-standing local-environment ones: `poetry-requirements` (no `poetry` module on this
+  host) and `black` on the pre-existing violation in `tools/e2e/scripts/verify_zero_loss.py`,
+  reverted again here to keep this diff scoped, exactly as in the #285-#288 sessions.


### PR DESCRIPTION
## What

Adds a `max_flush_rate_hz` parameter capping how fast an incident's buffered window is emitted once a `FlushEvent` releases it, so a large backlog is paced rather than burst-published at exactly the moment a robot is recovering from whatever triggered the incident.

Fourth implementation slice of #282, on top of #285 (`RecordRingBuffer`), #286 (`dc_triggers`), #287 (flush wiring) and #288 (`IncidentReleaser` state machine).

## How

- **`IncidentReleaser`**: `Flushing` stops being a state the machine passes straight through and becomes one it can sit in. `onFlush()` moves the window into a `pending_` queue; the new `drainRelease()` emits whatever the configured rate allows on each `tick()` and enters `PostRoll`/`Cooldown` only once the window is out. With the parameter at its default `0` the loop runs to completion in one call — byte-for-byte the previous burst behavior.
- **Rate semantics**: the cap is on the emission rate *over time*, not on how many Records one `tick()` may emit — a coarse tick catches up on everything that came due since the last one and no more. The alternative (at most one per tick) would cap the drain at the caller's tick rate, i.e. the Measurement's polling rate, making any `max_flush_rate_hz` above it a no-op.
- **Post-roll now runs from the end of the release**, not from the `FlushEvent`, so a slow drain doesn't eat the aftermath window it exists to capture. Samples collected *during* a release are buffered (as in every non-`PostRoll` state) and become the next incident's pre-roll — the safe choice over appending them to the pending queue, which would never drain if collection outpaced the configured rate.
- **`Measurement`**: a `release_timer_` paces the drain independently of the polling timer (which would otherwise release in bursts and never faster than collection), `offerSample()` ticks even on an empty collection so an idle `collect()` can't stall a release, and a new mutex serializes the three callbacks that now reach the state machine concurrently.
- **Parameter plumbing**: `max_flush_rate_hz` (double, default `0.0`) read in `loadMeasurementPlugins()` and threaded through `dc_core::Measurement::configure()`, inserted after `cooldown_sec` so all four buffering parameters stay together.

## Acceptance criteria

- [x] `max_flush_rate_hz` controls the emission rate during the Flushing state
- [x] `IncidentReleaser` unit test asserts emission spacing respects the configured rate for a buffered window larger than one publish interval
- [x] Lifecycle test confirms a large buffered window does not burst-publish faster than the configured rate

## Tests

`test_incident_releaser.cpp` 10 → 15 cases: the spacing criterion (5 Records at 2Hz across several ticks, including a coarse tick catching up exactly what came due); a property check ticking every 50ms for 6s over a 20-Record window at 4Hz asserting the count never exceeds `1 + elapsed * rate`; mid-release samples being buffered and driving the drain; post-roll starting when the release finishes and a mid-release `FlushEvent` being ignored; and the default still releasing in one burst.

`test_measurement_buffering.cpp` gains `MaxFlushRateSpreadsALargeBufferedWindowOverTime`: ~20 samples buffered at 50ms polling, released at 10Hz — at most 8 Records in the first 300ms (a burst would deliver all 20), the whole window still arriving, and n Records spanning at least 70% of `(n-1) * 100ms` (a burst spans ~0ms).

## Verification

`colcon build --packages-select dc_common dc_core dc_interfaces dc_measurements --cmake-args -DBUILD_TESTING=ON` in the Jazzy workspace image: zero warnings under `-Wall -Wextra -Wpedantic -Werror -Wdeprecated`. `colcon test` + `colcon test-result --all`: **241 tests, 0 errors, 0 failures, 0 skipped** (235 before: +5 unit cases, +1 lifecycle case). Docs updated in `doc/src/dc/measurements.md`; `pre-commit` clean apart from the two long-standing local-environment failures (`poetry-requirements`, and `black` on the pre-existing `verify_zero_loss.py` violation, reverted here as in previous sessions).

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DjSpuCpnvjudH3AZpNU6xk