### PR TITLE
docs: document Trigger vs Condition, FlushEvent, and incident_id

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -10,16 +10,33 @@ _Avoid_: metric, sensor log, sample
 
 **Condition**:
 A boolean predicate on robot state that gates whether a Measurement's Records are collected.
-_Avoid_: filter (as a synonym for Condition; "Trigger" is now a distinct DC concept, see below)
+A Condition is a *level*: it holds for as long as the predicate is true, and gates collection
+going forward only.
+_Avoid_: filter (as a synonym for Condition); **trigger** — "a Condition turning on" is not a
+Trigger, which is a distinct DC concept with its own plugin type (see below)
 
 **Trigger**:
 A plugin that fires a one-shot signal (a FlushEvent) on the false→true rising edge of a
-Condition composition, distinct from Condition's continuous gating. Used to release a
-Measurement's pre-event buffer around an incident (e.g. an emergency brake).
+Condition composition. A Trigger is an *edge*, where a Condition is a level: it fires once
+to release a Measurement's pre-event buffer around an incident (e.g. an emergency brake),
+rather than gating live collection while true. Built out of Condition plugins, using the same
+`if_all`/`if_any`/`if_none` composition Measurements use, and loaded by the trigger broadcast
+node — never by a Measurement.
+_Avoid_: using the word for a Condition becoming active, or for a Measurement's polling tick
 
 **FlushEvent**:
 The message a Trigger broadcast node publishes when its Trigger fires, carrying a fresh
-`incident_id` that downstream Measurements adopt for that one event.
+`incident_id` that downstream Measurements adopt for that one event. It is the whole contract
+between the Trigger side and the Measurement side — several Measurements can subscribe to the
+same flush topic.
+_Avoid_: flush signal, flush command
+
+**Incident**:
+One flush cycle: the pre-event window a FlushEvent released, plus the post-roll collected
+after it. Every Record and File of one cycle carries that event's `incident_id` — a top-level
+field of the Record envelope beside Tags, and its own column in a PostgreSQL Destination — so
+"everything from this one event" is a query, not a timestamp range reconstructed by hand.
+_Avoid_: event (a Record is not an event), alert, incident report
 
 **Group**:
 A merge of Records from several Measurements into one Record, based on time proximity.
@@ -64,6 +81,8 @@ _Avoid_: route (a "route" is the Shipper-side path a Tag selects)
 - The **Shipper** delivers Records to one or more **Destinations**
 - A **File** is uploaded to an object-storage **Destination**; its metadata becomes a **Record**
 - A **Record** carries **Tags**; each Tag names a **Destination**
+- A **Trigger** fires a **FlushEvent**; every Measurement listening for it releases its
+  buffered **Records** and **Files** as one **Incident**
 
 ## Example dialogue
 
@@ -74,3 +93,4 @@ _Avoid_: route (a "route" is the Shipper-side path a Tag selects)
 
 - "destination" was used for both the DC pluginlib class and the external system — resolved: a **Destination** is the external system; the per-destination pluginlib layer is retired.
 - "backend" was used for Fluent Bit's embedded engine — resolved: the engine is the **Shipper**, an external process, not an embedded library.
