### PR TITLE
test(dc_measurements): cover one FlushEvent releasing several Measurements

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -333,6 +333,7 @@ set(tests
   test_measurement_random
   test_measurement_same_as_previous
   test_measurement_serial_interface
+  test_measurement_shared_flush
   test_measurement_speed
   test_measurement_storage
   test_measurement_string_match

--- a/dc_measurements/test/test_measurement_shared_flush.cpp
+++ b/dc_measurements/test/test_measurement_shared_flush.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <functional>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "dc_interfaces/msg/flush_event.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+
+using json = nlohmann::json;
+
+namespace
+{
+// A non-default topic, so the test also covers several Measurements being pointed at a shared
+// flush topic of the deployment's choosing.
+const char* const kFlushTopic = "/dc/incident_flush";
+const char* const kFast = "dummy_fast";
+const char* const kSlow = "dummy_slow";
+const char* const kLive = "dummy_live";
+const int kFastPollingMs = 50;
+const int kSlowPollingMs = 150;
+}  // namespace
+
+// The fan-out half of the flush contract (#345): one FlushEvent, several Measurements, one
+// incident_id. Two Measurements buffer on the same flush topic at different polling rates; a
+// third has no buffer_duration_sec at all and so subscribes to nothing.
+class MeasurementSharedFlushTest : public ::testing::Test
+{
+protected:
+  MeasurementSharedFlushTest()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    received_.clear();
+    subs_.clear();
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ kFast, kSlow, kLive });
+    flush_pub_ = ms_node_->create_publisher<dc_interfaces::msg::FlushEvent>(kFlushTopic, rclcpp::QoS(10));
+
+    declareMeasurement(kFast, kFastPollingMs);
+    declareMeasurement(kSlow, kSlowPollingMs);
+    declareMeasurement(kLive, kFastPollingMs);
+
+    for (const std::string& name : { std::string(kFast), std::string(kSlow) })
+    {
+      ms_node_->declare_parameter(name + ".buffer_duration_sec", 10.0);
+      ms_node_->declare_parameter(name + ".flush_topic", std::string(kFlushTopic));
+      // data_pub_ is KeepLast(1): pacing the release keeps every Record of the window deliverable
+      // rather than only the last one of a synchronous burst (#289).
+      ms_node_->declare_parameter(name + ".max_flush_rate_hz", 20.0);
+    }
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareMeasurement(const std::string& name, const int polling_interval)
+  {
+    const std::string topic = "/dc/measurement/" + name;
+    ms_node_->declare_parameter(name + ".plugin", std::string("dc_measurements/Dummy"));
+    ms_node_->declare_parameter(name + ".topic_output", topic);
+    ms_node_->declare_parameter(name + ".record", json({ { "message", name } }).dump());
+    ms_node_->declare_parameter(name + ".polling_interval", polling_interval);
+    subs_.push_back(ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        topic, rclcpp::SystemDefaultsQoS(),
+        [this, name](const dc_interfaces::msg::StringStamped& msg) { received_[name].push_back(msg.data); }));
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void publishFlush(const std::string& incident_id)
+  {
+    dc_interfaces::msg::FlushEvent flush_msg;
+    flush_msg.incident_id = incident_id;
+    flush_pub_->publish(flush_msg);
+  }
+
+  // How many of this Measurement's Records carry exactly this incident_id.
+  int countTaggedWith(const std::string& name, const std::string& incident_id)
+  {
+    int count = 0;
+    for (const auto& data : received_[name])
+    {
+      json data_json = json::parse(data);
+      if (data_json.contains("incident_id") && data_json["incident_id"].get<std::string>() == incident_id)
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  // Every Record this Measurement published so far, for a failure message that names names.
+  std::string dumpOf(const std::string& name)
+  {
+    std::string out;
+    for (const auto& data : received_[name])
+    {
+      out += "\n  " + data;
+    }
+    return out;
+  }
+
+  // How many of this Measurement's Records carry an incident_id at all, whatever its value.
+  int countCarryingAnIncident(const std::string& name)
+  {
+    int count = 0;
+    for (const auto& data : received_[name])
+    {
+      if (json::parse(data).contains("incident_id"))
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  void spinFor(int milliseconds)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (
+        (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time)).count() <
+        milliseconds)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  // Spin until `done` holds, giving up after `timeout_ms` -- a bounded wait, so a behavior
+  // regression fails the test loudly instead of hanging until the suite times out.
+  bool spinUntil(const std::function<bool()>& done, int timeout_ms)
+  {
+    std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
+    while (!done())
+    {
+      if ((std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time))
+              .count() >= timeout_ms)
+      {
+        return false;
+      }
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+    return true;
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  std::vector<rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr> subs_;
+  rclcpp::Publisher<dc_interfaces::msg::FlushEvent>::SharedPtr flush_pub_;
+
+public:
+  std::map<std::string, std::vector<std::string>> received_;
+};
+
+// Acceptance criterion: a single FlushEvent releases the buffered window of every Measurement
+// listening on the shared topic, and every Record of both windows carries the same incident_id --
+// time-correlated context across streams, not just one. Their polling intervals differ, so the
+// windows hold different Record counts under that one id.
+TEST_F(MeasurementSharedFlushTest, OneFlushEventReleasesEveryBufferedWindowUnderOneIncidentId)
+{
+  startLifecycleNode();
+
+  // Both buffer silently over the same wall-clock window, each at its own rate.
+  spinFor(600);
+  ASSERT_TRUE(received_[kFast].empty()) << kFast << " published while buffering:" << dumpOf(kFast);
+  ASSERT_TRUE(received_[kSlow].empty()) << kSlow << " published while buffering:" << dumpOf(kSlow);
+
+  const std::string incident_id = "incident-9f3c1a-shared";
+  publishFlush(incident_id);
+  ASSERT_TRUE(spinUntil([this] { return received_[kFast].size() >= 8u && received_[kSlow].size() >= 3u; }, 5000))
+      << kFast << " released " << received_[kFast].size() << ", " << kSlow << " released " << received_[kSlow].size();
+  // Let the tail of both windows out.
+  spinFor(500);
+
+  for (const std::string& name : { std::string(kFast), std::string(kSlow) })
+  {
+    EXPECT_EQ(countTaggedWith(name, incident_id), static_cast<int>(received_[name].size()))
+        << name << " released a Record not tagged with the incident_id the FlushEvent carried";
+  }
+  // Different polling intervals, so different Record counts -- one incident either way.
+  EXPECT_GT(received_[kFast].size(), received_[kSlow].size());
+}
+
+// Acceptance criterion: a Measurement with no buffer_duration_sec subscribes to no flush topic,
+// so the same FlushEvent leaves it publishing live and its Records carry no incident_id.
+TEST_F(MeasurementSharedFlushTest, AMeasurementWithoutBufferingIsUnaffectedByTheFlush)
+{
+  startLifecycleNode();
+
+  // Publishing live all along, while the two buffering Measurements stay silent.
+  ASSERT_TRUE(spinUntil([this] { return received_[kLive].size() >= 3u; }, 3000));
+  ASSERT_TRUE(received_[kFast].empty()) << kFast << " published while buffering:" << dumpOf(kFast);
+  const size_t before_flush = received_[kLive].size();
+
+  publishFlush("incident-live-untouched");
+  spinFor(400);
+
+  EXPECT_GT(received_[kLive].size(), before_flush) << "the FlushEvent should not have interrupted live publishing";
+  EXPECT_EQ(countCarryingAnIncident(kLive), 0) << "a Measurement that never buffers has no incident to report";
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/progress.txt
+++ b/progress.txt
@@ -7302,3 +7302,56 @@ the Bridge's own drop counters extracted per run as the fidelity check (`dropped
 as a warning and folded into the doc rather than hidden). `prek run --all-files --skip
 build-doc` is green, `mdbook build` clean, and `tools/sim/.run/` — which `run.sh` has been
 writing to since #279 without ever being ignored — is now in `.gitignore`.
+
+## #345 - One FlushEvent releasing several Measurements under a shared incident_id
+
+Test-only slice of #282. Every test #287/#288/#289/#290 left behind drives a *single* `dummy`
+Measurement, so the behavior that justifies broadcasting the flush on a topic at all -- several
+Measurements releasing their windows off one event, all under one `incident_id` -- was resting on
+inference from single-Measurement runs. It isn't broken; it is now covered.
+
+**`dc_measurements/test/test_measurement_shared_flush.cpp`** (new, registered in `CMakeLists.txt`).
+A sibling of `test_measurement_buffering.cpp` rather than an extension of it: that fixture builds a
+one-Measurement server with one subscription, and the fan-out contract needs three Measurements on
+one node, so the fixture is a different shape (the `spinFor`/`spinUntil` helpers come along, the
+rest doesn't). The new fixture runs `dummy_fast` (50ms polling), `dummy_slow` (150ms) and
+`dummy_live` on one `MeasurementServer`, the first two buffering on the same **non-default**
+`flush_topic` (`/dc/incident_flush`, so the test also covers pointing several Measurements at a
+topic of the deployment's choosing -- user story 22), the third with no `buffer_duration_sec`.
+
+- `OneFlushEventReleasesEveryBufferedWindowUnderOneIncidentId` -- both buffer silently over the same
+  600ms, one `FlushEvent` releases both, and *every* Record of both windows carries exactly the
+  `incident_id` the event carried (string-compared, not merely "has the field"). The two windows
+  hold different Record counts, since the polling intervals differ -- asserted, so the test would
+  notice the two Measurements collapsing into one stream.
+- `AMeasurementWithoutBufferingIsUnaffectedByTheFlush` -- `dummy_live` publishes live throughout,
+  keeps publishing across the same `FlushEvent`, and not one of its Records carries an
+  `incident_id`. `flush_sub_` is only created when `buffer_duration_sec > 0`, so it is subscribed to
+  nothing; this is the behavioral proof of that.
+
+Both release paths run with `max_flush_rate_hz` at 20Hz: `data_pub_` is `KeepLast(1)`, so an unpaced
+window leaves the middleware delivering only its last Record (#289's finding, and the same reason
+#290's File test paces its release).
+
+**`CONTEXT.md`: nothing to do.** The issue's third acceptance criterion asked for an **Incident**
+glossary entry, noting the word was only defined in passing inside **Trigger**. That was true when
+#345 was filed and has since been fixed by #292 (commit `1ac1973`): `CONTEXT.md` carries a full
+**Incident** entry -- the flush cycle, pre-roll plus post-roll, `incident_id` as a top-level envelope
+field and a Postgres column, with its own _Avoid_ list -- and the pipeline summary below it names
+Incident too. Criterion already met on the branch, so the file is untouched here.
+
+**Verification.** `colcon build` + `colcon test` for `dc_measurements` inside
+`localhost/dc-workspace:latest` over this worktree: the package builds clean under `-Werror` and
+**176 tests, 0 errors, 0 failures** -- the 2 new cases included, `test_measurement_buffering` and
+`test_incident_releaser` unchanged. The new binary was also run 10 times in a row with no flake,
+which matters for timing-based lifecycle tests. `prek run --all-files --skip build-doc` is green
+(clang-format reflowed one constructor call).
+
+One trap worth recording for the next agent verifying a `dc_measurements` change locally: rebuilding
+only the test target and running it straight out of `build/` silently tests the **installed** code,
+not yours. `measurement.hpp` is header-only, so every Measurement plugin `.so` carries its own copy
+of `configure()`/`collectAndPublish()`; pluginlib resolves those through the ament index, i.e. from
+`install/`, and `LD_LIBRARY_PATH` does not override it. Against a stale install the new tests failed
+with `buffer_duration_sec` apparently ignored -- an ABI mismatch, not a bug. A full `colcon build`
+(which installs) is the only honest local run. `--parallel-workers 1` with `MAKEFLAGS=-j1` was
+needed to keep the container inside available memory; the default parallelism OOM-killed it twice.


### PR DESCRIPTION
Closes #345

## What

Test coverage for the *shared* half of the flush-broadcast contract: one `FlushEvent`, several
Measurements, one `incident_id` — user stories 4 and 22 of #282.

Every test #287/#288/#289/#290 left behind drives a single `dummy` Measurement, so the behavior
that justifies broadcasting the flush on a topic at all was resting on inference. Nothing suggests
it is broken, but it is the seam the deferred Group-level correlated buffering builds on.

## How

New `dc_measurements/test/test_measurement_shared_flush.cpp` (registered in `CMakeLists.txt`) — a
sibling of `test_measurement_buffering.cpp` rather than an extension of it, since that fixture is a
one-Measurement server with one subscription and this contract needs three Measurements on one
node.

The fixture runs `dummy_fast` (50 ms polling), `dummy_slow` (150 ms) and `dummy_live` on one
`MeasurementServer`. The first two buffer on the same **non-default** `flush_topic`
(`/dc/incident_flush`, so the test also covers pointing several Measurements at a topic of the
deployment's choosing); the third has no `buffer_duration_sec` at all.

- **`OneFlushEventReleasesEveryBufferedWindowUnderOneIncidentId`** — both buffer silently over the
  same 600 ms, one `FlushEvent` releases both, and *every* Record of both windows carries exactly
  the `incident_id` the event carried (string-compared, not merely "has the field"). The differing
  polling intervals give the two windows different Record counts under that one id — asserted, so
  the test would notice the two Measurements collapsing into one stream.
- **`AMeasurementWithoutBufferingIsUnaffectedByTheFlush`** — `dummy_live` publishes live
  throughout, keeps publishing across the same `FlushEvent`, and not one of its Records carries an
  `incident_id`. `flush_sub_` is only created when `buffer_duration_sec > 0`, so it subscribes to
  nothing; this is the behavioral proof of that.

Both release paths run with `max_flush_rate_hz` at 20 Hz: `data_pub_` is `KeepLast(1)`, so an
unpaced window leaves the middleware delivering only its last Record (#289's finding, and the same
reason #290's File test paces its release).

## Acceptance criteria

- [x] Two buffering Measurements on one shared flush topic; a single `FlushEvent` releases both
      windows and every Record from both carries the same `incident_id`
- [x] A sibling case confirms a Measurement with `buffer_duration_sec` unset, subscribed to
      nothing, is unaffected by the `FlushEvent` and publishes no `incident_id`
- [x] `CONTEXT.md` **Incident** glossary entry — **already present, no change needed.** The
      criterion described the state when #345 was filed; #292 (`1ac1973`) has since added a full
      **Incident** entry (the flush cycle, pre-roll plus post-roll, `incident_id` as a top-level
      envelope field and a Postgres column, with its own _Avoid_ list), and the pipeline summary
      below it names Incident too.

## Verification

`colcon build` + `colcon test` for `dc_measurements` inside `localhost/dc-workspace:latest` over
this worktree: the package builds clean under `-Werror`, and **176 tests, 0 errors, 0 failures** —
the 2 new cases included, `test_measurement_buffering` and `test_incident_releaser` unchanged. The
new binary was also run 10 times in a row with no flake, which matters for timing-based lifecycle
tests. `prek run --all-files --skip build-doc` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4bKqyAyuhCLMCWxQnKBiG