### PR TITLE
feat(dc_common): StateTransitionDetector and BatteryCycleAccumulator

### DIFF
--- a/dc_common/CMakeLists.txt
+++ b/dc_common/CMakeLists.txt
@@ -17,9 +17,9 @@ install(
   DESTINATION share/${PROJECT_NAME}
 )
 
-# RecordRingBuffer / FileScratchRing (#285): header-only, ROS-free utilities, same shape as
-# dc_core's condition_set.hpp -- no compiled library needed, just the headers on the include
-# path.
+# RecordRingBuffer / FileScratchRing (#285), StateTransitionDetector / BatteryCycleAccumulator
+# (#360): header-only, ROS-free utilities, same shape as dc_core's condition_set.hpp -- no
+# compiled library needed, just the headers on the include path.
 install(
   DIRECTORY include/
   DESTINATION include/
@@ -29,7 +29,8 @@ ament_export_include_directories(include)
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
 
-  foreach(test record_ring_buffer_test file_scratch_ring_test)
+  foreach(test record_ring_buffer_test file_scratch_ring_test state_transition_detector_test
+          battery_cycle_accumulator_test)
     ament_add_gtest(${PROJECT_NAME}_${test} test/${test}.cpp)
     target_include_directories(${PROJECT_NAME}_${test} PUBLIC
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/dc_common/include/dc_common/battery_cycle_accumulator.hpp
+++ b/dc_common/include/dc_common/battery_cycle_accumulator.hpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_COMMON_BATTERY_CYCLE_ACCUMULATOR_HPP_
+#define DC_COMMON_BATTERY_CYCLE_ACCUMULATOR_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+
+namespace dc_common
+{
+
+/**
+ * @brief Whether the pack is on a charger, as the hardware reports it.
+ *
+ * Values match `sensor_msgs/BatteryState`'s POWER_SUPPLY_STATUS_* constants so the battery
+ * Measurement (#361) adapts a message with a cast, but nothing here depends on that package.
+ */
+enum class PowerSupplyStatus : std::uint8_t
+{
+  Unknown = 0,
+  Charging = 1,
+  Discharging = 2,
+  NotCharging = 3,
+  Full = 4,
+};
+
+/**
+ * @brief One charging session: when it started, when it ended (unset while still charging), the
+ * charge percentage at each boundary, and the depth of the discharge that preceded it.
+ *
+ * Percentages are optional because hardware leaves the field unset often enough that a session
+ * with unknown boundaries is still worth recording.
+ */
+struct ChargingSession
+{
+  using TimePoint = std::chrono::system_clock::time_point;
+  using Duration = std::chrono::system_clock::duration;
+
+  /// Counts sessions from 1.
+  std::uint64_t sequence{ 0 };
+  TimePoint started{};
+  /// Unset while the session is still open -- see open().
+  std::optional<TimePoint> ended;
+  std::optional<double> start_percentage;
+  std::optional<double> end_percentage;
+  /// Percentage points discharged since the previous session ended (since the first sample, for
+  /// the first session).
+  double preceding_discharge_depth{ 0.0 };
+
+  bool open() const
+  {
+    return !ended.has_value();
+  }
+
+  /// How long the session ran, or has run so far when still open. Clamped at zero.
+  Duration duration(TimePoint now) const
+  {
+    const TimePoint end = ended.value_or(now);
+    return end > started ? end - started : Duration::zero();
+  }
+};
+
+/// What one BatteryCycleAccumulator::update() changed: at most one boundary crossing per sample.
+struct BatteryUpdate
+{
+  /// Set when this sample opened a session -- `ended` unset on it, `preceding_discharge_depth` final.
+  std::optional<ChargingSession> started;
+  /// Set when this sample closed one, with both boundaries filled in.
+  std::optional<ChargingSession> ended;
+};
+
+/**
+ * @class dc_common::BatteryCycleAccumulator
+ * @brief Turns charge-percentage and power-supply-status samples into charging-session boundaries,
+ * discharge depth and completed-cycle counts, with no ROS dependency.
+ *
+ * Sessions are delimited by the power-supply status alone, never by a percentage threshold, so a
+ * noisy percentage cannot open and close them repeatedly; an Unknown status carries no information
+ * about the charger and so neither opens nor closes one, leaving a momentary dropout as one session
+ * rather than two.
+ *
+ * Cycles come from accumulated discharge, not from counting full charges: every drop in percentage
+ * adds to a running total and a completed cycle is kFullCycle percentage points of it, so two half
+ * discharges are one cycle rather than two. Percentages are on a 0-100 scale (a
+ * `sensor_msgs/BatteryState` reports 0-1, so its adapter scales).
+ *
+ * Owns no clock -- timestamps arrive as arguments. Consumer is the battery Measurement (#361).
+ */
+class BatteryCycleAccumulator
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+
+  /// Percentage points of accumulated discharge that make one completed cycle.
+  static constexpr double kFullCycle = 100.0;
+
+  /**
+   * @brief Feed one sample. `percentage` is unset when the hardware did not report one; the status
+   * is still acted on.
+   */
+  BatteryUpdate update(std::optional<double> percentage, PowerSupplyStatus status, TimePoint at)
+  {
+    if (percentage.has_value())
+    {
+      if (last_percentage_.has_value() && *last_percentage_ > *percentage)
+      {
+        const double drop = *last_percentage_ - *percentage;
+        total_discharge_ += drop;
+        discharge_since_session_ += drop;
+      }
+      last_percentage_ = *percentage;
+    }
+
+    BatteryUpdate result;
+    if (status == PowerSupplyStatus::Unknown)
+    {
+      return result;
+    }
+
+    const bool on_charger = status == PowerSupplyStatus::Charging;
+    if (on_charger && !open_.has_value())
+    {
+      ChargingSession session;
+      session.sequence = ++sequence_;
+      session.started = at;
+      session.start_percentage = last_percentage_;
+      session.preceding_discharge_depth = discharge_since_session_;
+      open_ = session;
+      result.started = session;
+    }
+    else if (!on_charger && open_.has_value())
+    {
+      ChargingSession session = *open_;
+      session.ended = at;
+      session.end_percentage = last_percentage_;
+      open_.reset();
+      // Reset here rather than at the start, so the depth a session reports covers exactly the
+      // time off the charger; a dip while charging is noise as far as that depth goes.
+      discharge_since_session_ = 0.0;
+      result.ended = session;
+    }
+    return result;
+  }
+
+  bool charging() const
+  {
+    return open_.has_value();
+  }
+
+  /// The session still charging, or nullopt when the pack is not on a charger.
+  const std::optional<ChargingSession>& openSession() const
+  {
+    return open_;
+  }
+
+  /// Most recent percentage reported, or nullopt when none ever was.
+  const std::optional<double>& lastPercentage() const
+  {
+    return last_percentage_;
+  }
+
+  /// Percentage points discharged over the accumulator's whole life.
+  double accumulatedDischarge() const
+  {
+    return total_discharge_;
+  }
+
+  /// Percentage points discharged since the last session ended -- what the next one will report.
+  double dischargeSinceLastSession() const
+  {
+    return discharge_since_session_;
+  }
+
+  std::uint64_t completedCycles() const
+  {
+    return static_cast<std::uint64_t>(total_discharge_ / kFullCycle);
+  }
+
+private:
+  std::optional<double> last_percentage_;
+  std::optional<ChargingSession> open_;
+  double total_discharge_{ 0.0 };
+  double discharge_since_session_{ 0.0 };
+  std::uint64_t sequence_{ 0 };
+};
+
+}  // namespace dc_common
+
+#endif  // DC_COMMON_BATTERY_CYCLE_ACCUMULATOR_HPP_

--- a/dc_common/include/dc_common/state_transition_detector.hpp
+++ b/dc_common/include/dc_common/state_transition_detector.hpp
@@ -1,0 +1,142 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_COMMON_STATE_TRANSITION_DETECTOR_HPP_
+#define DC_COMMON_STATE_TRANSITION_DETECTOR_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+namespace dc_common
+{
+
+/**
+ * @brief One state change reported by a StateTransitionDetector.
+ *
+ * `dwell` is how long `from` was held before `at`; `sequence` counts transitions from 1, so a
+ * consumer stamping it onto a Record can tell a dropped Record apart from a state that never
+ * changed.
+ */
+template <typename State>
+struct StateTransition
+{
+  State from;
+  State to;
+  std::chrono::system_clock::time_point at;
+  std::chrono::system_clock::duration dwell;
+  std::uint64_t sequence;
+};
+
+/**
+ * @brief The state currently held, and how long it has been held as of a caller-supplied "now".
+ *
+ * Returned only by StateTransitionDetector::openInterval(): an interval that has not ended yet is
+ * reported through this type and never as a StateTransition, so an unterminated interval cannot be
+ * mistaken for a completed one of zero duration.
+ */
+template <typename State>
+struct OpenInterval
+{
+  State state;
+  std::chrono::system_clock::time_point entered;
+  std::chrono::system_clock::duration elapsed;
+  /// Sequence of the transition that entered this state; 0 when it is the first state ever seen.
+  std::uint64_t sequence;
+};
+
+/**
+ * @class dc_common::StateTransitionDetector
+ * @brief Turns a stream of (state, timestamp) samples into transitions, with no ROS dependency.
+ *
+ * Generic over the state type -- anything equality-comparable and copyable fits, so `driving_type`'s
+ * mode strings and a mission's outcome enum both work. update() reports a transition only when the
+ * state actually differs from the one held, so a Measurement polling the same state at 10 Hz emits
+ * nothing until it changes.
+ *
+ * Owns no clock: every timestamp arrives as an argument, so a test drives a whole shift in
+ * microseconds and shutdown behaviour is reproducible. Consumers are the intervention (#362) and
+ * mission Measurements; `driving_type` predates it and is not refactored onto it here.
+ */
+template <typename State>
+class StateTransitionDetector
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+  using Duration = std::chrono::system_clock::duration;
+
+  StateTransitionDetector() = default;
+
+  /// Seed with a state already known to be held since `at`, e.g. one restored across a restart.
+  StateTransitionDetector(State initial, TimePoint at) : state_(std::move(initial)), entered_(at)
+  {
+  }
+
+  /**
+   * @brief Feed one sample. Returns the transition it caused, or nullopt when it caused none --
+   * either because the state is unchanged or because it is the very first state seen (nothing was
+   * left, so there is no previous state or dwell to report).
+   */
+  std::optional<StateTransition<State>> update(State state, TimePoint at)
+  {
+    if (!state_.has_value())
+    {
+      state_ = std::move(state);
+      entered_ = at;
+      return std::nullopt;
+    }
+
+    if (*state_ == state)
+    {
+      return std::nullopt;
+    }
+
+    StateTransition<State> transition{ *state_, state, at, elapsed(entered_, at), ++sequence_ };
+    state_ = std::move(state);
+    entered_ = at;
+    return transition;
+  }
+
+  /// The state currently held, or nullopt when no sample has arrived yet.
+  const std::optional<State>& state() const
+  {
+    return state_;
+  }
+
+  /// Sequence number of the last transition reported; 0 when none has been.
+  std::uint64_t sequence() const
+  {
+    return sequence_;
+  }
+
+  /**
+   * @brief The interval still open as of `now`, or nullopt when no sample has arrived yet.
+   *
+   * What a consumer calls when collection stops, so an interval that never ended is recorded as
+   * open with the time it has actually run for.
+   */
+  std::optional<OpenInterval<State>> openInterval(TimePoint now) const
+  {
+    if (!state_.has_value())
+    {
+      return std::nullopt;
+    }
+    return OpenInterval<State>{ *state_, entered_, elapsed(entered_, now), sequence_ };
+  }
+
+private:
+  /// Clamped at zero: an out-of-order sample must not report a negative dwell downstream.
+  static Duration elapsed(TimePoint from, TimePoint to)
+  {
+    return to > from ? to - from : Duration::zero();
+  }
+
+  std::optional<State> state_;
+  TimePoint entered_{};
+  std::uint64_t sequence_{ 0 };
+};
+
+}  // namespace dc_common
+
+#endif  // DC_COMMON_STATE_TRANSITION_DETECTOR_HPP_