+- "trigger" was loose talk for a **Condition** becoming active, and the Condition entry told you to avoid the word — resolved: **Trigger** is now a real pluginlib type (`dc_triggers`) that fires on an edge; a Condition still gates on a level. The two are documented side by side in [doc/src/dc/triggers.md](./doc/src/dc/triggers.md#trigger-vs-condition).

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -10,6 +10,9 @@ DC has a small, fixed vocabulary. Using it precisely makes the rest of the docum
 | **Measurement**           | A source of sampled data (CPU, position, camera inspection…) that emits Records.                              |
 | **Record**                | One timestamped JSON document flowing through the pipeline.                                                   |
 | **Condition**             | A boolean predicate on robot state that gates whether a Measurement's Records are collected.                  |
+| **Trigger**               | A plugin that fires a one-shot signal on the false→true edge of a Condition composition, releasing a Measurement's pre-event buffer. Distinct from a Condition, which gates continuously. |
+| **FlushEvent**            | The message a Trigger broadcast node publishes when its Trigger fires, carrying the `incident_id` subscribed Measurements adopt. |
+| **Incident**              | One flush cycle — the pre-event window a Trigger released plus its post-roll — identified by the `incident_id` every Record and File of that cycle carries. |
 | **Group**                 | A merge of Records from several Measurements into one Record, based on time proximity.                        |
 | **File**                  | A binary artifact produced by a Measurement (image, video, map), uploaded to object storage as-is; only its metadata travels as a Record. |
 | **Destination**           | An external system that receives Records or Files (PostgreSQL, S3-compatible storage, console…).              |
@@ -27,11 +30,15 @@ Relationships between them:
 - The **Shipper** delivers Records to one or more **Destinations**
 - A **File** is uploaded to an object-storage **Destination**; its metadata becomes a **Record**
 - A **Record** carries a **Tag**; each Tag names a route Destinations subscribe to
+- A **Trigger** fires a **FlushEvent**; every Measurement listening for it releases its
+  buffered window as one **Incident**
 
 ```admonish example title="Words that mean something specific here"
 "Sink" is the Shipper's internal configuration unit, not the DC concept — the DC concept
 is **Destination**. "Route" is the Shipper-side path a **Tag** selects. A camera image is
 a **File**, not a Record; the Record is the JSON document describing where that File went.
+"Trigger" is not a synonym for a **Condition** turning on: a Condition is a level that gates
+collection while true, a **Trigger** is an edge that fires once.
 ```
 
 ## ROS 2
@@ -156,6 +163,15 @@ measurement_server:
 A Condition enables or disables one or more Measurements. For example, collect camera
 images only when the robot is stopped. A Measurement can require that all, any, or none
 of a set of Conditions are active. See [Conditions](./conditions.md).
+
+## Triggers and incidents
+
+A Condition can only give you data from the moment it turned true. When what matters is the
+run-up to an event — the seconds before an emergency brake — a **Trigger** is the mechanism:
+a Measurement holds its recent output in a rolling buffer instead of publishing it, and a
+Trigger firing on the false→true edge of a Condition composition broadcasts a **FlushEvent**
+that releases that buffer. Everything released by one firing, across every Measurement
+listening, shares one `incident_id`. See [Triggers](./triggers.md).
 
 ## Lifecycle Nodes and Bond
 

--- a/doc/src/dc/conditions.md
+++ b/doc/src/dc/conditions.md
@@ -5,6 +5,13 @@ A condition enables or disables one or multiple measurements to be published and
 
 Each condition is enabled or disabled through a pluginlib plugin. It has these configuration parameters:
 
+```admonish note title="A Condition is a level, not an edge"
+A Condition gates collection for as long as its predicate holds, so it can only give you data
+from the moment it became true onwards. To capture what happened *before* an event, use a
+[Trigger](./triggers.md): it is built out of these same Condition plugins but fires once on
+the false→true edge, releasing a window a Measurement had already buffered.
+```
+
 ## Available plugins:
 
 | Name                                                     | Description                                      |

--- a/doc/src/dc/triggers.md
+++ b/doc/src/dc/triggers.md
@@ -2,18 +2,71 @@
 
 ## Description
 
-A **Trigger** is distinct from a **Condition**: a Condition gates whether a Measurement's
-Records are collected right now, while a Trigger fires a one-shot signal that downstream
-Measurements react to — e.g. releasing a pre-event buffer of recent data (later slices of
-[#282](https://github.com/Minipada/ros2_data_collection/issues/282) wire that reaction up;
-this package only builds the signal itself).
+A **Trigger** fires a one-shot signal — a `dc_interfaces/msg/FlushEvent` — when a composition
+of [Conditions](./conditions.md) goes from false to true. Measurements listening for that
+event release the window of recent data they have been holding back, so the seconds *leading
+up to* an event are collected, not just the seconds after it.
 
-The `trigger_broadcast_node` loads the Condition plugins named in `condition_plugins` (the
-same Condition plugins Measurements use — see [Conditions](./conditions.md)) plus one
-Trigger plugin, polls the Trigger on a timer, and publishes a
-`dc_interfaces/msg/FlushEvent` on a configurable topic (`/dc/flush` by default) each time
-it fires. The node mints a fresh `incident_id` (a UUID) for every firing; nothing else
-generates one — every subscriber shares one ID per incident.
+The motivating case is incident review: when an autonomous robot emergency-brakes, what
+matters is what happened before the brake. A Condition cannot express that — it gates
+collection going forward, and by the time it turns true the run-up is gone. A Trigger can,
+because the Measurement was already buffering.
+
+## Trigger vs Condition
+
+Both are described with the same `if_all`/`if_any`/`if_none` Condition lists, and a Trigger is
+built out of Condition plugins — but they answer different questions.
+
+|                         | Condition                                                     | Trigger                                                                    |
+| ----------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Question it answers     | "Should this Measurement be collecting *right now*?"          | "Did something just happen?"                                               |
+| Shape of the signal     | A level: true for as long as the predicate holds              | An edge: fires once on the false→true transition                           |
+| Effect on collection    | Gates live publishing while true                              | Releases a pre-collected buffer, once                                      |
+| Data it can give you    | Everything *from* the moment it turned true                   | Everything from the `buffer_duration_sec` *before* the event, plus post-roll |
+| Where it is configured  | Per Measurement (`if_all_conditions`, …)                      | On the `trigger_broadcast_node`, once for the whole robot                  |
+| How Measurements see it | Directly, as their own gate                                   | Indirectly, as a `FlushEvent` on a topic several Measurements can share    |
+| Scope                   | One Measurement                                               | Every Measurement subscribed to its `flush_topic`                          |
+
+They compose: a Trigger is *made of* Conditions, and a buffering Measurement can still be
+gated by its own Conditions. Nothing about a Trigger changes what a Condition means.
+
+```admonish warning title="Trigger is a specific word here"
+Before this feature existed, "trigger" was loose talk for "a Condition turning on", and the
+[glossary](./concepts.md#glossary) told you to avoid the word. It now names a real, distinct
+plugin type. Say **Condition** for a gate that stays true, and **Trigger** only for the
+edge-firing plugin documented here.
+```
+
+## The flush broadcast
+
+The `trigger_broadcast_node` loads the Condition plugins named in `condition_plugins` (the same
+Condition plugins Measurements use) plus one Trigger plugin, polls the Trigger on a timer, and
+publishes a `FlushEvent` on a configurable topic (`/dc/flush` by default) each time it fires:
+
+```
+                    ┌──────────────────────┐
+   /odom, … ───────▶│  Condition plugins   │
+                    └──────────┬───────────┘
+                               │ if_all / if_any / if_none
+                    ┌──────────▼───────────┐
+                    │  Trigger (EdgeTrigger)│  false → true?
+                    └──────────┬───────────┘
+                               │ FlushEvent { incident_id, stamp }
+                    ┌──────────▼───────────┐
+                    │      /dc/flush       │
+                    └───┬──────────────┬───┘
+                        │              │
+              ┌─────────▼────┐  ┌──────▼───────┐
+              │ Measurement A│  │ Measurement B│   release their buffered windows,
+              │  (buffering) │  │  (buffering) │   both tagged with the same incident_id
+              └──────────────┘  └──────────────┘
+```
+
+The node mints a fresh `incident_id` (a UUID) for every firing; nothing else generates one, so
+every subscriber of one event shares one ID. Several Measurements can point at the same
+`flush_topic`, which is the whole reason the signal is broadcast on a topic rather than wired
+per Measurement: adding a sensor stream to an existing incident-capture setup needs no change
+to the Trigger.
 
 ```admonish note title="Only self-updating Conditions are meaningful here"
 A Measurement passes its own freshly-collected Record to each Condition it consults, so
@@ -21,6 +74,51 @@ plugins like `BoolEqual` read a field out of that Record. A Trigger has no Recor
 own: it only makes sense to compose Conditions that maintain their own state from a
 subscription, such as [Moving](./conditions/moving.md).
 ```
+
+```admonish info title="Running the broadcast node"
+`trigger_broadcast_node` is a lifecycle node, like the Measurement server, but it is not part
+of `dc_bringup`'s launch file yet — run it alongside the rest of the stack and transition it
+yourself (or add it to your own launch file and lifecycle manager `node_names`):
+
+    ros2 run dc_triggers trigger_broadcast_node --ros-args --params-file <your_params.yaml>
+
+A Measurement subscribes to a plain topic, so anything publishing a `FlushEvent` on
+`flush_topic` releases the buffer — including `ros2 topic pub`, which is how the
+`tools/e2e/scripts/run_incident.sh` scenario drives a flush.
+```
+
+## `FlushEvent`
+
+`dc_interfaces/msg/FlushEvent` is the entire contract between the Trigger side and the
+Measurement side:
+
+| Field         | Type                     | Description                                                        |
+| ------------- | ------------------------ | ------------------------------------------------------------------ |
+| `incident_id` | string                   | UUID minted by the broadcast node, one per firing                  |
+| `stamp`       | builtin_interfaces/Time  | When the Trigger fired                                             |
+
+A Measurement adopts the `incident_id` it receives; it never generates its own. An event that
+arrives while a Measurement is already flushing, in post-roll, or in cooldown is ignored.
+
+## `incident_id`
+
+`incident_id` is a top-level field of the Record envelope, beside `tags`, `run_id` and `name`
+— not a key nested inside the measurement's own data. Every Record and File released by one
+flush cycle carries the same value, so "everything from this one event" is a single query
+rather than a timestamp range reconstructed by hand:
+
+```sql
+SELECT * FROM dc_records WHERE incident_id = '3f2b1c7e-…' ORDER BY date;
+```
+
+- A `postgres` Destination writes it to its own **`incident_id` column** — the column must
+  exist in the table beforehand; see [Destinations](./destinations.md#incident_id).
+- A Record collected outside an incident carries no `incident_id` at all, leaving the column
+  NULL.
+- A [Group](./groups.md) lifts a member's `incident_id` onto the merged Record the same way it
+  does `tags`, so grouping does not bury it.
+- Other Destination types need no configuration: `incident_id` is already a top-level key of
+  the JSON they receive.
 
 ## Available plugins
 
@@ -47,3 +145,87 @@ parameters:
 | trigger.if_none_conditions   | Fire only once no named Condition is active                       | list\[str\] | []             |
 | trigger.topic                | Topic `FlushEvent` messages are published on                      | str         | "/dc/flush"    |
 | trigger.polling_interval     | Interval in milliseconds at which the composed Condition state is checked | int | 100            |
+
+## Measurement parameters
+
+The other half of the feature lives on each Measurement: what it buffers, and what it does
+once a `FlushEvent` releases it. All five are optional, and a Measurement that leaves
+`buffer_duration_sec` at 0 behaves exactly as it always has — this feature is entirely
+opt-in. They are documented in full, with the state machine and how Files are staged, in
+[Measurements](./measurements.md#plugin-parameters).
+
+| Parameter name             | Description                                                                                       | Type(s) | Default     |
+| -------------------------- | ------------------------------------------------------------------------------------------------- | ------- | ----------- |
+| buffer_duration_sec        | Seconds of history to hold instead of publishing live; 0 disables buffering entirely              | float   | 0           |
+| post_roll_duration_sec     | Seconds to keep publishing live after the release finishes, still tagged with the same `incident_id`; 0 means pre-roll only | float | 0 |
+| cooldown_sec               | Seconds to ignore further `FlushEvent`s once post-roll ends, before buffering re-arms itself; 0 re-arms immediately | float | 0 |
+| max_flush_rate_hz          | Ceiling in Records per second on how fast the released window is emitted; 0 releases it in one burst | float | 0           |
+| flush_topic                | Topic the `FlushEvent` that releases this Measurement is received on                              | str     | "/dc/flush" |
+
+An armed Measurement moves through four states per incident — **Buffering** (accumulate,
+publish nothing) → **Flushing** (release the window, oldest first, rate-limited) →
+**PostRoll** (publish live, same `incident_id`) → **Cooldown** (ignore further events) → back
+to Buffering, with no manual re-arm.
+
+```admonish tip title="Sizing max_flush_rate_hz"
+A Measurement's data publisher is `KeepLast(1)`. A whole window published back-to-back in one
+callback is coalesced down to its last Record before any subscriber runs, so a burst release
+(`max_flush_rate_hz: 0`) only delivers the full window to a subscriber that keeps up. Set a
+rate comfortably above the collection rate being released — 20 Hz for a 2 Hz Measurement — and
+the window is paced out intact, which is also what keeps a backlog dump from competing with
+live collection right after an incident.
+```
+
+## Example
+
+An emergency-brake capture: the robot buffers the last 10 seconds of uptime data, and the
+moment it starts moving the buffer is released and collection continues live for 5 more
+seconds. Swap the `moving` Condition for whatever expresses your event.
+
+`trigger_broadcast_node`'s parameters:
+
+```yaml
+trigger_broadcast_node:
+  ros__parameters:
+    condition_plugins: ["moving"]
+
+    moving:
+      plugin: "dc_conditions/Moving"
+      odom_topic: "/odom"
+
+    trigger:
+      plugin: "dc_triggers/EdgeTrigger"
+      if_all_conditions: ["moving"]
+      topic: "/dc/flush"
+      polling_interval: 100
+```
+
+The Measurements listening for it:
+
+```yaml
+measurement_server:
+  ros__parameters:
+    measurement_plugins: ["uptime", "memory"]
+
+    # Armed: publishes nothing until a FlushEvent arrives on /dc/flush, then releases the
+    # last 10 seconds of collection tagged with that event's incident_id.
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      polling_interval: 500
+      group_key: "uptime"
+      buffer_duration_sec: 10.0
+      post_roll_duration_sec: 5.0
+      cooldown_sec: 30.0
+      max_flush_rate_hz: 20.0
+      flush_topic: "/dc/flush"
+
+    # Not armed: collects live as usual, and its Records leave incident_id NULL.
+    memory:
+      plugin: "dc_measurements/Memory"
+      polling_interval: 1000
+      group_key: "memory"
+```
+
+A runnable end-to-end version of this — two Measurements, one armed, both landing in the same
+Postgres table, with the `incident_id` column asserted by query — is
+`tools/e2e/scripts/run_incident.sh`.

--- a/doc/src/dc/triggers/edge_trigger.md
+++ b/doc/src/dc/triggers/edge_trigger.md
@@ -11,5 +11,10 @@ again. No rule-evaluation logic of its own: composition is entirely delegated to
 
 ## Parameters
 
-See [Node parameters](../triggers.md#node-parameters) — `EdgeTrigger` has no parameters
+See [Plugin parameters](../triggers.md#plugin-parameters) — `EdgeTrigger` has no parameters
 of its own beyond the shared `trigger.*` ones every Trigger plugin reads.
+
+## Trigger vs Condition
+
+`EdgeTrigger` fires *once* per false→true transition; a Condition stays true and keeps gating
+for as long as its predicate holds. See [Trigger vs Condition](../triggers.md#trigger-vs-condition).

--- a/progress.txt
+++ b/progress.txt
@@ -6479,3 +6479,72 @@ payload. User stories 9 and 19 of #282.
   only be true once the real server is up *and* init.sql has been applied. `run_retention.sh`
   gets away with `pg_isready` only because its first query happens minutes later; not changed
   here, to keep this diff scoped.
+
+## #292 - Document Trigger vs Condition and update CONTEXT.md's vocabulary
+
+Seventh and last-but-one slice of #282 (Pre-event circular-buffer capture via a new Trigger
+plugin), and the only documentation-only one. User story 20 ("documentation covering the
+difference between Condition and Trigger, so that I don't confuse the two when designing a
+data collection config"). Nothing under any package's `src/` changed.
+
+- **`doc/src/dc/triggers.md` is the page the issue asks for, expanded rather than duplicated.**
+  The issue says "add a new documentation page (mirroring `conditions.md`)"; #286 already
+  created that page when it built `dc_triggers`, with the same Description / Available plugins
+  / Node parameters shape `conditions.md` has. Writing a *second* page next to it would have
+  split the Trigger docs in two and left the SUMMARY with two entries for one concept, so the
+  work went into the existing page instead. It now covers, in order: what a Trigger is and the
+  incident-review problem it solves; **Trigger vs Condition** as a seven-row comparison table
+  (level vs edge, what data each can give you, per-Measurement vs per-robot configuration,
+  scope) plus the note that they compose rather than compete; the flush broadcast, with an
+  ASCII diagram of Conditions → Trigger → `/dc/flush` → several Measurements; the `FlushEvent`
+  message's two fields and the rule that an event arriving mid-cycle is ignored; `incident_id`
+  with the `WHERE incident_id = '…'` query that is the point of it, and its Postgres-column,
+  Group-lift and outside-an-incident-is-NULL behaviours; the existing node/plugin parameter
+  tables; **all five Measurement-side parameters** (`buffer_duration_sec`,
+  `post_roll_duration_sec`, `cooldown_sec`, `max_flush_rate_hz`, `flush_topic`) with the
+  four-state cycle in one sentence; and a complete two-file worked example (broadcast node +
+  one armed and one live Measurement).
+- **Why the Measurement parameters are on both pages.** `measurements.md` keeps the canonical
+  long-form treatment (#287-#290 wrote it: the state machine, File staging into
+  `.dc_incident_scratch`, re-arm), and `triggers.md` links to it. The five-row table is
+  repeated there anyway because the acceptance criterion asks for one page documenting *all*
+  the configuration this feature introduced, and a reader arriving from "how do I capture the
+  seconds before an emergency brake?" should not have to assemble the answer from two pages.
+- **`max_flush_rate_hz` sizing is documented as a real constraint, not a preference.** The
+  data publisher is `KeepLast(1)`, so a burst release is coalesced to its last Record before a
+  subscriber runs — #290's finding, and the reason `e2e_incident_params.yaml` sets 20 Hz for a
+  2 Hz Measurement. That is now an `admonish tip` rather than a comment in one params file.
+- **The broadcast node is documented as not launch-wired.** `dc_bringup.launch.py` does not
+  start `trigger_broadcast_node`, so the page says to run it with `ros2 run` (it is a
+  lifecycle node; transition it yourself or add it to your own lifecycle manager's
+  `node_names`), and that anything publishing a `FlushEvent` on `flush_topic` releases the
+  buffer — `ros2 topic pub` included, which is how `run_incident.sh` drives its flush. Wiring
+  it into bringup is separate work, not smuggled into a docs issue.
+- **`CONTEXT.md`** gains the **Incident** entry (one flush cycle: released pre-roll window plus
+  post-roll, identified by the `incident_id` every Record and File of that cycle carries) and
+  sharpens the three neighbouring entries #286 left thin. **Condition** now says it is a
+  *level* and its `_Avoid_` line names **trigger** explicitly — "a Condition turning on" is not
+  a Trigger — which is the cross-reference the issue asks for; **Trigger** says it is an *edge*
+  and is loaded by the broadcast node, never by a Measurement; **FlushEvent** notes several
+  Measurements can share one flush topic. A Relationships bullet and a "Flagged ambiguities"
+  entry record the resolution: the word used to be banned, now it names a pluginlib type.
+- **`doc/src/dc/concepts.md`** mirrors that, since its glossary is the published twin of
+  CONTEXT.md's: three new rows (Trigger, FlushEvent, Incident), a relationships bullet, a
+  "Words that mean something specific here" sentence separating level from edge, and a short
+  `## Triggers and incidents` section next to `## Conditions`.
+- **`doc/src/dc/conditions.md`** gains an `admonish note` — a Condition is a level, not an edge;
+  for the run-up to an event use a Trigger — so the confusion is answered on the page where a
+  reader is most likely to have it, not only on the page they haven't found yet.
+- **`doc/src/dc/triggers/edge_trigger.md`**: fixed a wrong link (the shared `trigger.*`
+  parameters live under *Plugin* parameters, not *Node* parameters) and added the one-line
+  edge-vs-level contrast with a link to the comparison table.
+- **Verified**: `./tools/ci/pre-commit/build_doc.sh` (the `build-doc` pre-commit hook, same
+  script CI's docs job runs) exits 0 — strictdoc export, mdbook build and the linkcheck
+  backend, with no errors and no new warnings on the touched pages. Worth recording: the first
+  run *silently* mis-rendered one admonition, because an escaped-quote title
+  (`title="\"Trigger\" is a specific thing in DC"`) is not valid admonish config and the
+  preprocessor only logs "Error processing admonition" and emits the raw config block into the
+  page — mdbook still exits 0. Caught by grepping `doc/book/html/dc/triggers.html` for
+  `class="admonition` and counting; the title no longer contains quotes. `pre-commit run
+  --files` over the five changed files passes every hook that applies to them (the black and
+  poetry-requirements failures it reports are pre-existing on unrelated files, left alone).


### PR DESCRIPTION
Seventh slice of #282 (Pre-event circular-buffer capture via a new Trigger plugin), and the only documentation-only one — user story 20, "documentation covering the difference between Condition and Trigger". No package source changed.

## Where the page went

The issue asks for "a new documentation page (mirroring `conditions.md`)". #286 already created `doc/src/dc/triggers.md` when it built `dc_triggers`, with exactly that shape. A second page would have split the Trigger docs in two and put two SUMMARY entries on one concept, so the material went into the existing page.

It now covers, in order:

- what a Trigger is, and the incident-review problem a Condition cannot solve;
- **Trigger vs Condition** as a comparison table — level vs edge, what data each can give you, per-Measurement vs per-robot configuration, scope — plus the note that they compose (a Trigger is *made of* Conditions);
- the flush broadcast, with an ASCII diagram of Conditions → Trigger → `/dc/flush` → several Measurements;
- `FlushEvent`'s two fields, and that an event arriving mid-cycle is ignored;
- `incident_id`: the `WHERE incident_id = '…'` query that is the point of it, the Postgres column it needs, the Group lift, and NULL outside an incident;
- **all five Measurement-side parameters** (`buffer_duration_sec`, `post_roll_duration_sec`, `cooldown_sec`, `max_flush_rate_hz`, `flush_topic`) with the four-state cycle in one sentence — repeated here from `measurements.md` (which keeps the canonical long form and is linked) because the acceptance criterion asks for one page with all the configuration this feature introduced;
- a complete two-file worked example: broadcast node params, plus one armed and one live Measurement.

Two things it states because they are true and undocumented: `max_flush_rate_hz` needs to be set above the collection rate, since the data publisher is `KeepLast(1)` and a burst release is coalesced to its last Record (#290's finding, currently only a comment in `e2e_incident_params.yaml`); and `trigger_broadcast_node` is not in `dc_bringup`'s launch file, so the page shows `ros2 run` and notes it is a lifecycle node. Wiring it into bringup is separate work, not smuggled into a docs issue.

## Vocabulary

`CONTEXT.md` gains the **Incident** entry and sharpens the three entries #286 left thin: **Condition** now says it is a *level* and its `_Avoid_` line names **trigger** explicitly ("a Condition turning on" is not a Trigger) — the cross-reference the issue asks for; **Trigger** says it is an *edge*, loaded by the broadcast node and never by a Measurement; **FlushEvent** notes several Measurements can share one flush topic. A Relationships bullet and a "Flagged ambiguities" entry record that the word used to be banned and now names a pluginlib type.

`doc/src/dc/concepts.md` mirrors it (its glossary is CONTEXT.md's published twin): three new rows, a relationships bullet, a level-vs-edge sentence, and a short `## Triggers and incidents` section. `conditions.md` gains a note pointing at Triggers for pre-event capture, so the confusion is answered on the page a reader is most likely to have it on. `edge_trigger.md` had a wrong link — the shared `trigger.*` parameters are under *Plugin* parameters, not *Node* parameters — fixed.

## Verification

`./tools/ci/pre-commit/build_doc.sh` (the `build-doc` hook, the same script the docs CI job runs) exits 0: strictdoc export, mdbook build, linkcheck backend, no errors and no new warnings on the touched pages.

Worth flagging: the first run **silently** mis-rendered one admonition. An escaped-quote title (`title="\"Trigger\" is a specific thing in DC"`) is not valid admonish config, and the preprocessor only logs `Error processing admonition` and dumps the raw config block into the page — mdbook still exits 0. Caught by grepping the built `doc/book/html/dc/triggers.html` for `class="admonition` and counting; the title no longer contains quotes.

`pre-commit run --files` over the five changed doc files passes every hook that applies to them. Its `black` and `poetry-requirements` failures are pre-existing on unrelated files and were left alone.

Closes #292

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqzQwqpcZWsujmJGziBhp7