### PR TITLE
feat(dc_measurements): stage Files into a FileScratchRing while incident capture is armed

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -87,10 +87,15 @@ install(TARGETS dc_bridge DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  # Header-only, ROS-free utilities (#285). Tests only: uploader_test stages a File the way an
+  # armed Measurement does (#290) to check the Files pipeline ingests a released one unchanged.
+  # dc_bridge itself needs no part of it — the Bridge is deliberately unaware of incident capture.
+  find_package(dc_common REQUIRED)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
   foreach(t forwarder supervisor render misc uploader intent_queue retention thumbnail raw_config)
     ament_add_gtest(${t}_test test/${t}_test.cpp)
     target_link_libraries(${t}_test dc_bridge_core)
+    ament_target_dependencies(${t}_test dc_common)
     target_compile_definitions(${t}_test PRIVATE
       DC_BRIDGE_FIXTURES_DIR="${CMAKE_CURRENT_SOURCE_DIR}/test/fixtures/render")
   endforeach()

--- a/dc_bridge/package.xml
+++ b/dc_bridge/package.xml
@@ -47,6 +47,10 @@
   <exec_depend>ffmpeg</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
+  <!-- Tests only (uploader_test, #290): dc_common's header-only FileScratchRing, so the Files
+       pipeline can be exercised against a File staged exactly the way an armed Measurement
+       stages it. The Bridge itself has no incident-capture code and depends on none of it. -->
+  <test_depend>dc_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/dc_bridge/test/uploader_test.cpp
+++ b/dc_bridge/test/uploader_test.cpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <fstream>
 #include <map>
@@ -14,6 +15,10 @@
 #include <set>
 #include <string>
 #include <vector>
+
+// The Measurement side of #290 stages Files with this; the test uses the real thing rather than
+// imitating it, so what the Bridge is handed here is exactly what a released Record carries.
+#include "dc_common/file_scratch_ring.hpp"
 
 using namespace dc_bridge;
 using namespace dc_bridge::uploader;
@@ -769,4 +774,42 @@ TEST(UploaderThumbnails, MissingLocalFileNeverAttemptsAPreview)
   EXPECT_EQ(summary.missing, 1u);
   EXPECT_TRUE(thumbs.sources->empty());
   EXPECT_EQ(summary.thumbnails_failed, 0u);
+}
+
+// #290: pre-event circular-buffer capture staged this File into a dc_common::FileScratchRing
+// while its Measurement was armed, released it minutes later when a Trigger fired, and published
+// a Record pointing at the staged copy. The claim this test pins down is that the Bridge needs no
+// change for that: the released Record is an ordinary Files Record — an old timestamp, an
+// incident_id it ignores, a local_path that happens to live in a scratch directory — and the
+// existing pipeline uploads it byte for byte under the remote key the Measurement computed at
+// collection time.
+TEST(Uploader, IncidentReleasedScratchFilesAreIngestedUnmodified)
+{
+  Fixture fx({ "minio" });
+  auto produced = fx.write_file("frame.jpg", JPEG_BYTES);
+
+  dc_common::FileScratchRing ring(fx.tmp / "scratch", std::chrono::seconds(30));
+  const auto collected_at = std::chrono::system_clock::now() - std::chrono::minutes(5);
+  auto staged = ring.stage(produced, collected_at);
+  auto payload = camera_payload(staged.string(), { "minio" });
+  // What measurement.hpp's publishIncidentRecord() adds on the way out; nothing in the Files
+  // pipeline knows or cares about it.
+  payload["incident_id"] = "incident-42";
+  // Releasing hands the staged copies to the Bridge: the ring stops tracking them, so its rolling
+  // eviction can no longer delete one out from under an upload in flight.
+  ASSERT_EQ(ring.release().size(), 1u);
+  ring.evict(std::chrono::system_clock::now());
+  ASSERT_TRUE(std::filesystem::exists(staged));
+
+  auto up = fx.uploader(true);  // delete_when_sent: the staged copy is the Bridge's to clean up
+  auto rows = std::make_shared<std::vector<json>>();
+
+  auto summary = up.process_record(payload, "dc.measurement.camera", collect_rows(rows));
+
+  EXPECT_EQ(summary.files, 1u);
+  EXPECT_EQ(summary.verified, 1u);
+  EXPECT_TRUE(summary.group_complete);
+  EXPECT_EQ(fx.stores[0]->object_bytes("cam/2026/img.jpg"), JPEG_BYTES);
+  EXPECT_EQ(rows_of_kind(*rows, "file_status")[0]["local_path"], staged.string());
+  EXPECT_FALSE(std::filesystem::exists(staged));
 }

--- a/dc_common/include/dc_common/file_scratch_ring.hpp
+++ b/dc_common/include/dc_common/file_scratch_ring.hpp
@@ -35,7 +35,9 @@ struct ScratchedFile
  * copies older than the configured window, from disk and from window(). window() reports the
  * current contents as an ordered list of (path, timestamp), oldest first. Same push/evict/read
  * shape as RecordRingBuffer, and the same "evict is caller-driven, not push-driven" contract: the
- * window is relative to a caller-supplied "now", not to the last stage() call.
+ * window is relative to a caller-supplied "now", not to the last stage() call. Two ways out
+ * besides evict(): release() hands the window on without deleting anything (the staged copies now
+ * belong to whoever the caller passed them to), purge() deletes the lot regardless of age.
  *
  * Part of pre-event circular-buffer capture (#282) -- exercised purely against a tmp directory in
  * tests, same as RecordRingBuffer against an injected clock.
@@ -93,6 +95,41 @@ public:
   std::vector<ScratchedFile> window() const
   {
     return std::vector<ScratchedFile>(entries_.begin(), entries_.end());
+  }
+
+  /**
+   * @brief Hand the current window on: returns it oldest-first and stops tracking it, deleting
+   * nothing from disk. The RecordRingBuffer::clear() analogue -- what the ring "forgetting" an
+   * entry means for a File is "someone else owns it now", not "delete it".
+   *
+   * Called when an incident releases the buffered window (#290): from then on the staged copies
+   * belong to whoever the released Records were handed to (the Bridge's Files pipeline -- upload,
+   * retention sweep, delete_when_sent), so a later evict() must not delete a File out from under
+   * an upload in flight.
+   */
+  std::vector<ScratchedFile> release()
+  {
+    std::vector<ScratchedFile> released(entries_.begin(), entries_.end());
+    entries_.clear();
+    return released;
+  }
+
+  /**
+   * @brief Delete every staged File still tracked, from disk and from window(), whatever its age.
+   *
+   * The counterpart of release(): used when the Records referencing the staged copies are being
+   * dropped rather than published (a lifecycle cleanup), so nothing will ever pick them up and
+   * leaving them behind would just orphan them on disk. Tolerates a File already gone, same as
+   * evict().
+   */
+  void purge()
+  {
+    for (const auto& entry : entries_)
+    {
+      std::error_code ec;
+      std::filesystem::remove(entry.path, ec);
+    }
+    entries_.clear();
   }
 
   std::size_t size() const

--- a/dc_common/test/file_scratch_ring_test.cpp
+++ b/dc_common/test/file_scratch_ring_test.cpp
@@ -183,6 +183,61 @@ TEST(FileScratchRing, EvictToleratesAStagedFileAlreadyMissingFromDisk)
   EXPECT_TRUE(ring.empty());
 }
 
+TEST(FileScratchRing, ReleaseHandsTheWindowOnWithoutDeletingAnything)
+{
+  // #290: the released Files belong to the Bridge's Files pipeline from here on, so release()
+  // must forget them without touching disk -- and a later evict() must not delete them either.
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto first = ring.stage(fx.write_source("first.jpg"), at(0));
+  auto second = ring.stage(fx.write_source("second.jpg"), at(1));
+
+  auto released = ring.release();
+
+  EXPECT_EQ(paths_of(released), std::vector<std::filesystem::path>({ first, second }));
+  EXPECT_TRUE(ring.empty());
+  EXPECT_TRUE(std::filesystem::exists(first));
+  EXPECT_TRUE(std::filesystem::exists(second));
+
+  ring.evict(at(10000));  // long past the window: the ring no longer knows about them.
+  EXPECT_TRUE(std::filesystem::exists(first));
+  EXPECT_TRUE(std::filesystem::exists(second));
+}
+
+TEST(FileScratchRing, ReleaseOnEmptyRingReturnsNothing)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  EXPECT_TRUE(ring.release().empty());
+  EXPECT_TRUE(ring.empty());
+}
+
+TEST(FileScratchRing, PurgeDeletesEveryStagedFileWhateverItsAge)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto old_path = ring.stage(fx.write_source("old.jpg"), at(0));
+  auto new_path = ring.stage(fx.write_source("new.jpg"), at(9));
+
+  ring.purge();  // no "now": nothing staged survives, however fresh.
+
+  EXPECT_TRUE(ring.empty());
+  EXPECT_FALSE(std::filesystem::exists(old_path));
+  EXPECT_FALSE(std::filesystem::exists(new_path));
+}
+
+TEST(FileScratchRing, PurgeToleratesAStagedFileAlreadyMissingFromDisk)
+{
+  Fixture fx;
+  FileScratchRing ring(fx.scratch, std::chrono::seconds(10));
+  auto staged = ring.stage(fx.write_source("gone.jpg"), at(0));
+  std::filesystem::remove(staged);
+
+  ring.purge();
+
+  EXPECT_TRUE(ring.empty());
+}
+
 TEST(FileScratchRing, StageThrowsWhenSourceFileDoesNotExist)
 {
   Fixture fx;

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cmath>
 #include <ctime>
+#include <filesystem>
 #include <fstream>
 #include <memory>
 #include <mutex>
@@ -15,6 +16,7 @@
 #include <utility>
 #include <vector>
 
+#include "dc_common/file_scratch_ring.hpp"
 #include "dc_core/condition.hpp"
 #include "dc_core/condition_set.hpp"
 #include "dc_core/measurement.hpp"
@@ -542,16 +544,168 @@ public:
   // which buffers it or (during post-roll) publishes it live through publishIncidentRecord() (#288).
   void offerSample(dc_interfaces::msg::StringStamped msg)
   {
+    const auto now = std::chrono::system_clock::now();
     if (msg.data.empty() || msg.data == "null")
     {
       // Nothing to offer, but the phase deadlines and a rate-limited release still need driving.
       const std::lock_guard<std::mutex> lock(releaser_mutex_);
-      releaser_->tick(std::chrono::system_clock::now());
+      releaser_->tick(now);
       return;
     }
     enrichMsg(msg);
     const std::lock_guard<std::mutex> lock(releaser_mutex_);
-    releaser_->offer(msg.data, std::chrono::system_clock::now());
+    // Drive the phase transitions before deciding what to do with this sample's Files: during
+    // post-roll the Record is published live and its Files are left exactly where the Measurement
+    // wrote them, which is what the Bridge has always picked up.
+    releaser_->tick(now);
+    if (releaser_->state() != IncidentState::PostRoll)
+    {
+      stageSampleFiles(msg, now);
+    }
+    releaser_->offer(msg.data, now);
+  }
+
+  // A buffered Record's Files, staged (#290). Called for every sample the releaser is about to
+  // buffer rather than publish: each File the Record references is moved into the scratch ring and
+  // the Record rewritten to point at the staged copy, then the ring is aged like the Record ring
+  // buffer it shadows, so an armed Measurement's Files stay bounded by buffer_duration_sec instead
+  // of piling up in the save path with no Record to ever carry them to the Bridge.
+  //
+  // Caller holds releaser_mutex_.
+  void stageSampleFiles(dc_interfaces::msg::StringStamped& msg, const std::chrono::system_clock::time_point& now)
+  {
+    json data_json;
+    try
+    {
+      data_json = json::parse(msg.data);
+    }
+    catch (json::parse_error& e)
+    {
+      // enrichMsg() already logged whatever made this unparsable; buffer it as-is.
+      return;
+    }
+    if (stageRecordFiles(data_json, now))
+    {
+      msg.data = data_json.dump(-1, ' ', true);
+    }
+    // Rolling deletion of the aged-out staged Files -- the disk-backed half of the same eviction
+    // the ring buffer does to their Records, driven with the same `now` and the same window, so
+    // the two stay in step. Safe to run mid-release: onFlushEvent() released the window being
+    // drained out of the ring's ownership before the drain started.
+    if (file_scratch_ring_)
+    {
+      file_scratch_ring_->evict(now);
+    }
+  }
+
+  // Stage every File `value` references, rewriting each local_paths entry to its staged copy.
+  // Returns whether anything was staged. Walks the Record the same way dc_bridge's
+  // parse_file_group() does, so exactly the paths the Bridge would have uploaded are the ones
+  // that move: local_paths at any depth (a `nested` Measurement puts it under its own name),
+  // never base64 (inline content, not a path).
+  bool stageRecordFiles(json& value, const std::chrono::system_clock::time_point& stamp)
+  {
+    if (!value.is_object())
+    {
+      return false;
+    }
+
+    bool staged = false;
+    auto local_paths_it = value.find("local_paths");
+    if (local_paths_it != value.end() && local_paths_it->is_object())
+    {
+      for (auto it = local_paths_it->begin(); it != local_paths_it->end(); ++it)
+      {
+        staged = stageOneFile(*it, stamp) || staged;
+      }
+    }
+
+    for (auto it = value.begin(); it != value.end(); ++it)
+    {
+      const std::string& key = it.key();
+      if (key == "local_paths" || key == "remote_paths" || key == "base64")
+      {
+        continue;
+      }
+      // A `flatten`ed Record has no nested objects left: its keys are JSON pointers, so the File
+      // paths show up as "/local_paths/raw" (or "/<name>/local_paths/raw" when also nested).
+      if (it->is_string() && key.find("/local_paths/") != std::string::npos)
+      {
+        staged = stageOneFile(*it, stamp) || staged;
+        continue;
+      }
+      staged = stageRecordFiles(*it, stamp) || staged;
+    }
+    return staged;
+  }
+
+  // Move one File into the scratch ring and rewrite `path_value` to the staged copy.
+  bool stageOneFile(json& path_value, const std::chrono::system_clock::time_point& stamp)
+  {
+    if (!path_value.is_string())
+    {
+      return false;
+    }
+    const std::string original = path_value.get<std::string>();
+    if (original.empty())
+    {
+      return false;
+    }
+
+    try
+    {
+      const auto staged_path = scratchRing()->stage(original, stamp);
+      // Staging *moves* the File: the Record referencing the original is buffered, not published,
+      // so nothing will ever pick that original up -- neither the Bridge (which never sees the
+      // Record) nor its retention sweep. Leaving it behind would grow the save path without bound
+      // for as long as the Measurement stays armed, which is exactly what the bounded ring exists
+      // to prevent. The copy the ring made is what the released Record points at, and it uploads
+      // to the unchanged remote_paths key the Measurement computed at collection time.
+      std::error_code ec;
+      std::filesystem::remove(original, ec);
+      path_value = staged_path.string();
+      return true;
+    }
+    catch (const std::filesystem::filesystem_error& e)
+    {
+      RCLCPP_ERROR_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                   "Measurement " << measurement_name_ << ": could not stage File " << original
+                                                  << " into the incident scratch ring (" << e.what()
+                                                  << "); buffering the Record with the File left in place.");
+      return false;
+    }
+  }
+
+  // The scratch ring, created on the first Record that actually references a File so the many
+  // Measurements that produce none never grow a scratch directory. Caller holds releaser_mutex_.
+  const std::shared_ptr<dc_common::FileScratchRing>& scratchRing()
+  {
+    if (!file_scratch_ring_)
+    {
+      file_scratch_ring_ =
+          std::make_shared<dc_common::FileScratchRing>(scratchDir(), durationFromSeconds(buffer_duration_sec_));
+    }
+    return file_scratch_ring_;
+  }
+
+  // Where staged Files live: one stable directory per Measurement, next to the Files themselves
+  // (same filesystem, so staging is a cheap local move) but outside the dated save tree. The
+  // literal prefix of save_local_base_path is used -- everything up to its first strftime token --
+  // so the scratch directory doesn't roll over every hour the way the save path does.
+  std::filesystem::path scratchDir() const
+  {
+    std::string base = save_local_base_path_expanded_;
+    const auto token = base.find('%');
+    if (token != std::string::npos)
+    {
+      const auto slash = base.rfind('/', token);
+      base = (slash == std::string::npos) ? std::string() : base.substr(0, slash);
+    }
+    if (base.empty())
+    {
+      base = std::filesystem::temp_directory_path().string();
+    }
+    return std::filesystem::path(base) / ".dc_incident_scratch" / measurement_name_;
   }
 
   // Emits one Record belonging to an incident -- either released from the pre-roll buffer (stamped