--- a/dc_common/test/battery_cycle_accumulator_test.cpp
+++ b/dc_common/test/battery_cycle_accumulator_test.cpp
@@ -1,0 +1,255 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_common::BatteryCycleAccumulator (#360). No node, no rclcpp::init(): charge
+// percentage, power-supply status and the timestamp all arrive as arguments, so a week of
+// charge/discharge runs in microseconds.
+
+#include "dc_common/battery_cycle_accumulator.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+
+using dc_common::BatteryCycleAccumulator;
+using dc_common::PowerSupplyStatus;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+}  // namespace
+
+TEST(BatteryCycleAccumulator, StartsIdle)
+{
+  BatteryCycleAccumulator accumulator;
+  EXPECT_FALSE(accumulator.charging());
+  EXPECT_FALSE(accumulator.openSession().has_value());
+  EXPECT_FALSE(accumulator.lastPercentage().has_value());
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 0.0);
+  EXPECT_EQ(accumulator.completedCycles(), 0u);
+}
+
+TEST(BatteryCycleAccumulator, TwoPartialDischargesSummingToAFullOneAreOneCycle)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(100.0, PowerSupplyStatus::Discharging, at(0));
+  accumulator.update(50.0, PowerSupplyStatus::Discharging, at(3600));
+  accumulator.update(100.0, PowerSupplyStatus::Charging, at(7200));
+
+  // Half a pack gone, recharged: no cycle yet, however many charges have happened.
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 50.0);
+  EXPECT_EQ(accumulator.completedCycles(), 0u);
+
+  accumulator.update(50.0, PowerSupplyStatus::Discharging, at(10800));
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 100.0);
+  EXPECT_EQ(accumulator.completedCycles(), 1u);
+
+  // And the naive count would already be at three charges by here, still one cycle.
+  accumulator.update(100.0, PowerSupplyStatus::Charging, at(14400));
+  accumulator.update(75.0, PowerSupplyStatus::Discharging, at(18000));
+  EXPECT_EQ(accumulator.completedCycles(), 1u);
+}
+
+TEST(BatteryCycleAccumulator, ChargingIsNotDischarge)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(20.0, PowerSupplyStatus::Charging, at(0));
+  accumulator.update(60.0, PowerSupplyStatus::Charging, at(1800));
+  accumulator.update(100.0, PowerSupplyStatus::Full, at(3600));
+
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 0.0);
+  EXPECT_EQ(accumulator.completedCycles(), 0u);
+}
+
+TEST(BatteryCycleAccumulator, SessionsAreDelimitedByStatusNotByPercentage)
+{
+  // A percentage bouncing across any plausible threshold, with the pack never on a charger: not
+  // one session opens.
+  BatteryCycleAccumulator accumulator;
+  const double noisy[] = { 79.0, 81.0, 78.0, 82.0, 77.0, 83.0, 20.0, 21.0, 19.0, 22.0 };
+  int second = 0;
+  for (const double percentage : noisy)
+  {
+    const auto update = accumulator.update(percentage, PowerSupplyStatus::Discharging, at(second));
+    EXPECT_FALSE(update.started.has_value()) << "at second " << second;
+    EXPECT_FALSE(update.ended.has_value()) << "at second " << second;
+    second += 60;
+  }
+  EXPECT_FALSE(accumulator.charging());
+
+  // And a percentage that is falling while the charger says Charging still opens exactly one.
+  const auto opened = accumulator.update(21.0, PowerSupplyStatus::Charging, at(second));
+  EXPECT_TRUE(opened.started.has_value());
+  for (int i = 0; i < 5; ++i)
+  {
+    second += 60;
+    const auto update = accumulator.update(20.0 - i, PowerSupplyStatus::Charging, at(second));
+    EXPECT_FALSE(update.started.has_value());
+    EXPECT_FALSE(update.ended.has_value());
+  }
+  EXPECT_TRUE(accumulator.charging());
+}
+
+TEST(BatteryCycleAccumulator, SessionReportsItsBoundariesAndThePrecedingDischargeDepth)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(95.0, PowerSupplyStatus::Discharging, at(0));
+  accumulator.update(33.0, PowerSupplyStatus::Discharging, at(6000));
+
+  const auto opened = accumulator.update(33.0, PowerSupplyStatus::Charging, at(6060));
+  ASSERT_TRUE(opened.started.has_value());
+  const auto& started = *opened.started;
+  EXPECT_EQ(started.sequence, 1u);
+  EXPECT_EQ(started.started, at(6060));
+  EXPECT_TRUE(started.open());
+  ASSERT_TRUE(started.start_percentage.has_value());
+  EXPECT_DOUBLE_EQ(*started.start_percentage, 33.0);
+  EXPECT_DOUBLE_EQ(started.preceding_discharge_depth, 62.0);
+
+  const auto closed = accumulator.update(100.0, PowerSupplyStatus::Full, at(12060));
+  ASSERT_TRUE(closed.ended.has_value());
+  const auto& ended = *closed.ended;
+  EXPECT_EQ(ended.sequence, 1u);
+  EXPECT_FALSE(ended.open());
+  EXPECT_EQ(ended.started, at(6060));
+  ASSERT_TRUE(ended.ended.has_value());
+  EXPECT_EQ(*ended.ended, at(12060));
+  ASSERT_TRUE(ended.end_percentage.has_value());
+  EXPECT_DOUBLE_EQ(*ended.end_percentage, 100.0);
+  EXPECT_DOUBLE_EQ(ended.preceding_discharge_depth, 62.0);
+  EXPECT_EQ(ended.duration(at(99999)), std::chrono::seconds(6000));
+  EXPECT_FALSE(accumulator.charging());
+}
+
+TEST(BatteryCycleAccumulator, EachSessionReportsOnlyTheDischargeThatPrecededIt)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(100.0, PowerSupplyStatus::Discharging, at(0));
+  accumulator.update(70.0, PowerSupplyStatus::Discharging, at(1000));
+  const auto first = accumulator.update(70.0, PowerSupplyStatus::Charging, at(1100));
+  accumulator.update(100.0, PowerSupplyStatus::Full, at(2000));
+
+  accumulator.update(45.0, PowerSupplyStatus::Discharging, at(5000));
+  const auto second = accumulator.update(45.0, PowerSupplyStatus::Charging, at(5100));
+
+  ASSERT_TRUE(first.started.has_value());
+  ASSERT_TRUE(second.started.has_value());
+  EXPECT_DOUBLE_EQ(first.started->preceding_discharge_depth, 30.0);
+  EXPECT_DOUBLE_EQ(second.started->preceding_discharge_depth, 55.0);
+  EXPECT_EQ(second.started->sequence, 2u);
+}
+
+TEST(BatteryCycleAccumulator, SessionStillChargingIsReportedOpenWithTheTimeItHasRun)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(40.0, PowerSupplyStatus::Charging, at(600));
+
+  ASSERT_TRUE(accumulator.openSession().has_value());
+  const auto& open = *accumulator.openSession();
+  EXPECT_TRUE(open.open());
+  EXPECT_FALSE(open.ended.has_value());
+  EXPECT_EQ(open.duration(at(3000)), std::chrono::seconds(2400));
+  EXPECT_NE(open.duration(at(3000)), std::chrono::seconds(0));
+}
+
+TEST(BatteryCycleAccumulator, AnUnknownStatusNeitherOpensNorClosesASession)
+{
+  // A momentary status dropout mid-charge is one session, not two.
+  BatteryCycleAccumulator accumulator;
+  const auto opened = accumulator.update(30.0, PowerSupplyStatus::Charging, at(0));
+  ASSERT_TRUE(opened.started.has_value());
+
+  const auto dropout = accumulator.update(35.0, PowerSupplyStatus::Unknown, at(300));
+  EXPECT_FALSE(dropout.started.has_value());
+  EXPECT_FALSE(dropout.ended.has_value());
+  EXPECT_TRUE(accumulator.charging());
+
+  const auto resumed = accumulator.update(40.0, PowerSupplyStatus::Charging, at(600));
+  EXPECT_FALSE(resumed.started.has_value());
+
+  const auto closed = accumulator.update(100.0, PowerSupplyStatus::Full, at(1200));
+  ASSERT_TRUE(closed.ended.has_value());
+  EXPECT_EQ(closed.ended->sequence, 1u);
+  EXPECT_EQ(closed.ended->duration(at(1200)), std::chrono::seconds(1200));
+}
+
+TEST(BatteryCycleAccumulator, UnknownStatusStillAccumulatesDischarge)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(90.0, PowerSupplyStatus::Unknown, at(0));
+  accumulator.update(60.0, PowerSupplyStatus::Unknown, at(600));
+
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 30.0);
+  EXPECT_FALSE(accumulator.charging());
+}
+
+TEST(BatteryCycleAccumulator, NotChargingAndFullBothCloseASession)
+{
+  for (const auto status : { PowerSupplyStatus::NotCharging, PowerSupplyStatus::Full, PowerSupplyStatus::Discharging })
+  {
+    BatteryCycleAccumulator accumulator;
+    accumulator.update(50.0, PowerSupplyStatus::Charging, at(0));
+    const auto closed = accumulator.update(90.0, status, at(60));
+    EXPECT_TRUE(closed.ended.has_value()) << "status " << static_cast<int>(status);
+    EXPECT_FALSE(accumulator.charging());
+  }
+}
+
+TEST(BatteryCycleAccumulator, ASampleWithNoPercentageStillDelimitsSessions)
+{
+  // Hardware that reports a status but no charge percentage: the session is still recorded, its
+  // boundary percentages simply absent rather than filled with a made-up zero.
+  BatteryCycleAccumulator accumulator;
+  const auto opened = accumulator.update(std::nullopt, PowerSupplyStatus::Charging, at(0));
+  ASSERT_TRUE(opened.started.has_value());
+  EXPECT_FALSE(opened.started->start_percentage.has_value());
+
+  const auto closed = accumulator.update(std::nullopt, PowerSupplyStatus::Discharging, at(900));
+  ASSERT_TRUE(closed.ended.has_value());
+  EXPECT_FALSE(closed.ended->end_percentage.has_value());
+  EXPECT_DOUBLE_EQ(closed.ended->preceding_discharge_depth, 0.0);
+  EXPECT_EQ(closed.ended->duration(at(900)), std::chrono::seconds(900));
+}
+
+TEST(BatteryCycleAccumulator, ASampleWithNoPercentageKeepsTheLastKnownOne)
+{
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(64.0, PowerSupplyStatus::Discharging, at(0));
+  accumulator.update(std::nullopt, PowerSupplyStatus::Discharging, at(60));
+
+  ASSERT_TRUE(accumulator.lastPercentage().has_value());
+  EXPECT_DOUBLE_EQ(*accumulator.lastPercentage(), 64.0);
+
+  const auto opened = accumulator.update(std::nullopt, PowerSupplyStatus::Charging, at(120));
+  ASSERT_TRUE(opened.started.has_value());
+  ASSERT_TRUE(opened.started->start_percentage.has_value());
+  EXPECT_DOUBLE_EQ(*opened.started->start_percentage, 64.0);
+}
+
+TEST(BatteryCycleAccumulator, CountsCyclesAcrossManySmallTopUps)
+{
+  // The opportunity-charging pattern a fleet robot actually runs: ten 10-point discharges, each
+  // topped straight back up. One cycle, not ten.
+  BatteryCycleAccumulator accumulator;
+  accumulator.update(100.0, PowerSupplyStatus::Discharging, at(0));
+  int second = 0;
+  for (int i = 0; i < 10; ++i)
+  {
+    second += 600;
+    accumulator.update(90.0, PowerSupplyStatus::Discharging, at(second));
+    second += 60;
+    accumulator.update(90.0, PowerSupplyStatus::Charging, at(second));
+    second += 300;
+    accumulator.update(100.0, PowerSupplyStatus::Full, at(second));
+  }
+
+  EXPECT_DOUBLE_EQ(accumulator.accumulatedDischarge(), 100.0);
+  EXPECT_EQ(accumulator.completedCycles(), 1u);
+}

