### PR TITLE
docs: add a security policy and a private disclosure route

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Minipada/ros2_data_collection/security/advisories/new
+    about: Report it privately here, never as a public issue. See SECURITY.md.
   - name: Q&A
     url: https://github.com/Minipada/ros2_data_collection/discussions/categories/q-a
     about: Ask and answer questions

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported branches
+
+DC has no versioned releases yet, so there is nothing to support per version: fixes land on
+branch tips.
+
+| Branch   | What it is                                     | Security fixes                       |
+| -------- | ---------------------------------------------- | ------------------------------------ |
+| `jazzy`  | active development (DC 2.0, ROS 2 Jazzy)        | yes — fixes land here first          |
+| `humble` | legacy line (DC 1.x, ROS 2 Humble, Fluent Bit) | high and critical severity only      |
+| anything else (feature branches, forks) | not a release line             | no                                   |
+
+## Reporting a vulnerability
+
+**Do not open a public issue, discussion, or pull request for a security problem.**
+
+Report it through GitHub private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/Minipada/ros2_data_collection/security/advisories/new)
+(also reachable from the repository's *Security* tab). It is enabled on this repository and
+is the preferred route — the report, the discussion, the fix, and the resulting advisory all
+stay in one private place.
+
+If GitHub is not an option, email **<d.bensoussan@proton.me>** with `SECURITY` in the subject
+line. Say so in the mail if you want a PGP key and one will be sent back.
+
+Useful in a report:
+
+- the affected branch and commit, and which package(s) are involved
+- what an attacker gains, and what access they need to get it
+- reproduction steps: the DC configuration, launch file, or Destination setup that triggers it
+- your own severity assessment (a CVSS vector if you have one)
+- whether you intend to disclose publicly, and on what date
+
+## What to expect
+
+| Stage                                                | Target             |
+| ---------------------------------------------------- | ------------------ |
+| Acknowledgement that the report was received         | 3 business days    |
+| Initial assessment: accepted or rejected, + severity | 10 business days   |
+| Status update while a fix is being worked on         | every 14 days      |
+| Fix on `jazzy`                                       | severity-dependent |
+
+DC is maintained by one person with no commercial support contract behind it, so these are
+targets rather than an SLA. If the acknowledgement window passes in silence, chase through the
+other channel above.
+
+## Disclosure
+
+Disclosure is coordinated. The default embargo is 90 days from acknowledgement, or until a fix
+is on `jazzy`, whichever comes first — shorter for something trivially fixed, longer if the fix
+has to be coordinated upstream (ROS 2, Vector, the AWS SDK). Fixed issues are published as a
+GitHub Security Advisory, with a CVE requested through GitHub when the impact warrants one.
+Reporters are credited by name or handle unless they ask not to be.
+
+## Scope
+
+In scope: everything in this repository — the `dc_*` ROS 2 packages, the vendor packages
+(`vector_vendor`, `aws_sdk_vendor`), the CI and E2E tooling under `tools/`, and the container
+images built from it.
+
+Out of scope, and better reported upstream or as a normal issue:
+
+- ROS 2 itself and third-party dependencies (Vector, the AWS SDK, …), unless the vulnerability
+  comes from how DC uses them.
+- The demo configurations and the local infrastructure under `tools/infrastructure/` —
+  unauthenticated Postgres, default credentials, open ports. Those are deliberately trivial so
+  a demo runs on a laptop; they are not a deployment template. Documentation that presents one
+  of them as production-ready *is* a bug — file it as a normal issue.
+- Scanner output with no demonstrated impact on DC.

--- a/doc/src/dc/contributing.md
+++ b/doc/src/dc/contributing.md
@@ -6,6 +6,7 @@
 | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | Want to contribute                  | [Open a PR](https://github.com/Minipada/ros2_data_collection/pulls)                                                                           |
 | Found a bug                         | [File a ticket on Github Issues](https://github.com/Minipada/ros2_data_collection/issues/new?assignees=&labels=bug&template=issues.md&title=) |
+| Found a vulnerability               | [Report it privately](https://github.com/Minipada/ros2_data_collection/security/advisories/new), never as a public issue                      |
 | Feature request                     | [Describe what you want on Github Discussions](https://github.com/Minipada/ros2_data_collection/discussions)                                  |
 | Want to start a discussion          | [Start one on Github Discussions](https://github.com/Minipada/ros2_data_collection/discussions)                                               |
 | Be aware of the ongoing development | Take a look at the [Github Project](https://github.com/users/Minipada/projects/1) and what is being worked on                                 |
@@ -19,6 +20,13 @@ Since I want DC to be community driven, go to [Github discussions](https://githu
 ### Found a bug?
 
 If you find a problem, first search if an issue already exists. If a related issue doesn't exist, you can open a new issue using the [issue form](https://github.com/Minipada/ros2_data_collection/issues/new?assignees=&labels=bug&template=bug_report.md&title=).
+
+### Found a vulnerability?
+
+Do not open a public issue, discussion or pull request. Report it through
+[GitHub private vulnerability reporting](https://github.com/Minipada/ros2_data_collection/security/advisories/new)
+instead; the [security policy](https://github.com/Minipada/ros2_data_collection/blob/jazzy/SECURITY.md)
+states the supported branches, the response targets and what is in scope.
 
 ### General guidelines
 

--- a/doc/src/dc/introduction.md
+++ b/doc/src/dc/introduction.md
@@ -38,6 +38,7 @@ For detailed instructions:
 - [Requirements](https://minipada.github.io/ros2_data_collection/dc/requirements.html)
 - [Future work and Roadmap](https://minipada.github.io/ros2_data_collection/dc/future_work.html)
 - [Contributing](https://minipada.github.io/ros2_data_collection/dc/contributing.html)
+- [Security policy](https://github.com/Minipada/ros2_data_collection/blob/jazzy/SECURITY.md)
 - [FAQ](https://minipada.github.io/ros2_data_collection/dc/faq.html)
 - [About and contact](https://minipada.github.io/ros2_data_collection/dc/about_contact.html)
 
@@ -155,6 +156,13 @@ flowchart LR
     gr_inspection -- "Raw, rotated and/or inspected images (Files)" --> pl_rustfs
     gr_inspection -- "Raw, rotated and/or inspected images (Files)" --> pl_s3
 ```
+
+# Security
+
+Found a vulnerability? Do not open a public issue — report it privately through
+[GitHub private vulnerability reporting](https://github.com/Minipada/ros2_data_collection/security/advisories/new).
+The [security policy](https://github.com/Minipada/ros2_data_collection/blob/jazzy/SECURITY.md)
+covers the supported branches, the response targets, and what is in scope.
 
 # License
 This program is under the terms of the [Mozilla Public License Version 2.0](https://www.mozilla.org/en-US/MPL/2.0/).

--- a/progress.txt
+++ b/progress.txt
@@ -6697,3 +6697,54 @@ and that `nlohmann_json_schema_validator` in Jazzy implements `propertyNames`/`m
 `prek run --files …` passes on the three changed files. `doc/src/dc/measurements/thermal.md`'s
 Schema section carries the new schema plus a sentence on why the constraints are shaped this
 way instead of a `required` list.
+
+## #302 - Add SECURITY.md and a vulnerability disclosure contact
+
+The repository had no security policy, so the only route for someone finding a vulnerability
+was a public issue — which is the disclosure. `SECURITY.md` at the repo root now states the
+supported branches, the private reporting route, the response targets and the disclosure terms.
+
+**Supported branches, not versions.** DC has no tags and no releases (`0.1.0` in every
+`package.xml`, no `git tag`), so a "supported versions" table would have been fiction. The
+table names branch tips instead: `jazzy` gets fixes first (active DC 2.0 line), `humble` gets
+high/critical only (legacy DC 1.x, Fluent Bit), feature branches and forks get nothing.
+
+**Reporting route**: GitHub private vulnerability reporting, which was already enabled on the
+repository (`gh api repos/Minipada/ros2_data_collection/private-vulnerability-reporting` →
+`{"enabled":true}`), with `d.bensoussan@proton.me` as the fallback. The advisory link
+(`/security/advisories/new`) is the one the document leads with, so report, discussion, fix and
+advisory stay in one private place.
+
+**Response targets, stated as targets**: acknowledgement 3 business days, accept/reject +
+severity 10 business days, status update every 14 days, fix severity-dependent. Disclosure is
+coordinated with a 90-day default embargo (or until the fix lands on `jazzy`, whichever is
+first), published as a GHSA, CVE requested through GitHub when warranted, reporter credited.
+The document says outright that this is one maintainer with no support contract behind it and
+these are targets rather than an SLA — better than an SLA nobody can hold to.
+
+**Scope** is spelled out because of what this repo contains: the demo configs and
+`tools/infrastructure/` are deliberately trivial (unauthenticated Postgres, default
+credentials) so a demo runs on a laptop, and they attract scanner reports. Those are out of
+scope, as are ROS 2 and third-party dependencies (Vector, AWS SDK) unless DC's *use* of them is
+what creates the problem — but documentation presenting a demo credential as production-ready
+is explicitly called a bug, filed as a normal issue.
+
+**Linked from three places**, since a policy nobody finds is not a policy: the README
+(`README.md` is a symlink to `doc/src/dc/introduction.md`, so the link uses the
+`blob/jazzy/SECURITY.md` absolute form the docs already use for repo files — a relative link
+would break on the docs site) gets both a list entry and a `# Security` section before
+`# License`; `doc/src/dc/contributing.md` gets a TLDR row and a "Found a vulnerability?"
+subsection; and `.github/ISSUE_TEMPLATE/config.yml` gets a contact link, which puts "Report a
+security vulnerability" in the new-issue chooser itself — the moment someone is about to do the
+wrong thing.
+
+**Caveat worth knowing**: GitHub surfaces `SECURITY.md` from the **default branch**, which is
+still `humble`. Until this reaches `humble` (or the default branch moves to `jazzy`), the
+Security tab will keep showing no policy even though the file exists on `jazzy`. Private
+vulnerability reporting is repo-level and works regardless, so the reporting channel is live
+either way.
+
+**Verified**: `prek run --files SECURITY.md doc/src/dc/introduction.md doc/src/dc/contributing.md
+.github/ISSUE_TEMPLATE/config.yml --skip build-doc` passes (codespell, yaml syntax,
+end-of-file/whitespace fixers). Private vulnerability reporting confirmed enabled through the
+API, not just assumed.


### PR DESCRIPTION
The repository has no security policy, so the only route open to someone finding a
vulnerability is a public issue — which is the disclosure. This adds `SECURITY.md` at the repo
root and links it from everywhere a reporter is likely to look.

## What it says

- **Supported branches, not versions.** DC has no tags and no releases (every `package.xml` is
  at `0.1.0`), so a "supported versions" table would be fiction. The table names branch tips:
  `jazzy` gets fixes first, `humble` gets high/critical only, feature branches and forks get
  nothing.
- **Private reporting route**: GitHub private vulnerability reporting
  ([advisories/new](https://github.com/Minipada/ros2_data_collection/security/advisories/new)),
  with `d.bensoussan@proton.me` as the fallback. Already enabled on the repository — verified
  via `gh api repos/Minipada/ros2_data_collection/private-vulnerability-reporting` →
  `{"enabled":true}`, so the channel behind the document is live.
- **Response targets**: acknowledgement 3 business days, accept/reject + severity 10 business
  days, status update every 14 days. Stated as targets, with the single-maintainer reality
  spelled out, rather than as an SLA nobody can hold to.
- **Disclosure**: coordinated, 90-day default embargo or until the fix lands on `jazzy`,
  whichever is first; published as a GHSA, CVE requested through GitHub when warranted,
  reporter credited unless they decline.
- **Scope**: the demo configs and `tools/infrastructure/` (unauthenticated Postgres, default
  credentials) are deliberately trivial so a demo runs on a laptop — out of scope, as are ROS 2
  and third-party deps unless DC's *use* of them creates the problem. Documentation presenting
  a demo credential as production-ready is explicitly a bug, filed as a normal issue.

## Where it is linked

`README.md` is a symlink to `doc/src/dc/introduction.md`, so the link uses the
`blob/jazzy/SECURITY.md` absolute form the docs already use for repo files — a relative link
would break on the docs site. The README gets a list entry plus a `# Security` section;
`doc/src/dc/contributing.md` gets a TLDR row and a "Found a vulnerability?" subsection; and
`.github/ISSUE_TEMPLATE/config.yml` gets a contact link, which puts "Report a security
vulnerability" in the new-issue chooser itself — right where someone is about to do the wrong
thing.

## Caveat

GitHub surfaces `SECURITY.md` from the **default branch**, which is still `humble`. Until this
reaches `humble` (or the default branch moves to `jazzy`), the Security tab will show no policy
even though the file exists here. Private vulnerability reporting is repo-level and works
regardless.

## Verification

`prek run --files SECURITY.md doc/src/dc/introduction.md doc/src/dc/contributing.md
.github/ISSUE_TEMPLATE/config.yml --skip build-doc` passes. No code touched.

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ch5gm7LspscVZKJAHQP9B