### PR TITLE
feat: add incident_id as a first-class Record field and Postgres column

### DIFF
--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -2,7 +2,10 @@
 // parameters to a complete Vector configuration. `render()` produces Vector TOML with:
 // the shipper ingest protocol source (global acknowledgements enabled — #266, delivery
 // is confirmed end-to-end), one VRL transform normalizing each blessed destination's
-// timestamp, one `route` transform exposing the public per-Tag `dc.<tag>` routes (the
+// timestamp (and, for a `postgres` destination, the envelope's `incident_id` — #291, so
+// the incident an armed Measurement released a Record under is a queryable column rather
+// than an opaque payload key), one `route` transform exposing the public per-Tag
+// `dc.<tag>` routes (the
 // passthrough contract — see route_output_for_tag), disk-buffer settings, and the
 // blessed sinks (postgres, s3, file, console).
 //

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -182,6 +182,29 @@ std::string tag_condition(const std::set<std::string>& tags, const std::set<std:
   return out;
 }
 
+// Normalizes the Record envelope's `incident_id` (#291) for a Destination whose sink maps
+// top-level keys onto table columns.
+//
+// Vector's `postgres` sink has no column-mapping options of its own: it hands the event to
+// `jsonb_populate_record`, so a top-level key lands in the same-named column and anything
+// else is dropped. There is therefore no `columns = [...]` to write — this block is where the
+// generated config names `incident_id` as a field DC maps onto a column, which is what makes
+// the column part of the rendered contract (and what the render tests assert) rather than an
+// undocumented consequence of the key happening to be top-level.
+//
+// `to_string(...) ?? null` for the same reason the route predicates coerce `.tag`: VRL types
+// an event field as `any`. A Measurement whose own payload already carries a non-string
+// `incident_id` (an object, say) would otherwise reach the sink as a value the text column
+// cannot take and fail the whole insert batch; coerced, that Record still lands, with a NULL
+// in the column. Guarded by `exists` because `to_string(null)` is `""` — a Record that is not
+// part of an incident must leave the column NULL, not empty-string.
+std::string render_incident_id_normalization()
+{
+  return "  if exists(.incident_id) {\n"
+         "    .incident_id = to_string(.incident_id) ?? null\n"
+         "  }\n";
+}
+
 std::string render_normalize_source(const RenderConfig& config)
 {
   std::string out;
@@ -203,6 +226,10 @@ std::string render_normalize_source(const RenderConfig& config)
     else
     {
       out += "  ." + dest.time_key + " = format_timestamp!(.timestamp, format: \"%Y-%m-%dT%H:%M:%S%.9f\")\n";
+    }
+    if (std::holds_alternative<PostgresParams>(dest.kind))
+    {
+      out += render_incident_id_normalization();
     }
     out += "}\n";
   }

--- a/dc_bridge/test/fixtures/render/basic_double.toml
+++ b/dc_bridge/test/fixtures/render/basic_double.toml
@@ -31,6 +31,9 @@ inputs = ["dc_bridge_in"]
 source = """
 if includes(["dc.group.robot"], .tag) {
   .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+  if exists(.incident_id) {
+    .incident_id = to_string(.incident_id) ?? null
+  }
 }
 """
 type = "remap"

--- a/dc_bridge/test/fixtures/render/iso8601.toml
+++ b/dc_bridge/test/fixtures/render/iso8601.toml
@@ -31,6 +31,9 @@ inputs = ["dc_bridge_in"]
 source = """
 if includes(["dc.group.robot"], .tag) {
   .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
+  if exists(.incident_id) {
+    .incident_id = to_string(.incident_id) ?? null
+  }
 }
 """
 type = "remap"

--- a/dc_bridge/test/fixtures/render/multiple_destinations.toml
+++ b/dc_bridge/test/fixtures/render/multiple_destinations.toml
@@ -45,9 +45,15 @@ inputs = ["dc_bridge_in"]
 source = """
 if includes(["dc.group.robot"], .tag) {
   .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+  if exists(.incident_id) {
+    .incident_id = to_string(.incident_id) ?? null
+  }
 }
 if includes(["dc.measurement.uptime"], .tag) {
   .date = format_timestamp!(.timestamp, format: "%Y-%m-%dT%H:%M:%S%.9f")
+  if exists(.incident_id) {
+    .incident_id = to_string(.incident_id) ?? null
+  }
 }
 """
 type = "remap"

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -126,6 +126,59 @@ TEST(Render, FileAndConsoleDestinations)
   assert_matches_fixture(render(config), "file_and_console.toml");
 }
 