--- a/dc_common/test/state_transition_detector_test.cpp
+++ b/dc_common/test/state_transition_detector_test.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_common::StateTransitionDetector (#360). No node, no rclcpp::init(): every
+// timestamp is passed in, so a whole shift's worth of transitions runs in microseconds.
+
+#include "dc_common/state_transition_detector.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using dc_common::StateTransitionDetector;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+/// The closed mode set driving_type emits, standing in for the intervention Measurement's input.
+enum class Mode
+{
+  Autonomous,
+  Manual,
+  Teleop,
+  Unknown,
+};
+
+}  // namespace
+
+TEST(StateTransitionDetector, ReportsNoStateBeforeAnySample)
+{
+  StateTransitionDetector<Mode> detector;
+  EXPECT_FALSE(detector.state().has_value());
+  EXPECT_FALSE(detector.openInterval(at(10)).has_value());
+  EXPECT_EQ(detector.sequence(), 0u);
+}
+
+TEST(StateTransitionDetector, FirstSampleIsNotATransition)
+{
+  // Nothing was left, so there is no previous state or dwell to report -- but the state is held.
+  StateTransitionDetector<Mode> detector;
+  EXPECT_FALSE(detector.update(Mode::Autonomous, at(0)).has_value());
+  ASSERT_TRUE(detector.state().has_value());
+  EXPECT_EQ(*detector.state(), Mode::Autonomous);
+  EXPECT_EQ(detector.sequence(), 0u);
+}
+
+TEST(StateTransitionDetector, RepeatedIdenticalStateNeverTransitions)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(0));
+  for (int second = 1; second <= 1000; ++second)
+  {
+    EXPECT_FALSE(detector.update(Mode::Autonomous, at(second)).has_value()) << "at second " << second;
+  }
+  EXPECT_EQ(detector.sequence(), 0u);
+
+  // The dwell of that unbroken run is still counted from the first sample, not the last.
+  const auto transition = detector.update(Mode::Manual, at(1001));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(1001));
+}
+
+TEST(StateTransitionDetector, TransitionReportsPreviousStateAndItsDwell)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(0));
+
+  const auto transition = detector.update(Mode::Manual, at(120));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->from, Mode::Autonomous);
+  EXPECT_EQ(transition->to, Mode::Manual);
+  EXPECT_EQ(transition->at, at(120));
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(120));
+  EXPECT_EQ(transition->sequence, 1u);
+}
+
+TEST(StateTransitionDetector, SequenceStaysMonotonicThroughARapidBurst)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(0));
+
+  // Alternating modes at the same timestamp: a burst faster than the clock's resolution must still
+  // number every transition, otherwise a consumer cannot tell a dropped Record from a quiet period.
+  std::vector<std::uint64_t> sequences;
+  for (int i = 0; i < 50; ++i)
+  {
+    const auto transition = detector.update(i % 2 == 0 ? Mode::Manual : Mode::Autonomous, at(0));
+    ASSERT_TRUE(transition.has_value()) << "at burst step " << i;
+    EXPECT_EQ(transition->dwell, std::chrono::seconds(0));
+    sequences.push_back(transition->sequence);
+  }
+
+  for (std::size_t i = 0; i < sequences.size(); ++i)
+  {
+    EXPECT_EQ(sequences[i], i + 1);
+  }
+  EXPECT_EQ(detector.sequence(), 50u);
+}
+
+TEST(StateTransitionDetector, IntervalStillOpenIsReportedOpenWithTheTimeItHasRun)
+{
+  // The shutdown case: collection stops mid-intervention. The interval comes back through
+  // openInterval(), never as a transition, so it can't be averaged in as a zero-length one.
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(0));
+  detector.update(Mode::Manual, at(60));
+
+  const auto open = detector.openInterval(at(300));
+  ASSERT_TRUE(open.has_value());
+  EXPECT_EQ(open->state, Mode::Manual);
+  EXPECT_EQ(open->entered, at(60));
+  EXPECT_EQ(open->elapsed, std::chrono::seconds(240));
+  EXPECT_NE(open->elapsed, std::chrono::seconds(0));
+  EXPECT_EQ(open->sequence, 1u);
+}
+
+TEST(StateTransitionDetector, OpenIntervalOfTheFirstStateCarriesNoTransitionSequence)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(5));
+
+  const auto open = detector.openInterval(at(35));
+  ASSERT_TRUE(open.has_value());
+  EXPECT_EQ(open->state, Mode::Autonomous);
+  EXPECT_EQ(open->elapsed, std::chrono::seconds(30));
+  EXPECT_EQ(open->sequence, 0u);
+}
+
+TEST(StateTransitionDetector, OpenIntervalDoesNotConsumeTheState)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Teleop, at(0));
+
+  EXPECT_EQ(detector.openInterval(at(10))->elapsed, std::chrono::seconds(10));
+  EXPECT_EQ(detector.openInterval(at(20))->elapsed, std::chrono::seconds(20));
+
+  const auto transition = detector.update(Mode::Autonomous, at(30));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(30));
+}
+
+TEST(StateTransitionDetector, SeededStateDwellsFromTheSeedTimestamp)
+{
+  StateTransitionDetector<Mode> detector(Mode::Autonomous, at(100));
+
+  const auto transition = detector.update(Mode::Manual, at(160));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->from, Mode::Autonomous);
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(60));
+}
+
+TEST(StateTransitionDetector, OutOfOrderSampleDoesNotReportANegativeDwell)
+{
+  StateTransitionDetector<Mode> detector;
+  detector.update(Mode::Autonomous, at(100));
+
+  const auto transition = detector.update(Mode::Manual, at(40));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(0));
+  EXPECT_EQ(detector.openInterval(at(0))->elapsed, std::chrono::seconds(0));
+}
+
+TEST(StateTransitionDetector, WorksOverStringStatesToo)
+{
+  // driving_type's mode strings and a mission's outcome enum are meant to fit the same detector.
+  StateTransitionDetector<std::string> detector;
+  detector.update("autonomous", at(0));
+  EXPECT_FALSE(detector.update("autonomous", at(5)).has_value());
+
+  const auto transition = detector.update("teleop", at(45));
+  ASSERT_TRUE(transition.has_value());
+  EXPECT_EQ(transition->from, "autonomous");
+  EXPECT_EQ(transition->to, "teleop");
+  EXPECT_EQ(transition->dwell, std::chrono::seconds(45));
+  EXPECT_EQ(transition->sequence, 1u);
+}