@@ -589,8 +743,28 @@ public:
     {
       return;
     }
+    const auto now = std::chrono::system_clock::now();
     const std::lock_guard<std::mutex> lock(releaser_mutex_);
-    releaser_->onFlush(event.incident_id, std::chrono::system_clock::now());
+    releaser_->tick(now);
+    // Whether this event starts a cycle has to be read before onFlush() acts on it, since acting
+    // on it is exactly what makes isArmed() false.
+    const bool starts_cycle = releaser_->isArmed();
+    if (file_scratch_ring_ && starts_cycle)
+    {
+      // Staged Files that have aged out are not part of the window this incident releases (their
+      // Records were evicted from the ring buffer too): delete them first, so what survives to
+      // release() below is exactly what the released Records reference.
+      file_scratch_ring_->evict(now);
+    }
+    releaser_->onFlush(event.incident_id, now);
+    if (file_scratch_ring_ && starts_cycle)
+    {
+      // The released Records are on their way to the Bridge, which owns their Files from here
+      // (intent queue, upload, retention sweep, delete_when_sent). Stop tracking them so no later
+      // evict() can delete a File out from under an upload in flight -- #290's whole point being
+      // that the Bridge needs no change to ingest them, however old their timestamps are.
+      file_scratch_ring_->release();
+    }
   }
 
   virtual dc_interfaces::msg::StringStamped collect() = 0;
