### PR TITLE
feat(dc_simulation): publish battery state in the simulation

### DIFF
--- a/dc_demos/params/qrcodes_nav.yaml
+++ b/dc_demos/params/qrcodes_nav.yaml
@@ -422,7 +422,11 @@ docking_server:
       docking_threshold: 0.05
       staging_x_offset: -0.7
       use_external_detection_pose: false
-      use_battery_status: false
+      # Was false because nothing published sensor_msgs/BatteryState -- the demo still
+      # never docks, but battery_state now has a real source (waffle.model's
+      # LinearBatteryPlugin, bridged in dc_simulation/config/warehouse_bridge.yaml,
+      # #364), so SimpleChargingDock's is_charging_ check has something to subscribe to.
+      use_battery_status: true
       use_stall_detection: false
     docks: ["home_dock"]
     home_dock:

--- a/dc_simulation/README.md
+++ b/dc_simulation/README.md
@@ -27,11 +27,66 @@ simulation moved to gz-sim:
 | `/scan` | `gpu_lidar` sensor |
 | `/imu` | `imu` sensor |
 | `/{left,right}_intel_realsense_r200_depth/{image_raw,camera_info,depth/image_raw}` | two `rgbd_camera` sensors |
+| `/battery_state` | `LinearBatteryPlugin` (`worlds/waffle.model`) — see "Battery" below |
 
 Every sensor sets `<gz_frame_id>` to the matching link in `dc_description`'s URDF.
 Without it gz-sensors stamps messages with the scoped sensor name, which is not a TF
 frame, and every tf2 `MessageFilter` downstream — AMCL, both Nav2 costmaps — silently
 drops the message.
