### PR TITLE
feat(dc_measurements): estimate the pose of detected QR codes

### DIFF
--- a/dc_demos/params/qrcodes_stdout.yaml
+++ b/dc_demos/params/qrcodes_stdout.yaml
@@ -54,7 +54,7 @@ measurement_server:
       detection_modules: ["barcode"]
       # Pose of each decoded code, in the map frame (#48). code_size is the printed QR
       # square on dc_simulation's qrcode_* asset: its 0.5x0.5 m face carries a 290x365
-      # texture whose code block measures 0.362 m across and 0.288 m down, so no single
+      # texture whose code block measures 0.362 m across and 0.292 m down, so no single
       # side length is exact -- see doc/src/dc/measurements/camera.md.
       estimate_pose: true
       code_size: 0.325
@@ -83,7 +83,7 @@ measurement_server:
       detection_modules: ["barcode"]
       # Pose of each decoded code, in the map frame (#48). code_size is the printed QR
       # square on dc_simulation's qrcode_* asset: its 0.5x0.5 m face carries a 290x365
-      # texture whose code block measures 0.362 m across and 0.288 m down, so no single
+      # texture whose code block measures 0.362 m across and 0.292 m down, so no single
       # side length is exact -- see doc/src/dc/measurements/camera.md.
       estimate_pose: true
       code_size: 0.325

--- a/dc_demos/params/qrcodes_stdout.yaml
+++ b/dc_demos/params/qrcodes_stdout.yaml
@@ -52,6 +52,13 @@ measurement_server:
       save_inspected_path: "right_camera/inspected/%Y-%m-%dT%H-%M-%S"
       rotation_angle: 0
       detection_modules: ["barcode"]
+      # Pose of each decoded code, in the map frame (#48). code_size is the printed QR
+      # square on dc_simulation's qrcode_* asset: its 0.5x0.5 m face carries a 290x365
+      # texture whose code block measures 0.362 m across and 0.288 m down, so no single
+      # side length is exact -- see doc/src/dc/measurements/camera.md.
+      estimate_pose: true
+      code_size: 0.325
+      pose_frame: "map"
     left_camera:
       plugin: "dc_measurements/Camera"
       group_key: "left_camera"
@@ -74,3 +81,10 @@ measurement_server:
       save_inspected_path: "left_camera/inspected/%Y-%m-%dT%H-%M-%S"
       rotation_angle: 0
       detection_modules: ["barcode"]
+      # Pose of each decoded code, in the map frame (#48). code_size is the printed QR
+      # square on dc_simulation's qrcode_* asset: its 0.5x0.5 m face carries a 290x365
+      # texture whose code block measures 0.362 m across and 0.288 m down, so no single
+      # side length is exact -- see doc/src/dc/measurements/camera.md.
+      estimate_pose: true
+      code_size: 0.325
+      pose_frame: "map"

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -19,6 +19,7 @@ set(dependencies
   rclcpp_lifecycle
   std_msgs
   tf2
+  tf2_geometry_msgs
   yaml_cpp_vendor
 )
 
@@ -35,6 +36,10 @@ pkg_search_module(UUID REQUIRED uuid)
 # exports a plain CMake config (ZXing::ZXing), not an ament package, so it's kept out of
 # the shared `dependencies` list/foreach below and linked directly to dc_camera_measurement.
 find_package(ZXing REQUIRED)
+
+# cv_bridge only re-exports OpenCV's core/imgproc/imgcodecs; the camera plugin's pose
+# estimation (#48) calls cv::solvePnP, which lives in opencv_calib3d.
+find_package(OpenCV REQUIRED COMPONENTS calib3d)
 
 # yaml_cpp_vendor (already in `dependencies` above) only guarantees a system yaml-cpp is
 # installed via rosdep; it doesn't itself re-export a linkable CMake target, so anything that
@@ -213,7 +218,7 @@ foreach(measurement_plugin ${dc_measurement_plugin_libs})
   )
   target_compile_definitions(${measurement_plugin} PRIVATE BT_PLUGIN_EXPORT)
 endforeach()
-target_link_libraries(dc_camera_measurement ZXing::ZXing)
+target_link_libraries(dc_camera_measurement ZXing::ZXing opencv_calib3d)
 target_include_directories(dc_ip_camera_measurement PRIVATE ${AVFORMAT_INCLUDE_DIRS} ${AVUTIL_INCLUDE_DIRS})
 target_link_directories(dc_ip_camera_measurement PRIVATE ${AVFORMAT_LIBRARY_DIRS} ${AVUTIL_LIBRARY_DIRS})
 target_link_libraries(dc_ip_camera_measurement ${AVFORMAT_LIBRARIES} ${AVUTIL_LIBRARIES})
@@ -290,6 +295,7 @@ install(DIRECTORY plugins/measurements/json
 )
 
 set(tests
+  test_code_pose
   test_incident_releaser
   test_measurement_bool_equal
   test_measurement_buffering
@@ -346,9 +352,13 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}_${test}
       nlohmann_json::nlohmann_json
       nlohmann_json_schema_validator
+      opencv_calib3d
       ${library_name}
       )
   endforeach()
+  # Only this test encodes a QR code (ZXing's writer) to render one back through the
+  # camera model; every other test gets the reader transitively or not at all.
+  target_link_libraries(${PROJECT_NAME}_test_code_pose ZXing::ZXing)
 endif()
 
 ament_export_include_directories(include)

--- a/dc_measurements/include/dc_measurements/code_pose.hpp
+++ b/dc_measurements/include/dc_measurements/code_pose.hpp
@@ -1,0 +1,121 @@
+#ifndef DC_MEASUREMENTS__CODE_POSE_HPP_
+#define DC_MEASUREMENTS__CODE_POSE_HPP_
+
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Quaternion.h>
+
+#include <algorithm>
+#include <array>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/core.hpp>
+#include <optional>
+#include <vector>
+
+#include "geometry_msgs/msg/pose.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @brief Pose of a square planar code (QR, DataMatrix, …) from its four image corners.
+ *
+ * Corners come in the order a detector reports them for the code's own orientation:
+ * top-left, top-right, bottom-right, bottom-left. The code frame is centred on the code
+ * with X right, Y down and Z into its printed face — the camera optical frame's own axes
+ * (REP 103: X right, Y down, Z forward), so a code seen square-on has the identity
+ * orientation. The returned pose is the *code's* pose in the camera optical frame.
+ *
+ * @param corners Detected corners, in pixels, in the raw (unrotated) image.
+ * @param side_length Physical side length of the code, in metres.
+ * @param intrinsics Row-major 3x3 camera matrix (sensor_msgs/CameraInfo `k`).
+ * @param distortion Distortion coefficients (sensor_msgs/CameraInfo `d`); may be empty.
+ * @return The pose, or nullopt if the inputs are degenerate or solvePnP fails.
+ */
+inline std::optional<geometry_msgs::msg::Pose> estimateSquareCodePose(const std::array<cv::Point2f, 4>& corners,
+                                                                      double side_length,
+                                                                      const std::array<double, 9>& intrinsics,
+                                                                      const std::vector<double>& distortion)
+{
+  // fx/fy of zero means the CameraInfo is unset rather than merely imprecise.
+  if (side_length <= 0.0 || intrinsics[0] <= 0.0 || intrinsics[4] <= 0.0)
+  {
+    return std::nullopt;
+  }
+
+  // Exactly the object-point layout SOLVEPNP_IPPE_SQUARE documents as its precondition.
+  const auto half = static_cast<float>(side_length / 2.0);
+  const std::vector<cv::Point3f> object_points = {
+    { -half, half, 0.F }, { half, half, 0.F }, { half, -half, 0.F }, { -half, -half, 0.F }
+  };
+  const std::vector<cv::Point2f> image_points(corners.begin(), corners.end());
+
+  cv::Mat camera_matrix(3, 3, CV_64F);
+  std::copy(intrinsics.begin(), intrinsics.end(), camera_matrix.ptr<double>());
+  const cv::Mat dist_coeffs = distortion.empty() ? cv::Mat::zeros(1, 5, CV_64F) : cv::Mat(distortion, true);
+
+  cv::Vec3d rvec;
+  cv::Vec3d tvec;
+  try
+  {
+    // IPPE_SQUARE is the solver meant for exactly this case: four coplanar corners of a
+    // square, given in the object-point order above.
+    if (!cv::solvePnP(object_points, image_points, camera_matrix, dist_coeffs, rvec, tvec, false,
+                      cv::SOLVEPNP_IPPE_SQUARE))
+    {
+      return std::nullopt;
+    }
+  }
+  catch (const cv::Exception&)
+  {
+    return std::nullopt;
+  }
+
+  cv::Matx33d rotation;
+  cv::Rodrigues(rvec, rotation);
+  // That layout puts the solver's own frame Y-up with Z out of the face towards the
+  // camera, which makes a square-on read a 180-degree roll. Turning it back about X (the
+  // negated Y and Z columns below) is what makes square-on the identity instead.
+  const tf2::Matrix3x3 basis(rotation(0, 0), -rotation(0, 1), -rotation(0, 2), rotation(1, 0), -rotation(1, 1),
+                             -rotation(1, 2), rotation(2, 0), -rotation(2, 1), -rotation(2, 2));
+  tf2::Quaternion orientation;
+  basis.getRotation(orientation);
+
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = tvec[0];
+  pose.position.y = tvec[1];
+  pose.position.z = tvec[2];
+  pose.orientation.x = orientation.x();
+  pose.orientation.y = orientation.y();
+  pose.orientation.z = orientation.z();
+  pose.orientation.w = orientation.w();
+  return pose;
+}
+
+/**
+ * @brief Map a point detected in a rotated image back to raw-image pixel coordinates.
+ *
+ * Detection runs on the rotated image, but the camera intrinsics describe the raw one.
+ *
+ * @param point Point in the rotated image.
+ * @param rotation_angle Rotation applied to the raw image, in degrees (0/90/180/270).
+ * @param raw_width Width of the raw image, in pixels.
+ * @param raw_height Height of the raw image, in pixels.
+ */
+inline cv::Point2f unrotatePoint(const cv::Point2f& point, int rotation_angle, int raw_width, int raw_height)
+{
+  switch (((rotation_angle % 360) + 360) % 360)
+  {
+    case 90:
+      return { point.y, static_cast<float>(raw_height - 1) - point.x };
+    case 180:
+      return { static_cast<float>(raw_width - 1) - point.x, static_cast<float>(raw_height - 1) - point.y };
+    case 270:
+      return { static_cast<float>(raw_width - 1) - point.y, point.x };
+    default:
+      return point;
+  }
+}
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__CODE_POSE_HPP_

