### PR TITLE
feat(tools/sim): measure raw-mode collection volume against the simulated robot

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@
 #   build-workspace (build + colcon test + coverage) ─┬─▶ sim               (pull dc-workspace, simulation smoke check)
 #                                                      └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
 #   kpi-views (standalone: SQL + a throwaway Postgres, no workspace image needed)
+#   raw-volume (standalone: stdlib Python fixtures over the shared volume accounting)
 #
 # e2e calls the same tools/e2e/scripts/run.sh a developer runs locally, driving the
 # harness with plain podman (no compose) so nothing extra is installed on the runner;
@@ -311,6 +312,23 @@ jobs:
             echo "push $E2E_REF attempt $attempt failed; retrying in 10s"; sleep 10
           done
           exit 1
+
+  # tools/e2e/scripts/raw_volume.py is stdlib Python shared by the zero-loss verifier and
+  # the sim-backed volume benchmark (#326) — no workspace image, no simulator, no database.
+  # The benchmark itself is deliberately not a CI job: it boots gz-sim for a number nobody
+  # asserts a threshold on.
+  raw-volume:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/0.12.5/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Fixture tests for the raw-volume accounting
+        run: uv run --frozen pytest tools/e2e/test -q
 
   # The KPI definitions are SQL, not workspace code: this needs a database and nothing else.
   kpi-views:

--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,7 @@ cython_debug/
 # scratch state, not source.
 .ci-ws/
 tools/e2e/.run/
+tools/sim/.run/
 
 # dc_bridge local core test build dir (fast-iteration cmake, not colcon)
 dc_bridge/test/local/build/

--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -33,6 +33,18 @@ Without it gz-sensors stamps messages with the scoped sensor name, which is not 
 frame, and every tf2 `MessageFilter` downstream — AMCL, both Nav2 costmaps — silently
 drops the message.
 