+
+## Battery
+
+`worlds/waffle.model` carries a `gz-sim-linearbatteryplugin-system` battery
+(`libgz-sim8-linearbatteryplugin-system.so`, already in the workspace image). It
+discharges once the robot has driven at all — the plugin's own rule, not a `dc_simulation`
+choice: current draw latches on at the first nonzero wheel command and never resets
+itself — and recharges when it is told to over `gz.msgs.Boolean` services, which
+`models/charging_dock/model.sdf` turns into "when the robot noses up to a pad in the
+world" using two stock gz-sim systems (`TouchPlugin`, `TriggeredPublisher`) and no new
+code. `ros_gz_bridge` re-publishes the plugin's own `.../battery/linear_battery/state`
+topic as ROS `battery_state`, the unqualified name `opennav_docking`'s
+`SimpleChargingDock` subscribes to (`dc_demos/params/qrcodes_nav.yaml`'s
+`docking_server.use_battery_status`, on since #364).
+
+**Rates, and why.** The real TurtleBot3-Waffle spec — an 11.1 V Li-ion pack, about
+1.8 Ah — is kept where it costs nothing (`voltage`), but not for `capacity`: at the real
+size, a visible discharge needs on the order of two hours of continuous driving. Rates
+matter more than realism here, so `capacity` is 0.05 Ah, sized against `power_load` and
+`charging_time` so one discharge-then-recharge cycle fits in a couple of minutes:
+
+- `power_load` 18.0 W draws about 1.62 A at 11.1 V (`I = P / V`). Emptying 0.05 Ah at
+  1.62 A takes `capacity / I` ≈ 111 s of driving.
+- `charging_time` 0.02 h (72 s) is the SDF parameter's own unit — hours to go from empty
+  to full at the derived charging current (`capacity / charging_time`, 2.5 A here, above
+  the 1.62 A discharge current as gz-sim's own `linear_battery_demo.sdf` recommends).
+  `LinearBatteryPlugin` stops adding that current past 90% state of charge, so reaching
+  the cap from empty takes about `0.9 * 72 s` ≈ 65 s; `charging_dock/model.sdf`'s
+  `TriggeredPublisher` waits 90 s before calling `recharge/stop`, comfortably past that.
+
+**Docking mechanism.** `models/charging_dock/model.sdf` places a contact-sensor pad 0.8 m
+ahead of `warehouse.launch.py`'s default spawn pose. A `TouchPlugin` fires once when a
+`turtlebot3_waffle` collision has touched the pad continuously for 1 s, and two
+`TriggeredPublisher` plugins turn that into a `recharge/start` call and, after the 90 s
+above, a `recharge/stop` call plus re-arming the `TouchPlugin` for the next visit. Try it
+by hand against `warehouse.launch.py` (headless or not):
+
+```bash
+gz topic -e -t /model/turtlebot3_waffle/battery/linear_battery/state   # watch it discharge
+gz topic -t /cmd_vel -m gz.msgs.Twist -p "linear: {x: 0.3}"            # drive to the dock
+```
+
+**Sign convention.** `sensor_msgs/BatteryState` documents positive `current` as charging,
+negative as discharging; gz's own internal sign is the opposite (a plain discharge
+current is positive, and charging current is *subtracted*, so it only ever pushes the
+raw value negative). `LinearBatteryPlugin`'s `invert_current_sign` flips it, because
+`SimpleChargingDock` decides `is_charging_` from `current > charging_threshold_` (0.5 A
+default) — without the inversion it would never see a charge.
+
+**Percentage scale.** `fix_issue_225` reports `percentage` on a 0–100 scale rather than
+gz's un-fixed 0–1. That matches `dc_measurements`' battery plugin's own
+`percentage_scale` default of 100.0 (`plugins/measurements/json/battery.json`, #361) —
+built for exactly this gz-sim quirk, since `ros_gz_bridge` copies the field straight
+through with no rescaling of its own.
 
 ## What the robot's topics cost to collect
 

--- a/dc_simulation/config/warehouse_bridge.yaml
+++ b/dc_simulation/config/warehouse_bridge.yaml
@@ -41,6 +41,18 @@
   gz_type_name: "gz.msgs.IMU"
   direction: GZ_TO_ROS
 
+# waffle.model's LinearBatteryPlugin (#364). "battery_state" is not this repo's usual
+# unscoped-name convention (the gz topic itself is
+# /model/turtlebot3_waffle/battery/linear_battery/state) -- it is instead the fixed,
+# unqualified name opennav_docking's SimpleChargingDock subscribes to
+# (dc_demos/params/qrcodes_nav.yaml's docking_server.use_battery_status), so bridging
+# under any other name would leave that subscription silent.
+- ros_topic_name: "battery_state"
+  gz_topic_name: "/model/turtlebot3_waffle/battery/linear_battery/state"
+  ros_type_name: "sensor_msgs/msg/BatteryState"
+  gz_type_name: "gz.msgs.BatteryState"
+  direction: GZ_TO_ROS
+
 - ros_topic_name: "scan"
   gz_topic_name: "/scan"
   ros_type_name: "sensor_msgs/msg/LaserScan"

--- a/dc_simulation/models/charging_dock/model.config
+++ b/dc_simulation/models/charging_dock/model.config
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<model>
+  <name>charging_dock</name>
+  <version>1.0</version>
+  <sdf version="1.6">model.sdf</sdf>
+  <author>
+    <name>Battery state in the simulation (#364)</name>
+    <email>d.bensoussan@proton.me</email>
+  </author>
+  <description>
+    A static charging-dock pad for the TurtleBot3-Waffle's LinearBatteryPlugin battery
+    (see worlds/waffle.model). A contact sensor plus a TouchPlugin/TriggeredPublisher
+    chain calls the battery's recharge start/stop services when the robot noses up
+    against the pad, so the demo's battery goes through visible discharge/recharge
+    cycles without any new C++/Python code — see README.md's "Battery" section for the
+    rates and the reasoning.
+  </description>
+</model>

--- a/dc_simulation/models/charging_dock/model.sdf
+++ b/dc_simulation/models/charging_dock/model.sdf
@@ -1,0 +1,97 @@
+<?xml version="1.0"?>
+<sdf version="1.6">
+  <model name="charging_dock">
+    <static>true</static>
+    <link name="link">
+      <!-- A vertical pad, not a floor plate: the robot noses up against it rather than
+           driving over it, so contact does not depend on how much ground clearance the
+           chassis happens to have. Sized to cover waffle.model's base_collision box
+           (0.265 x 0.265 x 0.089 m, centred 0.048 m up) with margin on every side. -->
+      <collision name="pad_collision">
+        <pose>0 0 0.15 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.05 0.4 0.3</size>
+          </box>
+        </geometry>
+      </collision>
+      <visual name="pad_visual">
+        <pose>0 0 0.15 0 0 0</pose>
+        <geometry>
+          <box>
+            <size>0.05 0.4 0.3</size>
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.1 0.6 0.15 1</ambient>
+          <diffuse>0.1 0.6 0.15 1</diffuse>
+          <specular>0.1 0.1 0.1 1</specular>
+        </material>
+      </visual>
+      <sensor name="dock_contact" type="contact">
+        <contact>
+          <collision>pad_collision</collision>
+        </contact>
+        <update_rate>30</update_rate>
+      </sensor>
+    </link>
+
+    <!--
+      Docking/undocking without any new node: LinearBatteryPlugin (waffle.model) only
+      starts and stops recharging in response to its own recharge/start and
+      recharge/stop services, and neither it nor any other shipped gz-sim system
+      detects "robot left the dock" on its own. Two config-only plugins bridge that gap:
+
+      - TouchPlugin fires once, "/dock/touched" (true), after 1 s of continuous contact
+        between this pad and a turtlebot3_waffle collision, then disables itself (its own
+        documented behaviour — it is a single-use plugin).
+      - The first TriggeredPublisher below turns that into a recharge/start call.
+      - The second waits <delay_ms> (comfortably longer than the time
+        worlds/waffle.model's <charging_time> needs to reach the 90% cap
+        LinearBatteryPlugin stops injecting current at), then calls recharge/stop *and*
+        re-arms the TouchPlugin via its /dock/enable service, so the next visit fires
+        again. If the robot is still parked on the pad when that happens, contact never
+        broke, so TouchPlugin's 1 s timer restarts immediately and the pad fires another
+        short charge pulse — harmless (SoC is already at/near the cap) and stops as soon
+        as the robot drives off.
+
+      recharge/start and recharge/stop are plain gz-transport services with no reply
+      payload (advertised without a response type), the same shape the recharge/enable
+      service TouchPlugin advertises for itself uses — `gz.msgs.Empty` as `repType` here
+      matches gz-sim's own linear_battery_demo.sdf, which documents calling these
+      exact service shapes by hand.
+    -->
+    <plugin filename="gz-sim-touchplugin-system" name="gz::sim::systems::TouchPlugin">
+      <target>turtlebot3_waffle</target>
+      <namespace>dock</namespace>
+      <time>1.0</time>
+      <enabled>true</enabled>
+    </plugin>
+
+    <plugin filename="gz-sim-triggered-publisher-system" name="gz::sim::systems::TriggeredPublisher">
+      <input type="gz.msgs.Boolean" topic="/dock/touched">
+        <match>data: true</match>
+      </input>
+      <service name="/model/turtlebot3_waffle/battery/linear_battery/recharge/start"
+        reqType="gz.msgs.Boolean" repType="gz.msgs.Empty" timeout="1000"
+        reqMsg="data: true">
+      </service>
+    </plugin>
+
+    <plugin filename="gz-sim-triggered-publisher-system" name="gz::sim::systems::TriggeredPublisher">
+      <input type="gz.msgs.Boolean" topic="/dock/touched">
+        <match>data: true</match>
+      </input>
+      <!-- See worlds/waffle.model's <charging_time> comment for the 90 s figure. -->
+      <delay_ms>90000</delay_ms>
+      <service name="/model/turtlebot3_waffle/battery/linear_battery/recharge/stop"
+        reqType="gz.msgs.Boolean" repType="gz.msgs.Empty" timeout="1000"
+        reqMsg="data: true">
+      </service>
+      <service name="/dock/enable"
+        reqType="gz.msgs.Boolean" repType="gz.msgs.Empty" timeout="1000"
+        reqMsg="data: true">
+      </service>
+    </plugin>
+  </model>
+</sdf>

--- a/dc_simulation/worlds/qrcodes.world
+++ b/dc_simulation/worlds/qrcodes.world
@@ -33,6 +33,11 @@ SPDX-License-Identifier: MPL-2.0
     </plugin>
     <plugin filename="gz-sim-scene-broadcaster-system" name="gz::sim::systems::SceneBroadcaster">
     </plugin>
+    <!-- Required for models/charging_dock's <sensor type="contact"> to populate
+         ContactSensorData at all -- without this system loaded, the sensor is declared
+         but never actually detects anything (#364). -->
+    <plugin filename="gz-sim-contact-system" name="gz::sim::systems::Contact">
+    </plugin>
 
     <!--
       Gazebo Classic resolved "model://ground_plane" and "model://sun"
@@ -186,6 +191,20 @@ SPDX-License-Identifier: MPL-2.0
       <pose>-5.96 -1.64 -0.094592 0 0 0</pose>
       <include>
         <uri>model://warehouse</uri>
+      </include>
+    </model>
+
+    <!-- #364: a battery charging pad for waffle.model's LinearBatteryPlugin (see
+         models/charging_dock/model.sdf for the docking/undocking mechanism). Placed
+         0.8 m ahead of warehouse.launch.py's default spawn pose (-7.3, 1.37, yaw 0), on
+         open floor clear of both the warehouse structure and the QR-coded pallets --
+         close enough for a short manual `cmd_vel` drive to reach it (see README.md's
+         "Battery" section for the exact command). tb3_qrcodes.launch.py spawns
+         elsewhere in this same world, so reaching the dock there means driving there. -->
+    <model name="charging_dock">
+      <pose>-6.5 1.37 0 0 0 0</pose>
+      <include>
+        <uri>model://charging_dock</uri>
       </include>
     </model>
 

--- a/dc_simulation/worlds/waffle.model
+++ b/dc_simulation/worlds/waffle.model
@@ -601,5 +601,61 @@
       <joint_name>wheel_right_joint</joint_name>
     </plugin>
 
+    <!--
+      #364: libgz-sim8-linearbatteryplugin-system.so ships in the workspace image
+      already; ros_gz_bridge already converts gz.msgs.BatteryState to
+      sensor_msgs/msg/BatteryState (see config/warehouse_bridge.yaml). This is the
+      model-side half — a battery that discharges once the robot has driven at all
+      (LinearBatteryPlugin's own rule: current draw latches on at the first nonzero
+      wheel command and never resets itself) and recharges on a service call, which
+      models/charging_dock/model.sdf turns into "when the robot noses up to the dock".
+
+      Real TB3-Waffle spec is an 11.1 V Li-ion pack of about 1.8 Ah — kept here because
+      it costs nothing, unlike the capacity, which would need on the order of two hours
+      of continuous driving to show a real discharge. Rates matter more than realism, so
+      capacity is 0.05 Ah instead, sized against power_load and charging_time below so a
+      full discharge-then-recharge cycle fits in a couple of minutes of demo time rather
+      than an afternoon:
+
+      - power_load 18.0 W draws about 1.62 A at 11.1 V (I = P / V). Emptying a 0.05 Ah
+        pack at 1.62 A takes capacity / I =~ 111 s of driving.
+      - charging_time 0.02 h (72 s) is the SDF parameter's own unit (hours to go from
+        empty to full at the derived charging current, I = capacity / charging_time =
+        2.5 A here — above the 1.62 A discharge current, as gz-sim's own
+        linear_battery_demo.sdf recommends). LinearBatteryPlugin stops adding that
+        current once state of charge passes 90%, so reaching the cap from empty takes
+        about 0.9 * 72 s =~ 65 s; the charging_dock model's TriggeredPublisher waits 90 s
+        before calling recharge/stop, comfortably past that.
+
+      invert_current_sign is set because sensor_msgs/BatteryState documents positive
+      current as charging and negative as discharging, the opposite of gz's own internal
+      sign (a plain discharge current is positive; charging current is subtracted, so it
+      only ever pushes the raw current negative). Nav2's opennav_docking
+      SimpleChargingDock decides is_charging_ from `current > charging_threshold_`
+      (0.5 A default) — without the inversion, the reported current would be negative
+      while actually charging and dc_demos/params/qrcodes_nav.yaml's
+      use_battery_status: true would never see a charge.
+
+      fix_issue_225 reports percentage on a 0-100 scale rather than gz's un-fixed 0-1,
+      matching dc_measurements' battery plugin's own percentage_scale default of 100.0
+      (plugins/measurements/json/battery.json, #361) — built for exactly this gz-sim
+      quirk, since ros_gz_bridge copies the percentage field straight through with no
+      rescaling (see convert/sensor_msgs.hpp upstream).
+    -->
+    <plugin filename="gz-sim-linearbatteryplugin-system" name="gz::sim::systems::LinearBatteryPlugin">
+      <battery_name>linear_battery</battery_name>
+      <voltage>11.1</voltage>
+      <open_circuit_voltage_constant_coef>11.1</open_circuit_voltage_constant_coef>
+      <open_circuit_voltage_linear_coef>-2.0</open_circuit_voltage_linear_coef>
+      <capacity>0.05</capacity>
+      <resistance>0.07</resistance>
+      <smooth_current_tau>2.0</smooth_current_tau>
+      <fix_issue_225>true</fix_issue_225>
+      <invert_current_sign>true</invert_current_sign>
+      <power_load>18.0</power_load>
+      <enable_recharge>true</enable_recharge>
+      <charging_time>0.02</charging_time>
+    </plugin>
+
   </model>
 </sdf>

--- a/progress.txt
+++ b/progress.txt
@@ -7629,3 +7629,65 @@ SQL cannot parse.
 
 The demo still has no teleop topic, so a takeover has to be produced by hand for now — wiring one
 in is a follow-up, as #362 says.
+
+## #364 - Publish battery state in the simulation, so battery Records have a source in the demo
+
+Model and bridge-configuration only, as the issue called for — `libgz-sim8-linearbatteryplugin-
+system.so` and `ros_gz_bridge`'s `gz.msgs.BatteryState` → `sensor_msgs/msg/BatteryState`
+conversion both already ship; nothing here is new C++/Python.
+
+**`worlds/waffle.model`** grows a `LinearBatteryPlugin`. It discharges once the robot has driven
+at all (the plugin's own rule — current draw latches on at the first nonzero wheel command and
+never resets) and recharges over `gz.msgs.Boolean` services. Real TB3-Waffle spec (11.1 V Li-ion,
+~1.8 Ah) is kept where it costs nothing; `capacity` is shrunk to 0.05 Ah so a full
+discharge-then-recharge cycle fits a couple of minutes of demo time instead of an afternoon —
+`power_load` 18.0 W (≈1.62 A discharge, ≈111 s to empty) and `charging_time` 0.02 h (≈65 s to
+reach the plugin's 90% charging cap). `invert_current_sign` is required, not cosmetic:
+`sensor_msgs/BatteryState` documents positive current as charging, gz's own internal sign is the
+opposite, and `opennav_docking::SimpleChargingDock` decides `is_charging_` from
+`current > charging_threshold_` — without the flag it would never see a charge. `fix_issue_225`
+reports `percentage` on 0-100 rather than gz's 0-1, matching #361's battery plugin's own
+`percentage_scale` default of 100.0 (built for exactly this quirk, since `ros_gz_bridge` copies
+the field straight through unscaled).
+
+**Docking/undocking without new code.** `LinearBatteryPlugin` only starts/stops recharging on its
+own services and has no idea what a dock is; nothing shipped in gz-sim detects "left the dock"
+either. `models/charging_dock/model.sdf` is a new placeholder model — a vertical contact pad (the
+robot noses up to it rather than driving over it, sidestepping chassis ground-clearance
+uncertainty) plus a `TouchPlugin` + two `TriggeredPublisher` plugins: contact for 1 s calls
+`recharge/start`; 90 s later (comfortably past the ≈65 s charge-up above) a second plugin calls
+`recharge/stop` *and* re-arms the `TouchPlugin`'s single-use trigger via its own `/enable`
+service, so the next visit fires again. Placed in `qrcodes.world` 0.8 m ahead of
+`warehouse.launch.py`'s default spawn pose, on open floor; the world also gained the
+`gz-sim-contact-system` plugin the pad's `<sensor type="contact">` needs to produce any data at
+all.
+
+**Bridge and demo wiring.** `config/warehouse_bridge.yaml` bridges
+`/model/turtlebot3_waffle/battery/linear_battery/state` to ROS `battery_state` — not this file's
+usual unscoped-gz-name convention, but the fixed, unqualified topic name
+`opennav_docking::SimpleChargingDock` subscribes to, so `dc_demos/params/qrcodes_nav.yaml`'s
+`docking_server.use_battery_status` could flip from `false` to `true` (it was `false` only because
+nothing published the topic).
+
+**Verification.** `gz sdf -k` (via the prebuilt `dc-workspace` image, models bind-mounted over the
+installed copies): both `qrcodes.world` and `waffle.model` valid, no structural errors.
+`tools/sim/scripts/lint_launch_files.py`: SDF and bridge-vs-demo-params checks pass; the two
+`tb3_simulation_*.launch.py` failures (missing `nav2_bringup` demo assets) and the
+`qrcodes_waypoint_follower` import error are pre-existing artifacts of a partial bind-mount
+(python source not mounted), not regressions — confirmed by re-running against an unmodified
+container. Live end-to-end check, `warehouse.launch.py headless:=True` in that same container: at
+spawn, `battery_state` reads 100%/`FULL`; driving toward the pad flips it to `DISCHARGING` with
+`current` negative (confirms the sign inversion); on contact, `/dock/touched` fires and status
+flips to `CHARGING` immediately, though `current` keeps trending toward the pure-discharge value
+until state of charge actually crosses under 90% (correct — `LinearBatteryPlugin` only subtracts
+charging current below that threshold, docking while still >90% charged is a label-only no-op);
+once SoC crossed 90% mid-test, `current` swung from -1.66 A to +0.20 A within a couple of samples
+and `percentage` turned from falling to climbing — the full recharge path confirmed working
+end-to-end, not just wired.
+
+Left for later, out of this issue's scope: no `dc_demos` params file configures the battery
+Measurement plugin against the new `battery_state` topic (#361 shipped no demo wiring either), and
+the one-way `qrcodes_waypoint_follower.py` patrol never actually returns to the dock, so the cycle
+above is demonstrated by manual driving, not the autonomous demo — the issue's acceptance
+criteria ask for the capability and documented rates, not a scripted docking sequence nav2's own
+`docking_server` config still calls a "never docks" placeholder for.


### PR DESCRIPTION
## Summary

- `worlds/waffle.model` gains a `LinearBatteryPlugin` battery: discharges once the robot has driven at all, recharges over `gz.msgs.Boolean` services. Rates (`capacity`/`power_load`/`charging_time`) are chosen so a full discharge-then-recharge cycle fits a couple of minutes of demo time instead of two hours at the real TB3-Waffle spec — see `dc_simulation/README.md`'s new "Battery" section for the arithmetic and reasoning. `invert_current_sign` and `fix_issue_225` are set for correctness, not cosmetics: the former matches `sensor_msgs/BatteryState`'s sign convention so `opennav_docking::SimpleChargingDock`'s `is_charging_` check actually works, the latter matches `dc_measurements`' battery plugin's own `percentage_scale` default.
- New `dc_simulation/models/charging_dock/model.sdf`: a contact-sensor pad that turns "robot noses up against it" into `recharge/start`/`recharge/stop` service calls via `TouchPlugin` + `TriggeredPublisher` — no new C++/Python code, config only. Placed in `qrcodes.world`, which also gains the `gz-sim-contact-system` plugin the pad's contact sensor needs.
- `config/warehouse_bridge.yaml` bridges the plugin's own state topic to ROS `battery_state` — the fixed, unqualified name `opennav_docking::SimpleChargingDock` subscribes to.
- `dc_demos/params/qrcodes_nav.yaml`'s `docking_server.use_battery_status` flips from `false` to `true` now that the topic has a real source.

## Test plan

- [x] `gz sdf -k` on `qrcodes.world` and `waffle.model` (via the prebuilt `dc-workspace` image): both valid, no structural errors.
- [x] `tools/sim/scripts/lint_launch_files.py`: SDF checks and bridge-vs-demo-params checks pass (the two `tb3_simulation_*.launch.py`/`qrcodes_waypoint_follower` failures are pre-existing artifacts of a partial bind-mount for local testing, confirmed against an unmodified container).
- [x] Live end-to-end check, `warehouse.launch.py headless:=True`: battery starts at 100%/`FULL`; driving toward the pad shows `DISCHARGING` with negative `current` (confirms the sign inversion); touching the pad fires `/dock/touched` and flips status to `CHARGING`; once state of charge crossed the plugin's 90% cap during the test, `current` swung from -1.66 A to +0.20 A and `percentage` turned from falling to climbing — the recharge path confirmed working end-to-end, not just wired.
- [x] `prek run --all-files --skip build-doc`: all hooks pass.

Not covered here (documented as out of scope in `progress.txt`): no `dc_demos` params file wires the battery Measurement plugin to the new `battery_state` topic yet, and the existing one-way `qrcodes_waypoint_follower.py` patrol never returns to the dock, so the demonstrated cycle is manual driving rather than the autonomous demo — matching the issue's own acceptance criteria, which ask for the capability and documented rates rather than a scripted docking sequence nav2's `docking_server` config still only has a "never docks" placeholder for.

Closes #364

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01YSLC5XbdfHe9cGAewjcQQB