### PR TITLE
test(dc_bridge,e2e): prove the pipeline under degraded network conditions

### DIFF
--- a/dc_bridge/test/forwarder_test.cpp
+++ b/dc_bridge/test/forwarder_test.cpp
@@ -19,6 +19,7 @@
 #include <msgpack.hpp>
 #include <mutex>
 #include <nlohmann/json.hpp>
+#include <random>
 #include <string>
 #include <thread>
 #include <vector>
@@ -155,6 +156,121 @@ void read_frame_and_ack(int fd)
   pk.pack(std::string("ack"));
   pk.pack(chunk_id);
   ::send(fd, ack_buf.data(), ack_buf.size(), 0);
+}
+
+// --- Acknowledgement-policy mock ingest peer (#366) ---------------------------------
+//
+// Real robots ack over a link with tens of milliseconds of RTT, packet loss, and a
+// bufferbloated/slow-draining receive path — none of which loopback (the rest of this
+// file) ever exercises. A policy turns the three questions that raises about the
+// Forwarder — unacked window depth, backpressure classification, resend-under-delay —
+// into deterministic unit tests: no container, no network, just a peer that
+// acknowledges on a schedule instead of immediately or never. Every existing test above
+// is this policy's degenerate case (delay=0, never_ack_probability=0).
+struct AckPolicy
+{
+  // Delay applied before acknowledging a received chunk — models acknowledgement RTT.
+  std::chrono::milliseconds ack_delay{ 0 };
+  // Fraction of received chunks that are never acknowledged — models a lost ack.
+  double never_ack_probability{ 0.0 };
+  // Bytes read per recv() before sleeping drain_pause; 0 = read as fast as available.
+  // Models a peer that is draining its socket slowly rather than one that stopped
+  // reading altogether (drain_pause with drain_chunk_bytes == 0 would never actually
+  // throttle, since one recv() would drain everything available).
+  std::size_t drain_chunk_bytes{ 0 };
+  std::chrono::milliseconds drain_pause{ 0 };
+};
+
+// Runs `policy` against one already-accepted connection until the peer closes/errors or
+// `stop` is set. Every chunk id the frame parser completes is appended to `received` (in
+// wire order, so a resend that duplicates a chunk id shows up twice); every chunk id
+// actually acknowledged is appended to `acked`. Uses a real msgpack::unpacker (exactly
+// like Forwarder's own drain_acks()) so a small drain_chunk_bytes that splits one frame
+// across several recv() calls is still parsed correctly, rather than requiring every
+// frame to land in a single read.
+void run_ack_policy_peer(int conn_fd, const AckPolicy& policy, std::vector<std::string>& received,
+                         std::vector<std::string>& acked, std::mutex& mutex, std::atomic<bool>& stop)
+{
+  std::mt19937 rng{ std::random_device{}() };
+  std::uniform_real_distribution<double> unit{ 0.0, 1.0 };
+  msgpack::unpacker unpacker;
+
+  // A short receive timeout, not a blocking recv(): once the client under test goes idle
+  // (e.g. everything already acked), a blocking recv() would never return and `stop`
+  // would never be re-checked, hanging the test's own srv.join() forever.
+  timeval rcv_timeout{ 0, 100000 };  // 100ms
+  ::setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
+
+  while (!stop.load())
+  {
+    const std::size_t to_read = policy.drain_chunk_bytes == 0 ? std::size_t{ 8192 } : policy.drain_chunk_bytes;
+    unpacker.reserve_buffer(to_read);
+    ssize_t n = ::recv(conn_fd, unpacker.buffer(), to_read, 0);
+    if (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK))
+    {
+      continue;  // no data within the receive timeout; re-check `stop` and try again
+    }
+    if (n <= 0)
+    {
+      return;  // peer closed or errored
+    }
+    unpacker.buffer_consumed(static_cast<std::size_t>(n));
+    if (policy.drain_pause.count() > 0)
+    {
+      std::this_thread::sleep_for(policy.drain_pause);
+    }
+
+    msgpack::object_handle oh;
+    while (unpacker.next(oh))
+    {
+      msgpack::object top = oh.get();
+      if (top.type != msgpack::type::ARRAY || top.via.array.size < 3)
+      {
+        continue;
+      }
+      msgpack::object option = top.via.array.ptr[2];
+      std::string chunk_id;
+      if (option.type == msgpack::type::MAP)
+      {
+        for (std::uint32_t i = 0; i < option.via.map.size; ++i)
+        {
+          if (option.via.map.ptr[i].key.as<std::string>() == "chunk")
+          {
+            chunk_id = option.via.map.ptr[i].val.as<std::string>();
+          }
+        }
+      }
+      if (chunk_id.empty())
+      {
+        continue;
+      }
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        received.push_back(chunk_id);
+      }
+      if (unit(rng) < policy.never_ack_probability)
+      {
+        continue;
+      }
+      if (policy.ack_delay.count() > 0)
+      {
+        std::this_thread::sleep_for(policy.ack_delay);
+      }
+      msgpack::sbuffer ack_buf;
+      msgpack::packer<msgpack::sbuffer> pk(ack_buf);
+      pk.pack_map(1);
+      pk.pack(std::string("ack"));
+      pk.pack(chunk_id);
+      if (::send(conn_fd, ack_buf.data(), ack_buf.size(), MSG_NOSIGNAL) < 0)
+      {
+        return;
+      }
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        acked.push_back(chunk_id);
+      }
+    }
+  }
 }
 
 }  // namespace
@@ -468,5 +584,347 @@ TEST(Forwarder, WindowBoundDropsOldestRecordsWithWarning)
   EXPECT_FALSE(last_warning.empty());
 
   stop.store(true);
