### PR TITLE
feat(tools/infrastructure): utilisation, intervention rate and MTBF/MTTR KPI views

### DIFF
--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -19,6 +19,7 @@ dc_bridge:
           "/dc/measurement/camera",
           "/dc/measurement/cmd_vel",
           "/dc/measurement/distance_traveled",
+          "/dc/measurement/driving_type",
           "/dc/measurement/position",
           "/dc/measurement/speed",
           # Environment
@@ -78,6 +79,7 @@ measurement_server:
         "camera",
         "cmd_vel",
         "distance_traveled",
+        "driving_type",
         "position",
         "speed",
         # Environment
@@ -157,6 +159,19 @@ measurement_server:
       condition_max_measurements: 0
       include_measurement_name: true
       init_collect: false
+    # Nav2's smoothed output is the only command source the simulation has, so the mode is
+    # autonomous while it publishes and unknown otherwise. A real deployment adds its teleop
+    # topic here to tell a takeover apart from an idle robot.
+    driving_type:
+      plugin: "dc_measurements/DrivingType"
+      topic_output: "/dc/measurement/driving_type"
+      polling_interval: 5000
+      velocity_topics: ["/cmd_vel"]
+      velocity_modes: ["autonomous"]
+      velocity_timeout_s: 1.0
+      enable_validator: true
+      init_collect: true
+      include_measurement_name: true
     cmd_vel:
       plugin: "dc_measurements/CmdVel"
       enable_validator: true

--- a/doc/src/dc/demos/tb3_aws_minio_pgsql.md
+++ b/doc/src/dc/demos/tb3_aws_minio_pgsql.md
@@ -166,8 +166,9 @@ Robot measurements:
 1. [Camera images](../measurements/camera.md)
 2. [Command velocities](../measurements/cmd_vel.md)
 3. [Distance traveled](../measurements/distance_traveled.md)
-4. [Positions](../measurements/position.md)
-5. [Speed](../measurements/speed.md)
+4. [Driving type](../measurements/driving_type.md)
+5. [Positions](../measurements/position.md)
+6. [Speed](../measurements/speed.md)
 
 Environment measurements:
 
@@ -254,6 +255,7 @@ dc_bridge:
           "/dc/measurement/camera",
           "/dc/measurement/cmd_vel",
           "/dc/measurement/distance_traveled",
+          "/dc/measurement/driving_type",
           "/dc/measurement/position",
           "/dc/measurement/speed",
           # Environment

--- a/doc/src/dc/kpi_views.md
+++ b/doc/src/dc/kpi_views.md
@@ -4,35 +4,49 @@ DC collects Records; the numbers an operations team reports on are computed from
 Records in SQL, on the database, never on the robot. The window is a query parameter, so
 changing a KPI definition is re-applying one file — not redeploying a fleet.
 
-The starter set covers **availability** and **uptime**, from the
-[uptime Measurement](./measurements/uptime.md) alone. It lives in
-`tools/infrastructure/sql/kpi_views.sql` and reads the `dc` table the
-[PostgreSQL](./infrastructure_setup/postgresql.md) Destination writes into.
+The set covers **availability and uptime**, **utilisation**, **intervention rate** and
+**MTBF/MTTR**. It lives in `tools/infrastructure/sql/kpi_views.sql` and reads the `dc`
+table the [PostgreSQL](./infrastructure_setup/postgresql.md) Destination writes into.
 
 ## What it defines
 
-| Object                                        | Kind     | Reports                                                                                          |
-| --------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `dc_kpi_uptime_samples`                       | view     | One row per uptime Record: `robot_name`, `sample_time`, `uptime_seconds`, `run_id`, `prev_sample_time` |
-| `dc_kpi_availability(from, to [, max_gap])`   | function | Per robot over an arbitrary window: `samples`, `first_sample`, `last_sample`, `uptime_seconds`, `covered_seconds`, `window_seconds`, `availability` |
-| `dc_kpi_availability_5m`                      | view     | The same metric in 5-minute buckets, for charting — filter on `bucket_start`                      |
-| `dc_kpi_max_gap()`                            | function | The grace period every definition above shares (30 s)                                             |
+| Object                                                | Kind     | Reports                                                                                                                                             |
+| ----------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dc_kpi_uptime_samples`                               | view     | One row per uptime Record: `robot_name`, `sample_time`, `uptime_seconds`, `run_id`, `prev_sample_time`                                                 |
+| `dc_kpi_availability(from, to [, max_gap])`           | function | Per robot: `samples`, `first_sample`, `last_sample`, `uptime_seconds`, `covered_seconds`, `window_seconds`, `availability`                             |
+| `dc_kpi_availability_5m`                              | view     | The same metric in 5-minute buckets, for charting — filter on `bucket_start`                                                                          |
+| `dc_kpi_driving_samples`                              | view     | One row per driving_type Record: `robot_name`, `sample_time`, `mode`, `prev_sample_time`, and the `speed` last reported at or before it                |
+| `dc_kpi_utilisation(from, to [, max_gap [, min_speed]])` | function | Per robot: `samples`, `speed_samples`, `reported_seconds`, `autonomous_seconds`, `manual_seconds`, `teleop_seconds`, `unknown_seconds`, `productive_seconds`, `window_seconds`, `utilisation` |
+| `dc_kpi_utilisation_5m`                               | view     | Utilisation in 5-minute buckets                                                                                                                       |
+| `dc_kpi_intervention_events`                          | view     | One row per intervention Record, with `is_start`/`is_end` derived from the modes it names                                                              |
+| `dc_kpi_intervention_rate(from, to [, max_gap])`      | function | Per robot: `interventions`, `open_interventions`, `ended_interventions`, `autonomous_seconds`, `distance_km`, `per_autonomous_hour`, `per_km`, `mean_intervention_seconds`, `total_intervention_seconds` |
+| `dc_kpi_interventions_1h`                             | view     | Interventions in 1-hour buckets                                                                                                                       |
+| `dc_kpi_fault_events`                                 | view     | One row per fault Record: `component`, `from_level`, `to_level`, `previous_duration`, `sequence`, `reason`, `open`                                     |
+| `dc_kpi_reliability(from, to [, failure_levels])`     | function | Per component: `failures`, `repairs`, `open_faults`, `operating_seconds`, `downtime_seconds`, `mtbf_seconds`, `mttr_seconds`                           |
+| `dc_kpi_faults_1h`                                    | view     | Failures, repairs and downtime in 1-hour buckets                                                                                                      |
+| `dc_kpi_max_gap()`                                    | function | The grace period every definition above shares (30 s)                                                                                                 |
+| `dc_kpi_min_speed()`                                  | function | The speed at or above which the robot counts as moving (0.05 m/s)                                                                                     |
+| `dc_kpi_failure_levels()`                             | function | The diagnostic levels that count as broken (`ERROR`, `STALE`)                                                                                         |
 
 ```sql
--- Availability and uptime for the last 24 hours, per robot.
+-- Every metric for the last 24 hours, per robot.
 SELECT * FROM dc_kpi_availability(now() - INTERVAL '24 hours', now());
+SELECT * FROM dc_kpi_utilisation(now() - INTERVAL '24 hours', now());
+SELECT * FROM dc_kpi_intervention_rate(now() - INTERVAL '24 hours', now());
+SELECT * FROM dc_kpi_reliability(now() - INTERVAL '24 hours', now());
 