+// #291: `incident_id` is a first-class column, not a key buried in the payload. Vector's
+// postgres sink has no column-mapping options — a top-level event key lands in the
+// same-named column — so the mapping *is* this line of the normalize transform, and it must
+// be rendered for every postgres destination whatever its time_format.
+TEST(Render, PostgresDestinationsNormalizeIncidentIdIntoItsOwnColumn)
+{
+  for (auto tf : { TimeFormat::EpochNanos, TimeFormat::Double, TimeFormat::Iso8601 })
+  {
+    toml::table parsed = toml::parse(render(basic_config(tf)));
+    const std::string source(parsed["transforms"][NORMALIZE_TRANSFORM_ID]["source"].value_or(""));
+    EXPECT_NE(source.find("if exists(.incident_id) {"), std::string::npos) << source;
+    EXPECT_NE(source.find(".incident_id = to_string(.incident_id) ?? null"), std::string::npos) << source;
+  }
+}
+
+// One remap transform serves every destination, so the incident_id block has to sit inside
+// the branch guarding the postgres destination's own Tags — not at top level, where it would
+// also rewrite events no column-mapped sink ever sees.
+TEST(Render, IncidentIdNormalizationIsScopedToThePostgresDestinationsTags)
+{
+  auto config = config_with({
+      make_destination("pgsql", { "/dc/group/robot" }, TimeFormat::EpochNanos, postgres_kind()),
+      make_destination("debug_console", { "/dc/measurement/uptime" }, TimeFormat::EpochNanos, ConsoleParams{}),
+  });
+  toml::table parsed = toml::parse(render(config));
+  const std::string source(parsed["transforms"][NORMALIZE_TRANSFORM_ID]["source"].value_or(""));
+
+  const auto pg_branch = source.find("if includes([\"dc.group.robot\"], .tag) {");
+  const auto console_branch = source.find("if includes([\"dc.measurement.uptime\"], .tag) {");
+  const auto incident = source.find("if exists(.incident_id) {");
+  ASSERT_NE(pg_branch, std::string::npos) << source;
+  ASSERT_NE(console_branch, std::string::npos) << source;
+  ASSERT_NE(incident, std::string::npos) << source;
+  EXPECT_GT(incident, pg_branch) << source;
+  EXPECT_LT(incident, console_branch) << source;
+  // Exactly one destination is column-mapped, so exactly one block is rendered.
+  EXPECT_EQ(source.find("if exists(.incident_id) {", incident + 1), std::string::npos) << source;
+}
+
+// A config with no column-mapped sink has nothing to map incident_id onto; the field rides
+// along in the JSON payload as it always has.
+TEST(Render, NonPostgresDestinationsGetNoIncidentIdNormalization)
+{
+  auto config = config_with({
+      make_destination("local_log", { "/dc/group/robot" }, TimeFormat::EpochNanos,
+                       FileParams{ "/var/log/dc/records.log" }),
+      make_destination("debug_console", { "/dc/group/robot" }, TimeFormat::EpochNanos, ConsoleParams{}),
+  });
+  toml::table parsed = toml::parse(render(config));
+  const std::string source(parsed["transforms"][NORMALIZE_TRANSFORM_ID]["source"].value_or(""));
+  EXPECT_EQ(source.find("incident_id"), std::string::npos) << source;
+}
+
 TEST(Render, ConsoleSinkHasNoDiskBuffer)
 {
   auto config =

--- a/dc_group/dc_group/group_server.py
+++ b/dc_group/dc_group/group_server.py
@@ -68,12 +68,24 @@ class GroupServer(Node):
         """
         data_dict = {}
         plugins_list = []
+        incident_id = None
         collected_time = self.get_clock().now()
         for measurement in measurements:
             # https://github.com/ros2/rosidl_python/blob/0f5c8f360be92566ad86f4b29f3db1febfca2242/rosidl_generator_py/resource/_msg.py.em#L187-L189
             measurement_dict = message_converter.convert_ros_message_to_dictionary(measurement)
             m_data = json.loads(measurement.data)
             m_data.pop("tags", None)
+            # `incident_id` is an envelope field, not measurement data (#291): merged under a
+            # member's `group_key` it would become `<group_key>.incident_id`, which is no
+            # column any Destination table has and so is silently dropped by the Postgres
+            # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
+            # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
+            # FlushEvent mints one id for every Measurement listening, so the members of a
+            # released window all carry the same one — first non-null wins, and a partial
+            # Record built from a mix of released and live members still carries it.
+            member_incident_id = m_data.pop("incident_id", None)
+            if incident_id is None:
+                incident_id = member_incident_id
             if self.group_measurement_plugins:
                 if "plugin" in m_data:
                     plugins_list.append(m_data["plugin"])
@@ -98,6 +110,10 @@ class GroupServer(Node):
         if self.params[group]["nested_data"]:
             data_dict = unflatten_list(flat_dict=data_dict, separator=".")
         data_dict["tags"] = self.params[group]["tags"]
+        # Only when a member actually carried one: a Record collected outside an incident must
+        # leave the column NULL rather than write an explicit null into every grouped Record.
+        if incident_id is not None:
+            data_dict["incident_id"] = incident_id
         if self.group_measurement_plugins and plugins_list:
             data_dict["plugins"] = plugins_list
 

--- a/dc_group/test/test_group_sync_timeout.py
+++ b/dc_group/test/test_group_sync_timeout.py
@@ -1,4 +1,5 @@
-"""Tests for the Group node's sync-timeout drop/emit_partial behaviour (#126).
+"""Tests for the Group node's sync-timeout drop/emit_partial behaviour (#126), plus the
+envelope fields a merged Record has to carry through at top level (`incident_id`, #291).
 
 Every test drives a real `GroupServer` through a real executor against real DDS topics —
 `message_filters` has no timeout of its own, so what is under test is precisely the
@@ -329,6 +330,45 @@ def test_throttle_of_zero_logs_every_timeout(harness):
 
     assert len(group.records) >= 3
     assert len(group.sync_timeout_warnings()) == len(group.records)
+
+
+def test_incident_id_is_lifted_to_the_merged_records_top_level(harness):
+    """#291: a released member's incident_id survives merging as a first-class field."""
+    # Nested under the member's `group_key` it would be `<group_key>.incident_id`, which no
+    # Destination table has a column for and the Postgres sink therefore drops.
+    group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
+    group.publish(0, {"used": 12.0, "incident_id": "incident-42"})
+    group.publish(1, {"free": 34.0, "incident_id": "incident-42"})
+
+    assert group.wait_for_records(1), "no Record published for a complete set"
+    payload = group.payloads()[0]
+
+    assert payload["incident_id"] == "incident-42"
+    # Lifted, not copied: it must not also stay behind inside the members' own data.
+    assert payload["a"] == {"used": 12.0}
+    assert payload["b"] == {"free": 34.0}
+
+
+def test_incident_id_is_absent_when_no_member_carries_one(harness):
+    """A Record collected outside an incident leaves the column NULL, not empty-string."""
+    group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
+    group.publish(0, {"used": 12.0})
+    group.publish(1, {"free": 34.0})
+
+    assert group.wait_for_records(1), "no Record published for a complete set"
+    assert "incident_id" not in group.payloads()[0]
+
+
+def test_partial_record_keeps_the_incident_id_of_the_member_that_arrived(harness):
+    """A window released by one Measurement while another is silent is still an incident."""
+    group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
+    group.publish(0, {"used": 12.0, "incident_id": "incident-7"})
+
+    assert group.wait_for_records(1), "no partial Record published for the incomplete set"
+    payload = group.payloads()[0]
+
+    assert payload["incident_id"] == "incident-7"
+    assert payload["partial"] is True
 
 
 def test_unknown_policy_falls_back_to_drop(harness):

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -111,6 +111,27 @@ The destination's own column type can truncate independently of `time_format`. A
 `epoch_nanos` is exact, sortable and indexable.
 ```
 
+### `incident_id`
+
+A Measurement configured for [incident capture](./measurements.md) tags every Record it
+releases with the `incident_id` of the `FlushEvent` that released it. That field is part of
+the Record envelope, so a `postgres` Destination writes it to its own **`incident_id`
+column** — "everything from this one event" is `WHERE incident_id = '…'`, not a substring
+search through a JSON payload:
+
+```sql
+ALTER TABLE dc ADD COLUMN incident_id text;
+```
+
+The Bridge renders the mapping into the `dc_bridge_normalize` transform for every `postgres`
+Destination. Vector's `postgres` sink has no column options of its own — a top-level event
+key lands in the same-named column and everything else is dropped — so the column has to
+exist in the table before the first incident, exactly like every other column
+(`tools/e2e/sql/init.sql` and `tools/infrastructure/docker/config/postgresql/init.sql` both
+carry it). Records collected outside an incident have no `incident_id` and leave the column
+NULL. Other Destination types need nothing: `incident_id` is already a top-level key of the
+JSON they receive.
+
 Type-specific parameters:
 
 | Type       | Required                                    | Optional                                                                                                          |

--- a/doc/src/dc/groups.md
+++ b/doc/src/dc/groups.md
@@ -16,6 +16,12 @@ merged Record on `/dc/group/my_group`:
 A merged Record is an ordinary Record from there on: it carries the Tag derived from its
 output topic, and a Destination receives it by listing that topic in `inputs`.
 
+Envelope fields do not get nested under a member's key: a member's `tags` is replaced by the
+Group's own, and its `incident_id` — the id a Measurement stamps on a Record it released as
+part of an [incident](./measurements.md) — is lifted to the merged Record's top level, where
+a `postgres` Destination has a column for it. Buried under `<group_key>.incident_id` it would
+simply be dropped by that sink.
+
 ```admonish info
 The Group node is written in Python: allocating and passing a variable number of inputs to
 the `ApproximateTimeSynchronizer` is straightforward there and awkward in C++.
@@ -132,6 +138,9 @@ report, plus two keys that mark it as partial:
 - `missing_inputs` lists the input *topics* that contributed no Record, in `inputs` order.
 - `tags`, `name` and `plugins` behave as they do on a complete Record — `plugins` only
   lists the plugins that actually reported.
+- `incident_id` behaves the same way: if any member that *did* arrive was released as part
+  of an [incident](./measurements.md), the merged Record carries its `incident_id`, so a
+  partial Record of an incident is still queryable as one.
 
 ```admonish warning title="Add the columns before charting a partial Record"
 Vector's `postgres` sink silently drops top-level keys that have no matching column, so

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -128,6 +128,14 @@ The Measurement then re-arms itself back to **Buffering** with no manual interve
 second incident is captured exactly like the first. With both `post_roll_duration_sec` and
 `cooldown_sec` left at 0, a flush releases the pre-roll window and the Measurement is armed
 again immediately.
+
+`incident_id` is a top-level field of the Record envelope, beside `tags`, `run_id` and `name`
+— not a key nested inside the measurement's own data — so a `postgres` Destination stores it
+in its own `incident_id` column and "everything from this one event" is a plain
+`WHERE incident_id = '…'`. See [Destinations](./destinations.md#incident_id) for the column
+the table needs. A Record collected outside an incident carries no `incident_id` at all,
+leaving the column NULL. A [Group](./groups.md) lifts a member's `incident_id` onto the merged
+Record the same way it does `tags`, so grouping does not bury it.
 ```
 
 ```admonish info title="gate_condition vs. if_all/if_any/if_none_conditions"

--- a/progress.txt
+++ b/progress.txt
@@ -6368,3 +6368,88 @@ asserted.
   now sets `max_flush_rate_hz` to 20Hz so every released Record is delivered and the assertions
   cover the whole window; whether the publisher's depth should be raised for the burst path is a
   question for #282's parent, not something to change under this issue.
+
+## #291 - Add incident_id as a first-class field in the Record schema and Postgres sink config
+
+Sixth implementation slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), on top of #287's flush wiring, #288's `IncidentReleaser`, #289's rate limit and
+#290's File staging. Those slices made an armed Measurement release a window of Records
+each stamped with the `FlushEvent`'s `incident_id`; this one makes that id **queryable as a
+column** everywhere the Record can land, rather than a key riding along inside an opaque
+payload. User stories 9 and 19 of #282.
+
+- **`dc_bridge/src/render.cpp`** — `render_normalize_source()` now emits, inside the branch
+  guarding each **postgres** Destination's own Tags, one extra VRL block:
+
+      if exists(.incident_id) {
+        .incident_id = to_string(.incident_id) ?? null
+      }
+
+  The judgement call of this slice, so the reasoning in full. Vector's `postgres` sink has
+  no column-mapping options at all: it hands the event to `jsonb_populate_record`, so a
+  top-level key lands in the same-named column and everything else is dropped. There is no
+  `columns = [...]` to render — which is why the *mapping* has to be this block, and why the
+  block is worth rendering at all rather than relying on the key being top-level by accident:
+  it is where the generated config names `incident_id` as a field DC maps onto a column, and
+  it is what the config-generation tests can assert against. It also does real work.
+  `to_string(...) ?? null` is the same coercion the route predicates already apply to `.tag`
+  (VRL types an event field as `any`): a Measurement whose own payload carried a non-string
+  `incident_id` — an object, say — would otherwise reach the sink as a value a `text` column
+  cannot take and fail the *whole insert batch*; coerced, that Record still lands with a NULL
+  in the column. The `exists` guard is load-bearing: VRL's `to_string(null)` is `""`, so
+  without it every Record collected outside an incident would write an empty string where a
+  NULL belongs. Scoped to postgres destinations because they are the only column-mapped sink
+  — s3/file/console already receive `incident_id` as a JSON key and need nothing.
+- **Verified against the real pinned Vector binary**, not inferred: `vector validate
+  --no-environment` accepts the rendered `multiple_destinations.toml` fixture (the `??` is
+  neither rejected as invalid nor flagged as an unnecessary coalesce), and `vector vrl
+  --print-object` confirms all four cases — `"abc-123"` → `"abc-123"`, `7` → `"7"`,
+  `{"a":1}` → `null` (rescued instead of failing the batch), key absent → still absent, so
+  the column stays NULL rather than becoming `""`.
+- **Gold fixtures**: `basic_double.toml`, `iso8601.toml` and both destinations of
+  `multiple_destinations.toml` gain the block; `s3_aws`, `s3_custom_endpoint` and
+  `file_and_console` deliberately do not.
+- **`dc_bridge/test/render_test.cpp`** (48 → 51 cases): the block is rendered for a postgres
+  destination under every `time_format`; it sits *inside* that destination's tag branch and
+  is rendered exactly once even when a console destination shares the transform; and a config
+  with no column-mapped sink renders no `incident_id` at all.
+- **DDL** — the column has to exist before the first incident, since the sink neither creates
+  tables nor adds columns: `incident_id text` added to `tools/e2e/sql/init.sql`'s `dc_records`
+  and `tools/infrastructure/docker/config/postgresql/init.sql`'s `dc`. Not `dc_files`: the
+  Uploader's own metadata Records know nothing about incidents.
+- **`dc_group/dc_group/group_server.py`** — a Group nests each member's Record under its
+  `group_key`, so a released member's `incident_id` would have become
+  `<group_key>.incident_id`: no column any table has, silently dropped by the very sink this
+  issue is about. It is now popped from each member and lifted onto the merged Record's top
+  level, exactly the way `tags` already is (first non-null wins — one FlushEvent mints one id
+  for every Measurement listening, so members of a released window all carry the same one),
+  and only when a member actually carried one, so an ordinary grouped Record still leaves the
+  column NULL. Strictly field preservation, *not* the Group-level correlated buffering #282
+  defers. Three cases added to `dc_group/test/test_group_sync_timeout.py`: lifted to top level
+  and gone from the members' data, absent when no member carried one, and preserved on a
+  partial Record assembled by the sync timeout.
+- **`tools/e2e/scripts/run_incident.sh` + `tools/e2e/params/e2e_incident_params.yaml`** — the
+  fourth acceptance criterion ("verified queryable as a column value, not just JSON payload
+  text") is not something a unit test can answer, so it gets a real scenario harness, modelled
+  on #267's `run_retention.sh` (its own containers, its own params, Postgres only, not wired
+  into `ci.yaml`). An `uptime` Measurement armed with `buffer_duration_sec: 6.0` (and
+  `max_flush_rate_hz: 20.0` — #290's finding: an unpaced burst is coalesced away by the
+  KeepLast(1) data publisher) runs beside a never-armed `memory` Measurement, both into one
+  postgres Destination. It asserts, in order: `dc_records.incident_id` is a real `text` column;
+  the live Measurement is landing rows while the armed one has shipped *nothing* (without which
+  the final query could pass on a pipeline that never buffered); after one FlushEvent the
+  released window is reachable as `WHERE incident_id = '…'` — the column predicate that is the
+  entire point; and the id is on that window only, with the never-armed Measurement's rows
+  still `IS NULL`.
+  The FlushEvent is published with `ros2 topic pub --once -w 1` rather than by a `dc_triggers`
+  broadcast node: `/dc/flush` *is* the contract a Measurement subscribes to, `dc_triggers` has
+  its own tests for minting the event, and the broadcast node is not in `dc_bringup`'s launch
+  yet — wiring it there is separate work, and this scenario is about what happens to the id
+  downstream of the event, not about what produced it.
+- **Docs**: `destinations.md` gains an `incident_id` section (the column, the `ALTER TABLE`,
+  why the sink needs it to pre-exist, and that other Destination types need nothing);
+  `measurements.md`'s buffering block states that `incident_id` is a top-level envelope field
+  beside `tags`/`run_id`/`name` and links to it; `groups.md` documents the lift in both the
+  merge description and the partial-Record notes; `tools/e2e/README.md` gains the scenario.
+- **Not touched, deliberately**: the Streamlit demo dashboard (#282 puts incident browsing UI
+  out of scope) and `CONTEXT.md`'s glossary (#345 owns the **Incident** entry).

--- a/progress.txt
+++ b/progress.txt
@@ -6453,3 +6453,29 @@ payload. User stories 9 and 19 of #282.
   merge description and the partial-Record notes; `tools/e2e/README.md` gains the scenario.
 - **Not touched, deliberately**: the Streamlit demo dashboard (#282 puts incident browsing UI
   out of scope) and `CONTEXT.md`'s glossary (#345 owns the **Incident** entry).
+- **Verified**: `podman run` against the `localhost/dc-workspace` Jazzy image with this
+  worktree bind-mounted over `/root/ws/src/ros2_data_collection`, as in #284-#290. `colcon
+  build --packages-select dc_util dc_core dc_common dc_interfaces dc_measurements dc_group
+  dc_triggers dc_lifecycle_manager dc_bringup dc_bridge` finished all 10 packages with zero
+  warnings (14min38s of it `dc_measurements` alone -- every measurement/condition plugin
+  recompiles because they all include `measurement.hpp`), then `colcon test --packages-select
+  dc_bridge dc_group dc_common dc_measurements` + `colcon test-result --all`: **360 tests, 0
+  errors, 0 failures, 0 skipped**, including `render_test` 51 (was 48) and `dc_group`'s
+  pytest 15 (was 12).
+- **The E2E scenario was actually run**, not just written: the container was `podman commit`ed
+  into an image (`--change 'CMD []'` -- the long-lived iteration container's `sleep infinity`
+  CMD would otherwise be handed to `entrypoint.sh` and on to `ros2 launch` as arguments),
+  `Containerfile.e2e` built on top of it, and `DC_E2E_IMAGE=... ./tools/e2e/scripts/
+  run_incident.sh` run against real Postgres. Every gate passed: the text column exists, 5
+  live rows while the armed Measurement had shipped 0, and **16 rows returned by `WHERE
+  incident_id = 'e2e-incident-0001'`** -- the ~12-Record 6s pre-roll window plus the ~4
+  Records of 2s post-roll -- with the never-armed Measurement's rows still NULL.
+- **A real bug the first run caught**, worth recording because the same pattern is in
+  `run_retention.sh`: gating on `pg_isready` is not enough. The postgres image applies
+  `/docker-entrypoint-initdb.d` against a *temporary* server which it then shuts down and
+  restarts, and `pg_isready` answers yes to that one -- so the first query landed mid-shutdown
+  ("FATAL: the database system is shutting down") and `set -e` killed the run. The gate is now
+  `until psql -tAc "SELECT to_regclass('public.dc_records')" | grep -q dc_records`, which can
+  only be true once the real server is up *and* init.sql has been applied. `run_retention.sh`
+  gets away with `pg_isready` only because its first query happens minutes later; not changed
+  here, to keep this diff scoped.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -157,6 +157,31 @@ own camera path already covers the File pipeline's steady-state/outage behavior;
 this scenario into CI as its own job is left as a follow-up, same as the "not done" list
 below.
 
+## Incident-capture scenario (#291)
+
+A third narrow harness, for the `incident_id` field an armed Measurement stamps on the
+pre-event window it releases:
+
+```sh
+./tools/e2e/scripts/run_incident.sh
+```
+
+Same `dc-e2e` image and env vars again, this time against
+`params/e2e_incident_params.yaml`: an `uptime` Measurement armed with
+`buffer_duration_sec` beside a `memory` Measurement collecting live, both routed to one
+`postgres` Destination. The scenario publishes a single `FlushEvent` onto `/dc/flush`
+with a known id and asserts: (1) `dc_records.incident_id` exists as a real `text`
+column; (2) while armed, the buffered Measurement ships *nothing* while the live one
+keeps landing rows; (3) after the event, the released window is reachable as `WHERE
+incident_id = '…'` — a column predicate, which is the whole point of #291, since the
+same data buried in the JSON payload would not be; (4) the id is on the released window
+only, and the never-armed Measurement's rows keep `incident_id IS NULL`.
+
+The `FlushEvent` is published with `ros2 topic pub` rather than by a `dc_triggers`
+broadcast node: that topic is the contract Measurements subscribe to, `dc_triggers` has
+its own tests for minting the event, and the broadcast node is not in `dc_bringup`'s
+launch yet. Not run by `ci.yaml`, same as the retention scenario.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -233,6 +258,8 @@ below.
 - `params/e2e_retention_params.yaml` / `scripts/run_retention.sh` — the files retention
   scenario (#267) described above; a separate, narrower harness reusing the same
   `dc-e2e` image.
+- `params/e2e_incident_params.yaml` / `scripts/run_incident.sh` — the incident-capture
+  scenario (#291) described above, likewise reusing the same `dc-e2e` image.
 
 ## `.dockerignore`
 

--- a/tools/e2e/params/e2e_incident_params.yaml
+++ b/tools/e2e/params/e2e_incident_params.yaml
@@ -1,0 +1,56 @@
+# Incident-capture scenario (#291): two Measurements, one armed for pre-event buffering and
+# one collecting live, both landing in the same Postgres table. What it proves is that
+# `incident_id` reaches Postgres as a *column* — see tools/e2e/scripts/run_incident.sh, which
+# asserts it with `WHERE incident_id = '...'` rather than by matching payload text.
+measurement_server:
+  ros__parameters:
+    save_local_base_path: "$HOME/.dc/e2e/data/%Y/%M/%D/%H"
+    all_base_path: "e2e"
+    measurement_plugins: ["uptime", "memory"]
+
+    # Armed: publishes nothing until a FlushEvent arrives on /dc/flush, then releases the
+    # last `buffer_duration_sec` of collection tagged with that event's incident_id.
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      polling_interval: 500
+      group_key: "uptime"
+      buffer_duration_sec: 6.0
+      post_roll_duration_sec: 2.0
+      # Paced, not burst: the Measurement's data publisher is KeepLast(1), so a whole window
+      # published back-to-back in one callback would be coalesced down to its last Record
+      # before any subscriber ran. 20 Hz is far faster than the 2 Hz collection being
+      # released, so it costs the scenario nothing and delivers the whole window.
+      max_flush_rate_hz: 20.0
+
+    # The control: never armed, so every one of its Records must reach Postgres live and with
+    # a NULL incident_id. Without it, "no incident_id" and "no Records at all" would look the
+    # same in the final query.
+    memory:
+      plugin: "dc_measurements/Memory"
+      polling_interval: 1000
+      group_key: "memory"
+
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/e2e/buffer"
+    destinations: ["pgsql_records"]
+    pgsql_records:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime", "/dc/measurement/memory"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_records"
+      time_key: "date"
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224
+
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]

--- a/tools/e2e/scripts/run_incident.sh
+++ b/tools/e2e/scripts/run_incident.sh
@@ -124,8 +124,13 @@ podman run -d --network host --name "$PG_C" \
   -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
   docker.io/library/postgres:13 >/dev/null
 
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never became ready"; exit 1; }
+# Deliberately not `pg_isready`: the postgres image runs /docker-entrypoint-initdb.d against a
+# *temporary* server that is then shut down and restarted, and pg_isready answers yes to that
+# one. Waiting for `dc_records` to resolve instead gates on the only state that matters — the
+# real server is up and init.sql has been applied — and cannot match the throwaway one, whose
+# shutdown otherwise lands in the middle of the first query below.
+timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
+  || { log "Postgres never came up with sql/init.sql applied"; exit 1; }
 
 # The column has to be a column. A table without it would make every assertion below fail
 # for a reason that has nothing to do with the pipeline, so say so here instead.

--- a/tools/e2e/scripts/run_incident.sh
+++ b/tools/e2e/scripts/run_incident.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Incident-capture E2E scenario (#291). From the repo root:
+#
+#   ./tools/e2e/scripts/run_incident.sh
+#
+# Reuses the same dc-e2e image tools/e2e/scripts/run.sh builds/uses (see its header for the
+# build/prebuilt-image env vars this script shares: DC_E2E_IMAGE, DC_WORKSPACE_IMAGE), but
+# drives the DC stack against tools/e2e/params/e2e_incident_params.yaml: an `uptime`
+# Measurement armed for pre-event buffering (`buffer_duration_sec`) alongside a `memory`
+# Measurement collecting live, both routed to one `postgres` Destination.
+#
+# Asserts, against a real Postgres container, the real dc_bridge and the real Vector binary:
+#   1. while armed, the buffered Measurement ships nothing — its Records are held, not
+#      published — while the live one keeps landing rows. (Without this the final query
+#      could pass on a pipeline that simply never buffered anything.)
+#   2. after one FlushEvent, the released window is queryable as
+#      `WHERE incident_id = '<the id the event carried>'` — a *column* predicate. This is the
+#      point of the whole scenario: the same rows are reachable by column, not by grepping
+#      an opaque JSON payload, which is what #291 is for.
+#   3. every released Record carries that exact id and the Tag of the armed Measurement, and
+#      the live Measurement's rows keep `incident_id IS NULL` — the field marks an incident,
+#      it is not stamped on everything.
+#
+# The FlushEvent is published directly onto /dc/flush with `ros2 topic pub` instead of being
+# produced by a `dc_triggers` broadcast node. That topic *is* the contract a Measurement
+# subscribes to (dc_triggers has its own tests for minting the event); wiring the broadcast
+# node into dc_bringup's launch is separate work, and this scenario is about what happens to
+# the id downstream of the event, not about what produced it.
+#
+# Env vars: DC_E2E_IMAGE / DC_WORKSPACE_IMAGE (see run.sh); DC_E2E_KEEP ("true" to leave the
+# stack up after a failure for debugging); DC_E2E_LIVE_TIMEOUT_SECONDS (default 180 — how
+# long to wait for the live Measurement's first rows, which is also how long the armed one is
+# observed shipping nothing; generous because it covers the whole stack's startup, Vector
+# included); DC_E2E_INCIDENT_TIMEOUT_SECONDS (default 120 — from the FlushEvent to the
+# released window being committed, which includes the post-roll phase and Vector's own batch).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_DIR="$E2E_DIR/.run"
+
+LIVE_TIMEOUT_SECONDS="${DC_E2E_LIVE_TIMEOUT_SECONDS:-180}"
+INCIDENT_TIMEOUT_SECONDS="${DC_E2E_INCIDENT_TIMEOUT_SECONDS:-120}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+# Fixed rather than random: a failed run leaves rows in the Postgres volume that are worth
+# being able to find again by name, and the whole point is that the id the event carried is
+# the id the column holds — a generated one would prove the same thing while making a
+# debugging session guess what to query.
+INCIDENT_ID="e2e-incident-0001"
+BUFFERED_TAG="dc.measurement.uptime"
+LIVE_TAG="dc.measurement.memory"
+
+PG_C=dc_e2e_inc_postgres
+DC_C=dc_e2e_inc_dc
+VOLUMES=(dc_e2e_inc_pgdata dc_e2e_inc_buffer dc_e2e_inc_data)
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-incident $(date -u +%H:%M:%S)] $*"; }
+
+remove_stack() {
+  podman rm -f --ignore "$DC_C" "$PG_C" >/dev/null
+  for v in "${VOLUMES[@]}"; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+}
+
+pg_exec() {
+  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
+}
+
+# A count query that reads 0 rather than aborting the run while Postgres/the table is still
+# settling — every call site is inside a deadline loop that fails loudly on its own.
+pg_count() {
+  pg_exec "$1" 2>/dev/null | tr -d '[:space:]' || true
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  if podman container exists "$DC_C"; then
+    podman logs "$DC_C" > "$RUN_DIR/dc_incident.log" 2>&1
+  fi
+  remove_stack
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- obtain the DC stack image (shared with run.sh — see its header) ------------------
+if [ -n "${DC_E2E_IMAGE:-}" ]; then
+  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+  DC_IMAGE="$DC_E2E_IMAGE"
+else
+  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
+  else
+    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+    "$SCRIPT_DIR/build.sh"
+    WORKSPACE_IMAGE="dc-workspace:latest"
+  fi
+  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
+  DC_IMAGE="dc-e2e:latest"
+fi
+
+remove_stack
+
+# --- Postgres ------------------------------------------------------------------------
+log "starting Postgres (sql/init.sql — dc_records has the incident_id column under test)"
+podman run -d --network host --name "$PG_C" \
+  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+  -v dc_e2e_inc_pgdata:/var/lib/postgresql/data \
+  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+  docker.io/library/postgres:13 >/dev/null
+
+timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
+  || { log "Postgres never became ready"; exit 1; }
+
+# The column has to be a column. A table without it would make every assertion below fail
+# for a reason that has nothing to do with the pipeline, so say so here instead.
+COLUMN_TYPE="$(pg_exec "SELECT data_type FROM information_schema.columns WHERE table_name = 'dc_records' AND column_name = 'incident_id'" | tr -d '[:space:]')"
+if [ "$COLUMN_TYPE" != "text" ]; then
+  log "FAIL: dc_records has no text incident_id column (got '${COLUMN_TYPE:-none}') — check sql/init.sql"
+  exit 1
+fi
+log "PASS: dc_records.incident_id exists as a text column"
+
+# --- DC stack --------------------------------------------------------------------------
+log "starting the DC stack (uptime armed with buffer_duration_sec, memory collecting live)"
+podman run -d --network host --name "$DC_C" \
+  -v dc_e2e_inc_buffer:/root/.dc/e2e/buffer \
+  -v dc_e2e_inc_data:/root/.dc/e2e/data \
+  -v "$E2E_DIR/params/e2e_incident_params.yaml:/opt/e2e/e2e_params.yaml:ro" \
+  "$DC_IMAGE" >/dev/null
+
+# --- 1. armed means silent, live means flowing -------------------------------------------
+log "waiting up to ${LIVE_TIMEOUT_SECONDS}s for the live Measurement's first rows"
+DEADLINE=$(( $(date +%s) + LIVE_TIMEOUT_SECONDS ))
+LIVE_COUNT=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  LIVE_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$LIVE_TAG'")"
+  # Several rows, not one: enough collection has gone by that an unarmed Measurement would
+  # have shipped several Records too, which is what makes the armed one's silence meaningful.
+  if [ "${LIVE_COUNT:-0}" -ge 5 ] 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${LIVE_COUNT:-0}" -lt 5 ] 2>/dev/null; then
+  log "FAIL: the live Measurement produced only ${LIVE_COUNT:-0} rows in ${LIVE_TIMEOUT_SECONDS}s — the pipeline is not running"
+  exit 1
+fi
+log "PASS: ${LIVE_COUNT} live rows — the pipeline is delivering to Postgres"
+
+BUFFERED_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$BUFFERED_TAG'")"
+if [ "${BUFFERED_COUNT:-0}" -ne 0 ] 2>/dev/null; then
+  log "FAIL: the armed Measurement shipped ${BUFFERED_COUNT} rows before any FlushEvent — it is not buffering"
+  exit 1
+fi
+log "PASS: the armed Measurement shipped nothing while buffering"
+
+# --- 2. one FlushEvent, then the window is queryable by column ---------------------------
+log "publishing one FlushEvent on /dc/flush with incident_id='$INCIDENT_ID'"
+# `-w 1`: the publisher lives in a throwaway process, and a volatile subscription that has
+# not finished discovery yet simply never sees the sample — waiting for the Measurement's
+# subscription to match removes that race instead of papering over it with repeats. Wrapped
+# in `timeout` so a Measurement that never subscribed fails the run here, where the message
+# says why, rather than 120s later as an empty result set.
+if ! timeout 90 podman exec "$DC_C" bash -lc "
+  set +u
+  source /root/ws/install/setup.bash
+  set -u
+  ros2 topic pub --once -w 1 /dc/flush dc_interfaces/msg/FlushEvent '{incident_id: \"$INCIDENT_ID\"}'
+" >/dev/null; then
+  log "FAIL: could not publish a FlushEvent that a Measurement was subscribed to"
+  exit 1
+fi
+
+log "waiting up to ${INCIDENT_TIMEOUT_SECONDS}s for the released window to reach Postgres"
+DEADLINE=$(( $(date +%s) + INCIDENT_TIMEOUT_SECONDS ))
+INCIDENT_COUNT=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  # The assertion this whole scenario exists for: a column predicate, not a payload match.
+  INCIDENT_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id = '$INCIDENT_ID'")"
+  if [ "${INCIDENT_COUNT:-0}" -ge 2 ] 2>/dev/null; then
+    break
+  fi
+  sleep 2
+done
+
+if [ "${INCIDENT_COUNT:-0}" -lt 2 ] 2>/dev/null; then
+  log "FAIL: only ${INCIDENT_COUNT:-0} row(s) matched WHERE incident_id = '$INCIDENT_ID' within ${INCIDENT_TIMEOUT_SECONDS}s"
+  log "      (a released *window* is several Records; 0 means the id never became a column value at all)"
+  exit 1
+fi
+log "PASS: ${INCIDENT_COUNT} rows are queryable as WHERE incident_id = '$INCIDENT_ID' — a column, not payload text"
+
+# --- 3. the id marks the incident and nothing else ----------------------------------------
+WRONG_TAG="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id = '$INCIDENT_ID' AND tag <> '$BUFFERED_TAG'")"
+if [ "${WRONG_TAG:-0}" -ne 0 ] 2>/dev/null; then
+  log "FAIL: ${WRONG_TAG} incident row(s) came from a Measurement other than $BUFFERED_TAG"
+  exit 1
+fi
+
+OTHER_IDS="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id IS NOT NULL AND incident_id <> '$INCIDENT_ID'")"
+if [ "${OTHER_IDS:-0}" -ne 0 ] 2>/dev/null; then
+  log "FAIL: ${OTHER_IDS} row(s) carry an incident_id other than the one the FlushEvent minted"
+  exit 1
+fi
+
+LIVE_TAGGED="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$LIVE_TAG' AND incident_id IS NOT NULL")"
+if [ "${LIVE_TAGGED:-0}" -ne 0 ] 2>/dev/null; then
+  log "FAIL: ${LIVE_TAGGED} row(s) from the never-armed Measurement carry an incident_id"
+  exit 1
+fi
+log "PASS: the incident_id is on the released window only — the live Measurement's rows stay NULL"
+
+log "PASS: incident_id E2E scenario (#291)"

--- a/tools/e2e/sql/init.sql
+++ b/tools/e2e/sql/init.sql
@@ -15,6 +15,11 @@ CREATE TABLE IF NOT EXISTS dc_records (
   date bigint,
   tag text,
   group_key text,
+  -- The incident a Measurement released this Record under (#291) — NULL unless the Record
+  -- came out of a buffered pre-roll window or the post-roll that follows it. A column, not a
+  -- payload key, so `WHERE incident_id = ...` is a real query; scripts/run_incident.sh is
+  -- what proves that end to end.
+  incident_id text,
   -- memory
   used double precision,
   -- os

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -34,6 +34,10 @@ CREATE TABLE IF NOT EXISTS dc (
   nested boolean,
   tags jsonb,
   plugins jsonb,
+  -- The incident a Measurement released this Record under (#291). NULL for every Record
+  -- collected outside an incident, which is most of them; the UUID the Trigger broadcast
+  -- node minted for one firing otherwise, shared by every Record and File of that incident.
+  incident_id text,
   -- System (tb3_simulation_pgsql_minio: memory/os/uptime)
   used double precision,
   os text,


### PR DESCRIPTION
Closes #291

Sixth implementation slice of #282. #287–#290 made an armed Measurement release a window of Records each stamped with the `FlushEvent`'s `incident_id`. This slice makes that id **queryable as a column** everywhere the Record can land, rather than a key riding along inside an opaque payload — user stories 9 and 19 of the parent.

## The mapping

Vector's `postgres` sink has no column-mapping options at all: it hands the event to `jsonb_populate_record`, so a top-level key lands in the same-named column and everything else is dropped. There is no `columns = [...]` to render. The mapping is therefore a block the renderer emits into the normalize transform, inside each **postgres** Destination's own tag branch:

```
if exists(.incident_id) {
  .incident_id = to_string(.incident_id) ?? null
}
```

It also does real work, beyond naming the field in the generated contract:

- `to_string(...) ?? null` is the same coercion the route predicates already apply to `.tag` — VRL types an event field as `any`, and a Measurement whose own payload carried a non-string `incident_id` (an object, say) would otherwise reach the sink as a value a `text` column cannot take and fail the **whole insert batch**. Coerced, that Record still lands, with a NULL in the column.
- The `exists` guard is load-bearing: VRL's `to_string(null)` is `""`, so without it every Record collected outside an incident would write an empty string where a NULL belongs.
- Scoped to postgres destinations — s3/file/console already receive `incident_id` as an ordinary JSON key and need nothing.

**Verified against the real pinned Vector binary, not inferred.** `vector validate --no-environment` accepts the rendered fixture (the `??` is neither rejected nor flagged as an unnecessary coalesce), and `vector vrl --print-object` confirms all four cases: `"abc-123"` → `"abc-123"`, `7` → `"7"`, `{"a":1}` → `null` (rescued instead of failing the batch), key absent → still absent, so the column stays NULL rather than `""`.

## Also in this PR

- **DDL** — the sink neither creates tables nor adds columns, so `incident_id text` is added to `tools/e2e/sql/init.sql`'s `dc_records` and `tools/infrastructure/docker/config/postgresql/init.sql`'s `dc`. Not `dc_files`: the Uploader's own metadata Records know nothing about incidents.
- **`dc_group`** — a Group nests each member's Record under its `group_key`, so a released member's `incident_id` became `<group_key>.incident_id`: no column any table has, silently dropped by the very sink this issue is about. It is now lifted onto the merged Record's top level, exactly the way `tags` already is (first non-null wins — one FlushEvent mints one id for every Measurement listening), and only when a member actually carried one. This is field preservation, **not** the Group-level correlated buffering #282 defers.
- **Docs** — `destinations.md` gains an `incident_id` section (the column, the `ALTER TABLE`, why it must pre-exist); `measurements.md`, `groups.md` and the e2e `README.md` follow.

## Tests

- `dc_bridge/test/render_test.cpp` 48 → 51 cases: the block is rendered for a postgres destination under every `time_format`; it sits *inside* that destination's tag branch and is rendered exactly once even when a console destination shares the transform; a config with no column-mapped sink renders no `incident_id` at all. Gold fixtures updated (`s3_*` and `file_and_console` deliberately unchanged).
- `dc_group/test/test_group_sync_timeout.py` +3 cases: lifted to top level and gone from the members' data; absent when no member carried one; preserved on a partial Record assembled by the sync timeout.
- **`tools/e2e/scripts/run_incident.sh` + `params/e2e_incident_params.yaml`** — the fourth acceptance criterion ("verified queryable as a column value, not just JSON payload text") is not something a unit test can answer, so it gets a real scenario harness modelled on #267's `run_retention.sh` (own containers, own params, Postgres only, not wired into `ci.yaml`). An `uptime` Measurement armed with `buffer_duration_sec` runs beside a never-armed `memory` Measurement, both into one postgres Destination. It asserts, in order: `dc_records.incident_id` is a real `text` column; the live Measurement is landing rows while the armed one has shipped *nothing* (without which the final query could pass on a pipeline that never buffered); after one `FlushEvent` the released window is reachable as `WHERE incident_id = '…'` — the column predicate that is the entire point; and the id is on that window only, with the never-armed Measurement's rows still `IS NULL`.

  `max_flush_rate_hz` is set in those params because of #290's finding: an unpaced burst release is coalesced away by the `KeepLast(1)` data publisher before any subscriber runs.

  The `FlushEvent` is published with `ros2 topic pub --once -w 1` rather than by a `dc_triggers` broadcast node: `/dc/flush` *is* the contract a Measurement subscribes to, `dc_triggers` has its own tests for minting the event, and the broadcast node is not in `dc_bringup`'s launch yet — wiring it there is separate work, and this scenario is about what happens to the id downstream of the event, not about what produced it.

## Verification status

`render_test` (51 tests, 0 failures) and the Vector-binary checks above are done. The full `colcon test` sweep across the rebuilt packages and a live run of `run_incident.sh` are still in flight locally; I'll post the results as a comment. Opening now so CI builds in parallel.

`pre-commit run --files <changed>` passes clang-format, shellcheck, codespell, the mdbook doc build, yaml/toml lint and the rest. The only failures are the two long-standing local-environment ones (`poetry-requirements`, no `poetry` module on this host; `pycln`, a broken hook venv) plus `black` on the pre-existing violation in `tools/e2e/scripts/verify_zero_loss.py`, reverted here to keep the diff scoped, exactly as in #285–#290.

## Not touched, deliberately

The Streamlit demo dashboard (#282 puts incident-browsing UI out of scope) and `CONTEXT.md`'s glossary (#345 owns the **Incident** entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cnfbr8B991j1zi2UPPpjqF
