### PR TITLE
feat(dc_measurements): add the fault Measurement, raise/change/clear from diagnostics

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -148,6 +148,9 @@ list(APPEND dc_measurement_plugin_libs dc_dummy_measurement)
 add_library(dc_distance_traveled_measurement SHARED plugins/measurements/distance_traveled.cpp)
 list(APPEND dc_measurement_plugin_libs dc_distance_traveled_measurement)
 
+add_library(dc_fault_measurement SHARED plugins/measurements/fault.cpp)
+list(APPEND dc_measurement_plugin_libs dc_fault_measurement)
+
 add_library(dc_driving_type_measurement SHARED plugins/measurements/driving_type.cpp)
 list(APPEND dc_measurement_plugin_libs dc_driving_type_measurement)
 
@@ -321,6 +324,7 @@ set(tests
   test_measurement_driving_type
   test_measurement_dummy
   test_measurement_exist
+  test_measurement_fault
   test_measurement_gate_condition
   test_measurement_integer_equal
   test_measurement_integer_inferior

--- a/dc_measurements/include/dc_measurements/plugins/measurements/fault.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/fault.hpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__FAULT_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__FAULT_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dc_common/state_transition_detector.hpp"
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::Fault
+ * @brief One Record per diagnostic level change -- the transition `diagnostics`'s periodic
+ * snapshots leave a consumer to reconstruct by scanning for where a value changed. Built on the
+ * same dc_common::StateTransitionDetector as Intervention (#362), one detector per watched
+ * component so components fault and recover independently (#365).
+ */
+class Fault : public dc_measurements::Measurement
+{
+public:
+  Fault();
+  ~Fault() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void diagnosticsCb(const diagnostic_msgs::msg::DiagnosticArray& msg);
+  bool isWatched(const std::string& name) const;
+
+  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr subscription_;
+  std::string topic_;
+  // Which DiagnosticStatus.name values to track; empty tracks every component seen, matching
+  // Diagnostics' own `names` filter. Non-empty keeps one noisy, unwatched component from growing
+  // the detector map or flooding the pipeline.
+  std::vector<std::string> names_;
+
+  // The DiagnosticArray callback and the polling timer run in different callback groups under a
+  // multi-threaded executor, so everything they share is guarded.
+  mutable std::mutex mutex_;
+  std::map<std::string, dc_common::StateTransitionDetector<uint8_t>> detectors_;
+  // When each component's currently open fault (level != OK) started; erased once it clears. A
+  // component observed already faulted on its very first sample has no entry here -- the
+  // detector treats that sample as a baseline, not a transition, so no start was ever seen.
+  std::map<std::string, std::chrono::system_clock::time_point> fault_started_at_;
+  // Records wait here for a poll to carry them out, one per poll, so they travel the same publish
+  // path (Conditions, buffering, Group) as every other Record.
+  std::deque<std::pair<json, rclcpp::Time>> pending_records_;
+
+  // Per-Record, not per-component: a global counter across every watched component, so a
+  // consumer can tell a dropped Record apart from a component that never changed.
+  std::uint64_t record_seq_{ 0 };
+
+protected:
+  void onConfigure() override;
+  void onCleanup() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__FAULT_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -52,6 +52,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_fault_measurement">
+        <class name="dc_measurements/Fault" type="dc_measurements::Fault" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_fault
+            </description>
+        </class>
+    </library>
+
     <library path="dc_dummy_measurement">
         <class name="dc_measurements/Dummy" type="dc_measurements::Dummy" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/fault.cpp
+++ b/dc_measurements/plugins/measurements/fault.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/fault.hpp"
+
+#include <algorithm>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace dc_measurements
+{
+
+namespace
+{
+constexpr size_t kMaxPendingRecords = 64;
+
+double secondsOf(const std::chrono::system_clock::duration& d)
+{
+  return std::chrono::duration<double>(d).count();
+}
+
+std::string iso8601(const std::chrono::system_clock::time_point& tp)
+{
+  const auto secs = std::chrono::system_clock::to_time_t(tp);
+  const auto us =
+      std::chrono::duration_cast<std::chrono::microseconds>(tp.time_since_epoch()) % std::chrono::seconds(1);
+  std::tm tm{};
+  ::gmtime_r(&secs, &tm);
+  std::stringstream ss;
+  ss << std::put_time(&tm, "%Y-%m-%dT%H:%M:%S") << '.' << std::setfill('0') << std::setw(6) << us.count() << 'Z';
+  return ss.str();
+}
+
+std::string levelName(uint8_t level)
+{
+  switch (level)
+  {
+    case diagnostic_msgs::msg::DiagnosticStatus::OK:
+      return "OK";
+    case diagnostic_msgs::msg::DiagnosticStatus::WARN:
+      return "WARN";
+    case diagnostic_msgs::msg::DiagnosticStatus::ERROR:
+      return "ERROR";
+    case diagnostic_msgs::msg::DiagnosticStatus::STALE:
+      return "STALE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+}  // namespace
+
+Fault::Fault() : dc_measurements::Measurement()
+{
+}
+
+Fault::~Fault() = default;
+
+void Fault::onConfigure()
+{
+  auto node = getNode();
+  topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic", "/diagnostics");
+  names_ = dc_util::get_str_array_type_param(node, measurement_name_, "names", std::vector<std::string>{});
+
+  subscription_ = node->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
+      topic_, rclcpp::SystemDefaultsQoS(), std::bind(&Fault::diagnosticsCb, this, std::placeholders::_1));
+}
+
+void Fault::onCleanup()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& [name, started_at] : fault_started_at_)
+  {
+    RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with '" << name
+                                                  << "' still faulted, open since " << iso8601(started_at)
+                                                  << "; its last Record stays marked open, no duration is reported");
+  }
+}
+
+void Fault::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "fault.json");
+  }
+}
+
+bool Fault::isWatched(const std::string& name) const
+{
+  return names_.empty() || std::find(names_.begin(), names_.end(), name) != names_.end();
+}
+
+void Fault::diagnosticsCb(const diagnostic_msgs::msg::DiagnosticArray& msg)
+{
+  const rclcpp::Time stamp = getNode()->get_clock()->now();
+  const std::chrono::system_clock::time_point now{ std::chrono::nanoseconds(stamp.nanoseconds()) };
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& status : msg.status)
+  {
+    if (!isWatched(status.name))
+    {
+      continue;
+    }
+
+    const auto transition = detectors_[status.name].update(status.level, now);
+    if (!transition.has_value())
+    {
+      continue;
+    }
+
+    const bool raises = transition->from == diagnostic_msgs::msg::DiagnosticStatus::OK;
+    const bool clears = transition->to == diagnostic_msgs::msg::DiagnosticStatus::OK;
+
+    if (raises)
+    {
+      fault_started_at_[status.name] = transition->at;
+    }
+    const auto started_it = fault_started_at_.find(status.name);
+
+    json data;
+    data["seq"] = ++record_seq_;
+    data["component"] = status.name;
+    data["event"] = raises ? "raise" : (clears ? "clear" : "change");
+    data["from_level"] = levelName(transition->from);
+    data["to_level"] = levelName(transition->to);
+    data["previous_level_duration_s"] = secondsOf(transition->dwell);
+    data["reason"] = status.message;
+    data["state"] = clears ? "closed" : "open";
+    if (started_it != fault_started_at_.end())
+    {
+      data["fault_started_at"] = iso8601(started_it->second);
+      if (clears)
+      {
+        data["duration_s"] = secondsOf(transition->at - started_it->second);
+      }
+    }
+    if (clears)
+    {
+      fault_started_at_.erase(status.name);
+    }
+
+    pending_records_.emplace_back(std::move(data), stamp);
+  }
+
+  // One Record leaves per poll, so a component (or set of components) flapping far faster than
+  // the polling interval would otherwise queue without bound. The oldest goes first: the recent
+  // transitions are the ones still worth reporting.
+  while (pending_records_.size() > kMaxPendingRecords)
+  {
+    pending_records_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_
+                                               << ": fault Records are arriving faster than the polling interval "
+                                                  "can report them; dropping the oldest.");
+  }
+}
+
+dc_interfaces::msg::StringStamped Fault::collect()
+{
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_records_.empty())
+  {
+    return msg;
+  }
+
+  auto record = std::move(pending_records_.front());
+  pending_records_.pop_front();
+  msg.header.stamp = record.second;
+  msg.data = record.first.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::Fault, dc_core::Measurement)