@@ -733,6 +907,14 @@ public:
     {
       const std::lock_guard<std::mutex> lock(releaser_mutex_);
       releaser_.reset();
+      if (file_scratch_ring_)
+      {
+        // The buffered Records go with the releaser, so the Files they referenced would be
+        // orphaned in the scratch directory: nothing is left to publish them. Released ones are
+        // untracked by now (onFlushEvent()) and are the Bridge's, so purge() can't touch them.
+        file_scratch_ring_->purge();
+        file_scratch_ring_.reset();
+      }
     }
     onCleanup();
   }
@@ -833,8 +1015,14 @@ protected:
   rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr flush_sub_;
   // Paces a rate-limited release; only created when max_flush_rate_hz_ > 0 (#289).
   rclcpp::TimerBase::SharedPtr release_timer_;
+  // The Files half of incident capture (#290): while the releaser buffers a Record instead of
+  // publishing it, the Files that Record references are moved in here and the Record rewritten to
+  // point at the staged copies, which age out on the same window as the Records themselves.
+  // Created lazily by scratchRing(), on the first Record that references a File at all.
+  std::shared_ptr<dc_common::FileScratchRing> file_scratch_ring_;
   // The releaser is reached from three concurrent paths -- the polling timer, the FlushEvent
-  // subscription and release_timer_ -- so every entry into it is serialized here.
+  // subscription and release_timer_ -- so every entry into it, and into the scratch ring that
+  // shadows it, is serialized here.
   std::mutex releaser_mutex_;
 };
 

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -376,6 +376,12 @@ TEST_F(MeasurementBufferingTest, MaxFlushRateSpreadsALargeBufferedWindowOverTime
 TEST_F(MeasurementBufferingTest, FileProducingMeasurementStagesFilesWhileArmedAndReleasesTheStagedCopies)
 {
   ms_node_->declare_parameter("dummy.buffer_duration_sec", 1.0);
+  // Pace the release (#289). data_pub_ is KeepLast(1), so releasing a whole window in one
+  // synchronous burst leaves the middleware delivering only the last Record of it -- the very
+  // pressure the rate limit exists to relieve. At 20Hz every released Record reaches the
+  // subscription, so the assertions below cover the whole window rather than whichever Record
+  // happened to survive it.
+  ms_node_->declare_parameter("dummy.max_flush_rate_hz", 20.0);
   useFileProducingRecord();
 
   startLifecycleNode();
@@ -387,8 +393,8 @@ TEST_F(MeasurementBufferingTest, FileProducingMeasurementStagesFilesWhileArmedAn
   ASSERT_GE(staged_while_armed.size(), 3u) << "the produced Files should have been staged";
 
   publishFlush("incident-files");
-  ASSERT_TRUE(spinProducingUntil([this] { return !received_.empty(); }, 1000));
-  spinProducing(polling_interval_ * 3);
+  ASSERT_TRUE(spinProducingUntil([this] { return received_.size() >= 3u; }, 3000))
+      << "only " << received_.size() << " Records released";
 
   ASSERT_GE(received_.size(), 3u);
   EXPECT_EQ(countTaggedWith("incident-files"), static_cast<int>(received_.size()));

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -1,9 +1,14 @@
 #include <gtest/gtest.h>
+#include <unistd.h>
 
+#include <algorithm>
 #include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
 #include "dc_interfaces/msg/flush_event.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
@@ -11,22 +16,38 @@
 
 using json = nlohmann::json;
 
+// Stands in for the bytes a File-producing Measurement (camera, map, ...) writes out.
+const char* const kProducedContents = "fake-jpeg-body";
+
 class MeasurementBufferingTest : public ::testing::Test
 {
 protected:
   MeasurementBufferingTest()
   {
+    // Before SetUp(), which the constructor calls itself: the paths are what the parameters
+    // declared there point at.
+    tmp_ = std::filesystem::temp_directory_path() / ("dc_measurement_buffering_test_" + std::to_string(::getpid()));
+    produced_file_ = tmp_ / "produced" / "frame.jpg";
+    // Where measurement.hpp's scratchDir() puts this Measurement's staged Files, given
+    // save_local_base_path below (no strftime token in it, so it is used as-is).
+    scratch_dir_ = tmp_ / ".dc_incident_scratch" / "dummy";
     SetUp();
   }
 
   ~MeasurementBufferingTest() override
   {
+    std::error_code ec;
+    std::filesystem::remove_all(tmp_, ec);
   }
 
   void SetUp() override
   {
+    std::filesystem::create_directories(produced_file_.parent_path());
     ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
                                                                        std::vector<std::string>{ "dummy" });
+    // Keep the Files this test stages (and the scratch tree beside them) inside the fixture's
+    // tmp directory instead of the default $HOME/ros2/data.
+    ms_node_->declare_parameter("save_local_base_path", tmp_.string());
     sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
         "/dc/measurement/dummy", rclcpp::SystemDefaultsQoS(),
         std::bind(&MeasurementBufferingTest::dummyDataCallback, this, std::placeholders::_1));
@@ -90,6 +111,74 @@ protected:
     return count;
   }
 
+  // Turn the dummy Measurement into a File-producing one: a Record shaped exactly like camera's
+  // (local_paths + the remote_paths key the Bridge uploads it under), pointing at produced_file_.
+  void useFileProducingRecord()
+  {
+    json record;
+    record["local_paths"]["raw"] = produced_file_.string();
+    record["remote_paths"]["minio"]["raw"] = "cam/2026/frame.jpg";
+    ms_node_->set_parameter(rclcpp::Parameter("dummy.record", record.dump()));
+    writeProducedFile();
+  }
+
+  void writeProducedFile() const
+  {
+    std::ofstream(produced_file_, std::ios::binary) << kProducedContents;
+  }
+
+  // Spin while a File-producing Measurement keeps producing: the File is put back as soon as the
+  // Measurement has consumed it, the way a real one writes a fresh File on every collection. The
+  // Measurement's polling timer runs inside spin_some() on this thread, so there is no race --
+  // the File is always back in place before the next collection, and still there when the spin
+  // returns.
+  void spinProducing(int milliseconds)
+  {
+    spinProducingUntil([] { return false; }, milliseconds);
+  }
+
+  // spinUntil()'s producing counterpart; returns whether `done` held before `timeout_ms`.
+  bool spinProducingUntil(const std::function<bool()>& done, int timeout_ms)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (true)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      if (!std::filesystem::exists(produced_file_))
+      {
+        writeProducedFile();
+      }
+      if (done())
+      {
+        return true;
+      }
+      if ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time))
+              .count() >= timeout_ms)
+      {
+        return false;
+      }
+    }
+  }
+
+  // Names of the Files currently staged in this Measurement's scratch directory.
+  std::vector<std::string> scratchFiles() const
+  {
+    std::vector<std::string> names;
+    std::error_code ec;
+    for (const auto& entry : std::filesystem::directory_iterator(scratch_dir_, ec))
+    {
+      names.push_back(entry.path().filename().string());
+    }
+    std::sort(names.begin(), names.end());
+    return names;
+  }
+
+  static std::string fileContents(const std::filesystem::path& path)
+  {
+    std::ifstream in(path, std::ios::binary);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  }
+
   void spinFor(int milliseconds)
   {
     std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
@@ -122,6 +211,9 @@ protected:
   rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
   rclcpp::Publisher<dc_interfaces::msg::FlushEvent>::SharedPtr flush_pub_;
   int polling_interval_{ 50 };
+  std::filesystem::path tmp_;
+  std::filesystem::path produced_file_;
+  std::filesystem::path scratch_dir_;
 
 public:
   std::vector<std::string> received_;
@@ -275,6 +367,88 @@ TEST_F(MeasurementBufferingTest, MaxFlushRateSpreadsALargeBufferedWindowOverTime
   const int spacing_count = static_cast<int>(received_.size()) - 1;
   EXPECT_GE(receivedSpanMs(), (spacing_count * release_interval_ms * 7) / 10)
       << spacing_count + 1 << " Records arrived within " << receivedSpanMs() << "ms";
+}
+
+// Acceptance criterion (#290): a File-producing Measurement stages its Files into the scratch
+// ring while armed -- nothing is published, the File is moved out of the save path -- and on
+// flush the released Records reference the staged copies, incident-tagged like any other Record,
+// with the Bridge's remote_paths key untouched.
+TEST_F(MeasurementBufferingTest, FileProducingMeasurementStagesFilesWhileArmedAndReleasesTheStagedCopies)
+{
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", 1.0);
+  useFileProducingRecord();
+
+  startLifecycleNode();
+
+  // Armed: the Files accumulate in the scratch ring, silently.
+  spinProducing(polling_interval_ * 6);
+  EXPECT_TRUE(received_.empty());
+  const auto staged_while_armed = scratchFiles();
+  ASSERT_GE(staged_while_armed.size(), 3u) << "the produced Files should have been staged";
+
+  publishFlush("incident-files");
+  ASSERT_TRUE(spinProducingUntil([this] { return !received_.empty(); }, 1000));
+  spinProducing(polling_interval_ * 3);
+
+  ASSERT_GE(received_.size(), 3u);
+  EXPECT_EQ(countTaggedWith("incident-files"), static_cast<int>(received_.size()));
+  std::vector<std::filesystem::path> released_paths;
+  for (const auto& data : received_)
+  {
+    json data_json = json::parse(data);
+    ASSERT_TRUE(data_json.contains("local_paths")) << data;
+    const std::filesystem::path local_path = data_json["local_paths"]["raw"].get<std::string>();
+    EXPECT_EQ(local_path.parent_path(), scratch_dir_) << "released Record should reference the staged copy";
+    ASSERT_TRUE(std::filesystem::exists(local_path)) << local_path;
+    EXPECT_EQ(fileContents(local_path), kProducedContents) << "the released File must be unmodified";
+    // The Bridge uploads it under exactly the key the Measurement computed at collection time --
+    // staging moves the File, it doesn't rename its Destination.
+    EXPECT_EQ(data_json["remote_paths"]["minio"]["raw"], "cam/2026/frame.jpg");
+    released_paths.push_back(local_path);
+  }
+
+  // Released Files belong to the Bridge from here on: the ring must not delete them however far
+  // past buffer_duration_sec (1s) the Measurement keeps running and staging new ones.
+  spinProducing(1500);
+  for (const auto& path : released_paths)
+  {
+    EXPECT_TRUE(std::filesystem::exists(path)) << "a released File was evicted from under the Bridge: " << path;
+  }
+}
+
+// Acceptance criterion (#290): rolling eviction actually deletes aged-out staged Files from disk,
+// so an armed Measurement's Files stay bounded by buffer_duration_sec instead of filling the disk.
+TEST_F(MeasurementBufferingTest, RollingEvictionDeletesAgedOutScratchFilesFromDisk)
+{
+  const double buffer_duration_sec = 0.3;
+  ms_node_->declare_parameter("dummy.buffer_duration_sec", buffer_duration_sec);
+  useFileProducingRecord();
+
+  startLifecycleNode();
+
+  spinProducing(400);
+  const auto early = scratchFiles();
+  ASSERT_GE(early.size(), 2u);
+
+  // 800ms later every one of those is well past the 300ms window.
+  spinProducing(800);
+  const auto late = scratchFiles();
+
+  // Staging *moves* the File: stop putting it back and it is gone from the save path after the
+  // next collection. Nothing would ever have published it from there -- while armed the Record
+  // referencing it is buffered, so neither the Bridge nor its retention sweep ever sees it.
+  ASSERT_TRUE(std::filesystem::exists(produced_file_));
+  spinFor(polling_interval_ * 3);
+  EXPECT_FALSE(std::filesystem::exists(produced_file_));
+
+  for (const auto& name : early)
+  {
+    EXPECT_EQ(std::count(late.begin(), late.end(), name), 0) << name << " should have aged out of the scratch ring";
+    EXPECT_FALSE(std::filesystem::exists(scratch_dir_ / name)) << name << " was dropped but not deleted from disk";
+  }
+  // ~24 Files were produced over those 1.2s; a 300ms window at 50ms polling holds ~6 of them.
+  EXPECT_LE(late.size(), 10u) << "the scratch ring is growing with every collection instead of rolling";
+  EXPECT_TRUE(received_.empty()) << "still armed: nothing should have been published";
 }
 
 int main(int argc, char** argv)

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -107,6 +107,23 @@ broadcast node when its Trigger fires) then drives one incident-capture cycle:
    a flapping Trigger cannot produce a flood of overlapping incidents. Samples are buffered
    again during this phase, so the next incident still gets a full pre-roll window.
 