--- The same metric as a chart series.
+-- Any of them as a chart series.
 SELECT bucket_start, robot_name, availability FROM dc_kpi_availability_5m
 WHERE bucket_start >= now() - INTERVAL '24 hours' ORDER BY 1;
 ```
 
-## How availability is defined
+## Availability and uptime
 
-Each uptime Record vouches for the time back to the previous one, capped at the grace
-period and clipped to the window. A robot polling uptime every 5 s therefore reports 100 %
-availability, and only a silence longer than the grace period costs anything: a 5-minute
-outage in a 15-minute window leaves 630 of 900 seconds covered, so 70 %.
+Reads the [uptime Measurement](./measurements/uptime.md). Each uptime Record vouches for
+the time back to the previous one, capped at the grace period and clipped to the window. A
+robot polling uptime every 5 s therefore reports 100 % availability, and only a silence
+longer than the grace period costs anything: a 5-minute outage in a 15-minute window leaves
+630 of 900 seconds covered, so 70 %.
 
 Consequences worth knowing before you put the number on a report:
 
@@ -44,29 +58,142 @@ Consequences worth knowing before you put the number on a report:
   rather than reporting 0 %: nothing in the database distinguishes it from a robot that was
   never deployed. A fleet registry is what would fix that, and DC has none.
 
+## Utilisation
+
+Reads the [driving_type](./measurements/driving_type.md) and [speed](./measurements/speed.md)
+Measurements. Time is credited exactly the way availability credits it — back to the
+previous driving_type Record, capped at the grace period, clipped to the window — and
+attributed to the mode of the Record that closes the interval. Of that reported time, the
+share spent **moving under a known mode** is productive:
+
+```text
+utilisation = productive_seconds / reported_seconds
+```
+
+`manual` and `teleop` count as productive: a human driving the robot is still the robot
+being used. Only `unknown` — no command source has published within `velocity_timeout_s`,
+or no mode has ever been observed — does not.
+
+What it deliberately does not claim:
+
+- **Not "useful work".** A robot standing still while it inspects something reads as idle,
+  and a robot driving in circles reads as productive. Distinguishing the two needs the
+  Mission Measurement, which does not exist yet (see below).
+- **No speed Record in the window means `utilisation` is NULL, not 0 %.** A deployment that
+  collects `driving_type` but not `speed` has unreported movement, not zero movement.
+  `speed_samples` is in the output so a NULL can be told from an empty range.
+- **A speed Record vouches for the grace period after it, no longer.** Movement reported
+  once and then never again buys 30 seconds of productive time, not the rest of the window.
+- The per-mode seconds add up to `reported_seconds`, so the ratio can always be checked
+  against its parts.
+
+## Intervention rate
+
+Reads the `intervention` Measurement ([#362]) for the numerator and `driving_type` plus
+[distance_traveled](./measurements/distance_traveled.md) for the denominators. An
+intervention starts when a Record leaves `autonomous` for `manual` or `teleop`, and ends
+when one returns to `autonomous`; the end Record's `previous_duration` is the takeover's own
+length.
+
+```text
+per_autonomous_hour = interventions / (autonomous_seconds / 3600)
+per_km              = interventions / distance_km
+```
+
+Two denominators rather than one because they fail differently: a robot that spends a shift
+parked has few autonomous hours and no kilometres, and a robot doing tight manoeuvring has
+plenty of hours and few kilometres. Reporting both makes the difference visible instead of
+picking a winner.
+
+What it deliberately does not claim:
+
+- **A denominator nothing reported gives a NULL rate**, never a rate over zero. A robot with
+  no `driving_type` Records has `autonomous_seconds` NULL and `per_autonomous_hour` NULL;
+  the same holds for `distance_traveled` and `per_km`.
+- **A takeover still running is counted but never timed.** Only an end Record carries a
+  duration, so an open interval is absent from `mean_intervention_seconds` and
+  `total_intervention_seconds` rather than a zero in them. `open_interventions` counts the
+  Records the Measurement flagged open.
+- **A takeover that starts before the window or ends after it is counted in the window its
+  Record falls in.** The window selects events, not intervals.
+
+## MTBF and MTTR
+
+Reads the `fault` Measurement ([#365]). A **raise** is a Record entering a failure level
+from a healthy one; a **clear** is one leaving a failure level for a healthy one. Both carry
+`previous_duration` — how long the level just left was held — which is what the two averages
+are averages of:
+
+```text
+mtbf_seconds = mean healthy time preceding a raise
+mttr_seconds = mean time in a failure level preceding a clear
+```
+
+Failure levels default to `ERROR` and `STALE` and are a query parameter:
+`dc_kpi_reliability(from, to, ARRAY['ERROR'])` treats a silent component as reportable but
+not broken. `WARN` is not a failure by default, so `OK → WARN → ERROR` is one failure, timed
+from the last healthy state.
+
+What it deliberately does not claim:
+
+- **A change inside the failure set is not a second failure.** `ERROR → STALE` is neither a
+  raise nor a clear: a component that goes quiet while already broken is still one fault.
+- **A fault never cleared has no repair time.** It counts in `failures` and `open_faults`,
+  and is absent from `mttr_seconds` rather than averaged in as an instant repair.
+- **Grouped by component, never rolled up per robot.** "The robot is down" is a policy over
+  components that nothing here knows, and averaging independent components together reports
+  a number for a failure mode no component has.
+- **The durations come from the Records, so they can reach outside the window.** A failure
+  after eight healthy hours reports eight hours of MTBF in a one-hour window; the window
+  chooses which events count, not how long their intervals were.
+
+## Mission success rate is not here yet
+
+The fourth starter metric — completed, failed, cancelled and aborted missions as a share of
+missions started — has no source and no agreed contract. ROS has no standard mission
+lifecycle interface, so what a Mission Measurement consumes is a design decision still open
+in [#305]: how far a nav2 adapter infers, what the escape-hatch message in `dc_interfaces`
+looks like, and how a mission still running at shutdown is represented. A view written
+before that decision would pin the contract from the reporting end, which is the wrong end.
+
 ## What the data has to look like
 
-The views read the `dc` table's `name`, `robot_name`, `date` and `time` columns, so the
-robot's configuration has to fill them:
+The views read the `dc` table's columns directly, so the robot's configuration has to fill
+them:
 
-- the `uptime` Measurement runs with `include_measurement_name: true` (`name` is what tells
-  uptime Records apart from every other Measurement's);
+- every Measurement the views read runs with `include_measurement_name: true` — `name` is
+  what tells one Measurement's Records apart from another's;
 - `robot_name` is set, through `custom_keys_str` — Records without it are grouped under
   `unknown`;
 - the `postgres` Destination writes to the `dc` table with `time_key: "date"`, whose default
   format is epoch nanoseconds.
 
-`dc_demos/params/tb3_simulation_pgsql_minio.yaml` is a working example of all three.
+| Metric              | Measurements it needs                                    |
+| ------------------- | -------------------------------------------------------- |
+| Availability        | `uptime`                                                  |
+| Utilisation         | `driving_type`, `speed`                                   |
+| Intervention rate   | `intervention` ([#362]), `driving_type`, `distance_traveled` |
+| MTBF / MTTR         | `fault` ([#365])                                          |
+
+`dc_demos/params/tb3_simulation_pgsql_minio.yaml` is a working example of everything that
+exists today. The `intervention` and `fault` Measurements do not, so their views return no
+rows until they land — the columns they write into are already in
+`tools/infrastructure/docker/config/postgresql/init.sql`, since Vector's `postgres` sink
+maps a Record's keys onto existing columns and silently drops the rest.
 
 ## In the demo
 
 `tools/infrastructure/docker/docker-compose.postgresql.yaml` mounts the tables and the KPI
 definitions into PostgreSQL's init directory, so
 [bringing PostgreSQL up](./infrastructure_setup/postgresql.md) applies both. Grafana's
-provisioning ships a **ROS 2 Data Collection - KPI** dashboard reading them — availability,
-uptime, unreported time and Record counts over the dashboard's own time range. Start the
-demo, open [http://localhost:3000](http://localhost:3000) (admin/admin), and the panels
-populate as Records arrive; nothing has to be imported by hand.
+provisioning ships a **ROS 2 Data Collection - KPI** dashboard reading them. Start the demo,
+open [http://localhost:3000](http://localhost:3000) (admin/admin), and the availability and
+utilisation panels populate as Records arrive; nothing has to be imported by hand.
+
+The demo runs `driving_type` off Nav2's `/cmd_vel`, which is the only command source the
+simulation has: the mode is `autonomous` while Nav2 publishes and `unknown` otherwise. A
+real deployment adds its teleop topic to `velocity_topics` — that is also what makes an
+intervention distinguishable from an idle robot.
 
 ```admonish warning
 PostgreSQL runs its init directory only on an empty data directory. A database container
@@ -101,24 +228,34 @@ Then, on the reporting side:
 - **A read-only dashboard user** needs no more than:
 
   ```sql
-  GRANT SELECT ON dc_kpi_uptime_samples, dc_kpi_availability_5m TO grafana;
-  GRANT EXECUTE ON FUNCTION dc_kpi_availability(timestamptz, timestamptz, interval) TO grafana;
+  GRANT SELECT ON dc_kpi_uptime_samples, dc_kpi_availability_5m, dc_kpi_driving_samples,
+                  dc_kpi_utilisation_5m, dc_kpi_intervention_events, dc_kpi_interventions_1h,
+                  dc_kpi_fault_events, dc_kpi_faults_1h TO grafana;
+  GRANT EXECUTE ON FUNCTION dc_kpi_availability(timestamptz, timestamptz, interval),
+                            dc_kpi_utilisation(timestamptz, timestamptz, interval, double precision),
+                            dc_kpi_intervention_rate(timestamptz, timestamptz, interval),
+                            dc_kpi_reliability(timestamptz, timestamptz, text[]) TO grafana;
   ```
 