+## What the robot's topics cost to collect
+
+```bash
+./tools/sim/scripts/measure_raw_volume.sh     # per-Tag bytes, rates and a GB/day
+```
+
+Boots this world headless, drives the robot, runs `dc_bridge` in raw mode against its
+topics and reports what each one is worth in stored bytes — the source of the figures in
+[Raw topic collection](../doc/src/dc/raw_topics.md#how-much-data-is-this). Local and
+informational, never a CI gate; see the script's header for the profiles and why its rates
+are counted in simulated seconds.
+
 ## Running headless, without a GPU
 
 The rendering sensors (`gpu_lidar` and both `rgbd_camera`s) **do** work with no GPU and

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -147,9 +147,9 @@ The values above are the defaults, and they matter:
   everything twice, under two different Tags.
 - **High-rate sensor types are excluded**, by type rather than by name (a camera topic is
   not reliably called anything in particular). One 640×480 `sensor_msgs/msg/Image` is
-  roughly 900 kB of JSON numbers; at 30 Hz nothing downstream is sized for it. Override
-  the list deliberately if you want them — DC will not stop you, but read the next
-  section first.
+  900 kB on the wire and roughly 3.7 MB once every pixel byte is a JSON number; at 30 Hz
+  nothing downstream is sized for it. Override the list deliberately if you want them —
+  DC will not stop you, but read the next section first.
 
 To replace a list, write the replacement; note that an *empty* YAML list (`[]`) cannot be
 loaded by rclcpp (it has no inferable element type), so use a pattern that matches
@@ -198,38 +198,68 @@ acknowledged (see [Destinations](./destinations.md#delivery-guarantees)).
 
 ### How much data is this?
 
-Measured against a TurtleBot3-Waffle-shaped workload — the topic mix
-`dc_simulation`'s warehouse world bridges out, at the rates those sensors actually run
-(IMU 100 Hz, odom/tf/joint_states 50 Hz, camera 30 Hz, cmd_vel 20 Hz, lidar 10 Hz,
-battery 1 Hz) — collected into a `file` Destination:
+These figures come off a **simulated robot**, not a spreadsheet:
+`tools/sim/scripts/measure_raw_volume.sh` boots `dc_simulation`'s warehouse world, drives
+the TurtleBot3-Waffle in a slow circle, points a Bridge in raw mode at its live topics,
+and reports what a `file` Destination stored, per Tag. Everything below is one run of it —
+re-run it after anything that changes what a Record costs. It is a local tool, not a CI
+gate; its header explains the three configurations and why its rates are counted in
+*simulated* seconds.
 
-| Configuration | Stored |
+Rates are that world's Waffle's: IMU 200 Hz, odometry and TF 30 Hz (the `DiffDrive`
+plugin), lidar and both RGBD cameras 5 Hz. `/cmd_vel` and `/clock` are left out — the
+first is the benchmark's own driving, the second exists only because the robot is
+simulated.
+
+| Configuration | Shipped |
 |---|---|
-| **Defaults** (10 Hz cap, sensor types excluded) | 19 kB/s — **67 MB/hour, 1.6 GB/day** |
-| …plus `scan` and `tf` re-enabled | ≈ 4.3 GB/day |
-| …plus the 640×480 camera re-enabled | ≈ **1.6 TB/day** |
+| **Defaults** (10 Hz cap, sensor types excluded) | 24 kB/s — **86 MB/hour, 2.1 GB/day** |
+| …plus `scan` and `tf` re-enabled | 69 kB/s — **5.9 GB/day** |
+| …plus both 1280×720 cameras re-enabled | ≈ **9.5 TB/day**, if anything could carry it |
 
 Per-Record cost, which is what to multiply by your own topics' rates:
 
-| Message | Bytes per Record |
-|---|---|
-| `geometry_msgs/msg/Twist` | 202 |
-| `sensor_msgs/msg/JointState` (2 joints) | 326 |
-| `sensor_msgs/msg/Imu` | 488 |
-| `nav_msgs/msg/Odometry` | 605 |
-| `tf2_msgs/msg/TFMessage` (2 transforms) | 547 |
-| `sensor_msgs/msg/LaserScan` (360 ranges + intensities) | 2 585 |
-| `sensor_msgs/msg/Image` (640×480 `rgb8`) | **1 843 521** |
+| Topic (message) | Publishes at | Bytes per Record |
+|---|---|---|
+| `/joint_states` (`JointState`, 2 joints) | 1 000 Hz † | 355 |
+| `/tf` (`TFMessage`, 1 transform) | 30 Hz | 406 |
+| `…/camera_info` (`CameraInfo`) | 5 Hz | 581 |
+| `/odom` (`Odometry`) | 30 Hz | 669 |
+| `/imu` (`Imu`) | 200 Hz | 767 |
+| `/scan` (`LaserScan`, 360 ranges + intensities) | 5 Hz | 7 878 |
+| `…/image_raw` (`Image`, 1280×720 `rgb8`) | 5 Hz | **10 981 032** |
 
-The last row is the whole argument for the default type exclusions: one VGA frame costs
-as much as ~3 000 odometry Records, and JSON roughly **doubles** a byte array (every
-pixel byte becomes `"0,"`).
+† the simulator's `JointStatePublisher` runs every physics step; a real driver is far
+slower. It makes no difference to the total, which is the point of the next paragraph.
 
-**The size cap will not save you from a camera** — and it should not be asked to. That
-same 640×480 frame is 921 600 bytes on the wire, *under* the default
-`max_message_size_bytes` of 1 MiB, so it passes the size gate and lands as 1.8 MB of
-JSON. It is `exclude_types` that keeps images out, and removing that list removes the
-protection entirely.
+**The rate cap is what makes the first row affordable, not the topic list.** A topic
+publishing faster than `max_rate_hz` contributes `bytes_per_record × 10` per second no
+matter how fast it actually runs, so `joint_states` at 1 000 Hz and `imu` at 200 Hz cost
+3.6 kB/s and 7.7 kB/s respectively. Only the topics *below* the cap — the 5 Hz sensors —
+bill at their real rate, which is why re-enabling one 5 Hz lidar (7.9 kB per Record, 40
+kB/s, 3.5 GB/day) nearly triples the total on its own.
+
+The last row is the whole argument for the default type exclusions: one 1280×720 frame
+costs as much as ~16 000 odometry Records. JSON does not merely double a byte array —
+`10 981 032` bytes for a 2 764 800-byte frame is **four times** the wire size, because
+most pixel values print as three digits and a comma.
+
+Two cameras at 5 Hz is 110 MB/s of Records, and **nothing in the pipeline carries that**,
+which is why that row says "if anything could carry it": in the run it comes from, the
+Shipper refused 475 of the 894 Records offered to it (`dropped … 475 shipper`, 53 %). The
+collapse was not confined to the images either — `imu` arrived at 4 Hz instead of 200 and
+`odom` at 0.7 Hz instead of 30, because the Bridge spent the window serializing frames.
+Collecting a camera raw does not cost you a camera's worth of storage; it costs you the
+rest of your collection.
+
+**The size cap will not save you from a camera** — and it should not be asked to. A
+640×480 `rgb8` frame is 921 600 bytes on the wire, *under* the default
+`max_message_size_bytes` of 1 MiB, so it passes the size gate and lands as megabytes of
+JSON. (This world's 1280×720 frames are three times that and the default cap does drop
+them whole — which is why the benchmark's camera profile has to lift it to measure
+anything at all. Relying on that is a collection policy that silently switches on the day
+someone fits a smaller sensor.) It is `exclude_types` that keeps images out, and removing
+that list removes the protection entirely.
 
 The tempting fix — lower the size cap until frames stop fitting — is a bad trade, because
 **the two limits fail differently**:

--- a/progress.txt
+++ b/progress.txt
@@ -7243,3 +7243,62 @@ eyeballed. `prek run --all-files --skip build-doc` is green.
 and `unknown` otherwise — and routed to the `pgsql` Destination, so the utilisation panels
 populate on the existing demo. The intervention and fault panels stay empty until #362/#365,
 for the same reason a battery panel would.
+
+## #326 - Sim-backed benchmark for raw-mode collection volume
+
+`raw_topics.md`'s "How much data is this?" numbers came from a hand-written topic emulation:
+plausible rates typed into a generator, not a robot. Now they come off the simulated Waffle.
+`tools/sim/scripts/measure_raw_volume.sh` boots `dc_simulation`'s warehouse world headless,
+drives the robot in a slow circle, runs `dc_bridge` in raw mode against its live topics in
+three configurations (`tools/sim/params/raw_{defaults,sensors,camera}.yaml`) and reports
+per-Tag Records, bytes, bytes/Record, publish rate and a projected GB/day. Local and
+informational, in the spirit of `measure_resources.sh` — deliberately not in `ci.yaml`, which
+would pay minutes of gz-sim boot per PR for a number nobody asserts a threshold on.
+
+**The measurement's one real problem: the simulator does not run at real time.** This world
+sits at RTF ~0.04 on 8 CPUs with software rendering, so every wall-clock rate it produces is
+the renderer's number, not the robot's — and worse, `raw.max_rate_hz` limits Records per
+*wall* second, so at that factor the 10 Hz default fires against topics publishing at 250 Hz
+of simulated time (the first trial: 14 859 forwarded, 3 799 dropped rate). Measuring "the
+defaults" that way measures the box. The resolution splits the two halves of the number:
+the profiles collect with the limiter **off**, so every published message becomes a Record;
+the window is counted in *simulated* seconds sampled off `/clock` either side of it; and the
+report multiplies exact bytes-per-Record by `min(published_hz, 10)` — the rate raw mode
+would ship at on a robot where the limiter binds on real time. Bytes per Record are exact
+regardless of how slowly the world runs, and that is what the projection rests on.
+
+Reused rather than reimplemented, per the issue: `check_raw()`'s volume accounting moved to
+`tools/e2e/scripts/raw_volume.py` (`Volume`, `summarize_by_tag()`, `project()`), which the
+E2E verifier now calls for the same `stored_bytes`/`bytes_per_record`/`projected_mb_per_day`
+keys it published before (verified identical against a fixture). One wrinkle the sim exposed:
+with `time_key: "date"`, a Record's sink timestamp is the *message's* header stamp — sim time
+under a simulator, and the Bridge's wall clock for headerless messages, so spans across the
+two are meaningless. Hence `arrival_rates=False` for the sim reporter, which takes its window
+from `/clock` instead. Ten fixture tests (`tools/e2e/test/test_raw_volume.py`) pin the
+accounting; a standalone `raw-volume` CI job runs them (stdlib only, no image, no simulator).
+
+**What the run says.** Defaults: 24 kB/s, 2.1 GB/day. Plus `scan` and `tf`: 5.9 GB/day — the
+lidar alone is 3.5 GB/day at 7 878 bytes a Record and 5 Hz, because it publishes *below* the
+cap and so bills at its real rate, while `imu` at 200 Hz and `joint_states` at 1 000 Hz are
+decimated to 10. Per-Record: JointState 355, TFMessage 406, CameraInfo 581, Odometry 669,
+Imu 767, LaserScan (360 ranges + intensities) 7 878, and a 1280×720 `rgb8` Image **10 981 032**
+— four times its wire size, not the doubling the old text claimed, because most pixel bytes
+print as three digits and a comma.
+
+The camera profile's finding is the one worth having: it is not that images are expensive, it
+is that **the pipeline collapses**. Two cameras at 5 Hz is 110 MB/s of Records; the Shipper
+refused 475 of the 894 offered (53 %), and the rest of the collection went down with them —
+`imu` arrived at 4 Hz instead of 200, `odom` at 0.7 instead of 30, because the Bridge spent
+the window serializing frames. The old doc's "≈1.6 TB/day" reads as a storage bill; the
+measured behaviour is that you lose the robot's other telemetry first. That is now in the
+doc, along with the fact that this world's 2.7 MB frames are *over* the 1 MiB
+`max_message_size_bytes` default (the camera profile has to lift it to measure anything),
+which makes the existing "the size cap will not save you from a camera" argument concrete
+rather than hypothetical.
+
+Verified by running it: three profiles, each a fresh container from the workspace image, with
+the Bridge's own drop counters extracted per run as the fidelity check (`dropped 0 rate /
+0 oversize / 0 shipper / 0 undecodable` for `sensors`; the camera profile's 53 % is reported
+as a warning and folded into the doc rather than hidden). `prek run --all-files --skip
+build-doc` is green, `mdbook build` clean, and `tools/sim/.run/` — which `run.sh` has been
+writing to since #279 without ever being ignored — is now in `.gitignore`.

--- a/tools/e2e/scripts/raw_volume.py
+++ b/tools/e2e/scripts/raw_volume.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Stored-volume accounting for raw-mode (#227) Records.
+
+Both users of it — verify_zero_loss.py's `check_raw()` (one Tag, the E2E harness) and
+tools/sim/scripts/measure_raw_volume.sh's reporter (every Tag, the simulated robot) —
+have to answer the same question the same way, or the doc's numbers and the harness's
+numbers stop being comparable. What a Record *costs* is the bytes the Destination
+actually wrote: the JSON line plus the newline the sink terminates it with.
+"""
+
+import datetime
+import json
+
+
+class Volume:
+    """Bytes, Records and arrival span over one raw Destination's NDJSON output."""
+
+    def __init__(self) -> None:
+        self.records = 0
+        self.stored_bytes = 0
+        self.first_seen: datetime.datetime | None = None
+        self.last_seen: datetime.datetime | None = None
+
+    def add_line(self, line: str) -> None:
+        """Count one stored line, newline included — what the sink wrote to disk."""
+        self.records += 1
+        self.stored_bytes += len(line) + 1
+
+    def add_time(self, stored_at) -> None:
+        """Extend the arrival span with a Record's sink timestamp, if it parses."""
+        if not isinstance(stored_at, str):
+            return
+        try:
+            when = datetime.datetime.fromisoformat(stored_at.replace("Z", "+00:00"))
+        except ValueError:
+            return
+        if self.first_seen is None or when < self.first_seen:
+            self.first_seen = when
+        if self.last_seen is None or when > self.last_seen:
+            self.last_seen = when
+
+    @property
+    def span_seconds(self) -> float | None:
+        """Wall-clock seconds the Records arrived over, or None if unmeasurable.
+
+        Under a second of arrivals is not a rate — dividing by it turns sampling noise
+        into a throughput claim.
+        """
+        if self.first_seen is None or self.last_seen is None:
+            return None
+        span = (self.last_seen - self.first_seen).total_seconds()
+        return span if span >= 1.0 else None
+
+    def summary(self) -> dict:
+        """Volume as the report keys both callers publish."""
+        out = {
+            "stored_bytes": self.stored_bytes,
+            "bytes_per_record": self.stored_bytes // self.records if self.records else None,
+        }
+        span = self.span_seconds
+        if span:
+            out["span_seconds"] = round(span, 1)
+            out["records_per_second"] = round(self.records / span, 2)
+            out["bytes_per_second"] = round(self.stored_bytes / span, 1)
+            out["projected_mb_per_day"] = round(self.stored_bytes / span * 86400 / 1e6, 1)
+        return out
+
+
+def project(summary: dict, sim_seconds: float, max_rate_hz: float) -> dict:
+    """What one Tag's measured volume is worth on a robot running at real time (#326).
+
+    A simulator that runs at a fraction of real time makes wall-clock throughput
+    meaningless — every rate it produces is scaled by the real-time factor. Two things
+    survive that scaling: the bytes a Record costs, and the rate the robot publishes at,
+    which is measured in *simulated* seconds. Multiply them, after applying the rate
+    limiter that would bind on a real robot, and the projection is the robot's, not the
+    simulator's.
+
+    Args:
+        summary: one Tag's entry from `summarize_by_tag()`.
+        sim_seconds: simulated seconds the measurement window covered.
+        max_rate_hz: the profile's `raw.max_rate_hz` (0 = no limiter).
+    """
+    per_record = summary.get("bytes_per_record")
+    if not per_record or sim_seconds <= 0:
+        return {}
+    published_hz = summary["records"] / sim_seconds
+    shipped_hz = min(published_hz, max_rate_hz) if max_rate_hz else published_hz
+    bytes_per_second = per_record * shipped_hz
+    return {
+        "published_hz": round(published_hz, 2),
+        "shipped_hz": round(shipped_hz, 2),
+        "projected_bytes_per_second": round(bytes_per_second, 1),
+        "projected_gb_per_day": round(bytes_per_second * 86400 / 1e9, 3),
+    }
+
+
+def summarize_by_tag(path: str, arrival_rates: bool = True) -> dict:
+    """Per-Tag and total volume over a raw Destination's NDJSON file.
+
+    A line that isn't JSON still cost its bytes, so it counts toward the total under the
+    `(unparsable)` Tag rather than vanishing from the accounting.
+
+    Args:
+        path: the Destination's newline-delimited JSON.
+        arrival_rates: keep the timestamp-derived rates. Off for a simulated robot: the
+            sink timestamp is the Record's `date`, which for a message carrying a
+            `std_msgs/msg/Header` is the *message's* stamp — simulated time under a
+            simulator, and mixed with the Bridge's wall clock for messages without a
+            header. Spans across the two are meaningless; rates there come from the
+            simulated window instead (`project()`).
+    """
+    total = Volume()
+    per_tag: dict[str, Volume] = {}
+
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+                tag = event.get("tag") or "(untagged)"
+                stored_at = event.get("timestamp")
+            except json.JSONDecodeError:
+                tag, stored_at = "(unparsable)", None
+            total.add_line(line)
+            if arrival_rates:
+                total.add_time(stored_at)
+            volume = per_tag.setdefault(tag, Volume())
+            volume.add_line(line)
+            if arrival_rates:
+                volume.add_time(stored_at)
+
+    return {
+        "tags": {
+            tag: {"records": v.records, **v.summary()}
+            for tag, v in sorted(per_tag.items(), key=lambda kv: -kv[1].stored_bytes)
+        },
+        "total": {"records": total.records, **total.summary()},
+    }

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -60,11 +60,12 @@ Checks:
 """
 
 import argparse
-import datetime
 import json
 import os
 import subprocess
 import sys
+
+import raw_volume
 
 # Records lost at a point where the harness kills the workload generator — the mid-run
 # container restart, and the stop that ends the run. The generator publishes from inside
@@ -535,8 +536,8 @@ def check_raw(
     # the wall-clock span they arrived over, so every run reports what "collect this
     # topic raw" is worth in MB/day rather than leaving operators to guess. Reported,
     # never gated: throughput on a CI runner is not a property worth failing a build on.
-    total_bytes = 0
-    event_times: list = []
+    # Shared with the sim-backed benchmark (#326) so both report the same accounting.
+    volume = raw_volume.Volume()
 
     with open(path) as f:
         for line in f:
@@ -544,7 +545,7 @@ def check_raw(
             if not line:
                 continue
             total_lines += 1
-            total_bytes += len(line) + 1  # the newline the sink wrote
+            volume.add_line(line)
             try:
                 event = json.loads(line)
             except json.JSONDecodeError:
@@ -554,14 +555,7 @@ def check_raw(
                 unexpected_tags.add(event.get("tag"))
                 continue
             namespace_events += 1
-            stored_at = event.get("timestamp")
-            if isinstance(stored_at, str):
-                try:
-                    event_times.append(
-                        datetime.datetime.fromisoformat(stored_at.replace("Z", "+00:00"))
-                    )
-                except ValueError:
-                    pass
+            volume.add_time(event.get("timestamp"))
             # The introspection walk has to have produced every field of the message:
             # the two `string`s, and the nested Header with its nested builtin Time.
             stamp = (event.get("header") or {}).get("stamp") or {}
@@ -587,16 +581,8 @@ def check_raw(
         "distinct_values": len(arrived),
         "first_value": min(arrived) if arrived else None,
         "last_value": max(arrived) if arrived else None,
-        "stored_bytes": total_bytes,
-        "bytes_per_record": total_bytes // total_lines if total_lines else None,
+        **volume.summary(),
     }
-    # Only meaningful with two timestamps far enough apart to divide by.
-    if len(event_times) >= 2:
-        span = (max(event_times) - min(event_times)).total_seconds()
-        if span >= 1.0:
-            details["raw"]["span_seconds"] = round(span, 1)
-            details["raw"]["bytes_per_second"] = round(total_bytes / span, 1)
-            details["raw"]["projected_mb_per_day"] = round(total_bytes / span * 86400 / 1e6, 1)
 
     if total_lines == 0:
         violations.append(

--- a/tools/e2e/test/test_raw_volume.py
+++ b/tools/e2e/test/test_raw_volume.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Fixture tests for the shared raw-volume accounting (tools/e2e/scripts/raw_volume.py).
+
+Two consumers now publish figures from this module — the E2E harness's zero-loss verifier
+and the sim-backed benchmark (#326) whose numbers doc/src/dc/raw_topics.md quotes — so
+what a Record is counted as costing is worth pinning down.
+"""
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+import raw_volume
+
+
+def write_ndjson(path, events):
+    with open(path, "w") as f:
+        for event in events:
+            f.write(json.dumps(event, sort_keys=True) + "\n")
+    return str(path)
+
+
+@pytest.fixture
+def two_tags(tmp_path):
+    """Ten Records over two Tags, one arriving every second."""
+    events = [
+        {"tag": "dc.raw.imu", "timestamp": f"2026-08-18T09:00:{i:02d}.000Z", "value": i}
+        for i in range(10)
+    ]
+    events += [
+        {"tag": "dc.raw.odom", "timestamp": f"2026-08-18T09:00:{i:02d}.000Z", "pad": "x" * 100}
+        for i in range(4)
+    ]
+    return write_ndjson(tmp_path / "raw.ndjson", events)
+
+
+def test_a_record_costs_its_line_plus_its_newline(tmp_path):
+    path = write_ndjson(tmp_path / "raw.ndjson", [{"tag": "dc.raw.imu"}])
+    report = raw_volume.summarize_by_tag(path)
+    assert report["total"]["stored_bytes"] == os.path.getsize(path)
+    assert report["total"]["bytes_per_record"] == os.path.getsize(path)
+
+
+def test_volume_is_split_per_tag_and_summed(two_tags):
+    report = raw_volume.summarize_by_tag(two_tags)
+    tags = report["tags"]
+    assert set(tags) == {"dc.raw.imu", "dc.raw.odom"}
+    assert tags["dc.raw.imu"]["records"] == 10
+    assert tags["dc.raw.odom"]["records"] == 4
+    assert report["total"]["records"] == 14
+    assert (
+        tags["dc.raw.imu"]["stored_bytes"] + tags["dc.raw.odom"]["stored_bytes"]
+        == report["total"]["stored_bytes"]
+    )
+    # Biggest first: the report's whole job is saying what to exclude.
+    stored = [v["stored_bytes"] for v in tags.values()]
+    assert stored == sorted(stored, reverse=True)
+
+
+def test_arrival_rates_come_from_the_sink_timestamps(two_tags):
+    imu = raw_volume.summarize_by_tag(two_tags)["tags"]["dc.raw.imu"]
+    assert imu["span_seconds"] == 9.0
+    assert imu["records_per_second"] == round(10 / 9, 2)
+    assert imu["bytes_per_second"] == round(imu["stored_bytes"] / 9, 1)
+    assert imu["projected_mb_per_day"] == round(imu["stored_bytes"] / 9 * 86400 / 1e6, 1)
+
+
+def test_arrival_rates_are_omitted_when_asked(two_tags):
+    imu = raw_volume.summarize_by_tag(two_tags, arrival_rates=False)["tags"]["dc.raw.imu"]
+    assert "span_seconds" not in imu
+    assert imu["bytes_per_record"] > 0
+
+
+def test_a_span_under_a_second_is_not_a_rate(tmp_path):
+    path = write_ndjson(
+        tmp_path / "raw.ndjson",
+        [{"tag": "dc.raw.imu", "timestamp": f"2026-08-18T09:00:00.{i:03d}Z"} for i in range(3)],
+    )
+    assert "bytes_per_second" not in raw_volume.summarize_by_tag(path)["tags"]["dc.raw.imu"]
+
+
+def test_unreadable_lines_still_cost_their_bytes(tmp_path):
+    path = tmp_path / "raw.ndjson"
+    path.write_text('{"tag": "dc.raw.imu"}\nnot json at all\n\n')
+    report = raw_volume.summarize_by_tag(str(path))
+    assert report["total"]["records"] == 2
+    assert report["tags"]["(unparsable)"]["records"] == 1
+    # Everything but the blank line, which is no Record and cost nothing to store.
+    assert report["total"]["stored_bytes"] == os.path.getsize(path) - 1
+
+
+def test_the_projection_caps_the_publish_rate_at_the_limiter():
+    summary = {"records": 2000, "bytes_per_record": 500}
+    projected = raw_volume.project(summary, sim_seconds=10.0, max_rate_hz=10.0)
+    assert projected["published_hz"] == 200.0
+    assert projected["shipped_hz"] == 10.0
+    assert projected["projected_bytes_per_second"] == 5000.0
+    assert projected["projected_gb_per_day"] == round(5000 * 86400 / 1e9, 3)
+
+
+def test_a_topic_slower_than_the_limiter_is_projected_whole():
+    summary = {"records": 50, "bytes_per_record": 600}
+    projected = raw_volume.project(summary, sim_seconds=10.0, max_rate_hz=10.0)
+    assert projected["published_hz"] == 5.0
+    assert projected["shipped_hz"] == 5.0
+    assert projected["projected_bytes_per_second"] == 3000.0
+
+
+def test_an_unlimited_profile_projects_the_full_publish_rate():
+    summary = {"records": 2000, "bytes_per_record": 500}
+    assert raw_volume.project(summary, 10.0, max_rate_hz=0)["shipped_hz"] == 200.0
+
+
+def test_nothing_measured_projects_nothing():
+    assert raw_volume.project({"records": 0, "bytes_per_record": None}, 10.0, 10.0) == {}
+    assert raw_volume.project({"records": 5, "bytes_per_record": 100}, 0.0, 10.0) == {}

--- a/tools/sim/params/raw_camera.yaml
+++ b/tools/sim/params/raw_camera.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Profile `camera` of the sim-backed raw-volume benchmark (#326): profile `sensors` with
+# the two RGB cameras put back as well — the configuration doc/src/dc/raw_topics.md warns
+# against, measured instead of asserted.
+#
+# Two deliberate choices. The depth images stay excluded by name: they are a second, far
+# larger firehose (float32 per pixel, ~18 JSON characters each), and the point being
+# measured is what one ordinary colour camera costs. And `max_message_size_bytes: 0`,
+# because this world's cameras are 1280x720 — a 2.7 MB serialized frame that the default
+# 1 MiB circuit breaker drops whole, which would measure the breaker rather than the
+# camera.
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "/root/.dc/buffer"
+
+    destinations: ["raw_file"]
+    raw_file:
+      type: file
+      receives: records
+      path: "/root/.dc/raw/records.ndjson"
+      time_key: "date"
+
+    raw:
+      enabled: true
+      destination: "raw_file"
+      include: ["^/"]
+      exclude:
+        - "^/rosout$"
+        - "^/parameter_events$"
+        - "^/dc/measurement/"
+        - "^/dc/group/"
+        - "^/clock$"
+        - "^/cmd_vel$"
+        - "/depth/image_raw$"
+      # Nothing excluded by type at all: this is what removing the list gets you.
+      exclude_types: ["^$"]
+      rescan_interval_secs: 5.0
+      qos_depth: 10
+      # Deliberately uncapped, unlike the shipped default of 10: `max_rate_hz` limits
+      # Records per *wall-clock* second, and a world that runs at a few percent of real
+      # time would meet that limit at a sim-time rate ~25x the one a robot publishes at,
+      # measuring the simulator's slowness instead of the robot's traffic. Collect every
+      # message, measure the rate in simulated seconds, and let the report apply the
+      # default cap to the projection (report_raw_volume.py --max-rate-hz).
+      max_rate_hz: 0.0
+      max_message_size_bytes: 0
+      tag_prefix: "dc.raw."
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224

--- a/tools/sim/params/raw_defaults.yaml
+++ b/tools/sim/params/raw_defaults.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Profile `defaults` of the sim-backed raw-volume benchmark (#326): dc_bringup's shipped
+# dc_raw_params.yaml, pointed at a `file` Destination the harness can measure.
+#
+# The two departures from the shipped defaults are the Destination (a file instead of the
+# console) and `/clock` and `/cmd_vel` in `exclude` — both exist only because the robot is
+# simulated and driven by the benchmark, so collecting them would put simulator artefacts
+# in a figure that claims to describe a robot. See tools/sim/scripts/measure_raw_volume.sh.
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "/root/.dc/buffer"
+
+    destinations: ["raw_file"]
+    raw_file:
+      type: file
+      receives: records
+      # No `inputs`: raw mode routes to this Destination by Tag namespace, not by topic.
+      path: "/root/.dc/raw/records.ndjson"
+      time_key: "date"
+
+    raw:
+      enabled: true
+      destination: "raw_file"
+      include: ["^/"]
+      exclude:
+        - "^/rosout$"
+        - "^/parameter_events$"
+        - "^/dc/measurement/"
+        - "^/dc/group/"
+        - "^/clock$"
+        - "^/cmd_vel$"
+      exclude_types:
+        - "^sensor_msgs/msg/(Image|CompressedImage|PointCloud|PointCloud2|LaserScan)$"
+        - "^tf2_msgs/msg/TFMessage$"
+      rescan_interval_secs: 5.0
+      qos_depth: 10
+      # Deliberately uncapped, unlike the shipped default of 10: `max_rate_hz` limits
+      # Records per *wall-clock* second, and a world that runs at a few percent of real
+      # time would meet that limit at a sim-time rate ~25x the one a robot publishes at,
+      # measuring the simulator's slowness instead of the robot's traffic. Collect every
+      # message, measure the rate in simulated seconds, and let the report apply the
+      # default cap to the projection (report_raw_volume.py --max-rate-hz).
+      max_rate_hz: 0.0
+      max_message_size_bytes: 1048576
+      tag_prefix: "dc.raw."
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224

--- a/tools/sim/params/raw_sensors.yaml
+++ b/tools/sim/params/raw_sensors.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Profile `sensors` of the sim-backed raw-volume benchmark (#326): profile `defaults`
+# with the lidar and TF put back — the two exclusions an operator most often reverses,
+# and the ones that cost the most before an image topic is involved.
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "/root/.dc/buffer"
+
+    destinations: ["raw_file"]
+    raw_file:
+      type: file
+      receives: records
+      path: "/root/.dc/raw/records.ndjson"
+      time_key: "date"
+
+    raw:
+      enabled: true
+      destination: "raw_file"
+      include: ["^/"]
+      exclude:
+        - "^/rosout$"
+        - "^/parameter_events$"
+        - "^/dc/measurement/"
+        - "^/dc/group/"
+        - "^/clock$"
+        - "^/cmd_vel$"
+      # LaserScan and TFMessage removed from the default list; images stay out.
+      exclude_types:
+        - "^sensor_msgs/msg/(Image|CompressedImage|PointCloud|PointCloud2)$"
+      rescan_interval_secs: 5.0
+      qos_depth: 10
+      # Deliberately uncapped, unlike the shipped default of 10: `max_rate_hz` limits
+      # Records per *wall-clock* second, and a world that runs at a few percent of real
+      # time would meet that limit at a sim-time rate ~25x the one a robot publishes at,
+      # measuring the simulator's slowness instead of the robot's traffic. Collect every
+      # message, measure the rate in simulated seconds, and let the report apply the
+      # default cap to the projection (report_raw_volume.py --max-rate-hz).
+      max_rate_hz: 0.0
+      max_message_size_bytes: 1048576
+      tag_prefix: "dc.raw."
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224

--- a/tools/sim/scripts/measure_raw_volume.sh
+++ b/tools/sim/scripts/measure_raw_volume.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# What raw-mode collection costs on a real robot (#326). From the repo root:
+#
+#   ./tools/sim/scripts/measure_raw_volume.sh
+#
+# Boots dc_simulation's warehouse world headless in a container from the DC workspace
+# image, drives the TurtleBot3-Waffle in a slow circle, runs `dc_bridge` in raw mode
+# (#227) against its live topics, and reports per-Tag and total volume — Records, bytes
+# per Record, publish rate and a projected GB/day — for each of three configurations
+# (see tools/sim/params/raw_*.yaml). Informational and local: a number nobody asserts a
+# threshold on has no business gating a PR, and booting gz-sim would make every E2E run
+# minutes slower. It is deliberately not wired into ci.yaml.
+#
+# It needs the same workspace image tools/sim/scripts/run.sh uses (build it with
+# tools/e2e/scripts/build.sh, or set DC_SIM_IMAGE to one you have) and podman. An
+# equivalent local ROS 2 Jazzy + gz-sim Harmonic workspace works too, if you would rather
+# run the four steps by hand.
+#
+# Rates are measured in *simulated* seconds, not wall-clock ones. The warehouse is 317
+# model instances with two RGBD cameras and a lidar, and a machine with no GPU runs it far
+# under real time — a wall-clock throughput measured here would be the renderer's number,
+# not the robot's. Bytes per Record are exact regardless, so the profiles collect with the
+# rate limiter switched off (see the params files), the window is counted in simulated
+# seconds, and the report multiplies bytes per Record by the rate raw mode would actually
+# ship at on a robot running at real time — the publish rate, capped at the shipped
+# `max_rate_hz` default. A run therefore takes as long in wall-clock as this machine needs.
+#
+# Env vars (all optional):
+#   DC_SIM_IMAGE          workspace image to run (default dc-workspace:latest).
+#   DC_RAW_PROFILES       space-separated subset of: defaults sensors camera (all three
+#                         by default), each a file in tools/sim/params/raw_<name>.yaml.
+#   DC_RAW_SIM_SECONDS    simulated seconds to measure over (default 10).
+#   DC_RAW_CAMERA_SIM_SECONDS  the same for the `camera` profile (default 15). Ten
+#                         1280x720 frames a simulated second is ~110 MB of JSON, which
+#                         nothing downstream carries — expect the Bridge to shed most of
+#                         it and the window to hold a handful of frames.
+#   DC_RAW_WALL_TIMEOUT   wall-clock seconds a window may take before it is cut short and
+#                         reported over the simulated time it did cover (default 1800).
+#   DC_RAW_PROJECT_RATE_HZ  the `raw.max_rate_hz` the projection assumes (default 10, the
+#                         value dc_bringup/params/dc_raw_params.yaml ships; 0 = none).
+#   DC_SIM_KEEP           "true" to leave the last profile's container up for inspection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIM_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_DIR="$SIM_DIR/.run"
+
+IMAGE="${DC_SIM_IMAGE:-dc-workspace:latest}"
+PROFILES="${DC_RAW_PROFILES:-defaults sensors camera}"
+SIM_SECONDS="${DC_RAW_SIM_SECONDS:-10}"
+CAMERA_SIM_SECONDS="${DC_RAW_CAMERA_SIM_SECONDS:-15}"
+WALL_TIMEOUT="${DC_RAW_WALL_TIMEOUT:-1800}"
+PROJECT_RATE_HZ="${DC_RAW_PROJECT_RATE_HZ:-10}"
+KEEP="${DC_SIM_KEEP:-false}"
+CONTAINER=""
+
+log() { printf '\n\033[1m[raw-volume] %s\033[0m\n' "$*"; }
+fail() { printf '\n\033[1;31m[raw-volume] FAILED: %s\033[0m\n' "$*" >&2; exit 1; }
+
+for profile in $PROFILES; do
+  [ -f "$SIM_DIR/params/raw_$profile.yaml" ] || fail "no profile 'raw_$profile.yaml' in $SIM_DIR/params"
+done
+[[ "$SIM_SECONDS" =~ ^[0-9]+$ ]] || fail "DC_RAW_SIM_SECONDS must be a number, got '$SIM_SECONDS'"
+
+cleanup() {
+  local rc=$?
+  [ -n "$CONTAINER" ] || exit $rc
+  if [ "$KEEP" = "true" ]; then
+    log "DC_SIM_KEEP=true — leaving $CONTAINER running"
+    exit $rc
+  fi
+  podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  exit $rc
+}
+trap cleanup EXIT
+
+SOURCE='source /opt/ros/jazzy/setup.bash && source /root/ws/install/setup.bash'
+rin() { podman exec -e HOME=/root "$CONTAINER" bash -lc "$1"; }
+rbg() { podman exec -d -e HOME=/root "$CONTAINER" bash -lc "$1" >/dev/null; }
+
+# Simulated seconds, as a float, from the /clock the ros_gz_bridge republishes.
+sim_now() {
+  local out
+  out="$(rin "$SOURCE && timeout 30 ros2 topic echo --once --field clock /clock 2>/dev/null" |
+    awk '/^ *sec:/ { s = $2 } /^ *nanosec:/ { printf "%.3f", s + $2 / 1e9; exit }')"
+  [ -n "$out" ] || fail "could not read /clock — the simulation is not publishing time"
+  printf '%s' "$out"
+}
+
+mkdir -p "$RUN_DIR"
+
+for profile in $PROFILES; do
+  CONTAINER="dc-rawvol-$$-$profile"
+  log "profile '$profile': starting $CONTAINER from $IMAGE"
+  podman run -d --name "$CONTAINER" --shm-size=2g \
+    -v "$SIM_DIR/params:/opt/params:ro,Z" \
+    "$IMAGE" sleep infinity >/dev/null
+
+  log "launching the warehouse world headless"
+  rbg "$SOURCE && ros2 launch dc_simulation warehouse.launch.py headless:=True > /tmp/warehouse.log 2>&1"
+
+  # Same load-bearing assertion as tools/sim/scripts/run.sh: an illegal-SDF spawn
+  # rejection is one [Err] line, and everything downstream then measures an empty world.
+  waited=0
+  until rin "source /opt/ros/jazzy/setup.bash && timeout 30 gz model --list 2>/dev/null | grep -q turtlebot3_waffle" >/dev/null 2>&1; do
+    [ "$waited" -lt 900 ] || fail "turtlebot3_waffle never appeared in gz model --list"
+    sleep 15
+    waited=$((waited + 15))
+  done
+  log "robot spawned after ${waited}s"
+
+  # A stationary robot is the wrong thing to measure: odometry and TF of a robot that is
+  # not moving are zeros, and a JSON zero is a fraction of the ~17 characters a real
+  # double costs. Drive it in a slow circle instead. The publisher runs on wall time, so
+  # /cmd_vel itself is excluded from collection (see the params files).
+  rbg "$SOURCE && ros2 topic pub -r 1 /cmd_vel geometry_msgs/msg/Twist '{linear: {x: 0.15}, angular: {z: 0.3}}' > /tmp/drive.log 2>&1"
+
+  # Under the camera profile the graph query itself gets slow; a miss here only
+  # costs the report its type column.
+  rin "$SOURCE && timeout 180 ros2 topic list -t > /tmp/topics.txt 2>/dev/null" || true
+
+  log "launching dc_bridge in raw mode (profile '$profile')"
+  rbg "$SOURCE && ros2 launch dc_bringup dc_raw.launch.py dc_params_file:=/opt/params/raw_$profile.yaml > /tmp/bridge.log 2>&1"
+
+  RAW=/root/.dc/raw/records.ndjson
+  waited=0
+  until rin "test -s $RAW" >/dev/null 2>&1; do
+    [ "$waited" -lt 300 ] || fail "no raw Record reached the Destination in ${waited}s (see $RUN_DIR/$profile.bridge.log)"
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "first Record stored after ${waited}s — measuring"
+
+  # The window is the lines that appeared between the two marks, so nothing has to be
+  # killed to end it: the sink keeps appending, and the report reads only the slice. The
+  # sim clock is sampled next to each line count so the two windows line up.
+  if [ "$profile" = "camera" ]; then want="$CAMERA_SIM_SECONDS"; else want="$SIM_SECONDS"; fi
+  line0="$(rin "wc -l < $RAW" | tr -dc '0-9')"
+  sim0="$(sim_now)"
+  wall0="$(date +%s)"
+  while :; do
+    sim1="$(sim_now)"
+    wall1="$(date +%s)"
+    elapsed_sim="$(awk -v a="$sim0" -v b="$sim1" 'BEGIN { printf "%.2f", b - a }')"
+    if awk -v e="$elapsed_sim" -v w="$want" 'BEGIN { exit !(e >= w) }'; then break; fi
+    if [ $((wall1 - wall0)) -ge "$WALL_TIMEOUT" ]; then
+      log "wall-clock timeout after $((wall1 - wall0))s — reporting over ${elapsed_sim} simulated seconds"
+      break
+    fi
+    sleep 20
+  done
+  line1="$(rin "wc -l < $RAW" | tr -dc '0-9')"
+  log "${elapsed_sim}s of simulated time over $((wall1 - wall0))s wall, $((line1 - line0)) Records"
+
+  rin "sed -n '$((line0 + 1)),${line1}p' $RAW" > "$RUN_DIR/$profile.ndjson"
+  rin "cat /tmp/topics.txt" > "$RUN_DIR/$profile.topics.txt" 2>/dev/null || true
+  rin "cat /tmp/bridge.log" > "$RUN_DIR/$profile.bridge.log" 2>/dev/null || true
+  # The Bridge's own drop counters. Collection here is uncapped on purpose, so anything
+  # but zeros means the measurement saw fewer messages than the robot published.
+  rin "$SOURCE && timeout 60 ros2 service call /dc_bridge/ready std_srvs/srv/Trigger" \
+    > "$RUN_DIR/$profile.ready.txt" 2>&1 || true
+  counters="$(grep -o "raw: .*" "$RUN_DIR/$profile.ready.txt" | tail -1 || true)"
+  log "bridge counters — ${counters:-unavailable}"
+  if [ -z "$counters" ]; then
+    log "WARNING: could not read the Bridge's counters — drops would be invisible"
+  else
+    shed="$(printf '%s' "$counters" |
+      awk '{ f = 0; d = 0
+             for (i = 1; i <= NF; i++) {
+               if ($i == "forwarded,") f = $(i - 1)
+               if ($i ~ /^(rate|oversize|shipper|undecodable)/) d += $(i - 1)
+             }
+             if (f + d > 0) printf "%d %.2f", d, 100 * d / (f + d) }')"
+    read -r dropped share <<< "$shed"
+    if [ "${dropped:-0}" -gt 0 ]; then
+      log "WARNING: the Bridge shed $dropped Record(s) ($share% of what it saw) — the figures below undercount by that much"
+    fi
+  fi
+
+  python3 "$SCRIPT_DIR/report_raw_volume.py" "$RUN_DIR/$profile.ndjson" \
+    --profile "$profile" \
+    --sim-seconds "$elapsed_sim" \
+    --wall-seconds "$((wall1 - wall0))" \
+    --max-rate-hz "$PROJECT_RATE_HZ" \
+    --topic-types "$RUN_DIR/$profile.topics.txt" \
+    --json "$RUN_DIR/$profile.volume.json" || fail "reporting profile '$profile'"
+
+  if [ "$KEEP" != "true" ]; then
+    podman rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    CONTAINER=""
+  fi
+done
+
+log "done — reports in $RUN_DIR/*.volume.json"

--- a/tools/sim/scripts/report_raw_volume.py
+++ b/tools/sim/scripts/report_raw_volume.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Per-Tag volume report for the sim-backed raw-mode benchmark (#326).
+
+Reads the NDJSON one profile's `file` Destination collected (see
+tools/sim/scripts/measure_raw_volume.sh) and prints what raw mode costs, per Tag and in
+total. The accounting itself is tools/e2e/scripts/raw_volume.py — the same code the E2E
+harness's zero-loss verifier reports `stored_bytes`/`bytes_per_record` with, so the two
+sets of numbers mean the same thing.
+
+Rates are computed in *simulated* seconds and the projection is the robot's, not this
+machine's: see `raw_volume.project()`.
+"""
+
+import argparse
+import json
+import os
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+        "e2e",
+        "scripts",
+    ),
+)
+
+import raw_volume
+
+
+def topic_of(tag: str, prefix: str = "dc.raw.") -> str:
+    """The topic a raw Tag came from — the Tag mapping of raw_topics.md, reversed."""
+    return "/" + tag[len(prefix) :].replace(".", "/") if tag.startswith(prefix) else tag
+
+
+def human(n: float) -> str:
+    for unit, scale in (("GB", 1e9), ("MB", 1e6), ("kB", 1e3)):
+        if n >= scale:
+            return f"{n / scale:.2f} {unit}"
+    return f"{n:.0f} B"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ndjson", help="the profile's raw Destination output")
+    parser.add_argument("--profile", default="", help="profile name, for the heading")
+    parser.add_argument(
+        "--sim-seconds", type=float, required=True, help="simulated seconds the window covered"
+    )
+    parser.add_argument(
+        "--wall-seconds", type=float, required=True, help="wall-clock seconds it took"
+    )
+    parser.add_argument(
+        "--max-rate-hz",
+        type=float,
+        default=10.0,
+        help="the profile's raw.max_rate_hz, applied to the projection (0 = unlimited)",
+    )
+    parser.add_argument(
+        "--topic-types", help="`ros2 topic list -t` output, to name each Tag's message type"
+    )
+    parser.add_argument("--json", help="also write the report as JSON here")
+    args = parser.parse_args()
+
+    if not os.path.exists(args.ndjson) or os.path.getsize(args.ndjson) == 0:
+        print(f"no raw Records at {args.ndjson} — the profile collected nothing", file=sys.stderr)
+        return 1
+
+    types = {}
+    if args.topic_types and os.path.exists(args.topic_types):
+        for line in open(args.topic_types):
+            topic, _, rest = line.strip().partition(" [")
+            if rest.endswith("]"):
+                types[topic] = rest[:-1]
+
+    report = raw_volume.summarize_by_tag(args.ndjson, arrival_rates=False)
+    rtf = args.sim_seconds / args.wall_seconds if args.wall_seconds else 0.0
+    report["window"] = {
+        "profile": args.profile,
+        "sim_seconds": round(args.sim_seconds, 2),
+        "wall_seconds": round(args.wall_seconds, 1),
+        "real_time_factor": round(rtf, 4),
+        "max_rate_hz": args.max_rate_hz,
+    }
+
+    total_projected = 0.0
+    for tag, summary in report["tags"].items():
+        summary["topic"] = topic_of(tag)
+        summary["message_type"] = types.get(summary["topic"], "?")
+        summary.update(raw_volume.project(summary, args.sim_seconds, args.max_rate_hz))
+        total_projected += summary.get("projected_bytes_per_second", 0.0)
+    report["total"]["projected_bytes_per_second"] = round(total_projected, 1)
+    report["total"]["projected_gb_per_day"] = round(total_projected * 86400 / 1e9, 3)
+
+    heading = f"raw-mode volume — profile '{args.profile}'" if args.profile else "raw-mode volume"
+    print(f"\n{heading}")
+    print(
+        f"  window: {args.sim_seconds:.1f} simulated seconds over {args.wall_seconds:.0f} s "
+        f"wall (real-time factor {rtf:.3f}), max_rate_hz {args.max_rate_hz:g}"
+    )
+    header = (
+        f"{'topic':<46} {'type':<34} {'recs':>6} {'B/rec':>9} {'Hz':>7} {'B/s':>11} {'GB/day':>8}"
+    )
+    print(f"\n{header}\n{'-' * len(header)}")
+    for summary in report["tags"].values():
+        print(
+            f"{summary['topic']:<46} {summary['message_type']:<34} {summary['records']:>6} "
+            f"{summary['bytes_per_record'] or 0:>9} {summary.get('published_hz', 0):>7.1f} "
+            f"{summary.get('projected_bytes_per_second', 0):>11,.0f} "
+            f"{summary.get('projected_gb_per_day', 0):>8.3f}"
+        )
+    print(f"{'-' * len(header)}")
+    total = report["total"]
+    print(
+        f"{'TOTAL':<46} {'':<34} {total['records']:>6} {'':>9} {'':>7} "
+        f"{total['projected_bytes_per_second']:>11,.0f} {total['projected_gb_per_day']:>8.3f}"
+    )
+    print(
+        f"\n  stored: {human(total['stored_bytes'])} in this window; projected "
+        f"{human(total['projected_bytes_per_second'] * 3600)}/hour, "
+        f"{total['projected_gb_per_day']:.2f} GB/day"
+    )
+
+    # Which topics the projection's rate limiter actually decimates — the difference
+    # between what the robot publishes and what raw mode would ship.
+    capped = [
+        f"{s['topic']} ({s['published_hz']:g} Hz)"
+        for s in report["tags"].values()
+        if args.max_rate_hz and s.get("published_hz", 0) > args.max_rate_hz
+    ]
+    if capped:
+        print(
+            f"\n  decimated to {args.max_rate_hz:g} Hz by max_rate_hz in the projection: "
+            f"{', '.join(capped)}"
+        )
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"\n  report: {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
`doc/src/dc/raw_topics.md`'s "How much data is this?" table came from a hand-written topic
emulation — plausible rates typed into a generator. It now comes off the simulated robot.

`tools/sim/scripts/measure_raw_volume.sh` boots `dc_simulation`'s warehouse world headless,
drives the TurtleBot3-Waffle in a slow circle, runs `dc_bridge` in raw mode (#227) against
its live topics in three configurations, and reports per-Tag Records, bytes, bytes/Record,
publish rate and a projected GB/day:

```bash
./tools/sim/scripts/measure_raw_volume.sh          # all three profiles
DC_RAW_PROFILES=defaults ./tools/sim/scripts/measure_raw_volume.sh
```

Local and informational, in the spirit of `measure_resources.sh` — **not** wired into
`ci.yaml`, which would pay minutes of gz-sim boot per PR for a number nobody asserts a
threshold on.

## The measurement problem, and how it is resolved

The world runs at ~4 % of real time on 8 CPUs with software rendering, and `raw.max_rate_hz`
limits Records per **wall** second — so at that factor the 10 Hz default fires against topics
publishing at 250 Hz of simulated time (first trial: 14 859 forwarded, 3 799 dropped rate).
Measuring "the defaults" that way measures the box, not the robot.

So the two halves of the number are measured separately:

- the profiles collect with the limiter **off**, so every published message becomes a Record;
- the window is counted in **simulated** seconds, sampled off `/clock` either side of it;
- the report multiplies exact bytes-per-Record by `min(published_hz, max_rate_hz)` — the rate
  raw mode ships at on a robot where the limiter binds on real time.

Bytes per Record are exact however slowly the world runs, and that is what the projection
rests on.

## Reuse, not reimplementation

`check_raw()`'s volume accounting moved to `tools/e2e/scripts/raw_volume.py` (`Volume`,
`summarize_by_tag()`, `project()`); the E2E verifier calls it for the same
`stored_bytes`/`bytes_per_record`/`projected_mb_per_day` keys it published before, verified
identical against a fixture. One wrinkle the sim exposed: with `time_key: "date"` a Record's
sink timestamp is the *message's* header stamp — sim time under a simulator, wall clock for
headerless messages — so the sim reporter takes its window from `/clock` instead
(`arrival_rates=False`).

Ten fixture tests (`tools/e2e/test/test_raw_volume.py`) pin the accounting, run by a new
standalone `raw-volume` CI job (stdlib only — no image, no simulator, no database).

## What the run says

| Configuration | Shipped |
|---|---|
| Defaults (10 Hz cap, sensor types excluded) | 24 kB/s — 86 MB/hour, **2.1 GB/day** |
| …plus `scan` and `tf` | 69 kB/s — **5.9 GB/day** |
| …plus both 1280×720 cameras | ≈ **9.5 TB/day**, if anything could carry it |

Per Record: JointState 355, TFMessage 406, CameraInfo 581, Odometry 669, Imu 767, LaserScan
(360 ranges + intensities) 7 878, and a 1280×720 `rgb8` Image **10 981 032** — four times its
wire size, not the doubling the old text claimed.

The camera profile's finding is the one worth having: it is not that images are expensive, it
is that the pipeline **collapses**. Two cameras at 5 Hz is 110 MB/s of Records; the Shipper
refused 475 of the 894 offered (53 %), and the rest of the collection went with them — `imu`
arrived at 4 Hz instead of 200, `odom` at 0.7 instead of 30. The doc now says that, along with
the fact that this world's 2.7 MB frames are *over* the 1 MiB `max_message_size_bytes` default,
which makes the existing "the size cap will not save you from a camera" argument concrete.

## Verification

Run for real, three profiles, each a fresh container from the workspace image, with the
Bridge's own drop counters extracted per run as the fidelity check (`dropped 0 rate /
0 oversize / 0 shipper / 0 undecodable` for `sensors`; the camera profile's 53 % is reported
as a warning and folded into the doc rather than hidden). `prek run --all-files --skip
build-doc` green, `mdbook build` clean, 10/10 fixture tests pass. `tools/sim/.run/` — written
by `run.sh` since #279 and never ignored — is now in `.gitignore`.

Closes #326