--- a/dc_measurements/plugins/measurements/json/fault.json
+++ b/dc_measurements/plugins/measurements/json/fault.json
@@ -68,7 +68,8 @@
       "type": "string"
     },
     "duration_s": {
-      "description": "Seconds the whole fault lasted. Present only on the clear Record, and only when 'fault_started_at' is known",
+      "description":
+          "Seconds the whole fault lasted. Present only on the clear Record, and only when 'fault_started_at' is known",
       "type": "number",
       "minimum": 0
     }

--- a/dc_measurements/plugins/measurements/json/fault.json
+++ b/dc_measurements/plugins/measurements/json/fault.json
@@ -1,0 +1,87 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fault",
+  "description":
+      "A component's diagnostic level change, derived from /diagnostics: one Record per transition, so MTBF and MTTR have a source instead of scanning periodic snapshots for where a value changed",
+  "properties": {
+    "seq": {
+      "description":
+          "Monotonically increasing number of this Record, across every watched component, so a dropped Record is detectable rather than silently shortening an outage",
+      "type": "integer",
+      "minimum": 1
+    },
+    "component": {
+      "description": "Reporting component name (DiagnosticStatus.name)",
+      "type": "string"
+    },
+    "event": {
+      "description":
+          "'raise' when the component left OK, 'clear' when it returned to OK, 'change' for a transition between two non-OK levels (e.g. WARN to ERROR)",
+      "type": "string",
+      "enum": [
+        "raise",
+        "clear",
+        "change"
+      ]
+    },
+    "from_level": {
+      "description": "Level the component left",
+      "type": "string",
+      "enum": [
+        "OK",
+        "WARN",
+        "ERROR",
+        "STALE"
+      ]
+    },
+    "to_level": {
+      "description": "Level the component entered",
+      "type": "string",
+      "enum": [
+        "OK",
+        "WARN",
+        "ERROR",
+        "STALE"
+      ]
+    },
+    "previous_level_duration_s": {
+      "description": "Seconds 'from_level' had been held before this transition",
+      "type": "number",
+      "minimum": 0
+    },
+    "reason": {
+      "description": "DiagnosticStatus.message reported alongside the new level",
+      "type": "string"
+    },
+    "state": {
+      "description":
+          "'open' while the fault is still under way (a raise or a change), 'closed' once it clears -- a fault still open when collection stops keeps its last Record marked 'open' and no duration, so it cannot be read as a zero-length outage",
+      "type": "string",
+      "enum": [
+        "open",
+        "closed"
+      ]
+    },
+    "fault_started_at": {
+      "description":
+          "When the currently open fault started (ISO 8601, UTC), carried on every Record belonging to it so a raise and its eventual clear can be joined. Absent when the component was already faulted on its very first observed sample, since no start was ever seen",
+      "type": "string"
+    },
+    "duration_s": {
+      "description": "Seconds the whole fault lasted. Present only on the clear Record, and only when 'fault_started_at' is known",
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "seq",
+    "component",
+    "event",
+    "from_level",
+    "to_level",
+    "previous_level_duration_s",
+    "reason",
+    "state"
+  ],
+  "type": "object"
+}