+Files follow their Records. A Measurement that produces Files (camera, map, …) normally leaves
+them under `save_local_base_path` for the Bridge to upload as soon as the Record naming them is
+published — but an armed Measurement publishes nothing, so every File it produces while buffering
+(also during cooldown, and while a rate-limited release is still draining) is instead *moved* into
+a scratch directory beside the save path,
+`<save_local_base_path>/.dc_incident_scratch/<measurement_name>/`, and the buffered Record is
+rewritten to reference the staged copy. That scratch directory rolls on the same
+`buffer_duration_sec` window as the Records themselves: a staged File is deleted from disk at the
+same moment its Record ages out of the ring buffer, so an armed Measurement's Files stay bounded
+instead of accumulating images no Record will ever carry to the Bridge. On release the staged
+copies are handed on with the Records referencing them — `remote_paths` is untouched, so each File
+uploads to exactly the Destination key it was collected under — and the scratch ring stops
+tracking them, leaving the Bridge's usual retention sweep and `delete_when_sent` to clean them up.
+The Bridge needs no configuration for any of this: a released Record is an ordinary Files Record
+that happens to be older than usual. Files collected during **PostRoll** are published live and
+never staged at all.
+
 The Measurement then re-arms itself back to **Buffering** with no manual intervention — a
 second incident is captured exactly like the first. With both `post_roll_duration_sec` and
 `cooldown_sec` left at 0, a flush releases the pre-roll window and the Measurement is armed