+  srv.join();
+}
+
+// #366: the drop-with-warning mechanism above is already covered by a peer that never
+// acks at all. What's untested is the *shipped default* bound (10000 records) at an
+// acknowledgement delay representative of a real link — this is that measurement.
+TEST(Forwarder, WindowDepthStaysWellBelowShippedDefaultBoundAtRealisticAckDelay)
+{
+  MockServer server;
+  std::atomic<bool> stop{ false };
+  std::vector<std::string> received, acked;
+  std::mutex mutex;
+  AckPolicy policy;
+  policy.ack_delay = std::chrono::milliseconds(50);  // representative WiFi/uplink ack RTT
+
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    if (c >= 0)
+    {
+      run_ack_policy_peer(c, policy, received, acked, mutex, stop);
+      ::close(c);
+    }
+  });
+
+  ForwarderConfig cfg;  // shipped defaults: max_unacked_records = 10000
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  std::atomic<int> warnings{ 0 };
+  cfg.on_warning = [&](const std::string&) { ++warnings; };
+  Forwarder forwarder(cfg);
+
+  const int kRecords = 20;
+  std::size_t peak_depth = 0;
+  for (int i = 0; i < kRecords; ++i)
+  {
+    forwarder.send(make_record("dc.test", R"({"n": 1})"));
+    peak_depth = std::max(peak_depth, forwarder.unacked_count());
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));  // ~100 Hz, a realistic Measurement rate
+  }
+
+  poll_until(std::chrono::seconds(5), [&]() {
+    forwarder.poll();
+    return forwarder.unacked_count() == 0;
+  });
+
+  stop.store(true);
+  srv.join();
+
+  // In-flight volume ~= rate * ack delay: at 100 Hz / 50ms that's ~5 records, nowhere
+  // near the shipped 10000-record bound.
+  EXPECT_LE(peak_depth, 20u) << "unacked window depth at a realistic rate/delay should stay small";
+  EXPECT_EQ(warnings.load(), 0) << "the shipped default bound must not fire at a realistic bandwidth-delay product";
+}
+
+// #366: unlike WindowBoundDropsOldestRecordsWithWarning (a peer that never acks at all),
+// this peer acks every chunk — just too slowly to keep the window inside a small bound
+// once the send rate outruns the ack turnaround. Demonstrates the drop valve fires from
+// delay alone, not only from a dead/absent peer, and that the window still converges
+// once the burst ends.
+TEST(Forwarder, WindowBoundIsExceededAtAWorseRateDelayCombination)
+{
+  MockServer server;
+  std::atomic<bool> stop{ false };
+  std::vector<std::string> received, acked;
+  std::mutex mutex;
+  AckPolicy policy;
+  policy.ack_delay = std::chrono::milliseconds(300);  // long relative to the burst below
+
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    if (c >= 0)
+    {
+      run_ack_policy_peer(c, policy, received, acked, mutex, stop);
+      ::close(c);
+    }
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  cfg.max_unacked_records = 5;
+  cfg.max_unacked_bytes = 1024 * 1024;
+  cfg.warn_interval = std::chrono::milliseconds(0);
+  std::atomic<int> warnings{ 0 };
+  cfg.on_warning = [&](const std::string&) { ++warnings; };
+  Forwarder forwarder(cfg);
+
+  // A burst well faster than the 300ms ack delay: every record above the bound of 5 is
+  // sent before the first ack can possibly have arrived.
+  for (int i = 0; i < 10; ++i)
+  {
+    forwarder.send(make_record("dc.test", R"({"n": 1})"));
+  }
+
+  EXPECT_EQ(forwarder.unacked_count(), 5u) << "the bound must cap the window even though the peer is actively acking";
+  EXPECT_GT(warnings.load(), 0) << "exceeding the bound via delay alone must still warn";
+
+  bool converged = poll_until(std::chrono::seconds(5), [&]() {
+    forwarder.poll();
+    return forwarder.unacked_count() == 0;
+  });
+  stop.store(true);
+  srv.join();
+  EXPECT_TRUE(converged) << "once the burst ends, the window should still drain to zero — the bound doesn't wedge it";
+}
+
+// #366: distinguishes a peer that is slow to drain its socket (retryable backpressure,
+// connection kept) from one that has gone away (Io, connection dropped) — the two error
+// kinds a real congested/bufferbloated link and a dead peer must not be confused as.
+TEST(Forwarder, SlowDrainingPeerIsBackpressureWithConnectionRetained)
+{
+  MockServer server;
+  std::atomic<bool> stop{ false };
+  std::vector<std::string> received, acked;
+  std::mutex mutex;
+  AckPolicy policy;
+  policy.drain_chunk_bytes = 16;                       // read a few bytes at a time...
+  policy.drain_pause = std::chrono::milliseconds(50);  // ...pausing between reads
+
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    if (c >= 0)
+    {
+      run_ack_policy_peer(c, policy, received, acked, mutex, stop);
+      ::close(c);
+    }
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  cfg.write_timeout = std::chrono::milliseconds(20);  // shorter than the peer's drain cadence
+  Forwarder forwarder(cfg);
+
+  nlohmann::json big;
+  big["blob"] = std::string(200000, 'x');
+  Record big_record{ "dc.test", 1700000000ULL, 0u, big };
+
+  bool saw_backpressure = false;
+  for (int i = 0; i < 30 && !saw_backpressure; ++i)
+  {
+    try
+    {
+      forwarder.send(big_record);
+    }
+    catch (const ForwarderError& e)
+    {
+      if (e.kind() == ForwarderErrorKind::Backpressure)
+      {
+        saw_backpressure = true;
+      }
+    }
+  }
+
+  // EXPECT (not ASSERT): `srv` is a joinable std::thread still running run_ack_policy_peer,
+  // and an early return here without stop.store()+srv.join() would call std::terminate()
+  // on the way out, taking the whole test binary down instead of just failing this test.
+  EXPECT_TRUE(saw_backpressure) << "a peer that drains slowly should eventually stall a write past write_timeout";
+  if (saw_backpressure)
+  {
+    EXPECT_TRUE(forwarder.is_connected()) << "backpressure must not drop the connection — the peer may just be slow";
+  }
+
+  stop.store(true);
+  srv.join();
+}
+
+// #366: an ack that doesn't arrive within ack_timeout triggers a resend carrying the
+// SAME chunk id (UnackedRecordResendsAfterReconnect above covers the reconnect trigger;
+// this covers the timeout trigger). If the original, merely-delayed ack then arrives
+// after the resend, the peer has seen the chunk twice — a wire duplicate, not a loss —
+// and the window must still converge to zero rather than getting stuck or amplifying.
+TEST(Forwarder, ResendAfterAckTimeoutProducesDuplicateThenConverges)
+{
+  MockServer server;
+  std::atomic<bool> stop{ false };
+  std::vector<std::string> received, acked;
+  std::mutex mutex;
+  AckPolicy policy;
+  policy.ack_delay = std::chrono::milliseconds(300);  // longer than ack_timeout below
+
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+    if (c >= 0)
+    {
+      run_ack_policy_peer(c, policy, received, acked, mutex, stop);
+      ::close(c);
+    }
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  cfg.ack_timeout = std::chrono::milliseconds(100);
+  Forwarder forwarder(cfg);
+
+  forwarder.send(make_record("dc.test", R"({"n": 1})"));
+
+  // Poll past ack_timeout so the Forwarder resends the still-unacked record at least
+  // once before the peer's 300ms delayed ack for the ORIGINAL send has a chance to land.
+  bool resent = poll_until(std::chrono::milliseconds(500), [&]() {
+    forwarder.poll();
+    std::lock_guard<std::mutex> lock(mutex);
+    return received.size() >= 2;
+  });
+  // EXPECT (not ASSERT): see SlowDrainingPeerIsBackpressureWithConnectionRetained above —
+  // `srv` must always be stopped and joined before this test function can return.
+  EXPECT_TRUE(resent) << "an unacked record past ack_timeout should be resent, duplicating it on the wire";
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (received.size() >= 2)
+    {
+      EXPECT_EQ(received[0], received[1]) << "the resend must carry the same chunk id as the original send";
+    }
+  }
+
+  bool converged = poll_until(std::chrono::seconds(2), [&]() {
+    forwarder.poll();
+    return forwarder.unacked_count() == 0;
+  });
+  stop.store(true);
+  srv.join();
+  EXPECT_TRUE(converged) << "the duplicate ack(s) for the same chunk id must still clear the window, not wedge it";
+}
+
+// #366: handle_ack_object() finds the acked entry by chunk id via linear search, not by
+// position — this pins that an ack arriving out of send order evicts only the record it
+// actually names, leaving the other's exact byte count in the window.
+TEST(Forwarder, OutOfOrderAckEvictsOnlyTheAckedRecord)
+{
+  MockServer server;
+  std::atomic<bool> ack_a{ false };
+
+  std::thread srv([&]() {
+    int c = ::accept(server.listen_fd, nullptr, nullptr);
+
+    // Both frames may arrive in a single recv() (they're written back to back with
+    // nothing forcing a boundary), so parse incrementally with a real unpacker rather
+    // than assuming one recv() call == one frame.
+    msgpack::unpacker unpacker;
+    std::string chunk_a, chunk_b;
+    while (chunk_a.empty() || chunk_b.empty())
+    {
+      unpacker.reserve_buffer(4096);
+      ssize_t n = ::recv(c, unpacker.buffer(), 4096, 0);
+      if (n <= 0)
+      {
+        return;
+      }
+      unpacker.buffer_consumed(static_cast<std::size_t>(n));
+      msgpack::object_handle oh;
+      while (unpacker.next(oh))
+      {
+        msgpack::object top = oh.get();
+        std::string chunk_id;
+        if (top.type == msgpack::type::ARRAY && top.via.array.size >= 3 &&
+            top.via.array.ptr[2].type == msgpack::type::MAP)
+        {
+          const msgpack::object& option = top.via.array.ptr[2];
+          for (std::uint32_t i = 0; i < option.via.map.size; ++i)
+          {
+            if (option.via.map.ptr[i].key.as<std::string>() == "chunk")
+            {
+              chunk_id = option.via.map.ptr[i].val.as<std::string>();
+            }
+          }
+        }
+        if (chunk_a.empty())
+        {
+          chunk_a = chunk_id;
+        }
+        else if (chunk_b.empty())
+        {
+          chunk_b = chunk_id;
+        }
+      }
+    }
+
+    // Ack B first — out of send order.
+    msgpack::sbuffer ack_buf;
+    msgpack::packer<msgpack::sbuffer> pk(ack_buf);
+    pk.pack_map(1);
+    pk.pack(std::string("ack"));
+    pk.pack(chunk_b);
+    ::send(c, ack_buf.data(), ack_buf.size(), 0);
+
+    while (!ack_a.load())
+    {
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    msgpack::sbuffer ack_buf_a;
+    msgpack::packer<msgpack::sbuffer> pk_a(ack_buf_a);
+    pk_a.pack_map(1);
+    pk_a.pack(std::string("ack"));
+    pk_a.pack(chunk_a);
+    ::send(c, ack_buf_a.data(), ack_buf_a.size(), 0);
+    ::close(c);
+  });
+
+  ForwarderConfig cfg;
+  cfg.host = "127.0.0.1";
+  cfg.port = server.port;
+  Forwarder forwarder(cfg);
+
+  // Different payload sizes so record A's and record B's frame byte counts differ,
+  // making the eviction unambiguous from unacked_bytes() alone.
+  Record record_a{ "dc.test", 1700000000ULL, 0u, nlohmann::json::parse(R"({"n": 1})") };
+  nlohmann::json big;
+  big["blob"] = std::string(500, 'x');
+  Record record_b{ "dc.test", 1700000000ULL, 0u, big };
+
+  forwarder.send(record_a);
+  forwarder.send(record_b);
+  // EXPECT (not ASSERT) throughout: `srv` is a joinable std::thread whose lambda blocks
+  // on `ack_a`, and an ASSERT's early return without joining it would call
+  // std::terminate() on the way out of this test function, taking the whole binary down
+  // instead of just failing this one test.
+  EXPECT_EQ(forwarder.unacked_count(), 2u);
+
+  // A 22-char placeholder chunk id: generate_chunk_id() base64-encodes 16 random bytes
+  // without padding (ceil(16*8/6) = 22 chars), always this length regardless of the
+  // random content, and msgpack's fixstr encoding costs the same regardless of a
+  // string's actual characters — so this reproduces the exact frame byte count
+  // Forwarder used for its real (random) chunk id.
+  const std::string placeholder_chunk_id(22, '0');
+  const std::size_t expected_a_bytes = Forwarder::frame(record_a, placeholder_chunk_id).size();
+
+  bool b_evicted = poll_until(std::chrono::seconds(5), [&]() {
+    forwarder.poll();
+    return forwarder.unacked_count() == 1;
+  });
+  EXPECT_TRUE(b_evicted) << "the out-of-order ack for B should evict exactly B";
+  if (b_evicted)
+  {
+    EXPECT_EQ(forwarder.unacked_bytes(), expected_a_bytes) << "record A, not B, should remain in the window";
+  }
+
+  ack_a.store(true);
+  poll_until(std::chrono::seconds(5), [&]() {
+    forwarder.poll();
+    return forwarder.unacked_count() == 0;
+  });
   srv.join();
 }

--- a/progress.txt
+++ b/progress.txt
@@ -7691,3 +7691,82 @@ the one-way `qrcodes_waypoint_follower.py` patrol never actually returns to the 
 above is demonstrated by manual driving, not the autonomous demo — the issue's acceptance
 criteria ask for the capability and documented rates, not a scripted docking sequence nav2's own
 `docking_server` config still calls a "never docks" placeholder for.
+
+## #366 - Prove the pipeline under degraded network conditions: delayed acks and a shaped Destination link
+
+Every DC reliability claim to date was proven over intra-container loopback: microsecond RTT,
+zero loss, unbounded bandwidth, and a fault model where a Destination is either up or a stopped
+process. Real robots reach their Destinations over WiFi and a site uplink. This closes that gap
+at the two seams the PRD identified, without changing anything about the pipeline being measured.
+
+**Forwarder acknowledgement-policy mock peer (`dc_bridge/test/forwarder_test.cpp`).** The
+existing mock shipper ingest peer gains a test-only `AckPolicy` (ack delay, a probability of
+never acknowledging, a throttled drain rate) and a `run_ack_policy_peer()` driver built on a real
+`msgpack::unpacker` — same parsing discipline as Forwarder's own `drain_acks()`, so a drain rate
+that splits one frame across several `recv()` calls still parses correctly. Five new gtest cases:
+unacked window depth stays small (not the shipped 10000-record bound) at a realistic 100 Hz/50ms
+rate-delay combination; the same bound is exceeded by rate-vs-delay alone (not just a peer that
+never acks at all) and still converges once the burst ends; a slow-draining peer is classified as
+Backpressure with the connection retained, distinguishing it from a peer that's gone (Io, drops
+the connection); a resend past `ack_timeout` duplicates the chunk on the wire and the window still
+clears once the delayed original ack lands; an out-of-order ack evicts exactly the record it names
+(pinned via a 22-char placeholder chunk id — `generate_chunk_id()` base64-encodes 16 bytes without
+padding, always that length regardless of content).
+
+Two real bugs surfaced building this, both in the *test* harness, not Forwarder: the initial
+`run_ack_policy_peer` used a blocking `recv()` with no timeout, so once a test's client went idle
+the peer thread never re-checked its `stop` flag and `srv.join()` hung forever (fixed with a
+100ms `SO_RCVTIMEO`); and three tests used `ASSERT_*` ahead of `stop.store(true); srv.join()`,
+so a failing assertion returned early without joining a still-running `std::thread`, which
+`std::terminate()`s the whole test binary on destruction — fixed by demoting those to `EXPECT_*`
+with guarded follow-on checks, so one failing assertion reports as one failing test instead of
+aborting the entire suite. Built and run 5x against a scoped rebuild (dc_common + dc_bridge
+mounted over `localhost/dc-workspace:latest`, since a full `colcon build` wasn't warranted for a
+test-only change) — 17/17 passing, no flakiness, after `prek`'s `clang-format` reformatted the new
+code.
+
+**Network profile definitions (`tools/e2e/scripts/network_profiles.py`).** One declarative place
+for named, fixed conditions — `loopback` (unshaped), `good-wifi`, `poor-wifi`, `site-uplink` — each
+a `delay_ms`/`jitter_ms`/`loss_pct`/optional `rate_kbit`, with a CLI (`--shell` for a bash `eval`,
+`--tc-args` for a `tc qdisc ... netem` argument list, `--json`). An unknown name is a `ValueError`
+naming the known profiles, never a silent default. 10 pytest cases
+(`tools/e2e/test/test_network_profiles.py`).
+
+**`tools/e2e/scripts/run_degraded.sh` — the E2E sibling scenario.** Reuses `run.sh`'s image,
+reference workload shape, and `verify_zero_loss.py` unmodified, but Postgres/RustFS run on their
+own bridge network (`dc_e2e_deg_net`) instead of `--network host`, since nothing can be shaped
+without shaping the host itself under `--network host`. `params/e2e_degraded_params.yaml` is
+byte-for-byte `e2e_params.yaml` except the two Destination hosts (container-name DNS instead of
+`127.0.0.1`) — the Bridge-to-Shipper socket stays same-container loopback and out of scope, per
+the PRD.
+
+Traffic shaping was the PRD's stated single largest technical risk and was established first,
+empirically, before anything was built on it: rootless podman + `--cap-add=NET_ADMIN` on a
+short-lived helper container that joins a target's network namespace (`--network
+container:<name>`) can add a `tc netem` qdisc to that target's `eth0` with **no capability
+required on the target container itself** — verified with disposable alpine containers (a peer's
+measured RTT rose from <1ms to ~128ms after `netem delay 100ms 20ms loss 5%` was applied to the
+target's own interface from the joining helper). `run_degraded.sh` applies this via a
+`SHAPER_IMAGE` (alpine + iproute2, built once and cached) and `set_qdisc`/`clear_qdisc` helpers
+that track per-container qdisc state to choose `tc qdisc add` vs `change`. A shaping pre-check
+(`scripts/measure_rtt.py` — stdlib TCP connect-time sampling, since the Postgres/RustFS images
+ship neither `ping` nor `iputils`) measures the actual round trip before any workload runs and
+hard-fails the run if it isn't consistent with the requested profile, so a degraded run can never
+silently pass as loopback. A LINK fault (`tc netem loss 100%` on both Destinations, then restored)
+is induced partway through the run — the network disappearing without either process dying, a
+fault type distinct from `run.sh`'s container stop/restart, which resets Forwarder state and so
+tests something else. Conditions (profile + measured pre-check RTT) are written to
+`tools/e2e/.run/conditions.json`; `verify_zero_loss.py` gained one additive `--conditions-file`
+flag that folds that file into its report unchanged — no existing verification logic touched.
+
+Not wired into `ci.yaml`, matching the existing precedent for `run_retention.sh`/`run_incident.sh`
+(neither is CI-gating either) and the PRD's own "Out of Scope": whether this gates merges is left
+for once its runtime and stability are measured. The full container-network E2E path (bridge
+network + shaped Postgres/RustFS + the real DC stack under a degraded profile) was not run
+end-to-end here — the shaping *mechanism* was verified empirically in isolation (see above) and
+the script was built directly on that verified mechanism, but a full `run_degraded.sh` execution
+needs a full workspace image build (tens of minutes) that wasn't run as part of this session; that
+remains for a first real run to confirm.
+
+`tools/e2e/README.md` documents the new scenario and its layout entries; `Containerfile.e2e` gained
+`COPY` lines for `measure_rtt.py` (already needed by `run_degraded.sh`'s readiness/pre-check steps).

--- a/tools/e2e/Containerfile.e2e
+++ b/tools/e2e/Containerfile.e2e
@@ -19,6 +19,9 @@ COPY params/e2e_params.yaml /opt/e2e/e2e_params.yaml
 COPY params/e2e_passthrough_sink.toml /opt/e2e/e2e_passthrough_sink.toml
 COPY params/e2e_mcap_sink.toml /opt/e2e/e2e_mcap_sink.toml
 COPY scripts/mcap_summary.py /opt/e2e/mcap_summary.py
+# run_degraded.sh (#366): stdlib-only, run as one-off containers on its shaped bridge
+# network for readiness polling and the shaping pre-check (see measure_rtt.py's header).
+COPY scripts/measure_rtt.py /opt/e2e/measure_rtt.py
 COPY scripts/entrypoint.sh /opt/e2e/entrypoint.sh
 RUN chmod +x /opt/e2e/entrypoint.sh
 

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -182,6 +182,43 @@ broadcast node: that topic is the contract Measurements subscribe to, `dc_trigge
 its own tests for minting the event, and the broadcast node is not in `dc_bringup`'s
 launch yet. Not run by `ci.yaml`, same as the retention scenario.
 