--- a/progress.txt
+++ b/progress.txt
@@ -7105,3 +7105,67 @@ unrelated — whole quarter turns never crop. The perspective/tilt half of the #
 (100% vs. 0% for `zbar` at 35% skew) was independently measured and stands unchanged.
 
 No change to `camera.cpp`: nothing to mitigate, so no new parameter and no per-frame cost.
+
+## #360 - Two ROS-free modules in dc_common: StateTransitionDetector and BatteryCycleAccumulator
+
+The Measurements that record operational facts — battery (#361), intervention (#362), mission —
+all turn a stream of samples into transitions. That logic is the part worth testing hard and the
+part with nothing to do with ROS, so both modules land in `dc_common` beside
+`record_ring_buffer.hpp` and `file_scratch_ring.hpp`: header-only, no `rclcpp`, driven straight
+from gtest — the same core/adapter split ADR-0007 makes for the Bridge. Neither owns a clock;
+every timestamp arrives as an argument, so a test drives a whole shift in microseconds and
+shutdown behaviour is reproducible. `dc_common`'s `package.xml` still declares no ROS
+dependency, only `ament_cmake` + `ament_cmake_gtest`.
+
+**`StateTransitionDetector<State>`** (`include/dc_common/state_transition_detector.hpp`).
+`update(state, at)` returns `std::optional<StateTransition<State>>` — `from`, `to`, `at`, the
+`dwell` of `from`, and a `sequence` counting from 1. Nullopt for a repeated state (a Measurement
+polling at 10 Hz emits nothing until the mode changes) and nullopt for the very first sample,
+which has no previous state to report; the dwell of an unbroken run is still counted from the
+first sample of that run, not the last. Generic over the state type, so `driving_type`'s mode
+strings and a mission's outcome enum both fit — refactoring `driving_type` itself onto it stays
+out of scope, per the issue.
+
+The open-interval case has its own return type rather than a sentinel: `openInterval(now)` gives
+`OpenInterval<State>` (state, when entered, elapsed as of `now`, and the sequence of the
+transition that entered it — 0 for the first state ever seen). An interval that never ended
+therefore cannot come back as a `StateTransition` at all, which is what stops a takeover still
+running at shutdown being averaged in as a zero-length one. A second constructor seeds a state
+known to be held since a given time. Out-of-order samples clamp dwell at zero rather than
+reporting a negative duration downstream.
+
+**`BatteryCycleAccumulator`** (`include/dc_common/battery_cycle_accumulator.hpp`).
+`update(percentage, status, at)` takes `std::optional<double>` percent on a 0–100 scale and a
+`PowerSupplyStatus` whose values match `sensor_msgs/BatteryState`'s `POWER_SUPPLY_STATUS_*`
+constants — so #361's adapter is a cast and a ×100, while nothing here depends on that package.
+It returns a `BatteryUpdate` carrying at most one boundary crossing: `started` on the sample that
+opens a charging session, `ended` on the one that closes it.
+
+Two decisions worth recording. **Sessions are delimited by status alone**, never by a percentage
+threshold, so a percentage bouncing across any plausible threshold opens nothing; and an
+`Unknown` status carries no information about the charger, so it neither opens nor closes a
+session — a momentary status dropout mid-charge stays one session rather than becoming two.
+**Cycles come from accumulated discharge**, not from counting charges: every drop in percentage
+adds to a running total and a completed cycle is 100 points of it, so two half discharges are one
+cycle and the opportunity-charging pattern a fleet robot actually runs (ten 10-point top-ups) is
+one cycle, not ten. Each session reports its boundaries and `preceding_discharge_depth`, the
+discharge accumulated since the *previous* session ended — reset at session end rather than at
+session start, so the depth covers exactly the time off the charger and a dip while charging is
+noise as far as that number goes (it still counts toward the lifetime total).
+
+`ChargingSession` models "still open" the same way the detector does, structurally: `ended` is an
+`std::optional<TimePoint>`, `open()` is `!ended`, and `duration(now)` falls back to `now` while
+open. There is no state in which a running session reports a zero duration. Percentages at both
+boundaries are optional because `sensor_msgs/BatteryState` leaves the field unset often enough
+that a session with unknown boundaries is still worth recording — which is also the shape #361
+needs for "missing fields are absent, not null-filled".
+
+**Verification.** 24 new gtest cases (`test/state_transition_detector_test.cpp` 11,
+`test/battery_cycle_accumulator_test.cpp` 13), asserting only through the public interface — no
+private members, no call ordering. Both are added to the existing `foreach(test ...)` loop in
+`dc_common/CMakeLists.txt`, so `colcon test --packages-select dc_common` runs all four binaries:
+13/14/11/11, 0 failures. The ROS-free claim was checked rather than assumed: both test files
+compile and pass under plain `g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror` against
+`-lgtest -lgtest_main` in a container with `/opt/ros` and the DC workspace deleted and an empty
+environment (`env -i`) — no ament, no `rclcpp`, no message packages. `prek run --all-files
+--skip build-doc` is green.


### PR DESCRIPTION
Closes #360

The Measurements that record operational facts — battery (#361), intervention (#362), mission —
all turn a stream of samples into *transitions*. That logic is the part worth testing hard and the
part with nothing to do with ROS, so both modules land in `dc_common` beside
`record_ring_buffer.hpp` and `file_scratch_ring.hpp`: header-only, no `rclcpp`, driven straight
from gtest — the same core/adapter split ADR-0007 makes for the Bridge. Neither owns a clock;
every timestamp arrives as an argument, so a test drives a whole shift in microseconds and
shutdown behaviour is reproducible.

## `StateTransitionDetector<State>`

`update(state, at)` returns `std::optional<StateTransition<State>>` — `from`, `to`, `at`, the
`dwell` of `from`, and a `sequence` counting from 1. Nullopt for a repeated state (a Measurement
polling at 10 Hz emits nothing until the mode changes) and nullopt for the first sample, which has
no previous state to report; the dwell of an unbroken run is counted from the first sample of that
run, not the last. Generic over the state type, so `driving_type`'s mode strings and a mission's
outcome enum both fit — refactoring `driving_type` itself onto it stays out of scope, per the
issue.

The open-interval case gets its own return type rather than a sentinel: `openInterval(now)` gives
`OpenInterval<State>` (state, when entered, elapsed as of `now`, and the sequence of the
transition that entered it — 0 for the first state ever seen). An interval that never ended
therefore cannot come back as a `StateTransition` at all, which is what stops a takeover still
running at shutdown being averaged in as a zero-length one. A second constructor seeds a state
known to be held since a given time; out-of-order samples clamp dwell at zero rather than
reporting a negative duration downstream.

## `BatteryCycleAccumulator`

`update(percentage, status, at)` takes `std::optional<double>` percent on a 0–100 scale and a
`PowerSupplyStatus` whose values match `sensor_msgs/BatteryState`'s `POWER_SUPPLY_STATUS_*`
constants — so #361's adapter is a cast and a ×100, while nothing here depends on that package.
It returns a `BatteryUpdate` carrying at most one boundary crossing: `started` on the sample that
opens a charging session, `ended` on the one that closes it.

Two decisions worth calling out:

- **Sessions are delimited by status alone**, never by a percentage threshold, so a percentage
  bouncing across any plausible threshold opens nothing; and an `Unknown` status carries no
  information about the charger, so it neither opens nor closes a session — a momentary status
  dropout mid-charge stays one session rather than becoming two.
- **Cycles come from accumulated discharge**, not from counting charges: every drop in percentage
  adds to a running total and a completed cycle is 100 points of it, so two half discharges are
  one cycle, and the opportunity-charging pattern a fleet robot actually runs (ten 10-point
  top-ups) is one cycle rather than ten.

Each session reports its boundaries and `preceding_discharge_depth`, the discharge accumulated
since the *previous* session ended — reset at session end rather than session start, so the depth
covers exactly the time off the charger and a dip while charging is noise as far as that number
goes (it still counts toward the lifetime total). `ChargingSession` models "still open" the same
way the detector does, structurally: `ended` is an `std::optional<TimePoint>`, `open()` is
`!ended`, `duration(now)` falls back to `now` while open — there is no state in which a running
session reports a zero duration. Boundary percentages are optional because `BatteryState` leaves
the field unset often enough that a session with unknown boundaries is still worth recording,
which is also the shape #361 needs for "missing fields are absent, not null-filled".

## Verification

24 new gtest cases (`state_transition_detector_test.cpp` 11, `battery_cycle_accumulator_test.cpp`
13), asserting only through the public interface — no private members, no call ordering. Both are
added to the existing `foreach(test ...)` loop, so `colcon test --packages-select dc_common` runs
all four binaries in the workspace image: 13/14/11/11, 0 failures.

The ROS-free claim was checked rather than assumed: both test files compile and pass under plain
`g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror` against `-lgtest -lgtest_main` in a container
with `/opt/ros` and the DC workspace deleted and an empty environment (`env -i`) — no ament, no
`rclcpp`, no message packages. `dc_common`'s `package.xml` needed no change: it already declares
only `ament_cmake` + `ament_cmake_gtest`.

`prek run --all-files --skip build-doc` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CNssP926weLVvypaFb9Tqt