### PR TITLE
feat(tools/e2e): limits harness saturation probe (verdict from an observation window)

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -7848,3 +7848,45 @@ list the same way this issue does. Rebased onto `origin/jazzy`: `CMakeLists.txt`
 and this file needed manual conflict resolution to keep both sides' entries. `#366` (degraded
 network conditions testing) then merged into `jazzy` too, mid-rebase, conflicting with this file
 alone (both entries append at the same tail); rebased again, keeping both entries in issue order.
+
+## #377 - Limits harness: saturation probe (verdict from an observation window)
+
+`tools/e2e/scripts/saturation_probe.py`: a pure function (`evaluate(window, bounds)`,
+no I/O, no containers) that decides whether the pipeline has saturated given a
+chronologically ordered window of `Observation`s (`ack_latency_s`,
+`unacked_window_depth`, `disk_buffer_bytes`, `outage_declared`) and a `SaturationBounds`
+config, returning a `Verdict` (`status`: not_saturated/saturated/insufficient_data,
+`binding_signal`, `reason`, `figures`).
+
+**Priority order matches the PRD (#323) exactly**, each signal checked only once every
+higher-priority one has failed to trip: (1) acknowledgement latency at/above
+`ack_latency_bound_s` for the trailing `ack_latency_sustain_samples` observations — the
+"staying there" requirement is a tail check, not a whole-window one, so a spike that has
+already recovered by the end of the window never trips it; (2) unacked-window depth
+whose second-half mean exceeds its first-half mean by `unacked_window_depth_growth_threshold`;
+(3) disk-buffer bytes growing the same head/tail way, but only when no observation in the
+window has `outage_declared` set — checked over the whole window, not just the tail, since
+a growth trend that started under an outage and hasn't finished unwinding isn't steady-state
+growth either. Buffer *level* alone is never read as a signal at any priority — only its
+trend, and only combined with the outage flag, per the PRD's explicit rejection of
+utilisation as a signal (a full/growing buffer during a declared outage is the buffer
+working correctly; the same growth with no outage declared means the Shipper is
+undersized).
+
+A window shorter than `min_observations` (default 4) returns `INSUFFICIENT_DATA`
+unconditionally, before any signal is evaluated — even a too-short window whose few
+samples already look saturated returns that, never a default healthy or saturated
+verdict.
+
+13 pytest cases in `tools/e2e/test/test_saturation_probe.py`, covering all six acceptance
+criteria plus the signal-priority ordering (latency beats a concurrently growing unacked
+window; unacked depth beats a concurrently growing disk buffer) and the
+utilisation-vs-trend distinction directly (a buffer that's high but flat never trips it).
+Run via `uv run pytest tools/e2e/test/` alongside the existing `test_network_profiles.py`/
+`test_measure_rtt.py`/`test_raw_volume.py` — no `colcon build` or container needed, matching
+the issue's "runs entirely as unit tests" criterion.
+
+No CLI and no `__main__`, unlike `network_profiles.py`/`measure_rtt.py`: the issue scopes
+this to the verdict function alone, with the ramp controller (#379) and the other axis
+issues (#378, #380-386) that will call it left as separate work. `tools/e2e/README.md`'s
+Layout section gained one entry.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -305,6 +305,10 @@ that; see that file for the corresponding unit tests.
   applies, in one declarative place also meant for #323's limits harness to reuse.
 - `scripts/measure_rtt.py` — stdlib TCP connect-time sampler (#366), used both for
   Destination readiness polling and the shaping pre-check `run_degraded.sh` never skips.
+- `scripts/saturation_probe.py` — the limits harness's saturation verdict (#377, part of
+  #323): a pure function over a window of ack-latency/unacked-window-depth/disk-buffer
+  observations, checked in the PRD's stated priority order and unit-tested alone, with
+  no container or ramp controller of its own yet.
 
 ## `.dockerignore`
 

--- a/tools/e2e/scripts/saturation_probe.py
+++ b/tools/e2e/scripts/saturation_probe.py
@@ -1,0 +1,204 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Saturation probe (#377): a pure verdict function for #323's limits harness. Given a
+chronologically ordered window of observations, decides whether the pipeline has
+saturated and, if so, names the single binding signal responsible.
+
+Signals are checked in the PRD's stated priority order, each only once every
+higher-priority signal has failed to trip:
+
+1. **Acknowledgement latency** crossing `ack_latency_bound_s` and staying there — the
+   Shipper acknowledges a Record only once it is durably buffered, so a sustained rise in
+   that latency is the pipeline itself reporting it cannot keep up. "Staying there" is
+   checked over the window's trailing `ack_latency_sustain_samples` observations, not the
+   whole window, so a transient spike that has already recovered by the end of the
+   window does not trip the verdict.
+2. **Unacked-window depth** trending upward — checked only once latency hasn't already
+   decided the verdict, since a growing window is latency's own leading indicator, not an
+   independent failure mode.
+3. **Disk-buffer growth at steady state** — checked last, and only when no observation in
+   the window has `outage_declared` set. Buffer *utilisation* alone is deliberately never
+   read as a signal (see #323's PRD): a full buffer during a declared outage is the
+   buffer working correctly, and the same growth with no outage declared means the
+   Shipper is undersized. The two are told apart by the outage flag and the growth
+   trend, never by a threshold on the level itself.
+
+An observation window shorter than `min_observations` returns `INSUFFICIENT_DATA` rather
+than any healthy/saturated verdict — a probe run before enough data has accumulated must
+never be misread as "not saturated" by default.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from statistics import fmean
+
+
+class VerdictStatus(StrEnum):
+    NOT_SATURATED = "not_saturated"
+    SATURATED = "saturated"
+    INSUFFICIENT_DATA = "insufficient_data"
+
+
+class Signal(StrEnum):
+    ACK_LATENCY = "ack_latency"
+    UNACKED_WINDOW_DEPTH = "unacked_window_depth"
+    DISK_BUFFER = "disk_buffer"
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One sample in the window. Every check below assumes oldest-to-newest order."""
+
+    ack_latency_s: float
+    unacked_window_depth: float
+    disk_buffer_bytes: float
+    outage_declared: bool = False
+
+
+@dataclass(frozen=True)
+class SaturationBounds:
+    # Fewer than this many observations can't support a trend judgement at all.
+    min_observations: int = 4
+    # The stated acknowledgement-latency percentile bound (the PRD's primary signal),
+    # e.g. a p95 ack-latency SLO of 2s. Each Observation's ack_latency_s is assumed to
+    # already be that percentile figure for its sample interval — this module doesn't
+    # compute percentiles itself, only whether the figure crosses the bound and stays.
+    ack_latency_bound_s: float = 2.0
+    # How many trailing observations must all sit at/above the bound for a crossing to
+    # count as "staying there" rather than a transient spike.
+    ack_latency_sustain_samples: int = 3
+    # Minimum growth (mean of the window's second half minus its first half) in unacked
+    # records to count as "trending upward".
+    unacked_window_depth_growth_threshold: float = 20.0
+    # Minimum growth (same head/tail split) in disk-buffer bytes to count as growth at
+    # steady state.
+    disk_buffer_growth_threshold_bytes: float = 1_000_000.0
+
+
+@dataclass(frozen=True)
+class Verdict:
+    status: VerdictStatus
+    binding_signal: Signal | None
+    reason: str
+    figures: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def saturated(self) -> bool:
+        return self.status == VerdictStatus.SATURATED
+
+
+def evaluate(
+    window: Sequence[Observation], bounds: SaturationBounds = SaturationBounds()
+) -> Verdict:
+    """The saturation verdict for one observation window. Never raises on a short or
+    empty window — that's INSUFFICIENT_DATA, not an error, since a limits-harness ramp
+    controller calls this on every poll, including before the window has filled."""
+    if len(window) < bounds.min_observations:
+        return Verdict(
+            status=VerdictStatus.INSUFFICIENT_DATA,
+            binding_signal=None,
+            reason=(
+                f"window has {len(window)} observation(s), fewer than the "
+                f"{bounds.min_observations} required to assess a trend"
+            ),
+        )
+
+    for signal_check in (_ack_latency_signal, _unacked_window_depth_signal, _disk_buffer_signal):
+        verdict = signal_check(window, bounds)
+        if verdict is not None:
+            return verdict
+
+    return Verdict(
+        status=VerdictStatus.NOT_SATURATED,
+        binding_signal=None,
+        reason="no signal crossed its bound",
+    )
+
+
+def _split_halves(
+    window: Sequence[Observation],
+) -> tuple[Sequence[Observation], Sequence[Observation]]:
+    midpoint = len(window) // 2
+    return window[:midpoint], window[midpoint:]
+
+
+def _ack_latency_signal(window: Sequence[Observation], bounds: SaturationBounds) -> Verdict | None:
+    tail = window[-bounds.ack_latency_sustain_samples :]
+    if not tail or any(o.ack_latency_s < bounds.ack_latency_bound_s for o in tail):
+        return None
+    return Verdict(
+        status=VerdictStatus.SATURATED,
+        binding_signal=Signal.ACK_LATENCY,
+        reason=(
+            f"acknowledgement latency has stayed at or above the "
+            f"{bounds.ack_latency_bound_s}s bound for the trailing {len(tail)} "
+            f"observation(s)"
+        ),
+        figures={
+            "ack_latency_bound_s": bounds.ack_latency_bound_s,
+            "ack_latency_tail_min_s": min(o.ack_latency_s for o in tail),
+            "ack_latency_tail_max_s": max(o.ack_latency_s for o in tail),
+        },
+    )
+
+
+def _unacked_window_depth_signal(
+    window: Sequence[Observation], bounds: SaturationBounds
+) -> Verdict | None:
+    head, tail = _split_halves(window)
+    if not head or not tail:
+        return None
+    head_mean = fmean(o.unacked_window_depth for o in head)
+    tail_mean = fmean(o.unacked_window_depth for o in tail)
+    growth = tail_mean - head_mean
+    if growth < bounds.unacked_window_depth_growth_threshold:
+        return None
+    return Verdict(
+        status=VerdictStatus.SATURATED,
+        binding_signal=Signal.UNACKED_WINDOW_DEPTH,
+        reason=(
+            f"unacked-window depth grew by {growth:.1f} record(s) from the window's "
+            f"first half to its second, at or above the "
+            f"{bounds.unacked_window_depth_growth_threshold} bound"
+        ),
+        figures={
+            "unacked_window_depth_head_mean": head_mean,
+            "unacked_window_depth_tail_mean": tail_mean,
+            "unacked_window_depth_growth": growth,
+        },
+    )
+
+
+def _disk_buffer_signal(window: Sequence[Observation], bounds: SaturationBounds) -> Verdict | None:
+    # A full/growing buffer during a declared outage is the buffer doing its job, not a
+    # saturation signal — see the module docstring. Suppressed for the whole window, not
+    # just the tail: a growth trend that started under an outage and is still unwinding
+    # isn't steady-state growth either.
+    if any(o.outage_declared for o in window):
+        return None
+    head, tail = _split_halves(window)
+    if not head or not tail:
+        return None
+    head_mean = fmean(o.disk_buffer_bytes for o in head)
+    tail_mean = fmean(o.disk_buffer_bytes for o in tail)
+    growth = tail_mean - head_mean
+    if growth < bounds.disk_buffer_growth_threshold_bytes:
+        return None
+    return Verdict(
+        status=VerdictStatus.SATURATED,
+        binding_signal=Signal.DISK_BUFFER,
+        reason=(
+            f"disk-buffer bytes grew by {growth:.0f} at steady state (no outage "
+            f"declared in the window), at or above the "
+            f"{bounds.disk_buffer_growth_threshold_bytes} bound"
+        ),
+        figures={
+            "disk_buffer_head_mean": head_mean,
+            "disk_buffer_tail_mean": tail_mean,
+            "disk_buffer_growth": growth,
+        },
+    )

--- a/tools/e2e/test/test_saturation_probe.py
+++ b/tools/e2e/test/test_saturation_probe.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/saturation_probe.py (#377): the acceptance criteria
+from the issue, plus the signal-priority ordering and the "buffer growth is told apart
+from buffer utilisation" behaviour the PRD (#323) calls out explicitly.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+from saturation_probe import (
+    Observation,
+    Signal,
+    VerdictStatus,
+    evaluate,
+)
+
+DEFAULT_LATENCY = 0.2
+DEFAULT_DEPTH = 5.0
+DEFAULT_BUFFER = 1_000.0
+
+
+def _window(
+    latencies: list[float] | None = None,
+    depths: list[float] | None = None,
+    buffers: list[float] | None = None,
+    outages: list[bool] | None = None,
+    length: int = 8,
+) -> list[Observation]:
+    """Builds a window from per-field lists, defaulting any omitted field to a flat,
+    healthy series so a test only has to state the field(s) it cares about."""
+    latencies = latencies if latencies is not None else [DEFAULT_LATENCY] * length
+    depths = depths if depths is not None else [DEFAULT_DEPTH] * length
+    buffers = buffers if buffers is not None else [DEFAULT_BUFFER] * length
+    n = len(latencies)
+    outages = outages if outages is not None else [False] * n
+    assert len(depths) == len(buffers) == len(outages) == n
+    return [
+        Observation(
+            ack_latency_s=latencies[i],
+            unacked_window_depth=depths[i],
+            disk_buffer_bytes=buffers[i],
+            outage_declared=outages[i],
+        )
+        for i in range(n)
+    ]
+
+
+def test_a_steady_healthy_window_returns_not_saturated():
+    verdict = evaluate(_window())
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.saturated is False
+    assert verdict.binding_signal is None
+
+
+def test_a_monotonic_latency_climb_crossing_the_bound_returns_saturated_with_latency_named():
+    latencies = [0.2, 0.3, 0.5, 1.0, 1.8, 2.2, 2.5, 2.8, 3.0, 3.0]
+    verdict = evaluate(_window(latencies=latencies, length=len(latencies)))
+    assert verdict.status == VerdictStatus.SATURATED
+    assert verdict.binding_signal == Signal.ACK_LATENCY
+    assert verdict.figures["ack_latency_tail_min_s"] >= 2.0
+
+
+def test_a_transient_latency_spike_that_recovers_does_not_trip_the_verdict():
+    latencies = [0.2, 0.2, 0.2, 3.0, 3.0, 0.2, 0.2, 0.2]
+    verdict = evaluate(_window(latencies=latencies, length=len(latencies)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.binding_signal is None
+
+
+def test_steady_state_disk_buffer_growth_with_no_outage_trips_the_verdict():
+    buffers = [1_000.0, 1_000.0, 2_000.0, 3_000.0, 5_000_000.0, 8_000_000.0, 12_000_000.0]
+    verdict = evaluate(_window(buffers=buffers, length=len(buffers)))
+    assert verdict.status == VerdictStatus.SATURATED
+    assert verdict.binding_signal == Signal.DISK_BUFFER
+
+
+def test_identical_disk_buffer_growth_during_a_declared_outage_does_not_trip_the_verdict():
+    buffers = [1_000.0, 1_000.0, 2_000.0, 3_000.0, 5_000_000.0, 8_000_000.0, 12_000_000.0]
+    outages = [True] * len(buffers)
+    verdict = evaluate(_window(buffers=buffers, outages=outages, length=len(buffers)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.binding_signal is None
+
+
+def test_an_observation_window_with_insufficient_data_returns_an_explicit_result():
+    verdict = evaluate(_window(length=2))
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA
+    assert verdict.saturated is False
+    assert verdict.binding_signal is None
+
+
+def test_insufficient_data_is_returned_even_when_the_few_samples_look_saturated():
+    # Every sample is already over the latency bound; a naive default would call this
+    # healthy or saturated, but there aren't enough samples to say either.
+    verdict = evaluate(_window(latencies=[3.0, 3.0], length=2))
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA
+
+
+def test_an_empty_window_returns_insufficient_data_not_an_error():
+    verdict = evaluate([])
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA
+
+
+def test_unacked_window_depth_trending_upward_trips_the_verdict_as_the_secondary_signal():
+    depths = [5.0, 5.0, 10.0, 20.0, 35.0, 55.0]
+    verdict = evaluate(_window(depths=depths, length=len(depths)))
+    assert verdict.status == VerdictStatus.SATURATED
+    assert verdict.binding_signal == Signal.UNACKED_WINDOW_DEPTH
+
+
+def test_a_flat_unacked_window_depth_does_not_trip_the_verdict():
+    depths = [5.0, 6.0, 5.0, 6.0, 5.0, 6.0]
+    verdict = evaluate(_window(depths=depths, length=len(depths)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+
+
+def test_latency_takes_priority_over_a_concurrently_growing_unacked_window():
+    latencies = [0.2, 0.3, 0.5, 1.0, 1.8, 2.2, 2.5, 2.8, 3.0, 3.0]
+    depths = [5.0, 5.0, 10.0, 20.0, 35.0, 55.0, 80.0, 110.0, 145.0, 185.0]
+    verdict = evaluate(_window(latencies=latencies, depths=depths, length=len(latencies)))
+    assert verdict.binding_signal == Signal.ACK_LATENCY
+
+
+def test_unacked_window_depth_takes_priority_over_a_concurrently_growing_disk_buffer():
+    depths = [5.0, 5.0, 10.0, 20.0, 35.0, 55.0]
+    buffers = [1_000.0, 1_000.0, 2_000.0, 3_000.0, 5_000_000.0, 8_000_000.0]
+    verdict = evaluate(_window(depths=depths, buffers=buffers, length=len(depths)))
+    assert verdict.binding_signal == Signal.UNACKED_WINDOW_DEPTH
+
+
+def test_disk_buffer_growth_is_measured_by_trend_not_by_a_level_threshold():
+    # A buffer that is high but flat (utilisation alone) must never trip the verdict —
+    # only growth does, per the PRD's explicit rejection of utilisation as a signal.
+    verdict = evaluate(_window(buffers=[50_000_000.0] * 8))
+    assert verdict.status == VerdictStatus.NOT_SATURATED


### PR DESCRIPTION
## Summary

- Adds `tools/e2e/scripts/saturation_probe.py`, a pure verdict function for #323's limits harness: given a chronologically ordered window of ack-latency / unacked-window-depth / disk-buffer / outage-declared observations, decides saturated / not-saturated / insufficient-data and names the binding signal.
- Signal priority matches the PRD exactly: acknowledgement latency crossing its bound and staying there (primary) → unacked-window depth trending upward (secondary) → disk-buffer growth at steady state, i.e. only when no outage is declared in the window (tertiary). Buffer *utilisation* alone is never a signal — only its growth trend, told apart from a declared outage by the `outage_declared` flag, matching the PRD's explicit rejection of a level threshold.
- A window shorter than `min_observations` returns an explicit `INSUFFICIENT_DATA` verdict, never a default healthy/saturated one.
- Pure function: no containers, no I/O, no network — runs entirely as unit tests.

Closes #377

## Test plan

- [x] `uv run pytest tools/e2e/test/test_saturation_probe.py -v` — 13/13 passing, covering all six acceptance criteria plus signal-priority ordering and the utilisation-vs-trend distinction
- [x] `uv run pytest tools/e2e/test/` — full suite (37 tests) still green
- [x] `uv run ruff check` / `ruff format --diff` clean
- [x] `prek run` on the changed files — all hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011iv7L8vX7KgrAukeeXKfa6