--- a/dc_measurements/test/test_measurement_fault.cpp
+++ b/dc_measurements/test/test_measurement_fault.cpp
@@ -115,6 +115,16 @@ protected:
     }
   }
 
+  // The detector treats a component's very first observed sample as a baseline, not a transition
+  // (matching every other StateTransitionDetector consumer): no Record comes out of it, and the
+  // level it carries never fires again since nothing is left to compare against. Every test that
+  // wants to observe an actual "raise" therefore has to establish OK as the baseline first.
+  void establishOkBaseline(const std::string& name)
+  {
+    publishDiagnostics(makeStatus(name, diagnostic_msgs::msg::DiagnosticStatus::OK, "nominal"));
+    spinFor(std::chrono::milliseconds(100));
+  }
+
   // Republishes `status` until a *new* Record matching `predicate` shows up, so a best-effort
   // sample lost before the plugin subscribed doesn't make the test flaky.
   nlohmann::json publishUntilRecord(const diagnostic_msgs::msg::DiagnosticStatus& status,
@@ -200,6 +210,7 @@ TEST_F(MeasurementFaultTest, ReturningToOkClearsTheFaultAndReportsItsDuration)
   declareCommonParameters();
   startLifecycleNode();
   waitForSubscriber("/test/diagnostics");
+  establishOkBaseline("motor_driver");
 
   const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor fault");
   const auto raise = publishUntilRecord(error, isEvent("raise"));
@@ -223,6 +234,7 @@ TEST_F(MeasurementFaultTest, WorseningLevelIsAChangeNotAClearAndKeepsTheFaultOpe
   declareCommonParameters();
   startLifecycleNode();
   waitForSubscriber("/test/diagnostics");
+  establishOkBaseline("motor_driver");
 
   const auto warn = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::WARN, "Motor warm");
   const auto raise = publishUntilRecord(warn, isEvent("raise"));
@@ -245,6 +257,7 @@ TEST_F(MeasurementFaultTest, FlappingComponentGetsOneRecordPerTransitionWithIncr
   declareCommonParameters();
   startLifecycleNode();
   waitForSubscriber("/test/diagnostics");
+  establishOkBaseline("wifi");
 
   const auto ok = makeStatus("wifi", diagnostic_msgs::msg::DiagnosticStatus::OK, "Link up");
   const auto warn = makeStatus("wifi", diagnostic_msgs::msg::DiagnosticStatus::WARN, "Weak signal");
@@ -272,6 +285,7 @@ TEST_F(MeasurementFaultTest, FaultOpenAtShutdownStaysOpenAndReportsNoDuration)
   declareCommonParameters();
   startLifecycleNode();
   waitForSubscriber("/test/diagnostics");
+  establishOkBaseline("motor_driver");
 
   const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor fault");
   publishUntilRecord(error, isEvent("raise"));

--- a/dc_measurements/test/test_measurement_fault.cpp
+++ b/dc_measurements/test/test_measurement_fault.cpp
@@ -80,7 +80,7 @@ protected:
   }
 
   static diagnostic_msgs::msg::DiagnosticStatus makeStatus(const std::string& name, uint8_t level,
-                                                            const std::string& message)
+                                                           const std::string& message)
   {
     diagnostic_msgs::msg::DiagnosticStatus status;
     status.name = name;

--- a/dc_measurements/test/test_measurement_fault.cpp
+++ b/dc_measurements/test/test_measurement_fault.cpp
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "diagnostic_msgs/msg/diagnostic_array.hpp"
+#include "diagnostic_msgs/msg/diagnostic_status.hpp"
+
+class MeasurementFaultTest : public ::testing::Test
+{
+protected:
+  MeasurementFaultTest()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "fault" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/fault", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementFaultTest::dataCallback, this, std::placeholders::_1));
+    diag_pub_ = ms_node_->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/test/diagnostics",
+                                                                                  rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    stopCollection();
+  }
+
+  // Idempotent: one test stops collection mid-fault on purpose, and TearDown must not then drive
+  // the lifecycle node through a transition it is no longer in a state for.
+  void stopCollection()
+  {
+    if (stopped_)
+    {
+      return;
+    }
+    stopped_ = true;
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("fault.plugin", std::string("dc_measurements/Fault"));
+    ms_node_->declare_parameter("fault.group_key", std::string("fault"));
+    ms_node_->declare_parameter("fault.topic_output", std::string("/dc/measurement/fault"));
+    ms_node_->declare_parameter("fault.topic", std::string("/test/diagnostics"));
+    ms_node_->declare_parameter("fault.polling_interval", 50);
+    ms_node_->declare_parameter("fault.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+    callback_active_ = true;
+  }
+
+  static diagnostic_msgs::msg::DiagnosticStatus makeStatus(const std::string& name, uint8_t level,
+                                                            const std::string& message)
+  {
+    diagnostic_msgs::msg::DiagnosticStatus status;
+    status.name = name;
+    status.level = level;
+    status.message = message;
+    return status;
+  }
+
+  void publishDiagnostics(const diagnostic_msgs::msg::DiagnosticStatus& status)
+  {
+    diagnostic_msgs::msg::DiagnosticArray msg;
+    msg.header.stamp = ms_node_->get_clock()->now();
+    msg.status.push_back(status);
+    diag_pub_->publish(msg);
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  void waitForSubscriber(const std::string& topic)
+  {
+    while (ms_node_->count_subscribers(topic) == 0)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  // Republishes `status` until a *new* Record matching `predicate` shows up, so a best-effort
+  // sample lost before the plugin subscribed doesn't make the test flaky.
+  nlohmann::json publishUntilRecord(const diagnostic_msgs::msg::DiagnosticStatus& status,
+                                    const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = records_.size();
+    for (int i = 0; i < 400; ++i)
+    {
+      publishDiagnostics(status);
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  // The schema the plugin itself validates against, applied here directly so a Record that only
+  // half fills it fails the test rather than only logging.
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path =
+        ament_index_cpp::get_package_share_directory("dc_measurements") + "/plugins/measurements/json/fault.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diag_pub_;
+  std::vector<nlohmann::json> records_;
+
+  bool stopped_{ false };
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementFaultTest, LevelChangeRaisesAnOpenFaultRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/diagnostics");
+
+  // Staying OK must not produce a Record.
+  const auto ok = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::OK, "Motor nominal");
+  publishDiagnostics(ok);
+  spinFor(std::chrono::milliseconds(200));
+  ASSERT_TRUE(records_.empty()) << "A component that stays put must not produce a Record";
+
+  const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor fault");
+  const auto raise = publishUntilRecord(error, isEvent("raise"));
+
+  EXPECT_EQ(raise["seq"], 1);
+  EXPECT_EQ(raise["component"], "motor_driver");
+  EXPECT_EQ(raise["from_level"], "OK");
+  EXPECT_EQ(raise["to_level"], "ERROR");
+  EXPECT_EQ(raise["reason"], "Motor fault");
+  EXPECT_EQ(raise["state"], "open");
+  EXPECT_GT(raise["previous_level_duration_s"].get<double>(), 0.0);
+  ASSERT_TRUE(raise.contains("fault_started_at"));
+  EXPECT_FALSE(raise["fault_started_at"].get<std::string>().empty());
+  EXPECT_FALSE(raise.contains("duration_s")) << "An open fault has no duration yet";
+  expectValidatesAgainstSchema(raise);
+}
+
+TEST_F(MeasurementFaultTest, ReturningToOkClearsTheFaultAndReportsItsDuration)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/diagnostics");
+
+  const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor fault");
+  const auto raise = publishUntilRecord(error, isEvent("raise"));
+
+  const auto ok = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::OK, "Motor nominal");
+  const auto clear = publishUntilRecord(ok, isEvent("clear"));
+
+  EXPECT_EQ(clear["seq"], 2);
+  EXPECT_EQ(clear["from_level"], "ERROR");
+  EXPECT_EQ(clear["to_level"], "OK");
+  EXPECT_EQ(clear["state"], "closed");
+  ASSERT_TRUE(clear.contains("duration_s"));
+  EXPECT_GT(clear["duration_s"].get<double>(), 0.0);
+  // Both Records name the same fault, so the pair can be joined downstream.
+  EXPECT_EQ(clear["fault_started_at"], raise["fault_started_at"]);
+  expectValidatesAgainstSchema(clear);
+}
+
+TEST_F(MeasurementFaultTest, WorseningLevelIsAChangeNotAClearAndKeepsTheFaultOpen)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/diagnostics");
+
+  const auto warn = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::WARN, "Motor warm");
+  const auto raise = publishUntilRecord(warn, isEvent("raise"));
+  ASSERT_EQ(raise["to_level"], "WARN");
+
+  const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor overheating");
+  const auto change = publishUntilRecord(error, isEvent("change"));
+
+  EXPECT_EQ(change["from_level"], "WARN");
+  EXPECT_EQ(change["to_level"], "ERROR");
+  EXPECT_EQ(change["state"], "open");
+  EXPECT_FALSE(change.contains("duration_s")) << "The fault is still open, not cleared";
+  // Still the same fault as the original raise: its start does not move.
+  EXPECT_EQ(change["fault_started_at"], raise["fault_started_at"]);
+  expectValidatesAgainstSchema(change);
+}
+
+TEST_F(MeasurementFaultTest, FlappingComponentGetsOneRecordPerTransitionWithIncreasingSequence)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/diagnostics");
+
+  const auto ok = makeStatus("wifi", diagnostic_msgs::msg::DiagnosticStatus::OK, "Link up");
+  const auto warn = makeStatus("wifi", diagnostic_msgs::msg::DiagnosticStatus::WARN, "Weak signal");
+
+  publishUntilRecord(warn, isEvent("raise"));
+  publishUntilRecord(ok, isEvent("clear"));
+  publishUntilRecord(warn, isEvent("raise"));
+  publishUntilRecord(ok, isEvent("clear"));
+
+  ASSERT_EQ(records_.size(), 4u);
+  std::vector<std::string> events;
+  for (const auto& record : records_)
+  {
+    events.push_back(record["event"].get<std::string>());
+  }
+  EXPECT_EQ(events, (std::vector<std::string>{ "raise", "clear", "raise", "clear" }));
+  for (size_t i = 0; i < records_.size(); ++i)
+  {
+    EXPECT_EQ(records_[i]["seq"].get<uint64_t>(), i + 1);
+  }
+}
+
+TEST_F(MeasurementFaultTest, FaultOpenAtShutdownStaysOpenAndReportsNoDuration)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/diagnostics");
+
+  const auto error = makeStatus("motor_driver", diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Motor fault");
+  publishUntilRecord(error, isEvent("raise"));
+
+  // Collection stops with the fault still open.
+  stopCollection();
+  spinFor(std::chrono::milliseconds(200));
+
+  ASSERT_EQ(records_.size(), 1u) << "Shutdown must not invent a clearing Record";
+  EXPECT_EQ(records_.back()["state"], "open");
+  EXPECT_FALSE(records_.back().contains("duration_s"))
+      << "An unterminated fault must not report a duration that could be read as a zero-length outage";
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -28,6 +28,7 @@
   - [Dummy](./dc/measurements/dummy.md)
   - [Distance traveled](./dc/measurements/distance_traveled.md)
   - [Driving type](./dc/measurements/driving_type.md)
+  - [Fault](./dc/measurements/fault.md)
   - [Intervention](./dc/measurements/intervention.md)
   - [IP Camera](./dc/measurements/ip_camera.md)
   - [Map](./dc/measurements/map.md)

--- a/doc/src/dc/measurements.md
+++ b/doc/src/dc/measurements.md
@@ -171,6 +171,7 @@ error is logged: it blocks collection when listed in `if_all_conditions` or
 | [CPU](./measurements/cpu.md)                             | CPU statistics                                                                                          |
 | [Distance traveled](./measurements/distance_traveled.md) | Total distance traveled by the robot                                                                    |
 | [Dummy](./measurements/dummy.md)                         | Dummy event, for testing and debugging                                                                  |
+| [Fault](./measurements/fault.md)                         | Component diagnostic level transitions: one Record per raise, change or clear, a source for MTBF/MTTR   |
 | [IP Camera](./measurements/ip_camera.md)                 | IP camera videos as files                                                                               |
 | [Map](./measurements/map.md)                             | ROS map files (yaml and pgm) and metadata used by the robot to localize and navigate                    |
 | [Memory](./measurements/memory.md)                       | System memory usage                                                                                     |

--- a/doc/src/dc/measurements/fault.md
+++ b/doc/src/dc/measurements/fault.md
@@ -1,0 +1,111 @@
+# Fault
+
+## Description
+
+Reports the transitions `diagnostics`'s periodic snapshots leave a consumer to reconstruct:
+`diagnostics` writes the current `DiagnosticStatus` level on every poll, so recovering "when did
+this component break, and when was it fixed" means scanning for where a value changed in
+SQL -- exactly the failure mode transition Records exist to prevent. Fault subscribes to the same
+`/diagnostics` topic (`diagnostic_msgs/DiagnosticArray`) and emits one Record per component **only
+when its level actually changes**, feeding each watched component's stream of `(level, timestamp)`
+samples to its own `dc_common::StateTransitionDetector`, a header-only `dc_common` type generic
+over the state being tracked and owning no clock of its own.
+
+Every Record carries the component, the level it left (`from_level`) and entered (`to_level`), how
+long the previous level had been held (`previous_level_duration_s`), and the status message as the
+reason. Levels are the `DiagnosticStatus` constants `OK`, `WARN`, `ERROR` and `STALE` -- reported
+by name, so a silent (`STALE`) component is never confused with a broken (`ERROR`) one.
+
+Each transition is also classified as an `event`:
+
+- **raise** -- the component left `OK`. A new fault opens (`"state": "open"`), and
+  `fault_started_at` records when.
+- **change** -- a transition between two non-`OK` levels (e.g. `WARN` to `ERROR`). The fault stays
+  open; `fault_started_at` is unchanged from the raise that opened it.
+- **clear** -- the component returned to `OK`. The fault closes (`"state": "closed"`) and the
+  Record carries `duration_s`, the length of the whole fault, alongside the same `fault_started_at`
+  the raise carried -- so the pair can be joined downstream for MTTR. MTBF is the gap between
+  successive `raise` events for a component.
+
+A fault still open when collection stops keeps its last Record's `"state": "open"` and no
+`duration_s`: no closing Record is invented, so it cannot be read as a zero-length outage. Every
+Record carries a `seq` that increments by one across every watched component, so a dropped Record
+is a detectable gap rather than a silently shortened outage. A component observed already faulted
+on its very first sample has no `fault_started_at` on that Record -- the detector treats the first
+sample as a baseline, not a transition, since no start was ever seen.
+
+## Parameters
+
+| Parameter | Description                                                                             | Type      | Default            |
+| --------- | ---------------------------------------------------------------------------------------- | --------- | ------------------- |
+| **topic** | Topic to subscribe to for diagnostics                                                    | str       | "/diagnostics" (Optional) |
+| **names** | Which `DiagnosticStatus.name` values to watch; empty watches every component seen        | list[str] | [] (Optional)       |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fault",
+  "properties": {
+    "seq": { "type": "integer", "minimum": 1 },
+    "component": { "type": "string" },
+    "event": { "type": "string", "enum": ["raise", "clear", "change"] },
+    "from_level": { "type": "string", "enum": ["OK", "WARN", "ERROR", "STALE"] },
+    "to_level": { "type": "string", "enum": ["OK", "WARN", "ERROR", "STALE"] },
+    "previous_level_duration_s": { "type": "number", "minimum": 0 },
+    "reason": { "type": "string" },
+    "state": { "type": "string", "enum": ["open", "closed"] },
+    "fault_started_at": { "type": "string" },
+    "duration_s": { "type": "number", "minimum": 0 }
+  },
+  "required": ["seq", "component", "event", "from_level", "to_level", "previous_level_duration_s", "reason", "state"],
+  "type": "object"
+}
+```
+
+## Measurement configuration
+
+```yaml
+...
+fault:
+  plugin: "dc_measurements/Fault"
+  topic_output: "/dc/measurement/fault"
+  group_key: "fault"
+  tags: ["console"]
+  topic: "/diagnostics"
+  names: ["motor_driver", "battery"]
+```
+
+Example Record data, a raise:
+
+```json
+{
+  "seq": 1,
+  "component": "motor_driver",
+  "event": "raise",
+  "from_level": "OK",
+  "to_level": "ERROR",
+  "previous_level_duration_s": 3612.4,
+  "reason": "Motor fault",
+  "state": "open",
+  "fault_started_at": "2026-08-18T09:12:33.123456Z"
+}
+```
+
+and its clear:
+
+```json
+{
+  "seq": 2,
+  "component": "motor_driver",
+  "event": "clear",
+  "from_level": "ERROR",
+  "to_level": "OK",
+  "previous_level_duration_s": 214.9,
+  "reason": "Motor nominal",
+  "state": "closed",
+  "fault_started_at": "2026-08-18T09:12:33.123456Z",
+  "duration_s": 214.9
+}
+```

--- a/progress.txt
+++ b/progress.txt
@@ -7770,3 +7770,81 @@ remains for a first real run to confirm.
 
 `tools/e2e/README.md` documents the new scenario and its layout entries; `Containerfile.e2e` gained
 `COPY` lines for `measure_rtt.py` (already needed by `run_degraded.sh`'s readiness/pre-check steps).
+
+## #365 - Add Measurement: fault -- raise and clear events from diagnostics, so MTBF and MTTR have a source
+
+`diagnostics` records snapshots: every poll writes the current `DiagnosticStatus` level, so the
+database holds `ERROR, ERROR, ERROR…` and recovering "when did this break, when was it fixed"
+means scanning for where a value changed in SQL -- exactly the failure mode transition Records
+exist to prevent. `fault` subscribes to the same `/diagnostics` topic and emits a Record only when
+a component's level actually changes, following intervention's precedent (#362, merged to `jazzy`
+while this branch was in flight): a separate Measurement projecting `diagnostics`'s signal rather
+than a mode on it, so a deployment already collecting snapshots keeps them unchanged, and one that
+wants only faults doesn't have to collect snapshots to get them.
+
+**Built on #360's `StateTransitionDetector`, one instance per watched component** (`std::map<name,
+StateTransitionDetector<uint8_t>>`), so components fault and recover independently -- a noisy
+`wifi` link flapping does not touch `motor_driver`'s sequence. Each transition is classified by
+where it starts/ends relative to `OK`: **raise** (left `OK`, opens a fault, `state: "open"`,
+`fault_started_at` recorded), **change** (between two non-`OK` levels, e.g. `WARN` to `ERROR`,
+still open, `fault_started_at` unchanged) and **clear** (back to `OK`, `state: "closed"`, carries
+`duration_s` and the same `fault_started_at` as the raise, so the pair joins downstream for MTTR;
+MTBF is the gap between successive raises). Levels are reported by name (`OK`/`WARN`/`ERROR`/
+`STALE`) rather than the raw integer, so `STALE` (a silent component) is never mistaken for `ERROR`
+(a broken one) in a query. `reason` is `DiagnosticStatus.message` on the entering status.
+
+**A fault still open at shutdown is never invented a duration.** No synthetic clear Record is
+published in `onCleanup()` (which only logs a warning per component still faulted, mirroring
+intervention's shutdown handling) -- the fault's last real Record already carries `state: "open"`
+and no `duration_s`, so it cannot be read as a zero-length outage. `seq` increments by one across
+every watched component (not per-component), so a dropped Record is a detectable gap in one global
+stream rather than a silently shortened outage. `names` (default: watch everything seen) filters
+which components are tracked at all, so one noisy, unwatched component cannot grow the detector map
+or flood the pipeline -- the DiagnosticArray callback also caps its pending-Records queue at 64,
+oldest dropped first, the same flood guard `battery.cpp`'s charging-session events use, since the
+callback and the polling timer run on different callback groups under the node's
+`MultiThreadedExecutor`.
+
+**A component already faulted on its very first observed sample gets no `fault_started_at`.** The
+detector treats the first sample as a baseline, not a transition (matching every other
+`StateTransitionDetector` consumer), so a component that starts life mid-fault has no recorded
+start -- consistent with intervention's same behavior for a takeover already under way when
+collection begins.
+
+**Schema.** `dc_measurements/plugins/measurements/json/fault.json`, validated through the existing
+`validateSchema("dc_measurements", ...)` path: `seq`, `component`, `event`, `from_level`,
+`to_level`, `previous_level_duration_s`, `reason` and `state` always required; `fault_started_at`
+and `duration_s` present only where the Record's `event` makes them meaningful.
+
+**Verification.** 5 gtest cases over the live plugin in `dc_measurements/test/
+test_measurement_fault.cpp`: a raise (component stays `OK` first and produces nothing, then
+transitions and the Record's fields, `state` and schema are checked), a clear (pairs with the
+preceding raise via `fault_started_at`, carries `duration_s`), a change that is not a clear
+(`WARN` to `ERROR`, stays open, `fault_started_at` unmoved), a flapping component (four alternating
+transitions, `seq` 1-4, events `raise, clear, raise, clear`), and a fault open at shutdown (one
+Record, `state: "open"`, no `duration_s`, nothing manufactured by `stopCollection()`). Registered in
+`dc_measurements/CMakeLists.txt` (library `dc_fault_measurement`, test `test_measurement_fault`)
+and `measurement_plugin.xml`. Documented in `doc/src/dc/measurements/fault.md`, listed in
+`SUMMARY.md` and the plugin table in `doc/src/dc/measurements.md`.
+
+Pushed and opened a PR (#374) before the local `colcon build`/`colcon test` run (`tools/e2e/
+scripts/build.sh`) finished, at the user's explicit request, so CI's own build runs in parallel
+with local verification rather than after it. CI's `build-workspace` job caught a real bug the
+local run (which separately hit "no space left on device" in this sandbox, an environment
+constraint unrelated to the code) hadn't reached yet: 4 of the 5 `test_measurement_fault` cases
+timed out, because `StateTransitionDetector` treats a component's very first observed sample as a
+baseline rather than a transition -- those four tests published the "raising" status as the very
+first sample ever seen for their component, so the detector correctly produced no Record and every
+subsequent `publishUntilRecord()` wait for it wired downstream timed out. Only the first test
+happened to publish `OK` first (to also assert "staying put produces nothing"), which incidentally
+established the baseline its own raise then relied on. Fixed by adding `establishOkBaseline()` and
+calling it before each test's first real transition; `build-workspace` (which runs `colcon test`)
+passed on the next CI run.
+
+`#362` (intervention) and `#364` (battery state in the simulation) both merged into `jazzy` while
+this branch was in flight, both touching `dc_measurements/CMakeLists.txt`'s `add_library`/test
+list the same way this issue does. Rebased onto `origin/jazzy`: `CMakeLists.txt` and
+`measurement_plugin.xml` merged cleanly (non-overlapping insertion points), `doc/src/SUMMARY.md`
+and this file needed manual conflict resolution to keep both sides' entries. `#366` (degraded
+network conditions testing) then merged into `jazzy` too, mid-rebase, conflicting with this file
+alone (both entries append at the same tail); rebased again, keeping both entries in issue order.