+## Degraded-network scenario (#366)
+
+A fourth scenario, proving the zero-loss guarantee above holds under stated network
+conditions instead of only over intra-container loopback:
+
+```sh
+./tools/e2e/scripts/run_degraded.sh                         # loopback profile (baseline)
+DC_E2E_PROFILE=poor-wifi ./tools/e2e/scripts/run_degraded.sh
+```
+
+Same `dc-e2e` image and reference workload as `run.sh` (`params/e2e_degraded_params.yaml`
+is byte-for-byte `params/e2e_params.yaml` except for the two Destination hosts — see that
+file's header), but Postgres and RustFS run on their own bridge network instead of
+`--network host`, so the path to them can be shaped without shaping the host itself. A
+named profile (`scripts/network_profiles.py`: `loopback`, `good-wifi`, `poor-wifi`,
+`site-uplink` — one declarative place, so two runs of the same name are comparable) is
+applied as a `tc netem` qdisc on Postgres's and RustFS's own interfaces, via a short-lived
+helper container that joins their network namespace (`--network container:<name>
+--cap-add=NET_ADMIN`) rather than granting either image any capability itself. A shaping
+pre-check measures the actual TCP connect-time round trip before any workload runs
+(`scripts/measure_rtt.py`) and hard-fails the run if the measurement isn't consistent with
+the requested profile — a degraded run must never pass silently as loopback because
+shaping failed to apply. Partway through the run, a LINK fault (`tc netem loss 100%` on
+both Destinations, then restored) proves the network going away is handled distinctly from
+`run.sh`'s container stop/restart — nothing here resets Forwarder state. The network
+conditions a run used, plus the measured pre-check round trip, are written to
+`tools/e2e/.run/conditions.json` and folded into `verify_zero_loss.py`'s report — a result
+is never separable from the conditions that produced it.
+
+Not wired into `ci.yaml`, same as the retention and incident scenarios below: whether it
+gates merges is left for once its runtime and stability are measured (#366's own "Out of
+Scope"). The Forwarder's own unacked-window-depth, backpressure-classification, and
+resend-under-delay behaviour under acknowledgement delay is covered separately and much
+more cheaply at `dc_bridge/test/forwarder_test.cpp`'s existing mock-ingest-peer seam (an
+`AckPolicy` describing when/whether a chunk gets acknowledged) — no container needed for
+that; see that file for the corresponding unit tests.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -260,6 +297,14 @@ launch yet. Not run by `ci.yaml`, same as the retention scenario.
   `dc-e2e` image.
 - `params/e2e_incident_params.yaml` / `scripts/run_incident.sh` — the incident-capture
   scenario (#291) described above, likewise reusing the same `dc-e2e` image.
+- `params/e2e_degraded_params.yaml` / `scripts/run_degraded.sh` — the degraded-network
+  scenario (#366) described above; a fourth sibling harness, reusing the same `dc-e2e`
+  image and `verify_zero_loss.py`, but its own bridge network so the path to the
+  Destinations can be shaped.
+- `scripts/network_profiles.py` — the named network conditions (#366) `run_degraded.sh`
+  applies, in one declarative place also meant for #323's limits harness to reuse.
+- `scripts/measure_rtt.py` — stdlib TCP connect-time sampler (#366), used both for
+  Destination readiness polling and the shaping pre-check `run_degraded.sh` never skips.
 
 ## `.dockerignore`
 

--- a/tools/e2e/params/e2e_degraded_params.yaml
+++ b/tools/e2e/params/e2e_degraded_params.yaml
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The degraded-network scenario's (#366) params: byte-for-byte params/e2e_params.yaml
+# except for the two Destination hosts, which name containers on run_degraded.sh's own
+# bridge network (dc_e2e_deg_net) instead of 127.0.0.1 — the shaped participants can't
+# share run.sh's --network host, or nothing could be shaped without shaping the host
+# itself (see run_degraded.sh's header). vector_forward_host and tcp_health.host stay
+# 127.0.0.1: that socket is the Bridge-to-Shipper path, which never leaves the
+# container's own network namespace (the Bridge forks and supervises the Shipper as a
+# child process) and is out of scope for this PRD — see #366's "Out of Scope".
+
+measurement_server:
+  ros__parameters:
+    save_local_base_path: "$HOME/.dc/e2e/data/%Y/%M/%D/%H"
+    all_base_path: "e2e"
+    measurement_plugins: ["memory", "os", "storage", "uptime", "tcp_health", "dummy", "synth00", "synth01", "synth02", "synth03", "synth04", "synth05", "synth06", "synth07", "synth08", "synth09", "synth10", "synth11", "synth12", "synth13", "camera"]
+
+    memory:
+      plugin: "dc_measurements/Memory"
+      polling_interval: 200
+      group_key: "memory"
+
+    os:
+      plugin: "dc_measurements/OS"
+      polling_interval: 1000
+      group_key: "os"
+
+    storage:
+      plugin: "dc_measurements/Storage"
+      polling_interval: 1000
+      path: "/tmp"
+      group_key: "storage"
+
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      polling_interval: 1000
+      group_key: "uptime"
+
+    tcp_health:
+      plugin: "dc_measurements/TCPHealth"
+      polling_interval: 1000
+      name: "vector_forward"
+      host: "127.0.0.1"
+      port: 24224
+      group_key: "tcp_health"
+
+    dummy:
+      plugin: "dc_measurements/Dummy"
+      polling_interval: 1000
+      group_key: "dummy"
+
+    camera:
+      plugin: "dc_measurements/Camera"
+      polling_interval: 15000
+      cam_name: "e2e_camera"
+      cam_topic: "/dc/e2e/camera/image_raw"
+      draw_det_barcodes: false
+      save_raw_img: true
+      save_rotated_img: false
+      save_detections_img: false
+      save_raw_base64: false
+      save_rotated_base64: false
+      save_inspected_base64: false
+      remote_keys: ["rustfs"]
+      remote_prefixes: ["camera"]
+      group_key: "camera"
+
+    synth00:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth00"
+      timer_based: true
+
+    synth01:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth01"
+      timer_based: true
+
+    synth02:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth02"
+      timer_based: true
+
+    synth03:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth03"
+      timer_based: true
+
+    synth04:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth04"
+      timer_based: true
+
+    synth05:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth05"
+      timer_based: true
+
+    synth06:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth06"
+      timer_based: true
+
+    synth07:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth07"
+      timer_based: true
+
+    synth08:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth08"
+      timer_based: true
+
+    synth09:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth09"
+      timer_based: true
+
+    synth10:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth10"
+      timer_based: true
+
+    synth11:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth11"
+      timer_based: true
+
+    synth12:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth12"
+      timer_based: true
+
+    synth13:
+      plugin: "dc_measurements/StringStamped"
+      enable_validator: false
+      polling_interval: 1000
+      topic: "/dc/e2e/synth/synth13"
+      timer_based: true
+
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/e2e/buffer"
+    destinations: ["pgsql_records", "pgsql_files", "rustfs", "raw_file"]
+    pgsql_records:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/memory", "/dc/measurement/os", "/dc/measurement/storage", "/dc/measurement/uptime", "/dc/measurement/tcp_health", "/dc/measurement/dummy", "/dc/measurement/synth00", "/dc/measurement/synth01", "/dc/measurement/synth02", "/dc/measurement/synth03", "/dc/measurement/synth04", "/dc/measurement/synth05", "/dc/measurement/synth06", "/dc/measurement/synth07", "/dc/measurement/synth08", "/dc/measurement/synth09", "/dc/measurement/synth10", "/dc/measurement/synth11", "/dc/measurement/synth12", "/dc/measurement/synth13"]
+      # dc_e2e_deg_postgres, not 127.0.0.1: run_degraded.sh's shaped bridge network
+      # resolves it via container-name DNS (podman's aardvark-dns on user-defined
+      # networks) — see this file's header.
+      host: "dc_e2e_deg_postgres"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_records"
+      time_key: "date"
+
+    pgsql_files:
+      type: postgres
+      receives: records
+      host: "dc_e2e_deg_postgres"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_files"
+      time_key: "date"
+
+    rustfs:
+      type: s3
+      receives: files
+      inputs: ["/dc/measurement/camera"]
+      bucket: "dc-e2e"
+      endpoint: "http://dc_e2e_deg_rustfs:9000"
+      region: "us-east-1"
+      access_key_id: "rustfsadmin"
+      secret_access_key: "rustfsadmin"
+      force_path_style: true
+
+    raw_file:
+      type: file
+      receives: records
+      path: "/root/.dc/e2e/data/raw/records.ndjson"
+      time_key: "date"
+
+    raw:
+      enabled: true
+      destination: "raw_file"
+      include: ["^/dc/e2e/synth/synth00$"]
+      exclude: ["^/rosout$", "^/parameter_events$", "^/dc/measurement/", "^/dc/group/"]
+      exclude_types: ["^sensor_msgs/msg/(Image|CompressedImage|PointCloud2)$"]
+      rescan_interval_secs: 1.0
+      max_rate_hz: 10.0
+
+    files:
+      delete_when_sent: false
+      metadata_destination: "pgsql_files"
+
+    custom_config_files: ["/opt/e2e/e2e_passthrough_sink.toml", "/opt/e2e/e2e_mcap_sink.toml"]
+
+    # Same-container loopback (Bridge-to-Shipper) — not shaped, see this file's header.
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224
+
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]

--- a/tools/e2e/scripts/measure_rtt.py
+++ b/tools/e2e/scripts/measure_rtt.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""TCP connect-time sampler (#366): measures how long it takes to open a TCP connection
+to host:port, `--count` times, and reports min/avg/max in milliseconds as JSON.
+
+Used by run_degraded.sh for two things that are the same measurement at different
+points in a run: (1) a readiness probe, retried until a Destination accepts connections
+at all, and (2) the shaping pre-check that a degraded run must never skip — a profile's
+`tc netem delay` shows up almost entirely in this number, since it delays every packet
+the shaped Destination sends, including the SYN-ACK a TCP connect blocks on. A run whose
+shaping silently failed to apply would otherwise produce a green result under a degraded
+label while having tested nothing (see run_degraded.sh's own header and #366's PRD).
+
+Deliberately stdlib-only (no `ping`/`iputils`, which the Postgres/RustFS images this
+measures do not ship) and run from inside the `dc-e2e` image, which does have Python and
+sits on the same shaped network as the real DC stack it stands in for.
+"""
+
+import argparse
+import json
+import socket
+import sys
+import time
+
+
+def sample(host: str, port: int, count: int, timeout: float) -> list[float]:
+    """Returns `count` connect-time samples in milliseconds. Raises OSError on the
+    first failed connection — a caller wanting readiness-style retries wraps this in
+    its own retry loop rather than getting partial success back from here."""
+    samples = []
+    for _ in range(count):
+        start = time.monotonic()
+        with socket.create_connection((host, port), timeout=timeout):
+            pass
+        samples.append((time.monotonic() - start) * 1000)
+    return samples
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("host")
+    parser.add_argument("port", type=int)
+    parser.add_argument("--count", type=int, default=10)
+    parser.add_argument("--timeout", type=float, default=5.0, help="per-connect timeout, seconds")
+    args = parser.parse_args()
+
+    try:
+        samples = sample(args.host, args.port, args.count, args.timeout)
+    except OSError as exc:
+        print(json.dumps({"error": str(exc)}), file=sys.stderr)
+        return 1
+
+    result = {
+        "host": args.host,
+        "port": args.port,
+        "samples_ms": [round(s, 2) for s in samples],
+        "min_ms": round(min(samples), 2),
+        "avg_ms": round(sum(samples) / len(samples), 2),
+        "max_ms": round(max(samples), 2),
+    }
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/e2e/scripts/network_profiles.py
+++ b/tools/e2e/scripts/network_profiles.py
@@ -1,0 +1,129 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Named network conditions (#366): one declarative place shared by run_degraded.sh and,
+later, #323's limits harness, so two runs of the same profile name are comparable.
+
+A profile is a fixed set of `tc netem` parameters applied to a shaped Destination's own
+network namespace (see run_degraded.sh's header for why that's the shapeable seam under
+this project's rootless container runtime): added delay, delay variation (jitter), a
+loss probability, and an optional rate cap. Conditions are named and held fixed for a
+run, not a ramped dimension — the PRD this implements explicitly rejects varying
+conditions mid-run, since a result whose conditions moved underneath it isn't
+interpretable.
+
+`loopback` is the zero-shaping baseline: no qdisc is applied for it at all (see
+`is_shaped`), so a loopback run's conditions match today's un-shaped E2E harness rather
+than merely approximating it. The three degraded profiles are illustrative real-link
+figures (a good office WiFi AP, a congested/bufferbloated WiFi AP, a constrained site
+uplink), not measurements of any specific deployment — the PRD's own "Out of Scope"
+section defers calibrating them against real hardware to a follow-up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+
+
+@dataclass(frozen=True)
+class NetworkProfile:
+    name: str
+    delay_ms: float
+    jitter_ms: float
+    loss_pct: float
+    # kbit/s egress cap, or None for no cap.
+    rate_kbit: int | None = None
+
+    @property
+    def is_shaped(self) -> bool:
+        """False only for a profile that must reproduce today's un-shaped behaviour."""
+        return bool(self.delay_ms or self.jitter_ms or self.loss_pct or self.rate_kbit)
+
+    def netem_args(self) -> list[str]:
+        """The `tc qdisc ... netem` argument list for this profile, or [] when
+        `is_shaped` is False (nothing to apply — the caller must not add a qdisc)."""
+        if not self.is_shaped:
+            return []
+        args = ["netem"]
+        if self.delay_ms or self.jitter_ms:
+            args += ["delay", f"{self.delay_ms}ms"]
+            if self.jitter_ms:
+                args.append(f"{self.jitter_ms}ms")
+        if self.loss_pct:
+            args += ["loss", f"{self.loss_pct}%"]
+        if self.rate_kbit:
+            args += ["rate", f"{self.rate_kbit}kbit"]
+        return args
+
+
+# Stated parameters, held fixed — see the module docstring for what each represents.
+PROFILES: dict[str, NetworkProfile] = {
+    "loopback": NetworkProfile("loopback", delay_ms=0, jitter_ms=0, loss_pct=0),
+    "good-wifi": NetworkProfile("good-wifi", delay_ms=20, jitter_ms=5, loss_pct=0.1),
+    "poor-wifi": NetworkProfile("poor-wifi", delay_ms=80, jitter_ms=30, loss_pct=2.0),
+    "site-uplink": NetworkProfile(
+        "site-uplink", delay_ms=150, jitter_ms=20, loss_pct=1.0, rate_kbit=2000
+    ),
+}
+
+
+def resolve(name: str) -> NetworkProfile:
+    """Looks up a profile by name. Raises ValueError, never silently substitutes a
+    default, on an unknown name — a typo in a profile name must fail loudly rather than
+    quietly running loopback under a degraded label."""
+    try:
+        return PROFILES[name]
+    except KeyError:
+        known = ", ".join(sorted(PROFILES))
+        raise ValueError(f"unknown network profile '{name}' (known profiles: {known})") from None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "profile", help="profile name, e.g. loopback / good-wifi / poor-wifi / site-uplink"
+    )
+    output = parser.add_mutually_exclusive_group()
+    output.add_argument(
+        "--shell",
+        action="store_true",
+        help="print PROFILE_*=value lines, one per parameter, for `eval $(...)` in a shell script",
+    )
+    output.add_argument("--json", action="store_true", help="print the profile as JSON")
+    output.add_argument(
+        "--tc-args",
+        action="store_true",
+        help="print the `tc qdisc ... netem` argument list, space-separated, for a shell "
+        "script to word-split onto a `tc qdisc add/change dev <if> root` command line "
+        "(empty line for an unshaped profile — the caller must not add a qdisc at all)",
+    )
+    args = parser.parse_args()
+
+    try:
+        profile = resolve(args.profile)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(asdict(profile)))
+        return 0
+
+    if args.tc_args:
+        print(" ".join(profile.netem_args()))
+        return 0
+
+    print(f"PROFILE_NAME={profile.name}")
+    print(f"PROFILE_DELAY_MS={profile.delay_ms}")
+    print(f"PROFILE_JITTER_MS={profile.jitter_ms}")
+    print(f"PROFILE_LOSS_PCT={profile.loss_pct}")
+    print(f"PROFILE_RATE_KBIT={profile.rate_kbit or 0}")
+    print(f"PROFILE_IS_SHAPED={'true' if profile.is_shaped else 'false'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/e2e/scripts/run_degraded.sh
+++ b/tools/e2e/scripts/run_degraded.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Degraded-network E2E scenario (#366). From the repo root:
+#
+#   ./tools/e2e/scripts/run_degraded.sh                       # loopback profile (baseline)
+#   DC_E2E_PROFILE=poor-wifi ./tools/e2e/scripts/run_degraded.sh
+#
+# run.sh's zero-loss guarantee has only ever been proven over intra-container loopback:
+# ~microsecond RTT, zero loss, unbounded bandwidth, and a fault model where a Destination
+# either runs or is a stopped process. Real robots reach their Destinations over WiFi and a
+# site uplink — tens of milliseconds of RTT, packet loss, bufferbloat, and a link that can
+# disappear for seconds without anything dying. This scenario asserts the same zero-loss
+# guarantee (verify_zero_loss.py, reused unmodified) under stated, reproducible network
+# conditions instead, plus a fault type run.sh has no equivalent of: the link going away
+# while the process behind it keeps running.
+#
+# Sibling of run.sh, not a mode inside it (own gates, own topology decision below) — same
+# `dc-e2e` image, same DC_E2E_IMAGE/DC_WORKSPACE_IMAGE env vars, same reference workload
+# (params/e2e_degraded_params.yaml, byte-for-byte params/e2e_params.yaml except for the
+# two Destination hosts — see that file's header for why). Not wired into ci.yaml, same as
+# run_retention.sh/run_incident.sh: whether it gates merges is left for once its runtime
+# and stability are measured (#366's own "Out of Scope").
+#
+# --- Why this needs its own network, and how shaping actually works here ---------------
+#
+# Every existing scenario runs `--network host`: every container shares the host's network
+# namespace, so nothing can be shaped without shaping the host itself. This scenario instead
+# puts Postgres and RustFS on their own bridge network ($NET below) with the `dc` stack
+# alongside them (reachable by container-name DNS, not 127.0.0.1 — podman's aardvark-dns on
+# a user-defined network resolves container names, verified empirically here). The
+# Bridge-to-Shipper socket stays out of scope (same-container loopback — see #366's "Out of
+# Scope" and e2e_degraded_params.yaml's header): what's actually shaped is the Shipper's
+# path to Postgres/RustFS, the only path that ever leaves a container.
+#
+# `tc qdisc ... netem` needs CAP_NET_ADMIN in whatever network namespace it targets. Rather
+# than grant that to the Postgres/RustFS images themselves, a short-lived helper container
+# joins the target's netns (`podman run --network container:<name> --cap-add=NET_ADMIN`) and
+# applies/changes/removes the qdisc from there — the target container runs completely
+# unmodified. Verified empirically in this environment: rootless podman +
+# `--cap-add=NET_ADMIN` on a netns-joining helper lets an otherwise-unprivileged container
+# add a `netem` qdisc to another container's `eth0`, and a peer on the same bridge network
+# measurably sees the added delay/jitter/loss. That this works at all was the single
+# largest technical risk in #366's PRD and was established before anything else here was
+# built; if it stops working in some other environment, the pre-check below (not a
+# ping/`iputils` dependency, which the Postgres/RustFS images don't ship — a stdlib TCP
+# connect-time sample, scripts/measure_rtt.py) fails the run loudly rather than silently
+# passing a green "degraded" result that never actually shaped anything.
+#
+# --- Fault model -------------------------------------------------------------------------
+#
+# In addition to the profile's steady-state shaping, one LINK fault is induced partway
+# through the run: `tc qdisc ... netem loss 100%` on Postgres's and RustFS's own interfaces
+# for DC_E2E_LINK_OUTAGE_SECONDS, then restored to the profile's own parameters (or removed
+# entirely, for the loopback profile). Both processes keep running throughout — unlike
+# run.sh's `podman stop`/`restart`, nothing here resets Forwarder state, so this is a
+# distinct fault type on purpose (see #366's PRD): "the network went away" tested apart
+# from "the process went down", which run.sh already covers.
+#
+# Env vars (all optional):
+#   DC_E2E_PROFILE                  named profile from scripts/network_profiles.py:
+#                                    loopback (default) / good-wifi / poor-wifi / site-uplink
+#   DC_E2E_STEADY_STATE_SECONDS     warmup under the profile before the link fault (default 30)
+#   DC_E2E_LINK_OUTAGE_SECONDS      link-fault duration (default 60)
+#   DC_E2E_DRAIN_SECONDS            settle time after the link is restored (default 30)
+#   DC_E2E_STARTUP_TIMEOUT_SECONDS  startup-latency gate (default 10, same as run.sh)
+#   DC_E2E_KEEP                     "true" to leave the stack (and its network) up after a
+#                                    failure for debugging
+#   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE   same meaning as run.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_DIR="$E2E_DIR/.run"
+
+PROFILE_NAME="${DC_E2E_PROFILE:-loopback}"
+STEADY_STATE_SECONDS="${DC_E2E_STEADY_STATE_SECONDS:-30}"
+LINK_OUTAGE_SECONDS="${DC_E2E_LINK_OUTAGE_SECONDS:-60}"
+DRAIN_SECONDS="${DC_E2E_DRAIN_SECONDS:-30}"
+STARTUP_TIMEOUT_SECONDS="${DC_E2E_STARTUP_TIMEOUT_SECONDS:-10}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+NET=dc_e2e_deg_net
+SHAPER_IMAGE=dc-e2e-shaper:latest
+PG_C=dc_e2e_deg_postgres
+RUSTFS_C=dc_e2e_deg_rustfs
+DC_C=dc_e2e_deg_dc
+VOLUMES=(dc_e2e_deg_pgdata dc_e2e_deg_rustfs_data dc_e2e_deg_buffer dc_e2e_deg_data)
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-degraded $(date -u +%H:%M:%S)] $*"; }
+
+remove_stack() {
+  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
+  for v in "${VOLUMES[@]}"; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+  podman network rm "$NET" >/dev/null 2>&1 || true
+}
+
+pg_exec() {
+  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  if podman container exists "$DC_C"; then
+    podman logs "$DC_C" > "$RUN_DIR/dc_degraded.log" 2>&1
+  fi
+  remove_stack
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- resolve the network profile (scripts/network_profiles.py — one declarative place) --
+log "resolving network profile '$PROFILE_NAME'"
+if ! PROFILE_SHELL_VARS="$(python3 "$SCRIPT_DIR/network_profiles.py" "$PROFILE_NAME" --shell)"; then
+  python3 "$SCRIPT_DIR/network_profiles.py" "$PROFILE_NAME" --shell || true
+  log "FAIL: unknown network profile '$PROFILE_NAME'"
+  exit 1
+fi
+eval "$PROFILE_SHELL_VARS"
+NETEM_ARGS="$(python3 "$SCRIPT_DIR/network_profiles.py" "$PROFILE_NAME" --tc-args)"
+log "profile '$PROFILE_NAME': delay=${PROFILE_DELAY_MS}ms jitter=${PROFILE_JITTER_MS}ms loss=${PROFILE_LOSS_PCT}% rate=${PROFILE_RATE_KBIT}kbit shaped=${PROFILE_IS_SHAPED}"
+
+# --- obtain the DC stack image (shared with run.sh — see its header) ------------------
+if [ -n "${DC_E2E_IMAGE:-}" ]; then
+  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+  DC_IMAGE="$DC_E2E_IMAGE"
+else
+  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
+  else
+    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+    "$SCRIPT_DIR/build.sh"
+    WORKSPACE_IMAGE="dc-workspace:latest"
+  fi
+  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
+  DC_IMAGE="dc-e2e:latest"
+fi
+
+# --- the netem shaper helper image: alpine + iproute2, built once and reused -----------
+if ! podman image exists "$SHAPER_IMAGE"; then
+  log "building the netem shaper helper image ($SHAPER_IMAGE — alpine + iproute2, cached after this)"
+  podman rm -f --ignore dc_e2e_shaper_build >/dev/null
+  podman run --name dc_e2e_shaper_build docker.io/library/alpine:3.20 \
+    sh -c 'apk add --no-cache iproute2' >/dev/null
+  podman commit dc_e2e_shaper_build "$SHAPER_IMAGE" >/dev/null
+  podman rm -f dc_e2e_shaper_build >/dev/null
+fi
+
+# tc_run/set_qdisc/clear_qdisc: apply netem to $1's OWN interface by joining its network
+# namespace, without $1 itself needing any capability (see this script's header).
+# QDISC_UP tracks, per target container, whether a netem qdisc is currently installed —
+# `tc qdisc change` requires one to already exist; `add` requires one not to.
+declare -A QDISC_UP=()
+
+tc_run() {
+  local target="$1"
+  shift
+  podman run --rm --network "container:$target" --cap-add=NET_ADMIN "$SHAPER_IMAGE" tc "$@"
+}
+
+set_qdisc() {
+  local target="$1"
+  shift
+  if [ "${QDISC_UP[$target]:-false}" = "true" ]; then
+    tc_run "$target" qdisc change dev eth0 root "$@"
+  else
+    tc_run "$target" qdisc add dev eth0 root "$@"
+    QDISC_UP[$target]=true
+  fi
+}
+
+clear_qdisc() {
+  local target="$1"
+  tc_run "$target" qdisc del dev eth0 root
+  QDISC_UP[$target]=false
+}
+
+# Clean any leftovers from a previous (possibly DC_E2E_KEEP=true) run.
+remove_stack
+
+# --- shaped bridge network + destinations ------------------------------------------------
+log "creating the shaped bridge network ($NET)"
+podman network create "$NET" >/dev/null
+
+log "starting Postgres + RustFS on $NET (unmodified — no special capabilities on either)"
+podman run -d --network "$NET" --name "$PG_C" \
+  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+  -v dc_e2e_deg_pgdata:/var/lib/postgresql/data \
+  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+  docker.io/library/postgres:13 >/dev/null
+podman run -d --network "$NET" --name "$RUSTFS_C" \
+  -v dc_e2e_deg_rustfs_data:/data \
+  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+
+timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
+  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+
+log "waiting for RustFS to accept TCP connections on $NET"
+timeout 60 bash -c "
+  until podman run --rm --network $NET '$DC_IMAGE' python3 /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do
+    sleep 1
+  done
+" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+
+log "creating the RustFS bucket"
+podman run --rm --network "$NET" \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+
+# --- apply the profile's steady-state shaping, then verify it actually took effect -----
+if [ "$PROFILE_IS_SHAPED" = "true" ]; then
+  log "applying profile '$PROFILE_NAME' to Postgres/RustFS's own interfaces: tc qdisc ... $NETEM_ARGS"
+  # shellcheck disable=SC2086  # NETEM_ARGS is a deliberate, simple-token word split
+  set_qdisc "$PG_C" $NETEM_ARGS
+  # shellcheck disable=SC2086
+  set_qdisc "$RUSTFS_C" $NETEM_ARGS
+else
+  log "profile '$PROFILE_NAME' is unshaped — no qdisc applied (today's loopback behaviour)"
+fi
+
+log "shaping pre-check: measuring the actual TCP connect-time round trip to $PG_C"
+RTT_JSON="$(podman run --rm --network "$NET" "$DC_IMAGE" python3 /opt/e2e/measure_rtt.py "$PG_C" 5432 --count 10 --timeout 3)"
+echo "$RTT_JSON" > "$RUN_DIR/rtt_precheck.json"
+AVG_MS="$(python3 -c "import json; print(json.load(open('$RUN_DIR/rtt_precheck.json'))['avg_ms'])")"
+log "measured avg connect time: ${AVG_MS}ms"
+
+if [ "$PROFILE_IS_SHAPED" = "true" ]; then
+  # A conservative floor, not the full delay: netem on Postgres's own egress only delays
+  # its outbound leg of the TCP handshake, not the client's SYN — asserting some
+  # meaningful fraction of the requested delay is enough to prove shaping took effect
+  # without the check being brittle to exactly which leg dominates the measurement.
+  MIN_EXPECTED_MS="$(python3 -c "print(max(${PROFILE_DELAY_MS} * 0.4, 5))")"
+  if ! python3 -c "import sys; sys.exit(0 if ${AVG_MS} >= ${MIN_EXPECTED_MS} else 1)"; then
+    log "FAIL: shaping pre-check failed — measured ${AVG_MS}ms is below the ${MIN_EXPECTED_MS}ms floor"
+    log "      expected for profile '$PROFILE_NAME' (delay=${PROFILE_DELAY_MS}ms). A degraded run"
+    log "      must never pass silently as loopback — this container runtime may not support"
+    log "      unprivileged tc/NET_ADMIN shaping the way this script assumes (see its header)."
+    exit 1
+  fi
+  log "PASS: shaping pre-check — ${AVG_MS}ms is consistent with profile '$PROFILE_NAME' actually applying"
+else
+  LOOPBACK_CEILING_MS=20
+  if ! python3 -c "import sys; sys.exit(0 if ${AVG_MS} < ${LOOPBACK_CEILING_MS} else 1)"; then
+    log "FAIL: shaping pre-check failed — loopback should be fast and unshaped, but measured ${AVG_MS}ms"
+    exit 1
+  fi
+  log "PASS: shaping pre-check — ${AVG_MS}ms confirms no shaping is applied for '$PROFILE_NAME'"
+fi
+
+python3 -c "
+import json
+rtt = json.load(open('$RUN_DIR/rtt_precheck.json'))
+conditions = {
+    'profile': '$PROFILE_NAME',
+    'delay_ms': $PROFILE_DELAY_MS,
+    'jitter_ms': $PROFILE_JITTER_MS,
+    'loss_pct': $PROFILE_LOSS_PCT,
+    'rate_kbit': $PROFILE_RATE_KBIT,
+    'link_outage_seconds': $LINK_OUTAGE_SECONDS,
+    'measured_rtt_precheck': rtt,
+}
+json.dump(conditions, open('$RUN_DIR/conditions.json', 'w'), indent=2)
+"
+log "conditions recorded: $RUN_DIR/conditions.json — a result is never separable from these"
+
+# --- start the DC stack, measure launch-to-first-Record -----------------------------
+log "starting the DC stack against params/e2e_degraded_params.yaml — measuring launch-to-first-Record latency"
+START_TS=$(date +%s.%N)
+podman run -d --network "$NET" --name "$DC_C" \
+  -v dc_e2e_deg_buffer:/root/.dc/e2e/buffer \
+  -v dc_e2e_deg_data:/root/.dc/e2e/data \
+  -v "$E2E_DIR/params/e2e_degraded_params.yaml:/opt/e2e/e2e_params.yaml:ro" \
+  "$DC_IMAGE" >/dev/null
+
+FIRST_RECORD_LATENCY=""
+DEADLINE=$(echo "$START_TS + $STARTUP_TIMEOUT_SECONDS + 5" | bc)
+while (( $(echo "$(date +%s.%N) < $DEADLINE" | bc) )); do
+  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
+  if [ "${COUNT:-0}" -gt 0 ] 2>/dev/null; then
+    FIRST_RECORD_LATENCY=$(echo "$(date +%s.%N) - $START_TS" | bc)
+    break
+  fi
+  sleep 0.2
+done
+
+if [ -z "$FIRST_RECORD_LATENCY" ]; then
+  log "FAIL: no Record landed in Postgres within $((STARTUP_TIMEOUT_SECONDS + 5))s of starting the stack"
+  exit 1
+fi
+log "first Record landed after ${FIRST_RECORD_LATENCY}s"
+if (( $(echo "$FIRST_RECORD_LATENCY > $STARTUP_TIMEOUT_SECONDS" | bc) )); then
+  log "FAIL: startup latency ${FIRST_RECORD_LATENCY}s exceeds the ${STARTUP_TIMEOUT_SECONDS}s gate"
+  exit 1
+fi
+log "PASS: startup latency gate (<${STARTUP_TIMEOUT_SECONDS}s) under profile '$PROFILE_NAME'"
+
+log "steady state for ${STEADY_STATE_SECONDS}s under profile '$PROFILE_NAME'"
+sleep "$STEADY_STATE_SECONDS"
+
+# --- the LINK fault: the network goes away, the processes do not ----------------------
+log "inducing a LINK fault for ${LINK_OUTAGE_SECONDS}s (tc netem loss 100%% — Postgres and RustFS keep running throughout, unlike run.sh's container stop)"
+set_qdisc "$PG_C" netem loss 100%
+set_qdisc "$RUSTFS_C" netem loss 100%
+sleep "$LINK_OUTAGE_SECONDS"
+
+log "restoring the link to profile '$PROFILE_NAME' (the processes were never stopped)"
+if [ "$PROFILE_IS_SHAPED" = "true" ]; then
+  # shellcheck disable=SC2086
+  set_qdisc "$PG_C" $NETEM_ARGS
+  # shellcheck disable=SC2086
+  set_qdisc "$RUSTFS_C" $NETEM_ARGS
+else
+  clear_qdisc "$PG_C"
+  clear_qdisc "$RUSTFS_C"
+fi
+
+log "draining for ${DRAIN_SECONDS}s"
+sleep "$DRAIN_SECONDS"
+
+log "stopping the workload so counts settle before verification"
+podman stop "$DC_C" >/dev/null
+sleep 5
+
+# --- extract the passthrough sink's output (ADR-0003) --------------------------------
+log "extracting the passthrough sink's output"
+podman run --rm --entrypoint bash \
+  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+  -c 'cat /vol/passthrough/records.ndjson 2>/dev/null || true' > "$RUN_DIR/passthrough_degraded.ndjson"
+
+# --- extract raw / generic-subscription mode's output (#227) -------------------------
+log "extracting raw mode's Destination output"
+podman run --rm --entrypoint bash \
+  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+  -c 'cat /vol/raw/records.ndjson 2>/dev/null || true' > "$RUN_DIR/raw_degraded.ndjson"
+
+# --- summarize the MCAP passthrough writer's output (ADR-0009, #210) -----------------
+log "summarizing the MCAP passthrough writer's output"
+podman run --rm --entrypoint python3 \
+  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+  /opt/e2e/mcap_summary.py /vol/mcap > "$RUN_DIR/mcap_summary_degraded.json"
+
+# --- verify (verify_zero_loss.py's own logic, unmodified — only conditions are added) --
+log "extracting the workload ledger (what the generator published)"
+podman run --rm --entrypoint bash \
+  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+  -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger_degraded.txt"
+
+log "verifying zero-loss against the published ledger, under profile '$PROFILE_NAME'"
+python3 "$SCRIPT_DIR/verify_zero_loss.py" \
+  --postgres-container "$PG_C" \
+  --num-synth-topics 14 \
+  --ledger-file "$RUN_DIR/workload_ledger_degraded.txt" \
+  --passthrough-file "$RUN_DIR/passthrough_degraded.ndjson" \
+  --mcap-summary-file "$RUN_DIR/mcap_summary_degraded.json" \
+  --raw-file "$RUN_DIR/raw_degraded.ndjson" \
+  --conditions-file "$RUN_DIR/conditions.json" \
+  --report "$RUN_DIR/verification_report_degraded.json"
+
+log "PASS: zero-loss E2E harness under network profile '$PROFILE_NAME' (#366)"

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -786,6 +786,14 @@ def main() -> int:
         help="newline-delimited JSON extracted from the raw (#227) `file` Destination",
     )
     parser.add_argument("--report", default=None, help="write a JSON report to this path")
+    parser.add_argument(
+        "--conditions-file",
+        default=None,
+        help="JSON file (e.g. from run_degraded.sh, #366) describing the network conditions "
+        "this run was verified under; merged into --report's 'conditions' key unchanged. A "
+        "result is never separable from the conditions that produced it — omitted, the report "
+        "carries no 'conditions' key at all, rather than implying an unstated (loopback) one.",
+    )
     args = parser.parse_args()
 
     pg = args.postgres_container
@@ -817,6 +825,9 @@ def main() -> int:
     check_raw(args.raw_file, boundaries, violations, notes, details)
 
     report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
+    if args.conditions_file:
+        with open(args.conditions_file) as f:
+            report["conditions"] = json.load(f)
     if args.report:
         with open(args.report, "w") as f:
             json.dump(report, f, indent=2)

--- a/tools/e2e/test/test_measure_rtt.py
+++ b/tools/e2e/test/test_measure_rtt.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/measure_rtt.py (#366), against a real loopback
+listening socket — no container, no network shaping needed to pin the sampler's own
+arithmetic and error handling.
+"""
+
+import os
+import socket
+import sys
+import threading
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+import measure_rtt
+
+
+@pytest.fixture
+def accepting_server():
+    """A listening socket on 127.0.0.1 that accepts and immediately drops every
+    connection, yielding (host, port)."""
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.bind(("127.0.0.1", 0))
+    server.listen(8)
+    host, port = server.getsockname()
+    stop = threading.Event()
+
+    def accept_loop():
+        server.settimeout(0.2)
+        while not stop.is_set():
+            try:
+                conn, _ = server.accept()
+                conn.close()
+            except TimeoutError:
+                continue
+
+    thread = threading.Thread(target=accept_loop, daemon=True)
+    thread.start()
+    try:
+        yield host, port
+    finally:
+        stop.set()
+        thread.join()
+        server.close()
+
+
+def test_sample_returns_one_measurement_per_count(accepting_server):
+    host, port = accepting_server
+    samples = measure_rtt.sample(host, port, count=5, timeout=2.0)
+    assert len(samples) == 5
+    assert all(s >= 0 for s in samples)
+
+
+def test_sample_raises_on_a_port_nothing_is_listening_on():
+    closed_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    closed_server.bind(("127.0.0.1", 0))
+    _, port = closed_server.getsockname()
+    closed_server.close()  # bound then closed: nothing listens on this port now
+
+    with pytest.raises(OSError):
+        measure_rtt.sample("127.0.0.1", port, count=1, timeout=1.0)
+
+
+def test_main_prints_min_avg_max_as_json(accepting_server, capsys):
+    host, port = accepting_server
+    # main() reads argv directly, so drive it through sys.argv instead of calling with args.
+    old_argv = sys.argv
+    try:
+        sys.argv = ["measure_rtt.py", host, str(port), "--count", "3"]
+        exit_code = measure_rtt.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exit_code == 0
+    import json
+
+    out = json.loads(capsys.readouterr().out)
+    assert out["host"] == host
+    assert out["port"] == port
+    assert len(out["samples_ms"]) == 3
+    assert out["min_ms"] <= out["avg_ms"] <= out["max_ms"]
+
+
+def test_main_fails_loudly_with_nothing_listening(capsys):
+    closed_server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    closed_server.bind(("127.0.0.1", 0))
+    _, port = closed_server.getsockname()
+    closed_server.close()
+
+    old_argv = sys.argv
+    try:
+        sys.argv = ["measure_rtt.py", "127.0.0.1", str(port), "--count", "1", "--timeout", "0.5"]
+        exit_code = measure_rtt.main()
+    finally:
+        sys.argv = old_argv
+
+    assert exit_code == 1
+    assert "error" in capsys.readouterr().err

--- a/tools/e2e/test/test_network_profiles.py
+++ b/tools/e2e/test/test_network_profiles.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/network_profiles.py (#366): a profile must resolve
+to the parameters it declares, an unknown name must be an explicit error rather than a
+silent default, and the loopback profile must be distinguishable from an absent one.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+import network_profiles
+
+
+def test_a_known_profile_resolves_to_its_declared_parameters():
+    profile = network_profiles.resolve("poor-wifi")
+    assert profile.name == "poor-wifi"
+    assert profile.delay_ms == 80
+    assert profile.jitter_ms == 30
+    assert profile.loss_pct == 2.0
+
+
+def test_an_unknown_profile_name_is_an_explicit_error():
+    with pytest.raises(ValueError, match="unknown network profile 'bogus'"):
+        network_profiles.resolve("bogus")
+
+
+def test_the_error_names_the_known_profiles_so_a_typo_is_diagnosable():
+    with pytest.raises(ValueError, match="loopback"):
+        network_profiles.resolve("bogus")
+
+
+def test_loopback_is_the_only_unshaped_profile():
+    assert network_profiles.resolve("loopback").is_shaped is False
+    for name in ("good-wifi", "poor-wifi", "site-uplink"):
+        assert network_profiles.resolve(name).is_shaped is True, name
+
+
+def test_loopback_produces_no_netem_args_so_no_qdisc_is_applied():
+    assert network_profiles.resolve("loopback").netem_args() == []
+
+
+def test_a_degraded_profile_produces_delay_jitter_and_loss_netem_args():
+    args = network_profiles.resolve("poor-wifi").netem_args()
+    assert args[0] == "netem"
+    assert "delay" in args and "80ms" in args and "30ms" in args
+    assert "loss" in args and "2.0%" in args
+
+
+def test_a_profile_with_a_rate_cap_includes_a_rate_netem_arg():
+    args = network_profiles.resolve("site-uplink").netem_args()
+    assert "rate" in args and "2000kbit" in args
+
+
+def test_a_profile_with_only_loss_and_no_delay_omits_the_delay_clause():
+    zero_delay = network_profiles.NetworkProfile(
+        "test-loss-only", delay_ms=0, jitter_ms=0, loss_pct=5.0
+    )
+    args = zero_delay.netem_args()
+    assert "delay" not in args
+    assert args == ["netem", "loss", "5.0%"]
+
+
+def test_two_runs_of_the_same_profile_name_are_identical():
+    assert network_profiles.resolve("good-wifi") == network_profiles.resolve("good-wifi")
+
+
+def test_distinct_profiles_are_distinguishable_by_name_not_just_object_identity():
+    loopback = network_profiles.resolve("loopback")
+    assert loopback.name == "loopback"
+    assert loopback != network_profiles.NetworkProfile("not-loopback", 0, 0, 0)


### PR DESCRIPTION
## Summary

Every DC reliability claim so far was established over intra-container loopback. This
closes that gap at the two seams #366's PRD identified, without changing anything about
the pipeline being measured.

- **`dc_bridge/test/forwarder_test.cpp`**: extends the existing mock shipper ingest peer
  with a test-only `AckPolicy` (ack delay, never-ack probability, throttled drain rate)
  and 5 new gtest cases covering unacked window depth at a realistic rate/delay, the
  shipped bound being exceeded by delay alone (not just an absent peer), backpressure
  vs. Io classification for a slow-draining vs. gone peer, resend-under-ack-timeout
  producing a wire duplicate that still converges, and out-of-order-ack eviction
  correctness. No container needed — pure unit tests at the existing seam.
- **`tools/e2e/scripts/network_profiles.py`**: named, fixed network conditions
  (`loopback`/`good-wifi`/`poor-wifi`/`site-uplink`) in one declarative place, with a
  CLI a shell script can consume. 10 pytest cases.
- **`tools/e2e/scripts/run_degraded.sh`**: a new sibling E2E scenario. Postgres/RustFS
  move to their own bridge network (so the path to them can be shaped without shaping
  the host), `tc netem` is applied via a short-lived helper container that joins the
  target's network namespace (`--network container:<name> --cap-add=NET_ADMIN`, so
  neither Destination image needs any capability), a shaping pre-check
  (`scripts/measure_rtt.py`, stdlib TCP connect-time sampling) hard-fails the run if the
  measured RTT isn't consistent with the requested profile, and a LINK fault (`tc netem
  loss 100%`, then restored) proves the network disappearing without the process dying
  is handled distinctly from the existing outage scenario's container stop/restart.
  Reuses `run.sh`'s image and `verify_zero_loss.py` unmodified (one additive
  `--conditions-file` flag folds the run's conditions into the report).

Not wired into `ci.yaml`, matching the existing precedent for the retention/incident
scenarios — whether it gates merges is left for once its runtime/stability are measured
(per the PRD's own "Out of Scope").

Traffic shaping was the PRD's stated single largest technical risk and was verified
empirically first, in isolation, before anything was built on it (see `progress.txt`).
The full container-network E2E path was not run end-to-end in this session — the
shaping mechanism itself was verified, and the Forwarder unit tests were built, rebuilt,
and run 5x for flakiness (17/17 passing) — but a first full `run_degraded.sh` execution
against a built workspace image remains to be done.

## Test plan

- [x] `dc_bridge`'s new `forwarder_test` cases built and run 5x against a scoped rebuild
      (dc_common + dc_bridge) — 17/17 passing, no flakiness
- [x] `tools/e2e/test` pytest suite (24 tests, including the 14 new ones) — all passing
- [x] `prek run --all-files --skip build-doc` — all hooks passing
- [x] Traffic-shaping mechanism (netns-joining helper + `tc netem`, unprivileged) verified
      empirically against disposable containers under this project's rootless podman
- [ ] A full `run_degraded.sh` run against a built `dc-e2e` image (needs a full workspace
      build; not run in this session)

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TryRM4gK1GQE8uCDE4iPhX