-- **Records stored elsewhere** — another schema, another table name — only affect
-  `dc_kpi_uptime_samples`: it is the single object that names the `dc` table, and everything
-  else is defined on top of it.
+- **Records stored elsewhere** — another schema, another table name — only affect the four
+  sample/event views: they are the only objects that name the `dc` table, and everything
+  else is defined on top of them.
 
 ## Testing a change
 
 The fixture test seeds PostgreSQL with a known Record sequence and asserts what the
-definitions report over it, including the outage cases that are awkward to reproduce by
-hand:
+definitions report over it, including the outage, open-interval and missing-denominator
+cases that are awkward to reproduce by hand:
 
 ```bash
 ./tools/infrastructure/scripts/test_kpi_views.sh
 ```
 
 It brings up a throwaway PostgreSQL with Podman, applies these same SQL files into a schema
-of its own, and runs `tools/infrastructure/test`. Add a case there for every definition you
-add.
+of its own, and runs `tools/infrastructure/test`. The intervention and fault cases seed the
+Records their Measurements will emit, so a definition change breaks a test here rather than
+a dashboard later. Add a case for every definition you add.
+
+[#305]: https://github.com/Minipada/ros2_data_collection/issues/305
+[#362]: https://github.com/Minipada/ros2_data_collection/issues/362
+[#365]: https://github.com/Minipada/ros2_data_collection/issues/365

--- a/progress.txt
+++ b/progress.txt
@@ -7169,3 +7169,77 @@ compile and pass under plain `g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror` a
 `-lgtest -lgtest_main` in a container with `/opt/ros` and the DC workspace deleted and an empty
 environment (`env -i`) — no ament, no `rclcpp`, no message packages. `prek run --all-files
 --skip build-doc` is green.
+
+## #363 - Utilisation, intervention rate and MTBF/MTTR views; mission success rate deferred
+
+#304 shipped one metric — availability and uptime — through the whole path (`dc_kpi_*` naming,
+a view that normalises the wide `dc` table per Measurement, the window as a function argument,
+a bucketed view for charting, a fixture test, provisioned panels). This finishes the starter
+set except for the one metric whose contract nobody has agreed yet.
+
+**Utilisation.** `dc_kpi_driving_samples` narrows `dc` to `driving_type` Records, each carrying
+the `speed` the robot last reported at or before it (correlated lookup bounded by
+`dc_kpi_max_gap()`, so a stale speed vouches for one grace period and no more).
+`dc_kpi_utilisation(from, to [, max_gap [, min_speed]])` credits time exactly the way
+`dc_kpi_availability()` does and splits it four ways — `autonomous_seconds`, `manual_seconds`,
+`teleop_seconds`, `unknown_seconds`, which add up to `reported_seconds` so the ratio can be
+checked against its parts. Productive is *moving under a known mode*: `manual` and `teleop`
+count (a human driving the robot is still the robot being used), `unknown` does not. **No speed
+Record in the window makes `utilisation` NULL, not 0 %** — a deployment collecting
+`driving_type` but not `speed` has unreported movement, not zero movement, and `speed_samples`
+is in the output so the two are distinguishable. It does not claim to measure useful work: a
+robot standing still to inspect something reads as idle, which needs the Mission Measurement.
+
+**Intervention rate.** `dc_kpi_intervention_events` derives `is_start` (leaving `autonomous`
+for `manual`/`teleop`) and `is_end` (returning to it) from the modes a Record names, so the
+shape of the metric is in one place. `dc_kpi_intervention_rate()` reports both denominators —
+`per_autonomous_hour` off `dc_kpi_utilisation()`'s `autonomous_seconds`, `per_km` off summed
+`distance_traveled` — because they fail differently: a robot parked all shift has no autonomous
+hours, a robot doing tight manoeuvring has hours but no kilometres. A denominator nothing
+reported gives NULL, never a rate over zero. Only an end Record carries a duration, so a
+takeover still running is counted in `interventions` and absent from
+`mean_intervention_seconds` rather than a zero in it.
+
+**MTBF/MTTR.** `dc_kpi_reliability(from, to [, failure_levels])` averages the fault Records'
+own `previous_duration`: healthy time before a raise is MTBF, time in a failure level before a
+clear is MTTR. `failure_levels` defaults to `ARRAY['ERROR','STALE']` and is a query parameter,
+so a deployment that treats a silent component as reportable-but-not-broken passes
+`ARRAY['ERROR']`. Three consequences the tests pin: `ERROR → STALE` is neither a raise nor a
+clear (a component that goes quiet while already broken is still one fault); `WARN` is not a
+failure, so `OK → WARN → ERROR` is one failure timed from the last healthy state; a fault never
+cleared counts in `failures` and `open_faults` and is left out of `mttr_seconds`. **Grouped by
+component, never rolled up per robot** — "the robot is down" is a policy over components that
+nothing here knows, and averaging independent components reports a number for a failure mode no
+component has.
+
+**Mission success rate is deliberately not here.** #305 — what a Mission Measurement consumes,
+how far a nav2 adapter infers, what the escape-hatch message in `dc_interfaces` looks like — is
+an open design decision that explicitly needs a human. A view written first would pin the
+contract from the reporting end, which is the wrong end. `doc/src/dc/kpi_views.md` says so in
+its own section rather than leaving a gap to rediscover.
+
+**The Records the views read.** `intervention` (#362) and `fault` (#365) do not exist yet, so
+their views return no rows until those Measurements land — which is fine, and is why the
+fixture test seeds the Records directly. Both are `StateTransitionDetector` projections and
+therefore share a column vocabulary, added to
+`tools/infrastructure/docker/config/postgresql/init.sql`: `previous_duration` (how long the
+state just left was held), `sequence` (a dropped Record is a detectable gap, not a wrong
+duration) and `open`, plus `mode`, `from_mode`/`to_mode`, and
+`component`/`from_level`/`to_level`/`reason`. Vector's `postgres` sink maps a Record's keys onto
+existing columns and silently drops the rest, so the columns have to exist before the
+Measurements do. `open` is reported, never load-bearing: correctness comes from only end/clear
+Records carrying a duration.
+
+**Verification.** `tools/infrastructure/test/test_kpi_views.py` goes from 10 to 29 cases, ~19
+new across the three metrics — the missing-speed NULL, a speed Record older than the grace
+period, another robot's speed, an open takeover, a missing denominator, `ERROR → STALE`, `WARN`,
+a never-cleared fault, the `failure_levels` parameter, and each bucketed view.
+`./tools/infrastructure/scripts/test_kpi_views.sh` is 29 passed. Every one of the dashboard's
+16 panel queries was run against a live PostgreSQL with the Grafana macros expanded, not just
+eyeballed. `prek run --all-files --skip build-doc` is green.
+
+**Demo.** `driving_type` is enabled in `tb3_simulation_pgsql_minio.yaml` off Nav2's `/cmd_vel`
+— the only command source the simulation has, so the mode is `autonomous` while Nav2 publishes
+and `unknown` otherwise — and routed to the `pgsql` Destination, so the utilisation panels
+populate on the existing demo. The intervention and fault panels stay empty until #362/#365,
+for the same reason a battery panel would.

--- a/tools/infrastructure/docker/config/grafana/dashboards/kpi.json
+++ b/tools/infrastructure/docker/config/grafana/dashboards/kpi.json
@@ -500,6 +500,731 @@
       ],
       "title": "Availability by robot",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "Share of the reported time the robot spent moving under a known driving mode (dc_kpi_utilisation). Blank when no speed Record covers the range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.3
+              },
+              {
+                "color": "green",
+                "value": 0.6
+              }
+            ]
+          },
+          "unit": "percentunit",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT robot_name, utilisation FROM dc_kpi_utilisation($__timeFrom(), $__timeTo())",
+          "refId": "A"
+        }
+      ],
+      "title": "Utilisation",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description": "Time in the range the robot was moving under a known driving mode.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 22
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT robot_name, productive_seconds FROM dc_kpi_utilisation($__timeFrom(), $__timeTo())",
+          "refId": "A"
+        }
+      ],
+      "title": "Productive time",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "Human takeovers over the autonomous time the range holds (dc_kpi_intervention_rate). Blank until the intervention Measurement lands.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 22
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT robot_name, per_autonomous_hour FROM dc_kpi_intervention_rate($__timeFrom(), $__timeTo())",
+          "refId": "A"
+        }
+      ],
+      "title": "Interventions per autonomous hour",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description": "The same takeovers over the distance travelled in the range.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 22
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT robot_name, per_km FROM dc_kpi_intervention_rate($__timeFrom(), $__timeTo())",
+          "refId": "A"
+        }
+      ],
+      "title": "Interventions per kilometre",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description": "dc_kpi_utilisation_5m \u2014 the same metric bucketed for charting.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "percentunit",
+          "decimals": 2,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql":
+              "SELECT bucket_start AS \"time\", robot_name AS metric, utilisation FROM dc_kpi_utilisation_5m WHERE $__timeFilter(bucket_start) ORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Utilisation over time (5-minute buckets)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "Every column dc_kpi_utilisation() reports. The per-mode seconds add up to reported_seconds, so the ratio can be checked against them.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "utilisation"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percentunit"
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "reported_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "autonomous_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "manual_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "teleop_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "unknown_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "productive_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "window_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 36
+      },
+      "id": 13,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM dc_kpi_utilisation($__timeFrom(), $__timeTo()) ORDER BY robot_name",
+          "refId": "A"
+        }
+      ],
+      "title": "Utilisation by robot",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "Every column dc_kpi_intervention_rate() reports. A takeover still running counts as an intervention but contributes no duration.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "autonomous_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mean_intervention_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total_intervention_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "distance_km"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "lengthkm"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 36
+      },
+      "id": 14,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM dc_kpi_intervention_rate($__timeFrom(), $__timeTo()) ORDER BY robot_name",
+          "refId": "A"
+        }
+      ],
+      "title": "Interventions by robot",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "dc_kpi_reliability() \u2014 per component, never rolled up per robot: averaging independent components reports a number for a failure mode no component has.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto"
+          },
+          "mappings": []
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mtbf_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "mttr_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "operating_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "downtime_seconds"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "s"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 15,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT * FROM dc_kpi_reliability($__timeFrom(), $__timeTo()) ORDER BY robot_name, component",
+          "refId": "A"
+        }
+      ],
+      "title": "MTBF and MTTR by component",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description": "dc_kpi_faults_1h \u2014 raises per component per hour. Blank until the fault Measurement lands.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql":
+              "SELECT bucket_start AS \"time\", robot_name || ' ' || component AS metric, failures FROM dc_kpi_faults_1h WHERE $__timeFilter(bucket_start) ORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Faults per hour",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -73,6 +73,22 @@ CREATE TABLE IF NOT EXISTS dc (
   -- (tb3_simulation_pgsql_minio); told apart by `name`. Nested under the `speed`/`cmd_vel`
   -- jsonb columns above instead when the Records go through a Group (qrcodes_minio_pgsql).
   computed double precision,
+  -- Operational events the KPI views read (tools/infrastructure/sql/kpi_views.sql):
+  -- driving_type.cpp's current mode, and the transition Records the intervention (#362)
+  -- and fault (#365) Measurements emit. Both are StateTransitionDetector projections, so
+  -- they share previous_duration (how long the state just left was held), `sequence` (a
+  -- dropped Record is a gap, not a wrong duration) and `open` (collection stopped inside
+  -- the interval, so it has no duration rather than a zero one).
+  mode text,
+  from_mode text,
+  to_mode text,
+  component text,
+  from_level text,
+  to_level text,
+  reason text,
+  previous_duration double precision,
+  sequence bigint,
+  open boolean,
   -- Infrastructure (tcp_health.cpp)
   host text,
   port integer,

--- a/tools/infrastructure/sql/kpi_views.sql
+++ b/tools/infrastructure/sql/kpi_views.sql
@@ -2,10 +2,10 @@
 --
 -- SPDX-License-Identifier: MPL-2.0
 
--- Starter KPI definitions over the `dc` table created by
--- tools/infrastructure/docker/config/postgresql/init.sql. Availability and uptime are
--- computed here, in SQL, never on the robot: the time window is a query parameter, so
--- changing a definition is re-applying this file rather than redeploying a fleet.
+-- KPI definitions over the `dc` table created by
+-- tools/infrastructure/docker/config/postgresql/init.sql. Every metric is computed
+-- here, in SQL, never on the robot: the time window is a query parameter, so changing a
+-- definition is re-applying this file rather than redeploying a fleet.
 --
 -- Every object is CREATE OR REPLACE: re-applying to a live database is safe.
 -- See doc/src/dc/kpi_views.md for how to point these at a real deployment.
@@ -109,6 +109,381 @@ SELECT
   )::double precision AS availability
 FROM dc_kpi_uptime_samples s
 GROUP BY 1, 2;
+
+-- Speed at or above which the robot counts as moving. Below it a Record says the robot
+-- was reporting, not that it was working.
+CREATE OR REPLACE FUNCTION dc_kpi_min_speed() RETURNS double precision
+  LANGUAGE sql IMMUTABLE AS $$ SELECT 0.05::double precision $$;
+
+-- The wide `dc` table narrowed to driving_type Records, each carrying the speed the robot
+-- last reported at or before it. NULL speed means no speed Record within the grace period,
+-- which reads as "not moving" — dc_kpi_utilisation() counts those samples separately.
+CREATE OR REPLACE VIEW dc_kpi_driving_samples AS
+SELECT
+  COALESCE(d.robot_name, 'unknown') AS robot_name,
+  to_timestamp(d.date / 1e9) AS sample_time,
+  d.mode,
+  lag(to_timestamp(d.date / 1e9)) OVER (
+    PARTITION BY COALESCE(d.robot_name, 'unknown') ORDER BY d.date
+  ) AS prev_sample_time,
+  (
+    SELECT s.computed
+    FROM dc s
+    WHERE s.name = 'speed'
+      AND s.computed IS NOT NULL
+      AND COALESCE(s.robot_name, 'unknown') = COALESCE(d.robot_name, 'unknown')
+      AND s.date <= d.date
+      AND s.date > d.date - EXTRACT(EPOCH FROM dc_kpi_max_gap()) * 1e9
+    ORDER BY s.date DESC
+    LIMIT 1
+  ) AS speed
+FROM dc d
+WHERE d.name = 'driving_type'
+  AND d.date IS NOT NULL
+  AND d.mode IS NOT NULL;
+
+-- Utilisation per robot over an arbitrary window: time spent moving under a known driving
+-- mode, over the time the robot reported a mode at all. Coverage is credited the same way
+-- dc_kpi_availability() credits it — back to the previous sample, capped at the grace
+-- period and clipped to the window — and attributed to the mode of the sample that closes
+-- the interval. Per-mode seconds are broken out so the ratio can be checked against them;
+-- autonomous_seconds is also dc_kpi_intervention_rate()'s denominator.
+CREATE OR REPLACE FUNCTION dc_kpi_utilisation(
+  window_start timestamptz,
+  window_end timestamptz,
+  max_gap interval DEFAULT dc_kpi_max_gap(),
+  min_speed double precision DEFAULT dc_kpi_min_speed()
+)
+RETURNS TABLE (
+  robot_name text,
+  samples bigint,
+  speed_samples bigint,
+  reported_seconds double precision,
+  autonomous_seconds double precision,
+  manual_seconds double precision,
+  teleop_seconds double precision,
+  unknown_seconds double precision,
+  productive_seconds double precision,
+  window_seconds double precision,
+  utilisation double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH credited AS (
+    SELECT
+      s.robot_name,
+      s.sample_time,
+      s.mode,
+      s.speed,
+      GREATEST(
+        EXTRACT(EPOCH FROM (
+          s.sample_time - GREATEST(
+            COALESCE(s.prev_sample_time, s.sample_time - max_gap),
+            s.sample_time - max_gap,
+            window_start
+          )
+        )),
+        0
+      )::double precision AS covered_seconds
+    FROM dc_kpi_driving_samples s
+    -- One grace period of history, so the first in-window sample knows its predecessor.
+    WHERE s.sample_time > window_start - max_gap
+      AND s.sample_time <= window_end
+  )
+  SELECT
+    c.robot_name,
+    count(*) FILTER (WHERE c.sample_time >= window_start),
+    count(*) FILTER (WHERE c.sample_time >= window_start AND c.speed IS NOT NULL),
+    sum(c.covered_seconds)::double precision,
+    COALESCE(sum(c.covered_seconds) FILTER (WHERE c.mode = 'autonomous'), 0)::double precision,
+    COALESCE(sum(c.covered_seconds) FILTER (WHERE c.mode = 'manual'), 0)::double precision,
+    COALESCE(sum(c.covered_seconds) FILTER (WHERE c.mode = 'teleop'), 0)::double precision,
+    COALESCE(sum(c.covered_seconds) FILTER (WHERE c.mode = 'unknown'), 0)::double precision,
+    COALESCE(
+      sum(c.covered_seconds) FILTER (WHERE c.mode <> 'unknown' AND c.speed >= min_speed), 0
+    )::double precision,
+    EXTRACT(EPOCH FROM (window_end - window_start))::double precision,
+    -- No speed Record in the window means the robot's movement is unreported, not zero:
+    -- the ratio is NULL rather than a plausible-looking 0 %.
+    CASE
+      WHEN count(*) FILTER (WHERE c.sample_time >= window_start AND c.speed IS NOT NULL) = 0
+        THEN NULL
+      ELSE LEAST(
+        COALESCE(
+          sum(c.covered_seconds) FILTER (WHERE c.mode <> 'unknown' AND c.speed >= min_speed), 0
+        ) / NULLIF(sum(c.covered_seconds), 0),
+        1
+      )
+    END::double precision
+  FROM credited c
+  GROUP BY c.robot_name
+$$;
+
+-- The same metric bucketed for charting, on the grace period's own defaults.
+CREATE OR REPLACE VIEW dc_kpi_utilisation_5m AS
+SELECT
+  to_timestamp(floor(EXTRACT(EPOCH FROM s.sample_time) / 300) * 300) AS bucket_start,
+  s.robot_name,
+  count(*)::bigint AS samples,
+  sum(
+    LEAST(
+      COALESCE(EXTRACT(EPOCH FROM (s.sample_time - s.prev_sample_time)), 0),
+      EXTRACT(EPOCH FROM dc_kpi_max_gap())
+    )
+  )::double precision AS reported_seconds,
+  COALESCE(
+    sum(
+      LEAST(
+        COALESCE(EXTRACT(EPOCH FROM (s.sample_time - s.prev_sample_time)), 0),
+        EXTRACT(EPOCH FROM dc_kpi_max_gap())
+      )
+    ) FILTER (WHERE s.mode <> 'unknown' AND s.speed >= dc_kpi_min_speed()),
+    0
+  )::double precision AS productive_seconds,
+  CASE
+    WHEN count(*) FILTER (WHERE s.speed IS NOT NULL) = 0 THEN NULL
+    ELSE LEAST(
+      COALESCE(
+        sum(
+          LEAST(
+            COALESCE(EXTRACT(EPOCH FROM (s.sample_time - s.prev_sample_time)), 0),
+            EXTRACT(EPOCH FROM dc_kpi_max_gap())
+          )
+        ) FILTER (WHERE s.mode <> 'unknown' AND s.speed >= dc_kpi_min_speed()),
+        0
+      ) / NULLIF(
+        sum(
+          LEAST(
+            COALESCE(EXTRACT(EPOCH FROM (s.sample_time - s.prev_sample_time)), 0),
+            EXTRACT(EPOCH FROM dc_kpi_max_gap())
+          )
+        ),
+        0
+      ),
+      1
+    )
+  END::double precision AS utilisation
+FROM dc_kpi_driving_samples s
+GROUP BY 1, 2;
+
+-- The wide `dc` table narrowed to the intervention Measurement's transition Records (#362).
+-- A start leaves `autonomous` for a human-driven mode; an end returns to it, and its
+-- previous_duration is the takeover's own length. Only an end carries a length, so a
+-- takeover that never ended is absent from the averages rather than a zero in them.
+CREATE OR REPLACE VIEW dc_kpi_intervention_events AS
+SELECT
+  COALESCE(d.robot_name, 'unknown') AS robot_name,
+  to_timestamp(d.date / 1e9) AS event_time,
+  d.from_mode,
+  d.to_mode,
+  d.previous_duration,
+  d."sequence",
+  COALESCE(d."open", false) AS open,
+  (d.from_mode = 'autonomous' AND d.to_mode IN ('manual', 'teleop')) AS is_start,
+  (d.from_mode IN ('manual', 'teleop') AND d.to_mode = 'autonomous') AS is_end
+FROM dc d
+WHERE d.name = 'intervention'
+  AND d.date IS NOT NULL
+  AND d.from_mode IS NOT NULL
+  AND d.to_mode IS NOT NULL;
+
+-- Interventions per hour of autonomous operation and per kilometre travelled, per robot
+-- over an arbitrary window. The two denominators come from Measurements of their own —
+-- driving_type through dc_kpi_utilisation(), distance_traveled summed over the window —
+-- so a denominator nothing reported gives a NULL rate, never a rate over zero.
+CREATE OR REPLACE FUNCTION dc_kpi_intervention_rate(
+  window_start timestamptz,
+  window_end timestamptz,
+  max_gap interval DEFAULT dc_kpi_max_gap()
+)
+RETURNS TABLE (
+  robot_name text,
+  interventions bigint,
+  open_interventions bigint,
+  ended_interventions bigint,
+  autonomous_seconds double precision,
+  distance_km double precision,
+  per_autonomous_hour double precision,
+  per_km double precision,
+  mean_intervention_seconds double precision,
+  total_intervention_seconds double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH events AS (
+    SELECT *
+    FROM dc_kpi_intervention_events e
+    WHERE e.event_time >= window_start AND e.event_time <= window_end
+  ),
+  counted AS (
+    SELECT
+      e.robot_name,
+      count(*) FILTER (WHERE e.is_start)::bigint AS interventions,
+      count(*) FILTER (WHERE e.open)::bigint AS open_interventions,
+      count(*) FILTER (WHERE e.is_end)::bigint AS ended_interventions,
+      avg(e.previous_duration) FILTER (WHERE e.is_end) AS mean_intervention_seconds,
+      COALESCE(sum(e.previous_duration) FILTER (WHERE e.is_end), 0)::double precision
+        AS total_intervention_seconds
+    FROM events e
+    GROUP BY e.robot_name
+  ),
+  driven AS (
+    SELECT u.robot_name, u.autonomous_seconds
+    FROM dc_kpi_utilisation(window_start, window_end, max_gap) u
+  ),
+  travelled AS (
+    SELECT
+      COALESCE(d.robot_name, 'unknown') AS robot_name,
+      sum(d.distance_traveled) / 1000.0 AS distance_km
+    FROM dc d
+    WHERE d.name = 'distance_traveled'
+      AND d.distance_traveled IS NOT NULL
+      AND to_timestamp(d.date / 1e9) >= window_start
+      AND to_timestamp(d.date / 1e9) <= window_end
+    GROUP BY 1
+  ),
+  robots AS (
+    SELECT counted.robot_name FROM counted
+    UNION SELECT driven.robot_name FROM driven
+    UNION SELECT travelled.robot_name FROM travelled
+  )
+  SELECT
+    r.robot_name,
+    COALESCE(c.interventions, 0),
+    COALESCE(c.open_interventions, 0),
+    COALESCE(c.ended_interventions, 0),
+    d.autonomous_seconds,
+    t.distance_km,
+    (COALESCE(c.interventions, 0) / NULLIF(d.autonomous_seconds / 3600.0, 0))::double precision,
+    (COALESCE(c.interventions, 0) / NULLIF(t.distance_km, 0))::double precision,
+    c.mean_intervention_seconds::double precision,
+    COALESCE(c.total_intervention_seconds, 0)::double precision
+  FROM robots r
+  LEFT JOIN counted c ON c.robot_name = r.robot_name
+  LEFT JOIN driven d ON d.robot_name = r.robot_name
+  LEFT JOIN travelled t ON t.robot_name = r.robot_name
+$$;
+
+-- Interventions bucketed for charting. An hour, not the 5 minutes availability uses: a
+-- rate over a bucket most robots see no takeover in charts as noise.
+CREATE OR REPLACE VIEW dc_kpi_interventions_1h AS
+SELECT
+  to_timestamp(floor(EXTRACT(EPOCH FROM e.event_time) / 3600) * 3600) AS bucket_start,
+  e.robot_name,
+  count(*) FILTER (WHERE e.is_start)::bigint AS interventions,
+  count(*) FILTER (WHERE e.open)::bigint AS open_interventions,
+  avg(e.previous_duration) FILTER (WHERE e.is_end)::double precision
+    AS mean_intervention_seconds
+FROM dc_kpi_intervention_events e
+GROUP BY 1, 2;
+
+-- The levels a component is broken at. STALE is a failure of its own — a silent component
+-- and a broken one are different faults — and WARN is deliberately not one.
+CREATE OR REPLACE FUNCTION dc_kpi_failure_levels() RETURNS text[]
+  LANGUAGE sql IMMUTABLE AS $$ SELECT ARRAY['ERROR', 'STALE'] $$;
+
+-- The wide `dc` table narrowed to the fault Measurement's transition Records (#365), one
+-- row per level change of one component. previous_duration is how long the component held
+-- the level it just left, which is what MTBF and MTTR are averages of.
+CREATE OR REPLACE VIEW dc_kpi_fault_events AS
+SELECT
+  COALESCE(d.robot_name, 'unknown') AS robot_name,
+  to_timestamp(d.date / 1e9) AS event_time,
+  d.component,
+  d.from_level,
+  d.to_level,
+  d.previous_duration,
+  d."sequence",
+  d.reason,
+  COALESCE(d."open", false) AS open
+FROM dc d
+WHERE d.name = 'fault'
+  AND d.date IS NOT NULL
+  AND d.component IS NOT NULL
+  AND d.to_level IS NOT NULL;
+
+-- MTBF and MTTR per component over an arbitrary window. A raise enters a failure level
+-- from a healthy one and carries the healthy time that preceded it; a clear leaves a
+-- failure level for a healthy one and carries the repair. A change inside the failure set
+-- (ERROR to STALE) is neither, so a fault that changes shape stays one fault.
+--
+-- Grouped by component, not rolled up per robot: "the robot is down" is a policy over
+-- components that nothing here knows, and averaging independent components together
+-- reports a number for a failure mode no component has.
+CREATE OR REPLACE FUNCTION dc_kpi_reliability(
+  window_start timestamptz,
+  window_end timestamptz,
+  failure_levels text[] DEFAULT dc_kpi_failure_levels()
+)
+RETURNS TABLE (
+  robot_name text,
+  component text,
+  failures bigint,
+  repairs bigint,
+  open_faults bigint,
+  operating_seconds double precision,
+  downtime_seconds double precision,
+  mtbf_seconds double precision,
+  mttr_seconds double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH events AS (
+    SELECT
+      e.*,
+      (e.to_level = ANY(failure_levels) AND NOT (e.from_level = ANY(failure_levels)))
+        AS is_raise,
+      (e.from_level = ANY(failure_levels) AND NOT (e.to_level = ANY(failure_levels)))
+        AS is_clear
+    FROM dc_kpi_fault_events e
+    WHERE e.event_time >= window_start
+      AND e.event_time <= window_end
+      AND e.from_level IS NOT NULL
+  )
+  SELECT
+    e.robot_name,
+    e.component,
+    count(*) FILTER (WHERE e.is_raise)::bigint,
+    count(*) FILTER (WHERE e.is_clear)::bigint,
+    count(*) FILTER (WHERE e.open)::bigint,
+    COALESCE(sum(e.previous_duration) FILTER (WHERE e.is_raise), 0)::double precision,
+    COALESCE(sum(e.previous_duration) FILTER (WHERE e.is_clear), 0)::double precision,
+    -- Averages over the events in the window, never over the window itself: a fault still
+    -- open has no repair time yet and is left out of MTTR rather than counted as instant.
+    avg(e.previous_duration) FILTER (WHERE e.is_raise)::double precision,
+    avg(e.previous_duration) FILTER (WHERE e.is_clear)::double precision
+  FROM events e
+  GROUP BY e.robot_name, e.component
+  HAVING count(*) FILTER (WHERE e.is_raise OR e.is_clear) > 0
+$$;
+
+-- Faults bucketed for charting, hourly for the same reason interventions are.
+CREATE OR REPLACE VIEW dc_kpi_faults_1h AS
+SELECT
+  to_timestamp(floor(EXTRACT(EPOCH FROM e.event_time) / 3600) * 3600) AS bucket_start,
+  e.robot_name,
+  e.component,
+  count(*) FILTER (
+    WHERE e.to_level = ANY(dc_kpi_failure_levels())
+      AND NOT (e.from_level = ANY(dc_kpi_failure_levels()))
+  )::bigint AS failures,
+  count(*) FILTER (
+    WHERE e.from_level = ANY(dc_kpi_failure_levels())
+      AND NOT (e.to_level = ANY(dc_kpi_failure_levels()))
+  )::bigint AS repairs,
+  COALESCE(
+    sum(e.previous_duration) FILTER (
+      WHERE e.from_level = ANY(dc_kpi_failure_levels())
+        AND NOT (e.to_level = ANY(dc_kpi_failure_levels()))
+    ),
+    0
+  )::double precision AS downtime_seconds
+FROM dc_kpi_fault_events e
+WHERE e.from_level IS NOT NULL
+GROUP BY 1, 2, 3;
 
 -- The lookup every object above starts from.
 CREATE INDEX IF NOT EXISTS dc_name_date_idx ON dc (name, date);

--- a/tools/infrastructure/test/test_kpi_views.py
+++ b/tools/infrastructure/test/test_kpi_views.py
@@ -1,11 +1,16 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-"""Fixture test for the starter KPI views (tools/infrastructure/sql/kpi_views.sql).
+"""Fixture test for the KPI views (tools/infrastructure/sql/kpi_views.sql).
 
-Seeds a known uptime Record sequence into PostgreSQL and asserts what the views report
-over it. The SQL files under test are the ones the demo stack applies, run into a throwaway
-schema of their own — tools/infrastructure/scripts/test_kpi_views.sh brings up the database.
+Seeds a known Record sequence into PostgreSQL and asserts what the views report over it —
+one section per metric. The SQL files under test are the ones the demo stack applies, run
+into a throwaway schema of their own — tools/infrastructure/scripts/test_kpi_views.sh
+brings up the database.
+
+The intervention and fault sections seed the Records the Measurements in #362 and #365 will
+emit; nothing collects them yet, which is exactly why a definition change has to break a
+test here rather than a dashboard later.
 """
 
 import os
@@ -199,3 +204,352 @@ def test_the_bucketed_view_charts_the_same_metric(db):
         1.0,
     ]
     assert buckets[-1]["uptime_seconds"] == pytest.approx(2495.0)
+
+
+# --- Utilisation -----------------------------------------------------------------------
+
+
+def driving(db, first=0, last=600, step=STEP, mode="autonomous", robot=ROBOT):
+    """Seed one driving_type Record every `step` seconds; `mode` may be a callable."""
+    pick = mode if callable(mode) else (lambda _offset: mode)
+    rows = [
+        (int(at(offset).timestamp()) * 10**9, "driving_type", robot, pick(offset))
+        for offset in range(first, last + 1, step)
+    ]
+    psycopg2.extras.execute_values(
+        db, "INSERT INTO dc (date, name, robot_name, mode) VALUES %s", rows
+    )
+    return rows
+
+
+def speeds(db, first=0, last=600, step=STEP, speed=0.4, robot=ROBOT):
+    """Seed one speed Record every `step` seconds; `speed` may be a callable."""
+    pick = speed if callable(speed) else (lambda _offset: speed)
+    rows = [
+        (int(at(offset).timestamp()) * 10**9, "speed", robot, pick(offset))
+        for offset in range(first, last + 1, step)
+    ]
+    psycopg2.extras.execute_values(
+        db, "INSERT INTO dc (date, name, robot_name, computed) VALUES %s", rows
+    )
+    return rows
+
+
+def utilisation(db, start, end):
+    """dc_kpi_utilisation() over [start, end], keyed by robot."""
+    db.execute("SELECT * FROM dc_kpi_utilisation(%s, %s)", (at(start), at(end)))
+    return {row["robot_name"]: row for row in db.fetchall()}
+
+
+def test_utilisation_is_moving_time_over_reported_time(db):
+    driving(db, last=1200)
+    speeds(db, last=1200, speed=lambda offset: 0.4 if offset <= 600 else 0.0)
+
+    kpi = utilisation(db, 300, 900)[ROBOT]
+
+    assert kpi["reported_seconds"] == pytest.approx(600.0)
+    assert kpi["autonomous_seconds"] == pytest.approx(600.0)
+    assert kpi["productive_seconds"] == pytest.approx(300.0)
+    assert kpi["utilisation"] == pytest.approx(0.5)
+    assert kpi["speed_samples"] == 600 // STEP + 1
+
+
+def test_time_in_an_unknown_mode_is_reported_but_never_productive(db):
+    driving(db, last=1200, mode=lambda offset: "autonomous" if offset <= 600 else "unknown")
+    speeds(db, last=1200)
+
+    kpi = utilisation(db, 300, 900)[ROBOT]
+
+    assert kpi["autonomous_seconds"] == pytest.approx(300.0)
+    assert kpi["unknown_seconds"] == pytest.approx(300.0)
+    # Moving the whole window, but only the half under a known mode counts.
+    assert kpi["productive_seconds"] == pytest.approx(300.0)
+    assert kpi["utilisation"] == pytest.approx(0.5)
+
+
+def test_a_human_driving_the_robot_is_still_utilisation(db):
+    driving(db, last=1200, mode=lambda offset: "autonomous" if offset <= 600 else "teleop")
+    speeds(db, last=1200)
+
+    kpi = utilisation(db, 300, 900)[ROBOT]
+
+    assert kpi["teleop_seconds"] == pytest.approx(300.0)
+    assert kpi["manual_seconds"] == pytest.approx(0.0)
+    assert kpi["utilisation"] == pytest.approx(1.0)
+
+
+def test_utilisation_without_speed_records_is_unknown_not_zero(db):
+    driving(db, last=1200)
+
+    kpi = utilisation(db, 300, 900)[ROBOT]
+
+    assert kpi["speed_samples"] == 0
+    assert kpi["reported_seconds"] == pytest.approx(600.0)
+    assert kpi["productive_seconds"] == pytest.approx(0.0)
+    assert kpi["utilisation"] is None
+
+
+def test_a_speed_record_older_than_the_grace_period_does_not_vouch_for_movement(db):
+    driving(db, last=1200)
+    # Movement reported once, then silence: it vouches for one grace period, no longer.
+    speeds(db, first=300, last=300)
+
+    kpi = utilisation(db, 300, 900)[ROBOT]
+
+    # The sample at the window's own start credits nothing, so a grace period minus one
+    # polling interval is all that speed Record can vouch for.
+    assert kpi["productive_seconds"] == pytest.approx(GRACE - STEP)
+    assert kpi["utilisation"] == pytest.approx((GRACE - STEP) / 600.0)
+
+
+def test_utilisation_ignores_another_robots_speed(db):
+    driving(db, last=1200, robot="Turtlebot")
+    speeds(db, last=1200, robot="Waffle")
+
+    kpi = utilisation(db, 300, 900)["Turtlebot"]
+
+    assert kpi["speed_samples"] == 0
+    assert kpi["utilisation"] is None
+
+
+def test_the_bucketed_utilisation_view_charts_the_same_metric(db):
+    driving(db, last=1200)
+    speeds(db, last=1200, speed=lambda offset: 0.4 if offset <= 600 else 0.0)
+
+    db.execute(
+        "SELECT * FROM dc_kpi_utilisation_5m"
+        " WHERE bucket_start >= %s AND bucket_start < %s ORDER BY bucket_start",
+        (at(300), at(900)),
+    )
+    buckets = db.fetchall()
+
+    assert [row["bucket_start"] for row in buckets] == [at(300), at(600)]
+    assert [round(row["utilisation"], 6) for row in buckets] == [1.0, round(STEP / 300.0, 6)]
+
+
+# --- Intervention rate -----------------------------------------------------------------
+
+
+def intervention(db, offset, from_mode, to_mode, previous_duration, sequence, open_=False):
+    """One intervention Record: a driving-mode transition the takeover is derived from."""
+    db.execute(
+        "INSERT INTO dc (date, name, robot_name, from_mode, to_mode, previous_duration,"
+        ' "sequence", "open") VALUES (%s, %s, %s, %s, %s, %s, %s, %s)',
+        (
+            int(at(offset).timestamp()) * 10**9,
+            "intervention",
+            ROBOT,
+            from_mode,
+            to_mode,
+            previous_duration,
+            sequence,
+            open_,
+        ),
+    )
+
+
+def travelled(db, first=0, last=600, step=STEP, metres=10.0, robot=ROBOT):
+    """Seed distance_traveled Records, each carrying the distance since the previous one."""
+    rows = [
+        (int(at(offset).timestamp()) * 10**9, "distance_traveled", robot, metres)
+        for offset in range(first, last + 1, step)
+    ]
+    psycopg2.extras.execute_values(
+        db, "INSERT INTO dc (date, name, robot_name, distance_traveled) VALUES %s", rows
+    )
+    return rows
+
+
+def intervention_rate(db, start, end):
+    """dc_kpi_intervention_rate() over [start, end], keyed by robot."""
+    db.execute("SELECT * FROM dc_kpi_intervention_rate(%s, %s)", (at(start), at(end)))
+    return {row["robot_name"]: row for row in db.fetchall()}
+
+
+def test_intervention_rate_is_per_autonomous_hour_and_per_kilometre(db):
+    driving(db, last=1200)
+    # 600 s autonomous and 1 km inside the window, with two takeovers in it.
+    travelled(db, first=305, last=900, metres=1000.0 / (600 // STEP))
+    intervention(db, 400, "autonomous", "teleop", 100.0, 1)
+    intervention(db, 460, "teleop", "autonomous", 60.0, 2)
+    intervention(db, 700, "autonomous", "manual", 240.0, 3)
+    intervention(db, 760, "manual", "autonomous", 60.0, 4)
+
+    kpi = intervention_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["interventions"] == 2
+    assert kpi["ended_interventions"] == 2
+    assert kpi["autonomous_seconds"] == pytest.approx(600.0)
+    assert kpi["distance_km"] == pytest.approx(1.0)
+    assert kpi["per_autonomous_hour"] == pytest.approx(12.0)
+    assert kpi["per_km"] == pytest.approx(2.0)
+    assert kpi["mean_intervention_seconds"] == pytest.approx(60.0)
+    assert kpi["total_intervention_seconds"] == pytest.approx(120.0)
+
+
+def test_an_intervention_still_running_is_counted_but_never_timed(db):
+    driving(db, last=1200)
+    intervention(db, 400, "autonomous", "teleop", 100.0, 1)
+    intervention(db, 460, "teleop", "autonomous", 60.0, 2)
+    # A takeover the window ends inside: it happened, but it has no duration yet.
+    intervention(db, 880, "autonomous", "manual", 420.0, 3, open_=True)
+
+    kpi = intervention_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["interventions"] == 2
+    assert kpi["ended_interventions"] == 1
+    assert kpi["open_interventions"] == 1
+    assert kpi["mean_intervention_seconds"] == pytest.approx(60.0)
+    assert kpi["total_intervention_seconds"] == pytest.approx(60.0)
+
+
+def test_a_denominator_nothing_reported_gives_no_rate(db):
+    intervention(db, 400, "autonomous", "teleop", 100.0, 1)
+
+    kpi = intervention_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["interventions"] == 1
+    assert kpi["autonomous_seconds"] is None
+    assert kpi["distance_km"] is None
+    assert kpi["per_autonomous_hour"] is None
+    assert kpi["per_km"] is None
+
+
+def test_a_robot_with_no_interventions_still_reports_its_denominators(db):
+    driving(db, last=1200)
+    travelled(db, first=305, last=900)
+
+    kpi = intervention_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["interventions"] == 0
+    assert kpi["per_autonomous_hour"] == pytest.approx(0.0)
+    assert kpi["mean_intervention_seconds"] is None
+
+
+def test_the_bucketed_intervention_view_charts_the_same_events(db):
+    intervention(db, 400, "autonomous", "teleop", 100.0, 1)
+    intervention(db, 460, "teleop", "autonomous", 60.0, 2)
+
+    db.execute("SELECT * FROM dc_kpi_interventions_1h ORDER BY bucket_start")
+    buckets = db.fetchall()
+
+    assert [row["interventions"] for row in buckets] == [1]
+    assert buckets[0]["mean_intervention_seconds"] == pytest.approx(60.0)
+
+
+# --- MTBF and MTTR ---------------------------------------------------------------------
+
+
+def fault(db, offset, component, from_level, to_level, previous_duration, sequence, open_=False):
+    """One fault Record: a diagnostic level change of one component."""
+    db.execute(
+        "INSERT INTO dc (date, name, robot_name, component, from_level, to_level,"
+        ' previous_duration, "sequence", reason, "open")'
+        " VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+        (
+            int(at(offset).timestamp()) * 10**9,
+            "fault",
+            ROBOT,
+            component,
+            from_level,
+            to_level,
+            previous_duration,
+            sequence,
+            f"{component} {to_level}",
+            open_,
+        ),
+    )
+
+
+def reliability(db, start, end, failure_levels=None):
+    """dc_kpi_reliability() over [start, end], keyed by component."""
+    if failure_levels is None:
+        db.execute("SELECT * FROM dc_kpi_reliability(%s, %s)", (at(start), at(end)))
+    else:
+        db.execute(
+            "SELECT * FROM dc_kpi_reliability(%s, %s, %s)",
+            (at(start), at(end), failure_levels),
+        )
+    return {row["component"]: row for row in db.fetchall()}
+
+
+def test_mtbf_and_mttr_average_the_records_own_durations(db):
+    # Two failures, each preceded by healthy time and followed by a repair.
+    fault(db, 400, "motors", "OK", "ERROR", 400.0, 1)
+    fault(db, 460, "motors", "ERROR", "OK", 60.0, 2)
+    fault(db, 700, "motors", "OK", "ERROR", 240.0, 3)
+    fault(db, 820, "motors", "ERROR", "OK", 120.0, 4)
+
+    kpi = reliability(db, 300, 900)["motors"]
+
+    assert kpi["failures"] == 2
+    assert kpi["repairs"] == 2
+    assert kpi["mtbf_seconds"] == pytest.approx(320.0)
+    assert kpi["mttr_seconds"] == pytest.approx(90.0)
+    assert kpi["downtime_seconds"] == pytest.approx(180.0)
+
+
+def test_a_change_inside_the_failure_set_is_not_a_second_failure(db):
+    # A component that goes quiet while already broken is still one fault.
+    fault(db, 400, "motors", "OK", "ERROR", 400.0, 1)
+    fault(db, 430, "motors", "ERROR", "STALE", 30.0, 2)
+    fault(db, 490, "motors", "STALE", "OK", 60.0, 3)
+
+    kpi = reliability(db, 300, 900)["motors"]
+
+    assert kpi["failures"] == 1
+    assert kpi["repairs"] == 1
+    assert kpi["mttr_seconds"] == pytest.approx(60.0)
+
+
+def test_a_warning_is_not_a_failure(db):
+    fault(db, 400, "motors", "OK", "WARN", 400.0, 1)
+    fault(db, 460, "motors", "WARN", "OK", 60.0, 2)
+
+    assert reliability(db, 300, 900) == {}
+
+
+def test_the_failure_levels_are_a_query_parameter(db):
+    fault(db, 400, "lidar", "OK", "STALE", 400.0, 1)
+    fault(db, 460, "lidar", "STALE", "OK", 60.0, 2)
+
+    assert reliability(db, 300, 900)["lidar"]["failures"] == 1
+    # A deployment that treats a silent component as reportable but not broken.
+    assert reliability(db, 300, 900, ["ERROR"]) == {}
+
+
+def test_a_fault_never_cleared_has_no_repair_time(db):
+    fault(db, 400, "motors", "OK", "ERROR", 400.0, 1, open_=True)
+
+    kpi = reliability(db, 300, 900)["motors"]
+
+    assert kpi["failures"] == 1
+    assert kpi["repairs"] == 0
+    assert kpi["open_faults"] == 1
+    assert kpi["mtbf_seconds"] == pytest.approx(400.0)
+    assert kpi["mttr_seconds"] is None
+    assert kpi["downtime_seconds"] == pytest.approx(0.0)
+
+
+def test_each_component_is_reported_separately(db):
+    fault(db, 400, "motors", "OK", "ERROR", 400.0, 1)
+    fault(db, 460, "motors", "ERROR", "OK", 60.0, 2)
+    fault(db, 500, "lidar", "OK", "STALE", 500.0, 1)
+
+    kpi = reliability(db, 300, 900)
+
+    assert set(kpi) == {"motors", "lidar"}
+    assert kpi["lidar"]["mttr_seconds"] is None
+    assert kpi["motors"]["mttr_seconds"] == pytest.approx(60.0)
+
+
+def test_the_bucketed_fault_view_charts_the_same_events(db):
+    fault(db, 400, "motors", "OK", "ERROR", 400.0, 1)
+    fault(db, 460, "motors", "ERROR", "OK", 60.0, 2)
+
+    db.execute("SELECT * FROM dc_kpi_faults_1h ORDER BY bucket_start, component")
+    buckets = db.fetchall()
+
+    assert [row["failures"] for row in buckets] == [1]
+    assert [row["repairs"] for row in buckets] == [1]
+    assert buckets[0]["downtime_seconds"] == pytest.approx(60.0)


### PR DESCRIPTION
Closes #363

#304 established where KPI definitions live, how they reach a database, how they are tested and
how they are charted, and shipped one metric through it. This finishes the starter set except
for the one whose contract nobody has agreed yet.

## Utilisation

`dc_kpi_driving_samples` narrows `dc` to `driving_type` Records, each carrying the `speed` the
robot last reported at or before it — a lookup bounded by `dc_kpi_max_gap()`, so a stale speed
Record vouches for one grace period and no longer.

`dc_kpi_utilisation(from, to [, max_gap [, min_speed]])` credits time exactly the way
`dc_kpi_availability()` does and splits it four ways: `autonomous_seconds`, `manual_seconds`,
`teleop_seconds`, `unknown_seconds`, which add up to `reported_seconds` so the ratio can always
be checked against its parts. Productive is *moving under a known mode* — `manual` and `teleop`
count, since a human driving the robot is still the robot being used.

What it deliberately does not claim:

- **No speed Record in the window makes `utilisation` NULL, not 0 %.** A deployment collecting
  `driving_type` but not `speed` has unreported movement, not zero movement; `speed_samples` is
  in the output so a NULL can be told from an empty range.
- **Not "useful work".** A robot standing still to inspect something reads as idle. That
  distinction needs the Mission Measurement.

## Intervention rate

`dc_kpi_intervention_events` derives `is_start` (leaving `autonomous` for `manual`/`teleop`) and
`is_end` (returning to it) from the modes a Record names, so the shape of the metric lives in
one place. `dc_kpi_intervention_rate()` reports **both** denominators — `per_autonomous_hour`
off `dc_kpi_utilisation()`'s `autonomous_seconds`, `per_km` off summed `distance_traveled` —
because they fail differently: a robot parked all shift has no autonomous hours, a robot doing
tight manoeuvring has hours and few kilometres.

- A denominator nothing reported gives a NULL rate, never a rate over zero.
- Only an end Record carries a duration, so a takeover still running is counted in
  `interventions` and absent from `mean_intervention_seconds` rather than a zero in it.

## MTBF and MTTR

`dc_kpi_reliability(from, to [, failure_levels])` averages the fault Records' own
`previous_duration`: healthy time before a raise is MTBF, time in a failure level before a clear
is MTTR. `failure_levels` defaults to `ARRAY['ERROR','STALE']` and is a query parameter, so a
deployment treating a silent component as reportable-but-not-broken passes `ARRAY['ERROR']`.

- `ERROR → STALE` is neither a raise nor a clear: a component that goes quiet while already
  broken is still one fault.
- `WARN` is not a failure by default, so `OK → WARN → ERROR` is one failure timed from the last
  healthy state.
- A fault never cleared counts in `failures` and `open_faults` and is left out of `mttr_seconds`.
- **Grouped by component, never rolled up per robot** — "the robot is down" is a policy over
  components that nothing here knows, and averaging independent components reports a number for
  a failure mode no component has.

## Mission success rate is deliberately not in this PR

#305 — how far a nav2 adapter infers, what the escape-hatch message in `dc_interfaces` looks
like, how a mission still running at shutdown is represented — is an open design decision that
says on its face it needs a human. A view written before it would pin the contract from the
reporting end, which is the wrong end. `doc/src/dc/kpi_views.md` has a section saying so rather
than leaving a gap to rediscover; that acceptance criterion is the one thing left open here.

## The Records the views read

`intervention` (#362) and `fault` (#365) do not exist yet, so their views return no rows until
those Measurements land. That is what the fixture test is for: it seeds the Records directly, so
a definition change breaks a test here rather than a dashboard later.

Both Measurements are `StateTransitionDetector` projections and share a column vocabulary, added
to `init.sql` now because Vector's `postgres` sink maps a Record's keys onto *existing* columns
and silently drops the rest: `previous_duration`, `sequence`, `open`, plus `mode`,
`from_mode`/`to_mode` and `component`/`from_level`/`to_level`/`reason`. `open` is reported but
never load-bearing — correctness comes from only end/clear Records carrying a duration.

## Demo and dashboard

`driving_type` is enabled in `tb3_simulation_pgsql_minio.yaml` off Nav2's `/cmd_vel` (the only
command source the simulation has, so the mode is `autonomous` while Nav2 publishes and
`unknown` otherwise) and routed to the `pgsql` Destination, so the utilisation panels populate
on the existing demo. Nine panels are added to the provisioned `dc-kpi` dashboard; the
intervention and fault ones stay empty until #362/#365, for the same reason a battery panel
would.

## Verification

- `tools/infrastructure/test/test_kpi_views.py` goes from 10 to 29 cases. New coverage: the
  missing-speed NULL, a speed Record older than the grace period, another robot's speed, an open
  takeover, a missing denominator, `ERROR → STALE`, `WARN`, a never-cleared fault, the
  `failure_levels` parameter, and each bucketed view.
- `./tools/infrastructure/scripts/test_kpi_views.sh` → **29 passed**.
- All 16 dashboard panel queries were run against a live PostgreSQL with the Grafana macros
  expanded, not eyeballed.
- `prek run --all-files --skip build-doc` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018dWQxJJEaDcsD5szRu2LEG