### PR DESCRIPTION
## Summary

- Adds a `fault` Measurement subscribing to `/diagnostics` that emits a Record only when a component's `DiagnosticStatus` level changes -- `diagnostics` records periodic snapshots, so recovering "when did this break, when was it fixed" today means scanning for where a value changed in SQL, silently producing a wrong duration the moment one Record is dropped.
- One `dc_common::StateTransitionDetector<uint8_t>` per watched component (the same building block as intervention, #362), classifying each transition as `raise` (left `OK`), `change` (between two non-`OK` levels, e.g. `WARN`→`ERROR`), or `clear` (back to `OK`, carries `duration_s`). Both the raise and the clear share `fault_started_at`, so the pair joins downstream for MTTR; MTBF is the gap between successive raises.
- Levels are reported by name (`OK`/`WARN`/`ERROR`/`STALE`) so `STALE` (silent) is never mistaken for `ERROR` (broken). A fault still open at shutdown keeps its last Record's `state: "open"` and no `duration_s` -- no closing Record is invented, so it can't be read as a zero-length outage.
- `seq` increments across every watched component (one global stream), so a dropped Record is a detectable gap. `names` (default: watch everything seen) limits which components are tracked; a pending-Records queue caps at 64, mirroring `battery.cpp`'s charging-session flood guard.
- JSON schema, gtest coverage (a raise, a clear, a change that is not a clear, a flapping component, a fault open at shutdown), and docs (`doc/src/dc/measurements/fault.md`, `SUMMARY.md`, plugin table).

## Test plan

- [ ] `colcon build` + `colcon test` for `dc_measurements` (running locally via `tools/e2e/scripts/build.sh` in parallel with this PR's CI build; will report back if either turns up something the other didn't)
- [x] `prek run --all-files --skip build-doc`: all 24 hooks pass

Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144yNQyXN9xNdGTuj3K8m23