--- a/progress.txt
+++ b/progress.txt
@@ -6339,3 +6339,32 @@ asserted.
   that the scratch directory rolls on the same `buffer_duration_sec` window, that `remote_paths`
   is untouched so each File uploads where it would have anyway, that post-roll Files are never
   staged, and that the Bridge needs no configuration for any of it.
+- **Verified**: `podman run` against the `localhost/dc-workspace` Jazzy image with this worktree
+  bind-mounted over `/root/ws/src/ros2_data_collection`, as in #284-#289. `colcon build
+  --packages-select dc_common dc_core dc_interfaces dc_measurements dc_bridge --cmake-args
+  -DBUILD_TESTING=ON` succeeded with zero warnings under `-Wall -Wextra -Wpedantic -Werror
+  -Wdeprecated` (13min for `dc_measurements` -- every measurement/condition plugin recompiles
+  because they all include `measurement.hpp`), then `colcon test` + `colcon test-result --all`:
+  **342 tests, 0 errors, 0 failures, 0 skipped** (#289's 241 across four packages, plus
+  dc_bridge's 147 which this slice touches for the first time, plus this slice's +4
+  `file_scratch_ring_test`, +2 `test_measurement_buffering`, +1 `uploader_test`). The
+  `FileScratchRing` unit test was also compiled and run standalone (`g++ -std=c++17 -Wall
+  -Wextra -Wpedantic -Werror -I dc_common/include ... -lgtest`) in seconds, which is the payoff
+  of #285 keeping it ROS-free. Two process notes for future sessions: `podman run --rm` throws
+  the build away with the container, so build and test have to happen in the *same* invocation
+  (a separate `colcon test` run silently tests the image's baked workspace and reports "0
+  tests"); iterating is much faster against a `podman run -d ... sleep infinity` container held
+  open across `podman exec` calls, where a test-only change rebuilds `dc_measurements` in 27s
+  instead of 13min.
+- **A real finding, from the first red test**: releasing a buffered window as one burst *drops
+  Records at the middleware*. `data_pub_` is created `KeepLast(1)`, so when `onFlush()` publishes
+  six Records synchronously before the subscription's executor gets a turn, only the last
+  survives -- the first version of
+  `FileProducingMeasurementStagesFilesWhileArmedAndReleasesTheStagedCopies` asserted three
+  released Records and got one. This is pre-existing (#287/#288 behavior, not this slice) and it
+  is exactly the pressure #289's `max_flush_rate_hz` exists to relieve, which is why the older
+  burst tests never caught it: `FlushEventReleasesBufferedWindowThenReturnsToBuffering` measures
+  `received_.size()` rather than asserting a count, and the #289 test paces its release. The test
+  now sets `max_flush_rate_hz` to 20Hz so every released Record is delivered and the assertions
+  cover the whole window; whether the publisher's depth should be raised for the burst path is a
+  question for #282's parent, not something to change under this issue.

--- a/progress.txt
+++ b/progress.txt
@@ -6241,3 +6241,101 @@ incident doesn't also have to push its entire pre-roll window through the Bridge
   long-standing local-environment ones: `poetry-requirements` (no `poetry` module on this
   host) and `black` on the pre-existing violation in `tools/e2e/scripts/verify_zero_loss.py`,
   reverted again here to keep this diff scoped, exactly as in the #285-#288 sessions.
+
+## #290 - Wire FileScratchRing into File-producing Measurements
+
+Fifth implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), on top of #285's `FileScratchRing`, #287's flush wiring, #288's `IncidentReleaser`
+and #289's rate limit. Records were already buffered and released as an incident; this slice
+makes the *Files* those Records reference follow them, so a File-producing Measurement
+(camera, map, ip_camera, ...) can be armed without either losing its Files or filling the
+disk with them. **No `dc_bridge` production change**: a released Record is an ordinary Files
+Record that happens to be older than usual, and the existing intent queue / uploader /
+retention path ingests it unchanged -- which is now pinned down by a test rather than
+asserted.
+
+- **`dc_common/include/dc_common/file_scratch_ring.hpp`** gains the two ways out of the ring
+  that wiring it into a Measurement actually needs, beside `evict()`:
+  - `release()` returns the window oldest-first and stops tracking it **without deleting
+    anything** -- the `RecordRingBuffer::clear()` analogue, since "forget this entry" for a
+    File means "someone else owns it now", not "delete it". Called when an incident releases
+    the window: from then on the staged copies belong to the Bridge (upload, retention sweep,
+    `delete_when_sent`), so no later `evict()` can delete one out from under an upload in
+    flight.
+  - `purge()` deletes every staged File still tracked whatever its age -- the counterpart,
+    for when the Records referencing them are dropped rather than published (lifecycle
+    cleanup), where leaving them behind would just orphan them on disk.
+- **`dc_measurements/include/dc_measurements/measurement.hpp`**:
+  - `offerSample()` now `tick()`s the releaser first and, unless the machine is in `PostRoll`,
+    runs the sample through `stageSampleFiles()` before offering it. During post-roll the
+    Record is published live, so its Files stay exactly where the Measurement wrote them --
+    the path the Bridge has always picked up.
+  - `stageRecordFiles()` walks the enriched Record the same way `dc_bridge`'s
+    `parse_file_group()` does -- `local_paths` at any depth (a `nested` Measurement puts it
+    under its own name), never `base64` (inline content, not a path) -- plus the JSON-pointer
+    keys a `flatten`ed Record carries instead (`/local_paths/raw`), so exactly the paths the
+    Bridge would have uploaded are the ones that move.
+  - `stageOneFile()` **moves** the File into the ring (`stage()` copies, then the original is
+    removed) rather than copying it. Deliberate, and the one judgement call in this slice: the
+    Record referencing the original is buffered, not published, so nothing will ever pick that
+    original up -- not the Bridge (which never sees the Record), not its retention sweep
+    (which only knows about pending intents). Copying would leave an armed Measurement growing
+    the save path without bound, which is exactly what the bounded ring exists to prevent. A
+    failed stage (source gone, disk full) is caught, logged throttled, and the Record is
+    buffered with the File left in place -- degraded, never dropped.
+  - Eviction is driven from the same call with the same `now` and the same window as the ring
+    buffer's own `evict()`, so a staged File is deleted from disk at the moment its Record
+    ages out of the window. Safe to run mid-release because `onFlushEvent()` releases the
+    window out of the ring's ownership *before* the (possibly rate-limited, possibly long)
+    drain starts.
+  - `onFlushEvent()` reads `isArmed()` before `onFlush()` acts on it (acting on it is what
+    makes it false), `evict()`s first so aged-out staged Files -- whose Records the ring buffer
+    evicted too -- are deleted rather than handed on, then `release()`s exactly what the
+    released Records reference.
+  - `cleanup()` `purge()`s the ring alongside resetting the releaser; released Files are
+    already untracked, so purge cannot touch anything the Bridge owns. The ring is created
+    lazily by `scratchRing()`, on the first Record that references a File at all, so the many
+    Measurements that produce none never grow a scratch directory.
+  - `scratchDir()` = `<literal prefix of save_local_base_path>/.dc_incident_scratch/<name>/`:
+    same filesystem as the Files themselves (staging is a local move), outside the dated save
+    tree, and truncated at the first strftime token so the scratch directory doesn't roll over
+    every hour the way the save path does. No new parameter -- nothing in the issue asks for
+    one, and the derived path needs no plumbing through `configure()`.
+  - `file_scratch_ring_` is touched only under the existing `releaser_mutex_`, which already
+    serializes the polling timer, the FlushEvent subscription and #289's release timer.
+- **Tests**:
+  - `dc_common/test/file_scratch_ring_test.cpp` (10 -> 14 cases): `release()` hands the window
+    on and a later `evict()` well past the window still doesn't delete it; `release()` on an
+    empty ring; `purge()` deletes fresh and aged entries alike; `purge()` tolerates a File
+    already gone.
+  - `dc_measurements/test/test_measurement_buffering.cpp` (5 -> 7 cases). The fixture now owns
+    a tmp directory and points `save_local_base_path` at it, and `useFileProducingRecord()`
+    turns the Dummy Measurement into a File-producing one by giving it a camera-shaped Record
+    (`local_paths` + the `remote_paths` key). `spinProducingUntil()`/`spinProducing()` put the
+    File back as soon as the Measurement has consumed it, the way a real one writes a fresh
+    File every collection -- no race, since the Measurement's polling timer runs inside
+    `spin_some()` on the test thread.
+    - `FileProducingMeasurementStagesFilesWhileArmedAndReleasesTheStagedCopies`: nothing
+      published while armed but Files accumulate in the scratch directory; on flush every
+      released Record carries the incident_id, references a staged copy (parent == scratch
+      dir) that exists with unmodified contents, and keeps its original `remote_paths` key --
+      staging moves the File, it does not rename its Destination; and 1.5s of further staging
+      past the 1s window leaves the released copies untouched (the `release()` criterion).
+    - `RollingEvictionDeletesAgedOutScratchFilesFromDisk`: 0.3s window, 50ms polling, ~24
+      Files produced over 1.2s -- every File staged in the first 400ms is gone from the ring
+      *and from disk* 800ms later, the directory stays bounded (<= 10 entries), and with the
+      producer stopped the source File is gone from the save path after the next collection,
+      which is the "moves, not copies" assertion.
+  - `dc_bridge/test/uploader_test.cpp` gains `IncidentReleasedScratchFilesAreIngestedUnmodified`
+    -- the integration criterion. It stages a File with the *real* `FileScratchRing` (so what
+    the Bridge is handed is what a released Record actually carries), stamps it 5 minutes in
+    the past, `release()`s it, adds the `incident_id` `publishIncidentRecord()` would, and runs
+    it through the unchanged `Uploader`: uploaded byte-for-byte under the unchanged remote key,
+    `file_status` row pointing at the staged path, `delete_when_sent` cleaning it up. The only
+    dc_bridge change is a `<test_depend>dc_common</test_depend>` + `find_package`/
+    `ament_target_dependencies` for the gtests -- no production code.
+- **Docs**: `doc/src/dc/measurements.md`'s buffering admonish block gains a "Files follow their
+  Records" paragraph -- where staged Files live, that staging moves rather than copies and why,
+  that the scratch directory rolls on the same `buffer_duration_sec` window, that `remote_paths`
+  is untouched so each File uploads where it would have anyway, that post-roll Files are never
+  staged, and that the Bridge needs no configuration for any of it.


### PR DESCRIPTION
Fifth implementation slice of #282 (pre-event circular-buffer capture), on top of #285's `FileScratchRing`, #287's flush wiring, #288's `IncidentReleaser` and #289's rate limit.

Records were already buffered and released as an incident. This makes the **Files** those Records reference follow them, so a File-producing Measurement (camera, map, ip_camera, …) can be armed without either losing its Files or filling the disk with them.

## What changed

**`dc_measurements` — staging while armed**

- While the releaser buffers a Record instead of publishing it, every File the Record references is moved into `<save_local_base_path>/.dc_incident_scratch/<measurement_name>/` and the Record is rewritten to point at the staged copy.
- Staging **moves** rather than copies, deliberately: the buffered Record is never published, so nothing — not the Bridge (which never sees it), not the Bridge's retention sweep (which only knows pending intents) — would ever pick the original up. Copying would grow the save path without bound for as long as the Measurement stays armed, which is exactly what the bounded ring exists to prevent. A failed stage is caught, logged throttled, and the Record is buffered with its File left in place: degraded, never dropped.
- The Record is walked the way `dc_bridge`'s `parse_file_group()` walks it — `local_paths` at any depth (a `nested` Measurement puts it under its own name), never `base64` — plus the JSON-pointer keys a `flatten`ed Record carries instead. So exactly the paths the Bridge would have uploaded are the ones that move, and `remote_paths` is untouched: each File still uploads to the Destination key it was collected under.
- Eviction runs with the same `now` and the same window as the ring buffer's own, so a staged File is deleted from disk at the moment its Record ages out. The ring is created lazily, on the first Record that references a File at all, so the many Measurements that produce none never grow a scratch directory.
- On an accepted `FlushEvent` the window is `release()`d out of the ring's ownership **before** the (possibly rate-limited, possibly long) drain starts, so no later eviction can delete a File out from under an upload in flight. `cleanup()` purges what is left, which by then is only Files no Record will ever carry. Files collected during **post-roll** are published live and never staged.

**`dc_common` — two exits from the ring beside `evict()`**

- `release()` returns the window and stops tracking it *without deleting anything* — the `RecordRingBuffer::clear()` analogue, since "forget this entry" for a File means "someone else owns it now".
- `purge()` deletes everything tracked whatever its age, for when the Records referencing them are dropped rather than published.

**`dc_bridge` — no production change**

A released Record is an ordinary Files Record that happens to be older than usual. The only change here is `<test_depend>dc_common</test_depend>` so a test can stage a File with the real ring.

## Acceptance criteria

- [x] File-producing Measurements stage Files into `FileScratchRing` while armed, with rolling deletion of the oldest once past `buffer_duration_sec`
- [x] On flush, the Measurement publishes `local_paths`-bearing Records for each released File, tagged with the same `incident_id` as concurrent Record releases
- [x] Integration test confirms released Files are picked up unmodified by the existing `dc_bridge` Files pipeline (no Bridge code changes required) — `Uploader.IncidentReleasedScratchFilesAreIngestedUnmodified` stages with the real ring, stamps the File five minutes in the past, releases it, adds the `incident_id`, and runs it through the unchanged `Uploader`: uploaded byte for byte under the unchanged remote key
- [x] Lifecycle/unit test confirms rolling eviction actually deletes aged-out scratch Files from disk — `RollingEvictionDeletesAgedOutScratchFilesFromDisk`: 0.3s window, 50ms polling, ~24 Files over 1.2s; everything staged in the first 400ms is gone from the ring *and from disk* 800ms later, and the directory stays bounded

## Tests

- `dc_common/test/file_scratch_ring_test.cpp`: 10 → 14 cases (`release()` semantics incl. a later `evict()` not touching released Files; `purge()`).
- `dc_measurements/test/test_measurement_buffering.cpp`: 5 → 7 cases. The fixture now owns a tmp directory as `save_local_base_path` and can turn the Dummy Measurement into a File-producing one with a camera-shaped Record; `spinProducing()` puts the File back as soon as the Measurement has consumed it, the way a real one writes a fresh File every collection.
- `dc_bridge/test/uploader_test.cpp`: the integration case above.

Docs: `doc/src/dc/measurements.md`'s buffering block gains a "Files follow their Records" section.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118K6sQ71GHETX8UHcLam9a