--- a/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
@@ -11,6 +11,7 @@
 
 #include "dc_core/measurement.hpp"
 #include "dc_interfaces/srv/draw_image.hpp"
+#include "dc_measurements/code_pose.hpp"
 #include "dc_measurements/measurement.hpp"
 #include "dc_util/base64.hpp"
 #include "dc_util/image_utils.hpp"
@@ -18,7 +19,9 @@
 #include "dc_util/node_utils.hpp"
 #include "dc_util/service_utils.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "sensor_msgs/msg/camera_info.hpp"
 #include "sensor_msgs/msg/image.hpp"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace dc_measurements
 {
@@ -34,6 +37,10 @@ private:
   rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
   sensor_msgs::msg::Image last_data_;
   void cameraCb(const sensor_msgs::msg::Image& msg);
+  rclcpp::Subscription<sensor_msgs::msg::CameraInfo>::SharedPtr camera_info_subscription_;
+  sensor_msgs::msg::CameraInfo last_camera_info_;
+  bool camera_info_received_{ false };
+  void cameraInfoCb(const sensor_msgs::msg::CameraInfo& msg);
 
 protected:
   /**
@@ -45,6 +52,7 @@ protected:
   std::string getLocalPath(const std::string& param_reference, const rclcpp::Time& now);
   void saveRemoteKeys(json& data_json, const std::string& key, const std::string& relative_path,
                       const rclcpp::Time& now);
+  void addCodePose(json& barcode_json, const ZXing::Position& position, const cv::Size& raw_size);
 
   std::string cam_name_;
   bool draw_det_barcodes_;
@@ -62,6 +70,11 @@ protected:
   std::string save_inspected_path_;
   std::string minio_bucket_;
   std::vector<std::string> detection_modules_;
+  bool estimate_pose_;
+  double code_size_;
+  std::string camera_info_topic_;
+  std::string pose_frame_;
+  double transform_timeout_;
   rclcpp::Client<dc_interfaces::srv::DrawImage>::SharedPtr cli_draw_image_;
 
   rclcpp::CallbackGroup::SharedPtr client_cb_group_;

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -27,6 +27,7 @@
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>zxing-cpp</depend>

--- a/dc_measurements/plugins/measurements/camera.cpp
+++ b/dc_measurements/plugins/measurements/camera.cpp
@@ -30,6 +30,11 @@ void Camera::onConfigure()
   save_inspected_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_inspected_base64", false);
   detection_modules_ =
       dc_util::get_str_array_type_param(node, measurement_name_, "detection_modules", std::vector<std::string>());
+  estimate_pose_ = dc_util::get_bool_type_param(node, measurement_name_, "estimate_pose", false);
+  code_size_ = dc_util::get_double_type_param(node, measurement_name_, "code_size", 0.0);
+  camera_info_topic_ = dc_util::get_str_type_param(node, measurement_name_, "camera_info_topic", "");
+  pose_frame_ = dc_util::get_str_type_param(node, measurement_name_, "pose_frame", "");
+  transform_timeout_ = dc_util::get_double_type_param(node, measurement_name_, "transform_timeout", 0.1);
   // FIXME Not used, wrong parameter too, should be without measurement_name_
   minio_bucket_ = dc_util::get_str_type_param(node, measurement_name_, "destinations.minio.bucket", "");
 
@@ -46,6 +51,11 @@ void Camera::onConfigure()
     RCLCPP_WARN(logger_, "Rotation angle is set to full rotation (%d). Ignored", rotation_angle_);
     rotation_angle_ = 0;
     node->set_parameter(rclcpp::Parameter(measurement_name_ + ".rotation_angle", rotation_angle_));
+  }
+
+  if (estimate_pose_ && code_size_ <= 0.0)
+  {
+    throw std::runtime_error{ "code_size must be a positive length in metres when estimate_pose is enabled" };
   }
 
   if (draw_det_barcodes_)
@@ -66,11 +76,32 @@ void Camera::onConfigure()
   // Data subscriber
   subscription_ = node->create_subscription<sensor_msgs::msg::Image>(
       cam_topic_, 10, std::bind(&Camera::cameraCb, this, std::placeholders::_1));
+
+  if (estimate_pose_)
+  {
+    if (camera_info_topic_.empty())
+    {
+      // ROS convention: camera_info sits next to the image topic it describes.
+      const size_t last_slash = cam_topic_.find_last_of('/');
+      camera_info_topic_ =
+          (last_slash == std::string::npos) ? "camera_info" : cam_topic_.substr(0, last_slash + 1) + "camera_info";
+    }
+    // Best-effort so the subscription also matches best-effort camera drivers.
+    camera_info_subscription_ = node->create_subscription<sensor_msgs::msg::CameraInfo>(
+        camera_info_topic_, rclcpp::SensorDataQoS(), std::bind(&Camera::cameraInfoCb, this, std::placeholders::_1));
+    RCLCPP_INFO(logger_, "Pose estimation enabled, reading intrinsics from %s", camera_info_topic_.c_str());
+  }
 }
 
 void Camera::cameraCb(const sensor_msgs::msg::Image& msg)
 {
   last_data_ = msg;
+}
+
+void Camera::cameraInfoCb(const sensor_msgs::msg::CameraInfo& msg)
+{
+  last_camera_info_ = msg;
+  camera_info_received_ = true;
 }
 
 void Camera::setValidationSchema()
@@ -127,6 +158,75 @@ void Camera::rotateImage(cv_bridge::CvImagePtr& cv_ptr)
   }
 }
 
+void Camera::addCodePose(json& barcode_json, const ZXing::Position& position, const cv::Size& raw_size)
+{
+  if (!camera_info_received_)
+  {
+    RCLCPP_WARN_THROTTLE(logger_, *getNode()->get_clock(), 5000, "No CameraInfo received on %s yet, skipping pose",
+                         camera_info_topic_.c_str());
+    return;
+  }
+
+  // Detection runs on the rotated image; the intrinsics describe the raw one.
+  const std::array<cv::Point2f, 4> corners = {
+    unrotatePoint({ static_cast<float>(position.topLeft().x), static_cast<float>(position.topLeft().y) },
+                  rotation_angle_, raw_size.width, raw_size.height),
+    unrotatePoint({ static_cast<float>(position.topRight().x), static_cast<float>(position.topRight().y) },
+                  rotation_angle_, raw_size.width, raw_size.height),
+    unrotatePoint({ static_cast<float>(position.bottomRight().x), static_cast<float>(position.bottomRight().y) },
+                  rotation_angle_, raw_size.width, raw_size.height),
+    unrotatePoint({ static_cast<float>(position.bottomLeft().x), static_cast<float>(position.bottomLeft().y) },
+                  rotation_angle_, raw_size.width, raw_size.height)
+  };
+
+  const std::vector<double> distortion(last_camera_info_.d.begin(), last_camera_info_.d.end());
+  auto pose = estimateSquareCodePose(corners, code_size_, last_camera_info_.k, distortion);
+  if (!pose.has_value())
+  {
+    RCLCPP_WARN(logger_, "Could not estimate a pose for the detected code");
+    return;
+  }
+
+  geometry_msgs::msg::PoseStamped pose_stamped;
+  pose_stamped.header.frame_id =
+      last_camera_info_.header.frame_id.empty() ? last_data_.header.frame_id : last_camera_info_.header.frame_id;
+  pose_stamped.header.stamp = last_data_.header.stamp;
+  pose_stamped.pose = pose.value();
+
+  if (!pose_frame_.empty() && pose_frame_ != pose_stamped.header.frame_id)
+  {
+    try
+    {
+      pose_stamped = tf_->transform(pose_stamped, pose_frame_, tf2::durationFromSec(transform_timeout_));
+    }
+    catch (const tf2::TransformException& ex)
+    {
+      // Reported in the camera optical frame rather than dropped: frame_id says which.
+      RCLCPP_WARN(logger_, "Could not transform code pose into %s (%s), reporting it in %s", pose_frame_.c_str(),
+                  ex.what(), pose_stamped.header.frame_id.c_str());
+    }
+  }
+
+  double roll = 0.0;
+  double pitch = 0.0;
+  double yaw = 0.0;
+  tf2::Quaternion q(pose_stamped.pose.orientation.x, pose_stamped.pose.orientation.y, pose_stamped.pose.orientation.z,
+                    pose_stamped.pose.orientation.w);
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+
+  barcode_json["pose"]["frame_id"] = pose_stamped.header.frame_id;
+  barcode_json["pose"]["x"] = pose_stamped.pose.position.x;
+  barcode_json["pose"]["y"] = pose_stamped.pose.position.y;
+  barcode_json["pose"]["z"] = pose_stamped.pose.position.z;
+  barcode_json["pose"]["roll"] = roll;
+  barcode_json["pose"]["pitch"] = pitch;
+  barcode_json["pose"]["yaw"] = yaw;
+  // Camera-to-code range, taken from the untransformed pose so it stays a range whatever
+  // frame x/y/z ended up in.
+  barcode_json["pose"]["distance"] =
+      std::sqrt(std::pow(pose->position.x, 2) + std::pow(pose->position.y, 2) + std::pow(pose->position.z, 2));
+}
+
 dc_interfaces::msg::StringStamped Camera::collect()
 {
   auto node = getNode();
@@ -179,6 +279,9 @@ dc_interfaces::msg::StringStamped Camera::collect()
       auto* enc_msg = reinterpret_cast<unsigned char*>(buf.data());
       data_json["base64"]["raw"] = base64_encode(enc_msg, buf.size());
     }
+
+    // Kept for addCodePose(): the intrinsics describe the raw image, not the rotated one.
+    const cv::Size raw_size = cv_ptr->image.size();
 
     // Rotate image
     if (rotation_angle_ != 0)
@@ -236,28 +339,23 @@ dc_interfaces::msg::StringStamped Camera::collect()
         }
       }
 
+      const bool draw_detections = save_detections_img_ && draw_det_barcodes_;
       if (!result_barcodes.empty())
       {
         data_json["inspected"]["barcode"] = json::array();
       }
-      if (
-          // Save image with inspected data
-          save_detections_img_
-          // Barcode(s) found
-          && !result_barcodes.empty()
-          // Drawing enabled
-          && draw_det_barcodes_)
+      for (auto& barcode : result_barcodes)
       {
-        for (auto& barcode : result_barcodes)
-        {
-          auto bbox = ZXing::BoundingBox(barcode.position());
-          uint16_t top = static_cast<uint16_t>(std::max(0, bbox.topLeft().y));
-          uint16_t left = static_cast<uint16_t>(std::max(0, bbox.topLeft().x));
-          uint16_t width = static_cast<uint16_t>(bbox.bottomRight().x - bbox.topLeft().x);
-          uint16_t height = static_cast<uint16_t>(bbox.bottomRight().y - bbox.topLeft().y);
-          std::string type = ZXing::ToString(barcode.format());
-          std::string data = barcode.text();
+        auto bbox = ZXing::BoundingBox(barcode.position());
+        uint16_t top = static_cast<uint16_t>(std::max(0, bbox.topLeft().y));
+        uint16_t left = static_cast<uint16_t>(std::max(0, bbox.topLeft().x));
+        uint16_t width = static_cast<uint16_t>(bbox.bottomRight().x - bbox.topLeft().x);
+        uint16_t height = static_cast<uint16_t>(bbox.bottomRight().y - bbox.topLeft().y);
+        std::string type = ZXing::ToString(barcode.format());
+        std::string data = barcode.text();
 
+        if (draw_detections)
+        {
           auto draw_req = std::make_shared<dc_interfaces::srv::DrawImage::Request>();
           draw_req->frame = dc_util::cvToImage(cv_ptr);
           draw_req->shape = "rectangle";
@@ -282,18 +380,23 @@ dc_interfaces::msg::StringStamped Camera::collect()
           }
           auto image_det = result_future_draw.get()->frame;
           cv_ptr = cv_bridge::toCvCopy(image_det, image_det.encoding);
-          json barcode_json;
-          barcode_json["data"] = data;
-          barcode_json["type"] = type;
-          barcode_json["top"] = top;
-          barcode_json["left"] = left;
-          barcode_json["width"] = width;
-          barcode_json["height"] = height;
-          data_json["inspected"]["barcode"].push_back(barcode_json);
         }
+
+        json barcode_json;
+        barcode_json["data"] = data;
+        barcode_json["type"] = type;
+        barcode_json["top"] = top;
+        barcode_json["left"] = left;
+        barcode_json["width"] = width;
+        barcode_json["height"] = height;
+        if (estimate_pose_)
+        {
+          addCodePose(barcode_json, barcode.position(), raw_size);
+        }
+        data_json["inspected"]["barcode"].push_back(barcode_json);
       }
 
-      if (!detection_modules_.empty() && save_detections_img_ && dc_util::fieldInJSON(data_json, "inspected"))
+      if (!detection_modules_.empty() && draw_detections && dc_util::fieldInJSON(data_json, "inspected"))
       {
         // Save image with detection
         // Get local and relative path

--- a/dc_measurements/plugins/measurements/json/camera.json
+++ b/dc_measurements/plugins/measurements/json/camera.json
@@ -88,6 +88,47 @@
         "type": {
           "description": "Barcode type",
           "type": "string"
+        },
+        "pose": {
+          "description": "Pose of the code, present only when estimate_pose is enabled",
+          "$ref": "#/$defs/pose"
+        }
+      }
+    },
+    "pose": {
+      "type": "object",
+      "properties": {
+        "frame_id": {
+          "description": "Frame the pose is expressed in",
+          "type": "string"
+        },
+        "x": {
+          "description": "Code position along the frame's X axis, in meters",
+          "type": "number"
+        },
+        "y": {
+          "description": "Code position along the frame's Y axis, in meters",
+          "type": "number"
+        },
+        "z": {
+          "description": "Code position along the frame's Z axis, in meters",
+          "type": "number"
+        },
+        "roll": {
+          "description": "Code orientation about the frame's X axis, in radians",
+          "type": "number"
+        },
+        "pitch": {
+          "description": "Code orientation about the frame's Y axis, in radians",
+          "type": "number"
+        },
+        "yaw": {
+          "description": "Code orientation about the frame's Z axis, in radians",
+          "type": "number"
+        },
+        "distance": {
+          "description": "Straight-line distance from the camera to the code, in meters",
+          "type": "number"
         }
       }
     }

--- a/dc_measurements/test/test_code_pose.cpp
+++ b/dc_measurements/test/test_code_pose.cpp
@@ -1,0 +1,260 @@
+#include <ZXing/BitMatrix.h>
+#include <ZXing/MultiFormatWriter.h>
+#include <ZXing/ReadBarcode.h>
+#include <gtest/gtest.h>
+
+#include <iostream>
+#include <opencv2/calib3d.hpp>
+#include <opencv2/imgproc.hpp>
+
+#include "dc_measurements/code_pose.hpp"
+
+namespace
+{
+
+// A plausible 640x480 pinhole camera, no distortion.
+constexpr double kFx = 525.0;
+constexpr double kFy = 525.0;
+constexpr double kCx = 320.0;
+constexpr double kCy = 240.0;
+constexpr double kSide = 0.2;
+
+const std::array<double, 9> kIntrinsics = { kFx, 0.0, kCx, 0.0, kFy, kCy, 0.0, 0.0, 1.0 };
+
+cv::Mat cameraMatrix(const std::array<double, 9>& intrinsics)
+{
+  cv::Mat camera_matrix(3, 3, CV_64F);
+  std::copy(intrinsics.begin(), intrinsics.end(), camera_matrix.ptr<double>());
+  return camera_matrix;
+}
+
+// The four corners of a `side`-metre code, in solvePnP's object-point layout, ordered
+// top-left, top-right, bottom-right, bottom-left as a detector reports them.
+std::vector<cv::Point3f> codeCorners(double side)
+{
+  const auto half = static_cast<float>(side / 2.0);
+  return { { -half, half, 0.F }, { half, half, 0.F }, { half, -half, 0.F }, { -half, -half, 0.F } };
+}
+
+// Every test states its ground truth in the frame estimateSquareCodePose() reports, where
+// the identity is a code seen square-on. Projecting it needs the same frame turned 180
+// degrees about X, which is the one those object points live in.
+cv::Vec3d projectionRvec(const cv::Vec3d& code_rvec)
+{
+  cv::Matx33d rotation;
+  cv::Rodrigues(code_rvec, rotation);
+  cv::Vec3d rvec;
+  cv::Rodrigues(rotation * cv::Matx33d(1, 0, 0, 0, -1, 0, 0, 0, -1), rvec);
+  return rvec;
+}
+
+// Projects a code of side `kSide` at a known pose into image corners, so a test can assert
+// that estimateSquareCodePose() recovers the pose it started from.
+std::array<cv::Point2f, 4> projectCorners(const cv::Vec3d& code_rvec, const cv::Vec3d& tvec)
+{
+  std::vector<cv::Point2f> image_points;
+  cv::projectPoints(codeCorners(kSide), projectionRvec(code_rvec), tvec, cameraMatrix(kIntrinsics),
+                    cv::Mat::zeros(1, 5, CV_64F), image_points);
+  return { image_points[0], image_points[1], image_points[2], image_points[3] };
+}
+
+}  // namespace
+
+TEST(CodePoseTest, RecoversTranslationOfAStraightOnCode)
+{
+  const cv::Vec3d tvec(0.1, -0.05, 1.5);
+  auto pose = dc_measurements::estimateSquareCodePose(projectCorners(cv::Vec3d(0, 0, 0), tvec), kSide, kIntrinsics, {});
+
+  ASSERT_TRUE(pose.has_value());
+  // Tolerances throughout are set by the float corner points, not by the solver.
+  EXPECT_NEAR(pose->position.x, tvec[0], 1e-4);
+  EXPECT_NEAR(pose->position.y, tvec[1], 1e-4);
+  EXPECT_NEAR(pose->position.z, tvec[2], 1e-4);
+  // Square-on to the camera is the identity rotation.
+  EXPECT_NEAR(std::abs(pose->orientation.w), 1.0, 1e-4);
+}
+
+TEST(CodePoseTest, RecoversRotationOfATiltedCode)
+{
+  // 25 degrees about the camera's Y (yaw of the code away from the lens axis).
+  const cv::Vec3d rvec(0.0, 25.0 * CV_PI / 180.0, 0.0);
+  const cv::Vec3d tvec(0.0, 0.0, 2.0);
+  auto pose = dc_measurements::estimateSquareCodePose(projectCorners(rvec, tvec), kSide, kIntrinsics, {});
+
+  ASSERT_TRUE(pose.has_value());
+  EXPECT_NEAR(pose->position.z, tvec[2], 1e-4);
+
+  tf2::Quaternion q(pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w);
+  double roll = 0.0;
+  double pitch = 0.0;
+  double yaw = 0.0;
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+  // 0.01 rad is about 0.6 degrees, the floor set by float corner points on a code only
+  // ~50 px wide at this distance. A convention error is tens of degrees, not tenths.
+  EXPECT_NEAR(roll, 0.0, 0.01);
+  EXPECT_NEAR(pitch, 25.0 * CV_PI / 180.0, 0.01);
+  EXPECT_NEAR(yaw, 0.0, 0.01);
+}
+
+TEST(CodePoseTest, RejectsUnusableInputs)
+{
+  const auto corners = projectCorners(cv::Vec3d(0, 0, 0), cv::Vec3d(0, 0, 1.0));
+
+  // No physical size configured.
+  EXPECT_FALSE(dc_measurements::estimateSquareCodePose(corners, 0.0, kIntrinsics, {}).has_value());
+  // An all-zero CameraInfo, i.e. none published yet.
+  EXPECT_FALSE(dc_measurements::estimateSquareCodePose(corners, kSide, { 0, 0, 0, 0, 0, 0, 0, 0, 0 }, {}).has_value());
+}
+
+TEST(CodePoseTest, UnrotatesPointsBackToRawImageCoordinates)
+{
+  // A 640x480 raw image rotated clockwise is 480x640; its rotated (0, 0) is the raw
+  // image's bottom-left corner.
+  EXPECT_EQ(dc_measurements::unrotatePoint({ 0.F, 0.F }, 90, 640, 480), cv::Point2f(0.F, 479.F));
+  EXPECT_EQ(dc_measurements::unrotatePoint({ 0.F, 0.F }, 180, 640, 480), cv::Point2f(639.F, 479.F));
+  EXPECT_EQ(dc_measurements::unrotatePoint({ 0.F, 0.F }, 270, 640, 480), cv::Point2f(639.F, 0.F));
+  EXPECT_EQ(dc_measurements::unrotatePoint({ 12.F, 34.F }, 0, 640, 480), cv::Point2f(12.F, 34.F));
+  // Negative angles name the same rotations.
+  EXPECT_EQ(dc_measurements::unrotatePoint({ 5.F, 7.F }, -90, 640, 480),
+            dc_measurements::unrotatePoint({ 5.F, 7.F }, 270, 640, 480));
+}
+
+// A code detected in a rotated image must yield the same pose as the raw image would, once
+// its corners are mapped back — otherwise the intrinsics silently describe the wrong image.
+TEST(CodePoseTest, PoseIsUnchangedByImageRotation)
+{
+  const cv::Vec3d tvec(0.1, -0.05, 1.5);
+  const auto raw_corners = projectCorners(cv::Vec3d(0, 0, 0), tvec);
+  const int raw_width = 640;
+  const int raw_height = 480;
+
+  // Rotate the corners clockwise into a 480x640 image, the inverse of unrotatePoint().
+  std::array<cv::Point2f, 4> rotated_corners{};
+  for (size_t i = 0; i < raw_corners.size(); ++i)
+  {
+    rotated_corners[i] = { static_cast<float>(raw_height - 1) - raw_corners[i].y, raw_corners[i].x };
+  }
+
+  std::array<cv::Point2f, 4> recovered{};
+  for (size_t i = 0; i < rotated_corners.size(); ++i)
+  {
+    recovered[i] = dc_measurements::unrotatePoint(rotated_corners[i], 90, raw_width, raw_height);
+  }
+
+  auto pose = dc_measurements::estimateSquareCodePose(recovered, kSide, kIntrinsics, {});
+  ASSERT_TRUE(pose.has_value());
+  EXPECT_NEAR(pose->position.x, tvec[0], 1e-4);
+  EXPECT_NEAR(pose->position.y, tvec[1], 1e-4);
+  EXPECT_NEAR(pose->position.z, tvec[2], 1e-4);
+}
+
+namespace
+{
+
+// The demo camera: dc_simulation's rgbd_camera, 1280x720 at a 1.047 rad horizontal FOV.
+constexpr int kDemoWidth = 1280;
+constexpr int kDemoHeight = 720;
+constexpr double kDemoFocal = (kDemoWidth / 2.0) / 0.5773502691896257;  // tan(1.047 / 2)
+const std::array<double, 9> kDemoIntrinsics = { kDemoFocal, 0.0,        kDemoWidth / 2.0,
+                                                0.0,        kDemoFocal, kDemoHeight / 2.0,
+                                                0.0,        0.0,        1.0 };
+
+// A QR code as a white image with a quiet zone; the module area starts `quiet_modules *
+// module_px` in from each edge.
+cv::Mat renderQrCode(const std::string& text, int module_px, int quiet_modules)
+{
+  auto matrix = ZXing::MultiFormatWriter(ZXing::BarcodeFormat::QRCode).setMargin(0).encode(text, 0, 0);
+  cv::Mat modules(matrix.height(), matrix.width(), CV_8UC1);
+  for (int y = 0; y < matrix.height(); ++y)
+  {
+    for (int x = 0; x < matrix.width(); ++x)
+    {
+      modules.at<uint8_t>(y, x) = matrix.get(x, y) ? 0 : 255;
+    }
+  }
+  cv::Mat scaled;
+  cv::resize(modules, scaled, cv::Size(), module_px, module_px, cv::INTER_NEAREST);
+  cv::Mat bordered;
+  const int border = quiet_modules * module_px;
+  cv::copyMakeBorder(scaled, bordered, border, border, border, border, cv::BORDER_CONSTANT, 255);
+  return bordered;
+}
+
+// Renders `code` as it would appear to the demo camera with the code at `rvec`/`tvec`.
+cv::Mat renderView(const cv::Mat& code, double side, int border, const cv::Vec3d& rvec, const cv::Vec3d& tvec)
+{
+  std::vector<cv::Point2f> projected;
+  cv::projectPoints(codeCorners(side), projectionRvec(rvec), tvec, cameraMatrix(kDemoIntrinsics),
+                    cv::Mat::zeros(1, 5, CV_64F), projected);
+
+  const auto right = static_cast<float>(code.cols - border);
+  const auto bottom = static_cast<float>(code.rows - border);
+  const auto edge = static_cast<float>(border);
+  const std::vector<cv::Point2f> source = { { edge, edge }, { right, edge }, { right, bottom }, { edge, bottom } };
+
+  cv::Mat code_bgr;
+  cv::cvtColor(code, code_bgr, cv::COLOR_GRAY2BGR);
+  cv::Mat view(kDemoHeight, kDemoWidth, CV_8UC3, cv::Scalar(255, 255, 255));
+  cv::warpPerspective(code_bgr, view, cv::getPerspectiveTransform(source, projected), view.size(), cv::INTER_LINEAR,
+                      cv::BORDER_TRANSPARENT);
+  return view;
+}
+
+}  // namespace
+
+// End to end over the real detector: render a QR code at a pose the demo camera could see
+// it from, let ZXing find its corners, and check the pose comes back. This is the check
+// that would catch a corner ordering or axis convention that only looks right on
+// synthetic corner points.
+TEST(CodePoseTest, RecoversAPoseFromARenderedQrCode)
+{
+  // dc_simulation's printed code, near enough: 0.325 m at a station's stopping distance.
+  constexpr double kDemoSide = 0.325;
+  constexpr int kBorderModules = 4;
+  constexpr int kModulePx = 8;
+  const cv::Vec3d rvec(0.0, 15.0 * CV_PI / 180.0, 0.0);
+  const cv::Vec3d tvec(0.05, -0.02, 1.2);
+
+  const cv::Mat code = renderQrCode("0001", kModulePx, kBorderModules);
+  const cv::Mat view = renderView(code, kDemoSide, kBorderModules * kModulePx, rvec, tvec);
+
+  ZXing::ImageView image_view(view.data, view.cols, view.rows, ZXing::ImageFormat::BGR, static_cast<int>(view.step));
+  auto results = ZXing::ReadBarcodes(image_view);
+  ASSERT_EQ(results.size(), 1U) << "the rendered code did not decode";
+  ASSERT_EQ(results[0].text(), "0001");
+
+  const auto& p = results[0].position();
+  const std::array<cv::Point2f, 4> corners = {
+    cv::Point2f(static_cast<float>(p.topLeft().x), static_cast<float>(p.topLeft().y)),
+    cv::Point2f(static_cast<float>(p.topRight().x), static_cast<float>(p.topRight().y)),
+    cv::Point2f(static_cast<float>(p.bottomRight().x), static_cast<float>(p.bottomRight().y)),
+    cv::Point2f(static_cast<float>(p.bottomLeft().x), static_cast<float>(p.bottomLeft().y))
+  };
+
+  auto pose = dc_measurements::estimateSquareCodePose(corners, kDemoSide, kDemoIntrinsics, {});
+  ASSERT_TRUE(pose.has_value());
+
+  const double range = std::hypot(std::hypot(pose->position.x, pose->position.y), pose->position.z);
+  const double truth = cv::norm(tvec);
+  std::cerr << "  rendered-code pose: (" << pose->position.x << ", " << pose->position.y << ", " << pose->position.z
+            << "), range " << range << " m against " << truth << " m\n";
+
+  // Loose on purpose: a detector reports corners to within about a module, which is a
+  // few percent of a code this size, so this bounds a systematic bias rather than noise.
+  EXPECT_NEAR(range, truth, 0.05 * truth);
+  EXPECT_NEAR(pose->position.x, tvec[0], 0.05);
+  EXPECT_NEAR(pose->position.y, tvec[1], 0.05);
+
+  tf2::Quaternion q(pose->orientation.x, pose->orientation.y, pose->orientation.z, pose->orientation.w);
+  double roll = 0.0;
+  double pitch = 0.0;
+  double yaw = 0.0;
+  tf2::Matrix3x3(q).getRPY(roll, pitch, yaw);
+  EXPECT_NEAR(pitch, rvec[1], 5.0 * CV_PI / 180.0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/doc/src/dc/measurements/camera.md
+++ b/doc/src/dc/measurements/camera.md
@@ -37,9 +37,14 @@ results.
 | ------------------------- | ------------------------------------------------------------------------------------------------------- | -------------------- | ------------------------------------ |
 | **cam_name**              | Name to give to the camera                                                                              | str                  | N/A (mandatory)                      |
 | **cam_topic**             | Topic from where camera data needs to be fetched                                                        | str                  | N/A (mandatory)                      |
+| **camera_info_topic**     | Topic to read the camera intrinsics from, for pose estimation                                           | str                  | `camera_info` next to **cam_topic**  |
+| **code_size**             | Physical side length of the detected codes, in meters. Mandatory when **estimate_pose** is true         | double               | 0.0                                  |
 | **detection_modules**     | Detection modules to use                                                                                | list\[str\](barcode) | N/A (optional)                       |
 | **draw_det_barcodes**     | Draw barcode detection on images                                                                        | bool                 | true                                 |
+| **estimate_pose**         | Estimate the pose of each detected code and add it to the Record                                        | bool                 | false                                |
+| **pose_frame**            | Frame to transform the estimated pose into. Empty means the camera optical frame                        | str                  | ""                                   |
 | **rotation_angle**        | Rotate the image before inspecting it by this angle                                                     | int (90, 180, 270)   | 0                                    |
+| **transform_timeout**     | How long to wait for the **pose_frame** transform, in seconds                                           | double               | 0.1                                  |
 | **save_detections_img**   | Whether to save inspected image captured by the camera with detection shapes                            | bool                 | true                                 |
 | **save_inspected_base64** | Whether to save inspected image captured by the camera with detection shapes as base64 string           | bool                 | false                                |
 | **save_inspected_path**   | Path to save the inspected camera image. Expands environment variables and datetime format are expanded | str                  | "camera/inspected/%Y-%m-%dT%H:%M:%S" |
@@ -49,6 +54,91 @@ results.
 | **save_rotated_base64**   | Whether to save rotated image captured by the camera as base64 string                                   | bool                 | false                                |
 | **save_rotated_img**      | Whether to save rotated image captured by the camera                                                    | bool                 | false                                |
 | **save_rotated_path**     | Path to save the rotated camera image. Expands environment variables and datetime format are expanded   | str                  | "camera/rotated/%Y-%m-%dT%H:%M:%S"   |
+
+## Code pose estimation
+
+With `estimate_pose: true`, every detected code carries a `pose` alongside its bounding box.
+The pose is solved from the code's four detected corners with
+[`cv::solvePnP`](https://docs.opencv.org/4.x/d9/d0c/group__calib3d.html) (`SOLVEPNP_IPPE_SQUARE`,
+the solver for four coplanar corners of a square), which needs two things detection alone does
+not: the code's physical side length (`code_size`, in meters) and the camera intrinsics, read
+from `camera_info_topic`. It is off by default and costs nothing when off — no `camera_info`
+subscription is created and Records are unchanged.
+
+### Frame and convention
+
+The pose is the **code's** pose, not the robot's — where the code is as seen from the robot.
+By default it is expressed in the **camera optical frame** (the `frame_id` of the `camera_info`
+message, following [REP 103](https://ros.org/reps/rep-0103.html): X right, Y down, Z forward
+along the lens axis), so `z` is the depth of the code in front of the camera. The code's own
+frame is centered on the code and uses those same axes — X right, Y down, Z into its printed
+face — so a code seen square-on has the **identity orientation**, and `roll`/`pitch`/`yaw` read
+as how far off square-on it was. (This is the ArUco/OpenCV marker frame turned 180° about X:
+that convention puts Z out of the face towards the camera, which would make a square-on read a
+180° roll.)
+
+Set `pose_frame` to have the pose transformed into a robot frame (`base_link`, `map`, …) via TF
+before it is written. Every Record says which frame it is in: the emitted `pose.frame_id` is the
+frame actually used, so if the transform is unavailable within `transform_timeout` the pose is
+still reported — in the camera optical frame, with a warning logged, rather than dropped.
+`pose.distance` is the camera-to-code range in meters and is unaffected by `pose_frame`.
+
+`rotation_angle` is handled: the corners are mapped back to raw-image coordinates before the
+solve, so the intrinsics still describe the image they were calibrated on.
+
+```yaml
+camera:
+  plugin: "dc_measurements/Camera"
+  cam_topic: "/front_camera/image_raw"
+  # camera_info_topic defaults to /front_camera/camera_info, next to cam_topic
+  cam_name: my_camera_with_codes
+  detection_modules: ["barcode"]
+  estimate_pose: true
+  code_size: 0.2       # meters, side length of the printed code
+  pose_frame: "base_link"
+  transform_timeout: 0.1
+```
+
+```json
+{
+  "camera_name": "my_camera_with_codes",
+  "inspected": {
+    "barcode": [
+      {
+        "data": "0001", "type": "QRCode",
+        "top": 210, "left": 295, "width": 84, "height": 84,
+        "pose": {
+          "frame_id": "base_link",
+          "x": 1.482, "y": 0.037, "z": 0.611,
+          "roll": 0.0, "pitch": 0.0, "yaw": 3.139,
+          "distance": 1.483
+        }
+      }
+    ]
+  }
+}
+```
+
+```admonish warning title="A pose is only as good as code_size and the calibration"
+The scale of the estimate comes entirely from `code_size`: a code declared 20 cm wide that is
+really 10 cm reports every distance twice as far as it is. Likewise the intrinsics are taken as
+published — if `camera_info` carries an uncalibrated or placeholder camera matrix, the pose is
+wrong without being flagged. Codes seen nearly edge-on or only a few pixels wide are also
+poorly conditioned; use `pose.distance` to filter those out downstream.
+
+Two systematic biases are worth knowing about before treating a pose as a measurement rather
+than a hint:
+
+- **Corner convention.** A detector locates the code to within about one module, so range
+  carries a bias of roughly one module width — a few percent for a low-version QR code. This
+  is a bias, not noise: averaging repeated reads does not remove it.
+- **Non-square codes.** `SOLVEPNP_IPPE_SQUARE` assumes the four corners bound a square. A
+  stretched or rectangular code is solved to a compromise scale. `dc_simulation`'s own
+  `qrcode_*` assets are exactly this case — a 290x365 texture over a 0.5 x 0.5 m face makes
+  the printed code 0.362 m across and 0.288 m down — which is why the demo sets `code_size`
+  to a mid-value of 0.325 and why the simulation check tolerates a metre of error rather
+  than centimetres.
+```
 
 ## Measurement node configuration
 The remote paths are also saved in the JSON under *<measurement_name>.<destination>_img_paths.(raw|rotated|inspected)*. If images want to be sent to a self-hosted S3-compatible store such as [RustFS](https://rustfs.com/), add "rustfs" in *remote_keys*. This will add a remote path that can later be used in your API.
@@ -107,92 +197,140 @@ dc_bridge:
 
 ```json
 {
-  "$schema":"http://json-schema.org/draft-07/schema#",
-  "title":"Camera",
-  "description":"Camera images with detected objects",
-  "properties":{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Camera",
+  "description": "Camera images with detected objects",
+  "properties": {
     "camera_name": {
       "description": "Name of the camera",
       "type": "string"
     },
-    "local_img_paths":{
-      "description":"Paths of saved images",
-      "type":"object",
-      "items":{
-        "$ref":"#/$defs/local_img_paths"
+    "local_paths": {
+      "description": "Paths of saved images",
+      "type": "object",
+      "items": {
+        "$ref": "#/$defs/paths"
       }
     },
-    "inspected":{
-      "description":"Inspected content of an image",
-      "type":"object",
-      "items":{
-        "$ref":"#/$defs/inspected"
-      }
-    }
-  },
-  "$defs":{
-    "local_img_paths":{
-      "type":"object",
-      "properties":{
-        "raw":{
-          "description":"Raw image",
-          "type":"string"
-        },
-        "rotated":{
-          "description":"Rotated image",
-          "type":"string"
-        },
-        "inspected":{
-          "description":"Inspected image",
-          "type":"string"
+    "remote_paths": {
+      "description": "Dictionary of paths where metadata and images will be remotely stored",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "items": {
+          "$ref": "#/$defs/paths"
         }
       }
     },
-    "inspected":{
-      "type":"object",
-      "properties":{
-        "barcode":{
-          "description":"Barcode inspected data",
-          "type":"array",
-          "items":{
-            "$ref":"#/$defs/barcode"
+    "inspected": {
+      "description": "Inspected content of an image",
+      "type": "object",
+      "items": {
+        "$ref": "#/$defs/inspected"
+      }
+    }
+  },
+  "$defs": {
+    "paths": {
+      "type": "object",
+      "properties": {
+        "raw": {
+          "description": "Raw image",
+          "type": "string"
+        },
+        "rotated": {
+          "description": "Rotated image",
+          "type": "string"
+        },
+        "inspected": {
+          "description": "Inspected image",
+          "type": "string"
+        }
+      }
+    },
+    "inspected": {
+      "type": "object",
+      "properties": {
+        "barcode": {
+          "description": "Barcode inspected data",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/barcode"
           }
         }
       }
     },
-    "barcode":{
-      "type":"object",
-      "properties":{
-        "data":{
-          "description":"Barcode data",
-          "type":"array",
-          "items":{
-            "type":"integer"
-          }
+    "barcode": {
+      "type": "object",
+      "properties": {
+        "data": {
+          "description": "Barcode data",
+          "type": "string"
         },
-        "height":{
-          "description":"Barcode height",
-          "type":"integer"
+        "height": {
+          "description": "Barcode height",
+          "type": "integer"
         },
-        "width":{
-          "description":"Barcode width",
-          "type":"integer"
+        "width": {
+          "description": "Barcode width",
+          "type": "integer"
         },
-        "top":{
-          "description":"Barcode top position",
-          "type":"integer"
+        "top": {
+          "description": "Barcode top position",
+          "type": "integer"
         },
-        "left":{
-          "description":"Barcode left position",
-          "type":"integer"
+        "left": {
+          "description": "Barcode left position",
+          "type": "integer"
         },
-        "type":{
-          "description":"Barcode type",
-          "type":"string"
+        "type": {
+          "description": "Barcode type",
+          "type": "string"
+        },
+        "pose": {
+          "description": "Pose of the code, present only when estimate_pose is enabled",
+          "$ref": "#/$defs/pose"
+        }
+      }
+    },
+    "pose": {
+      "type": "object",
+      "properties": {
+        "frame_id": {
+          "description": "Frame the pose is expressed in",
+          "type": "string"
+        },
+        "x": {
+          "description": "Code position along the frame's X axis, in meters",
+          "type": "number"
+        },
+        "y": {
+          "description": "Code position along the frame's Y axis, in meters",
+          "type": "number"
+        },
+        "z": {
+          "description": "Code position along the frame's Z axis, in meters",
+          "type": "number"
+        },
+        "roll": {
+          "description": "Code orientation about the frame's X axis, in radians",
+          "type": "number"
+        },
+        "pitch": {
+          "description": "Code orientation about the frame's Y axis, in radians",
+          "type": "number"
+        },
+        "yaw": {
+          "description": "Code orientation about the frame's Z axis, in radians",
+          "type": "number"
+        },
+        "distance": {
+          "description": "Straight-line distance from the camera to the code, in meters",
+          "type": "number"
         }
       }
     }
   },
-  "type":"object"
+  "type": "object"
 }
 ```

--- a/doc/src/dc/measurements/camera.md
+++ b/doc/src/dc/measurements/camera.md
@@ -135,7 +135,7 @@ than a hint:
 - **Non-square codes.** `SOLVEPNP_IPPE_SQUARE` assumes the four corners bound a square. A
   stretched or rectangular code is solved to a compromise scale. `dc_simulation`'s own
   `qrcode_*` assets are exactly this case — a 290x365 texture over a 0.5 x 0.5 m face makes
-  the printed code 0.362 m across and 0.288 m down — which is why the demo sets `code_size`
+  the printed code 0.362 m across and 0.292 m down — which is why the demo sets `code_size`
   to a mid-value of 0.325 and why the simulation check tolerates a metre of error rather
   than centimetres.
 ```

--- a/progress.txt
+++ b/progress.txt
@@ -6867,3 +6867,26 @@ image already carries for `cv_bridge`.
   simulation harness's `detect` stage (it needs the full warehouse world under Nav2, tens of
   minutes on a GPU-less machine) — the `gt_err` assertion it adds is exercised by CI's `sim`
   job, not locally.
+
+- **Follow-up: the sim `detect` stage failed on the first run, and the cause was the ground
+  truth, not the pose.** `[sim] FAILED: no estimated code poses recorded (estimate_pose off, or
+  no CameraInfo)` — with the same run reporting `5 QR codes read over 5 stations`. Neither
+  named cause was real. `qrcodes.world`'s comments contain `--`, which XML forbids *inside* a
+  comment: libsdformat's TinyXML2 accepts the file, `xml.etree.ElementTree` rejects it outright
+  at line 82. `ground_truth_codes()` caught `ParseError` and returned `[]`, so `gt_err` was
+  never emitted whatever the pose was, and the check then blamed the two components furthest
+  from the fault. `lint_launch_files.read_code_planes()` already reads this same file correctly
+  and shows why: it strips comments with `re.sub(r"<!--.*?-->", ...)` first and never uses a
+  strict parser. `ground_truth_codes()` now does the same.
+- **Reading that reference properly turned up a second bug in the same function.** The world's
+  `<pose>` values are in the *world* frame; the estimated pose is transformed into the *map*
+  frame. `lint_launch_files` carries the measured offset as `WORLD_TO_MAP = (-7.300, 1.425)`,
+  so the comparison was silently off by 7.4 m in x. It is now imported from there rather than
+  copied, so the two readers of this world cannot drift apart. Verified against the installed
+  world inside the workspace image: 80 QR models, map-frame x -18.608..-12.498, which lines up
+  with the pallet blocks `WORLD_TO_MAP`'s own comment measures off `qrcodes.pgm`.
+- **The check now distinguishes its three outcomes** — no pose at all, poses but none in the
+  map frame (it prints the frames it did see), or a `gt_err` to compare — because the original
+  single message sent this investigation to the wrong component. Also aligned the asset's
+  printed size with `lint_launch_files`' own measured `CODE_HALF_W`/`CODE_HALF_H`: 0.362 m
+  across by **0.292** m down, not the 0.288 derived here from the texture geometry.

--- a/progress.txt
+++ b/progress.txt
@@ -6748,3 +6748,122 @@ either way.
 .github/ISSUE_TEMPLATE/config.yml --skip build-doc` passes (codespell, yaml syntax,
 end-of-file/whitespace fixers). Private vulnerability reporting confirmed enabled through the
 API, not just assumed.
+
+## #48 - Camera measurement: estimate pose from detected QR codes
+
+A detection Record now optionally carries the pose of each code it decoded, so an inspection
+answers "where was it?" and not only "was it there?".
+
+**The issue's own gate was stale and is not honoured.** #48 was originally blocked on the ViSP
+migration (lagadic/vision_visp#121). Pose from a planar marker is `cv::solvePnP` over four
+corners given a physical size and the camera intrinsics, and #123 already put a detector in
+process that hands back exactly those four corners (`ZXing::Result::position()`), so ViSP would
+have been a large dependency for a solved problem. `SOLVEPNP_IPPE_SQUARE` is the solver for this
+exact case — four coplanar corners of a square — and it lives in `opencv_calib3d`, which the
+image already carries for `cv_bridge`.
+
+- **Off by default, and free when off.** `estimate_pose` defaults to false; with it false no
+  `camera_info` subscription is created and the Record is byte-for-byte what it was. Turning it
+  on needs the two things detection alone does not have: `code_size` (the printed side length,
+  in metres — `onConfigure()` throws if it is not positive, the same way `rotation_angle` already
+  validates) and intrinsics from `camera_info_topic`, which defaults to `camera_info` alongside
+  `cam_topic` rather than to nothing, since that is the ROS convention every driver follows.
+  Subscribed best-effort (`SensorDataQoS`) so a best-effort camera driver still matches.
+
+- **The maths lives in its own header so it can be tested without a ROS graph.**
+  `dc_measurements/include/dc_measurements/code_pose.hpp` is header-only:
+  `estimateSquareCodePose(corners, side, k, d)` returns `std::optional<geometry_msgs::msg::Pose>`
+  and `unrotatePoint()` maps a rotated-image pixel back to the raw image. Neither touches a node,
+  a parameter or a topic, so `test_code_pose` exercises them directly instead of standing up a
+  MeasurementServer and hoping. Degenerate input (`code_size` 0, an all-zero camera matrix, a
+  `cv::Exception` out of solvePnP) returns nullopt rather than a plausible-looking wrong pose.
+
+- **The convention is written down because it is the part that silently goes wrong — and the
+  first version of it was wrong.** The pose is the *code's* pose, not the robot's. The reported
+  code frame is centred on the code with X right, Y **down**, Z **into** its printed face: the
+  camera optical frame's own axes, so a code seen square-on is the identity orientation and
+  roll/pitch/yaw read as how far off square-on it was. That is the ArUco/OpenCV marker frame
+  turned 180 degrees about X, which is why the code negates the Y and Z columns of the matrix
+  solvePnP returns. The first draft instead declared the object points Y-up *and* claimed the
+  identity for square-on, which is self-contradictory: `SOLVEPNP_IPPE_SQUARE` documents its
+  object-point layout as a precondition, and that layout's frame has Z pointing back at the
+  camera. It survived the synthetic tests — they projected through the same wrong object points,
+  so the error cancelled — and was caught only by the end-to-end test, which renders a real QR
+  code and lets ZXing find the corners: a 15-degree tilt came back as `rpy=(164, 0.13, -90)`
+  instead of `(0, 15, 0)`. Worth recording because the render itself was the tell: mapping the
+  bitmap's top-left onto the Y-up "top-left" object point drew the code upside down, and ZXing
+  duly reported its corners in the code's own (rotated) orientation. A synthetic-corner test can
+  never catch this class of bug on its own.
+
+- **Also checked, because it was the first suspicion for that failure: ZXing's corners are
+  perspective-faithful.** A QR code below version 2 has no alignment pattern, so a detector has
+  to derive the fourth corner (the one without a finder pattern) somehow, and extrapolating it
+  as a parallelogram would destroy exactly the out-of-plane information a PnP solve needs.
+  Measured on rendered codes at 0, 15, 30 and 40 degrees of tilt, the diagonal-midpoint skew of
+  ZXing's reported quad tracks the true projected quad closely (20.1 vs 21.1 px at 15 degrees,
+  38.1 vs 40.8 at 30, 51.2 vs 52.7 at 40) for a 21-module version-1 code as well as a 25-module
+  one. Orientation is recoverable from a version-1 code; the bug was ours.
+
+- **Frames and the failure mode.** The output frame is the camera optical frame (REP 103) unless
+  `pose_frame` names one to transform into via TF. Every emitted pose carries the `frame_id` it
+  is actually in, which is what makes the failure mode safe: if the transform is not available
+  inside `transform_timeout` the pose is still written, in the camera frame, with a warning —
+  dropping it would lose the reading, and reporting it silently in the wrong frame is the thing
+  `frame_id` exists to prevent. `pose.distance` is deliberately computed from the *untransformed*
+  pose so it stays a camera-to-code range whatever `pose_frame` is.
+
+- **`rotation_angle` is handled, not ignored.** Detection runs on the rotated image while the
+  intrinsics describe the raw one, so corners are mapped back through `unrotatePoint()` before
+  the solve. Without that, any camera configured with a rotation would have produced a
+  confidently wrong pose. `PoseIsUnchangedByImageRotation` is the test that pins it: project a
+  known pose, rotate the corners into a 90-degree image, map them back, and require the same
+  pose out.
+
+- **A pre-existing bug had to be fixed for the feature to be reachable at all.** `camera.cpp`
+  built its `inspected.barcode` entries *inside* the `save_detections_img_ && draw_det_barcodes_`
+  branch, so a deployment with drawing off recorded no detections whatsoever — the codes were
+  decoded and thrown away. The loop now always records the entry and draws separately. The image
+  saving stays gated on drawing exactly as before (the old condition tested
+  `fieldInJSON(data_json, "inspected")`, which only the drawing branch could ever set, so this is
+  the same behaviour spelled out rather than implied); the only visible change is that detections
+  now reach the Record with `draw_det_barcodes: false`.
+
+- **Schema and docs.** `camera.json` gains a `pose` `$def` (frame_id, x/y/z, roll/pitch/yaw,
+  distance) referenced from the barcode entry. `doc/src/dc/measurements/camera.md` gains the
+  parameter rows, a "Code pose estimation" section with the frame/convention explanation, a
+  worked YAML plus the JSON it produces, and a warning covering the two *systematic* biases (a
+  detector locates corners to about one module, so range carries a percent-level bias averaging
+  will not remove; and IPPE_SQUARE assumes a square, so a stretched code solves to a compromise
+  scale). The page's embedded schema block was stale — it still described `local_img_paths` and a
+  `data` array of integers, neither of which the plugin has emitted for some time — and is now
+  generated from `camera.json` itself rather than re-hand-edited.
+
+- **The demo proves frames and axes, not centimetres, and the reason is the asset.**
+  `dc_simulation`'s `qrcode_*` model stretches a 290x365 texture across a 0.5 x 0.5 m face (the
+  COLLADA node scales the 2x2x2 cube by 0.25 in Y and Z), so its printed code measures 0.362 m
+  across and 0.288 m down — not square, and therefore not a metrologically sound target for a
+  square-marker solver. `qrcodes_stdout.yaml` (the params the simulation check runs) turns pose
+  estimation on with a mid-value `code_size: 0.325` and `pose_frame: "map"`, and
+  `verify_sim.py`'s recorder now prints each code's map-frame pose next to `gt_err`, the
+  horizontal distance to the nearest QR model parsed out of `qrcodes.world` — the simulator's own
+  ground truth. `run.sh`'s `detect` stage fails if the closest such reading is more than a metre
+  out. A metre is loose on purpose: it cannot certify accuracy, but it does catch every failure
+  that a decoded-payload check cannot — wrong frame, flipped axis, uninitialised intrinsics,
+  a pose left in the camera frame. Making the asset square is separate work, not smuggled in
+  here: #51 tuned detection against these exact renders and changing them would move that too.
+
+- **Verified**: the six `test_code_pose` cases pass, compiled and run against the workspace image
+  (`libzxing-dev` 2.2.1, OpenCV 4.6, Jazzy). Four are synthetic — round-tripping a known pose
+  through `cv::projectPoints` and back, the degenerate-input rejections, and the rotation
+  mapping. The other two are the ones that carry weight: `RecoversAPoseFromARenderedQrCode`
+  encodes a QR with ZXing's own writer, renders it through the demo camera's intrinsics
+  (1280x720, 1.047 rad horizontal FOV) at a known pose, decodes it back with
+  `ZXing::ReadBarcodes` and recovers a range of **1.19593 m against 1.20121 m of ground truth,
+  0.44%**, with the tilt inside 5 degrees; `PoseIsUnchangedByImageRotation` pins the
+  `rotation_angle` mapping. Angular tolerances sit at 0.01 rad rather than 1e-5 because the
+  corner points are `cv::Point2f` and the test code spans only ~50 px — a convention error is
+  tens of degrees, so this still separates the two cleanly. `prek run clang-format` passes on
+  every touched C++ file and `ruff check`/`ruff format` on `verify_sim.py`. Not run here: the
+  simulation harness's `detect` stage (it needs the full warehouse world under Nav2, tens of
+  minutes on a GPU-less machine) — the `gt_err` assertion it adds is exercised by CI's `sim`
+  job, not locally.

--- a/tools/sim/scripts/run.sh
+++ b/tools/sim/scripts/run.sh
@@ -261,6 +261,22 @@ if has_stage detect; then
   codes=$(rin 'grep -a "format=QRCode" /tmp/codes.log | grep -ao "code=[0-9]*" | sort -u | tr "\n" " "' 2>/dev/null || true)
   log "$reads QR codes read over $reached stations: ${codes:-none}"
   [ "$reads" -ge "$want" ] || fail "only $reads QR codes read, wanted at least $want (see $RUN_DIR/sim.log)"
+
+  # Pose estimation (#48). The recorder reports each map-frame code pose next to the
+  # nearest QR model in the world file, so this asserts against the simulator's own
+  # ground truth. The tolerance is deliberately loose: dc_simulation's qrcode_* asset
+  # stretches a 290x365 texture over a square face, so its printed code is 0.362 m
+  # across and 0.288 m down and no single code_size is exact. A metre still catches
+  # every failure worth catching here -- wrong frame, flipped axis, uninitialised
+  # intrinsics -- which a decoded-payload check cannot.
+  best=$(rin 'grep -ao "gt_err=[0-9.]*" /tmp/codes.log | cut -d= -f2 | sort -g | head -1' 2>/dev/null | head -1 | tr -dc '0-9.' || true)
+  if [ -n "${best:-}" ]; then
+    log "best QR-code pose landed ${best} m from the world's own placement"
+    awk -v e="$best" 'BEGIN { exit !(e < 1.0) }' \
+      || fail "closest estimated code pose was ${best} m from any QR model in the world"
+  else
+    fail "no estimated code poses recorded (estimate_pose off, or no CameraInfo)"
+  fi
 fi
 
 log "simulation check passed (stages: $STAGES)"

--- a/tools/sim/scripts/run.sh
+++ b/tools/sim/scripts/run.sh
@@ -266,16 +266,25 @@ if has_stage detect; then
   # nearest QR model in the world file, so this asserts against the simulator's own
   # ground truth. The tolerance is deliberately loose: dc_simulation's qrcode_* asset
   # stretches a 290x365 texture over a square face, so its printed code is 0.362 m
-  # across and 0.288 m down and no single code_size is exact. A metre still catches
+  # across and 0.292 m down (lint_launch_files' measured CODE_HALF_W/CODE_HALF_H) and
+  # no single code_size is exact. A metre still catches
   # every failure worth catching here -- wrong frame, flipped axis, uninitialised
   # intrinsics -- which a decoded-payload check cannot.
+  #
+  # Three distinguishable outcomes, because the first version of this check reported all
+  # of them as "estimate_pose off, or no CameraInfo" and sent the investigation to the
+  # wrong component: the real cause was the ground-truth reader returning nothing.
+  poses=$(count_in_container 'grep -ac "code_pose=" /tmp/codes.log')
   best=$(rin 'grep -ao "gt_err=[0-9.]*" /tmp/codes.log | cut -d= -f2 | sort -g | head -1' 2>/dev/null | head -1 | tr -dc '0-9.' || true)
   if [ -n "${best:-}" ]; then
     log "best QR-code pose landed ${best} m from the world's own placement"
     awk -v e="$best" 'BEGIN { exit !(e < 1.0) }' \
       || fail "closest estimated code pose was ${best} m from any QR model in the world"
+  elif [ "${poses:-0}" -gt 0 ]; then
+    frames=$(rin 'grep -ao "frame=[^ ]*" /tmp/codes.log | sort -u | tr "\n" " "' 2>/dev/null || true)
+    fail "$poses code poses recorded but none in the map frame (frames seen: ${frames:-none}); the pose_frame TF lookup or the world ground truth is failing"
   else
-    fail "no estimated code poses recorded (estimate_pose off, or no CameraInfo)"
+    fail "no estimated code poses recorded: estimate_pose off, no CameraInfo on the camera_info topic, or the solve rejected every detection"
   fi
 fi
 

--- a/tools/sim/scripts/verify_sim.py
+++ b/tools/sim/scripts/verify_sim.py
@@ -253,6 +253,41 @@ CHECKS = {"topics": check_topics, "cmd_vel": check_cmd_vel, "nav": check_nav}
 MEASUREMENTS = ["/dc/measurement/right_camera", "/dc/measurement/left_camera"]
 
 
+def ground_truth_codes(path=None):
+    """Map-frame (x, y) of every QR-code model placed in the world.
+
+    The world is the only ground truth for #48's pose estimation: a code's estimated
+    position is only meaningful next to where the simulator actually put it. Returns an
+    empty list rather than raising, so a recorder still logs detections if the world
+    moves.
+
+    Args:
+        path: the installed qrcodes.world; found via the ament index when omitted.
+    """
+    # stdlib ElementTree, not defusedxml: the input is this repo's own world file,
+    # installed in the image the check runs in.
+    import os
+    import xml.etree.ElementTree as ElementTree
+
+    from ament_index_python.packages import get_package_share_directory
+
+    try:
+        if path is None:
+            share = get_package_share_directory("dc_simulation")
+            path = os.path.join(share, "worlds", "qrcodes.world")
+        root = ElementTree.parse(path).getroot()
+    except (OSError, LookupError, ElementTree.ParseError):
+        return []
+    codes = []
+    for model in root.iter("model"):
+        if not any("qrcode_" in (i.findtext("uri") or "") for i in model.iter("include")):
+            continue
+        parts = (model.findtext("pose") or "").split()
+        if len(parts) >= 2:
+            codes.append((float(parts[0]), float(parts[1])))
+    return codes
+
+
 class Recorder(Node):
     """Prints one line per QR code the demo reads, with the pose it read it from.
 
@@ -268,6 +303,7 @@ class Recorder(Node):
         from dc_interfaces.msg import StringStamped
 
         self.pose = None
+        self.ground_truth = ground_truth_codes()
         self.create_subscription(PoseWithCovarianceStamped, "/amcl_pose", self._on_pose, 10)
         for topic in MEASUREMENTS:
             self.create_subscription(
@@ -291,9 +327,31 @@ class Recorder(Node):
             # pallet. Only a QRCode read means the demo saw what it came for.
             print(
                 f"{topic} pose={self.pose} format={barcode.get('type', '?')} "
-                f"code={barcode['data']}",
+                f"code={barcode['data']}{self._code_pose(barcode)}",
                 flush=True,
             )
+
+    def _code_pose(self, barcode):
+        """Estimated code pose (#48) and how far it lands from the world's own placement.
+
+        `gt_err` is the horizontal distance to the nearest QR model in the world file —
+        the assertion run.sh makes, and the only one that catches a pose that decodes
+        correctly but comes out in the wrong frame or with a flipped axis.
+
+        Args:
+            barcode: one entry of a Camera Record's `inspected.barcode`.
+        """
+        pose = barcode.get("pose")
+        if not pose:
+            return ""
+        line = (
+            f" code_pose=({round(pose['x'], 3)}, {round(pose['y'], 3)}, {round(pose['z'], 3)})"
+            f" frame={pose['frame_id']} distance={round(pose['distance'], 3)}"
+        )
+        if self.ground_truth and pose["frame_id"] == "map":
+            err = min(math.hypot(x - pose["x"], y - pose["y"]) for x, y in self.ground_truth)
+            line += f" gt_err={round(err, 3)}"
+        return line
 
 
 def main():

--- a/tools/sim/scripts/verify_sim.py
+++ b/tools/sim/scripts/verify_sim.py
@@ -15,6 +15,7 @@ Usage:
 
 import json
 import math
+import pathlib
 import sys
 
 import rclpy
@@ -257,34 +258,41 @@ def ground_truth_codes(path=None):
     """Map-frame (x, y) of every QR-code model placed in the world.
 
     The world is the only ground truth for #48's pose estimation: a code's estimated
-    position is only meaningful next to where the simulator actually put it. Returns an
-    empty list rather than raising, so a recorder still logs detections if the world
-    moves.
+    position is only meaningful next to where the simulator actually put it.
+
+    Comments are stripped and the models read with regexes rather than ElementTree, the
+    same way lint_launch_files.read_code_planes() reads this file: qrcodes.world's
+    comments contain `--`, which XML forbids inside a comment, so libsdformat's lenient
+    TinyXML2 accepts the file but every strict parser rejects it outright.
 
     Args:
         path: the installed qrcodes.world; found via the ament index when omitted.
+
+    Returns:
+        A list of (x, y) in the map frame.
     """
-    # stdlib ElementTree, not defusedxml: the input is this repo's own world file,
-    # installed in the image the check runs in.
     import os
-    import xml.etree.ElementTree as ElementTree
+    import re
 
     from ament_index_python.packages import get_package_share_directory
 
-    try:
-        if path is None:
-            share = get_package_share_directory("dc_simulation")
-            path = os.path.join(share, "worlds", "qrcodes.world")
-        root = ElementTree.parse(path).getroot()
-    except (OSError, LookupError, ElementTree.ParseError):
-        return []
+    # WORLD_TO_MAP is measured off qrcodes.pgm; shared rather than copied so the two
+    # readers of this world cannot drift apart.
+    from lint_launch_files import WORLD_TO_MAP
+
+    if path is None:
+        path = os.path.join(get_package_share_directory("dc_simulation"), "worlds", "qrcodes.world")
+    world = re.sub(r"<!--.*?-->", "", pathlib.Path(path).read_text(), flags=re.S)
+
     codes = []
-    for model in root.iter("model"):
-        if not any("qrcode_" in (i.findtext("uri") or "") for i in model.iter("include")):
+    for body in re.findall(r"<model name=\"[^\"]+\">(.*?)</model>", world, re.S):
+        if not re.search(r"<uri>model://qrcode_[^<]*</uri>", body):
             continue
-        parts = (model.findtext("pose") or "").split()
-        if len(parts) >= 2:
-            codes.append((float(parts[0]), float(parts[1])))
+        pose = re.search(r"<pose>([^<]+)</pose>", body)
+        if not pose:
+            continue
+        values = [float(v) for v in pose.group(1).split()]
+        codes.append((values[0] + WORLD_TO_MAP[0], values[1] + WORLD_TO_MAP[1]))
     return codes
 
 


### PR DESCRIPTION
Closes #48

A detection Record can now carry the pose of each code it decoded, so an inspection answers *where was it?* and not only *was it there?*

## The issue's own gate is stale, and is not honoured

#48 was blocked on the ViSP migration (lagadic/vision_visp#121). Pose from a planar marker is `cv::solvePnP` over four corners given a physical size and the camera intrinsics — and #123 already put a detector in process that hands back exactly those four corners (`ZXing::Result::position()`). `SOLVEPNP_IPPE_SQUARE` is the solver for this exact case, and it lives in `opencv_calib3d`, which the image already carries for `cv_bridge`. ViSP would have been a large dependency for a solved problem.

## Optional, and free when off

`estimate_pose` defaults to `false`. With it false, no `camera_info` subscription is created and the Record is byte-for-byte what it was.

| Parameter | Default | |
|---|---|---|
| `estimate_pose` | `false` | turns the whole thing on |
| `code_size` | `0.0` | printed side length in metres; `onConfigure()` throws if not positive when enabled |
| `camera_info_topic` | `camera_info` beside `cam_topic` | the ROS convention, rather than nothing |
| `pose_frame` | `""` | empty = camera optical frame; else transformed via TF |
| `transform_timeout` | `0.1` | |

## Frame and convention

The reported code frame uses the camera optical frame's own axes — **X right, Y down, Z into the printed face** — so a code seen square-on is the **identity orientation** and roll/pitch/yaw read as how far off square-on it was. That is the ArUco/OpenCV marker frame turned 180° about X (that convention puts Z back towards the camera, making square-on a 180° roll).

Every pose carries the `frame_id` it is actually in. If the `pose_frame` transform is unavailable within `transform_timeout` the pose is still written — in the camera frame, with a warning — rather than dropped: losing the reading is worse, and a silently mislabelled frame is what `frame_id` exists to prevent. `pose.distance` is computed from the untransformed pose so it stays a camera-to-code range whatever `pose_frame` is.

`rotation_angle` is handled rather than ignored: corners are mapped back to raw-image coordinates before the solve, since the intrinsics describe the raw image.

## A pre-existing bug had to be fixed first

`camera.cpp` built its `inspected.barcode` entries **inside** the `save_detections_img_ && draw_det_barcodes_` branch, so a deployment with drawing off decoded codes and threw them away. The loop now always records, and draws separately. Image saving stays gated on drawing exactly as before (the old condition tested `fieldInJSON(data_json, "inspected")`, which only the drawing branch could set) — the only visible change is that detections now reach the Record with `draw_det_barcodes: false`.

## The first version of the convention was wrong, and only the end-to-end test caught it

The initial draft declared the object points Y-up *and* claimed the identity for square-on — self-contradictory, since `SOLVEPNP_IPPE_SQUARE` documents its object-point layout as a precondition and that layout's frame has Z pointing back at the camera. It passed every synthetic test, because those projected through the same wrong object points and the error cancelled. `RecoversAPoseFromARenderedQrCode` — which renders a real QR and lets ZXing find the corners — returned `rpy=(164, 0.13, -90)` for a 15° tilt. **A synthetic-corner test cannot catch this class of bug on its own.**

Also checked, since it was the first suspicion: ZXing's corners *are* perspective-faithful even for a version-1 code with no alignment pattern. The diagonal-midpoint skew of its reported quad tracks the true projected quad (20.1 vs 21.1 px at 15°, 38.1 vs 40.8 at 30°, 51.2 vs 52.7 at 40°). Orientation is recoverable; the bug was ours.

## Verification

Six `test_code_pose` cases, run against the workspace image (`libzxing-dev` 2.2.1, OpenCV 4.6, Jazzy). The two that carry weight:

- **`RecoversAPoseFromARenderedQrCode`** encodes a QR with ZXing's own writer, renders it through the demo camera's intrinsics (1280x720, 1.047 rad hFOV) at a known pose, decodes it back with `ZXing::ReadBarcodes`, and recovers a range of **1.19593 m against 1.20121 m of ground truth — 0.44%**, tilt within 5°.
- **`PoseIsUnchangedByImageRotation`** pins the `rotation_angle` mapping.

Angular tolerances are 0.01 rad rather than 1e-5: the corners are `cv::Point2f` and the test code spans ~50 px. A convention error is tens of degrees, so this still separates the two cleanly.

## What the demo can and cannot prove

`dc_simulation`'s `qrcode_*` model stretches a 290x365 texture across a 0.5 x 0.5 m face, so its printed code is **0.362 m across and 0.288 m down** — not square, and so not a metrologically sound target for a square-marker solver. `qrcodes_stdout.yaml` turns pose estimation on with a mid-value `code_size: 0.325` and `pose_frame: "map"`; `verify_sim.py`'s recorder prints each code's map-frame pose next to `gt_err`, the horizontal distance to the nearest QR model parsed out of `qrcodes.world` — the simulator's own ground truth — and `run.sh`'s `detect` stage fails if the closest reading is over a metre out.

A metre is loose on purpose. It cannot certify accuracy, but it catches every failure a decoded-payload check cannot: wrong frame, flipped axis, uninitialised intrinsics, a pose left in the camera frame. Making the asset square is separate work — #51 tuned detection against these exact renders.

Not run locally: the simulation harness's `detect` stage (full warehouse world under Nav2, tens of minutes without a GPU). CI's `sim` job exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRQE1EsJQ2g1VMKZCFTopo