### PR TITLE
feat(tools/e2e): add limits harness curve reporter (#380)

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -8005,3 +8005,66 @@ stays-clear directions where applicable), and the empty-policy rejection.
 controller's own paragraph (renamed conceptually to cover both #377 and #379 now
 landed) and a matching entry in Layout; the curve reporter and topology composer remain
 the two not-yet-implemented pieces of #323.
+
+## #380 - Limits harness: curve reporter (stable, diffable saturation report)
+
+`tools/e2e/scripts/curve_reporter.py`: a pure function turning a set of per-axis ramp
+runs into a stable, diffable structured report plus a human-readable summary — the
+fourth of #323's four "deep" modules, after the saturation probe (#377), the load
+driver (#378), and the ramp controller (#379). Only the topology composer (integration)
+remains unimplemented in that epic.
+
+**Interface**: input is a `Sequence[AxisRun]`, one per axis (shipper fan-in, single-robot
+ceiling, uploader concurrency, drain rate, …). Each `AxisRun` carries the axis name and
+unit, a `RunOutcome` (`KNEE_FOUND`/`BOUND_NOT_FOUND`, mirroring `RampOutcome`'s values
+without importing `ramp_controller` — the same decoupling `ramp_controller` uses for
+`saturation_probe.Verdict`), `highest_clear_level`/`tripped_level`, and an ascending
+sequence of `LevelResult`s. Each `LevelResult` states its own `PointKind`
+(`MEASURED`/`EXTRAPOLATED`), its `RunComposition` (real DC stacks vs. synthetic
+senders), and an optional `ResourceSample` (cpu/mem/disk percentages from the existing
+resource sampler) — `None` by construction for an `EXTRAPOLATED` point, since there is
+nothing measured to report for a level that was never driven. `build_report()` is the
+entry point: no I/O, no containers, no dependency on `ramp_controller`/
+`saturation_probe`.
+
+**Stability**: `build_report()` sorts axes by name and each axis's points by level, so
+the same set of runs produces the same `CurveReport` regardless of the order runs were
+collected or handed in — the issue's first acceptance criterion, verified both by
+calling it twice on identical input and by calling it on the same runs in two different
+orders and diffing the JSON. `to_json()` additionally serialises with `sort_keys=True`
+so key order is never a source of a spurious diff either.
+
+**Binding constraint**: `_binding_constraint()` picks the resource (CPU, memory, or
+disk) whose usage peaked highest across a run's *measured* points only — never guessed
+from an extrapolated point, and never reported at all when the axis never saturated
+(`BOUND_NOT_FOUND`) or its knee has no accompanying resource sample (`KNEE_FOUND` but no
+measured `ResourceSample`, e.g. the sampler wasn't wired up for that run). Ties break
+CPU-then-memory-then-disk, the same order the PRD lists the three resources in.
+
+**Honesty**: every `LevelResult` — measured or extrapolated — is labelled as such in
+both the structured `AxisReport.points` and `render_summary()`'s per-point line, and an
+extrapolated point is rendered as "not measured" rather than with fabricated
+cpu/mem/disk figures. Composition (real stacks vs. synthetic senders) is likewise
+reported per point, not just per axis, since a ramp's real/synthetic mix can itself
+change level to level (e.g. the shipper-fan-in axis's "level" often *is* a growing
+synthetic-sender count against a fixed handful of real stacks).
+
+**Test coverage** (`tools/e2e/test/test_curve_reporter.py`, 19 cases, synthetic run data
+only, no containers/network): the issue's four acceptance criteria — identical input
+produces an identical report and identical JSON across two calls and across two input
+orderings; points within an axis always come out ascending by level regardless of input
+order; the binding constraint correctly names CPU, memory, or disk depending on which
+peaked highest across a run's measured points, with an explicit tie-break test and two
+"no constraint to report" cases (bound not found; knee found but nothing measured);
+measured vs. extrapolated points are distinguishable in both the structured report
+(extrapolated points carry no `ResourceSample`) and the rendered summary text (exact
+`[measured]`/`[extrapolated]` substring assertions, including the "not measured" text
+for a fabrication-free extrapolated line) — plus composition-per-point assertions,
+structural validation (`AxisRun` rejects an empty `points` sequence or an unnamed axis,
+`RunComposition`/`ResourceSample` reject negative values), and a multi-axis case
+proving each axis's binding constraint is computed independently of the others.
+
+`tools/e2e/README.md` gained the curve reporter's own paragraph after the ramp
+controller's (in the "Synthetic load driver (#378)" section, which now covers all four
+deep modules) and a matching entry in Layout; the topology composer remains the one
+not-yet-implemented piece of #323.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -263,8 +263,28 @@ mode #323's PRD calls out as mattering most. The controller touches no I/O and k
 nothing about what a "level" means (a connection count, a rate, an upload
 concurrency, …); `driver` and `probe` are plain callables, so `test_ramp_controller.py`
 covers it entirely with in-process fakes, including the ramp-policy boundary cases
-(first step, last step, a single-step ramp). The curve reporter and topology composer
-#323 describes alongside them are separate, not-yet-implemented pieces of that epic.
+(first step, last step, a single-step ramp).
+
+The curve reporter (`scripts/curve_reporter.py`, #380) turns a set of per-axis runs —
+each an ascending sequence of levels tried, whether each level was actually driven and
+measured or is a projected `EXTRAPOLATED` point, its real-vs-synthetic composition, and
+a CPU/memory/disk `ResourceSample` where one was taken — into a stable, diffable
+`CurveReport` (`build_report()`) plus a human-readable summary (`render_summary()`). It
+is a pure function, decoupled from `ramp_controller`/`saturation_probe` the same way
+those two are decoupled from each other: no I/O, no containers, its own `RunOutcome`
+mirroring `RampOutcome`'s values. `build_report()` sorts axes by name and each axis's
+points by level so the same set of runs always yields the same report regardless of
+collection order — required for a diff between two runs to show only a real change. The
+binding constraint at saturation (CPU, memory, or disk) is the resource that peaked
+highest across a run's *measured* points only (CPU-then-memory-then-disk as the
+deterministic tie-break), and is reported as unavailable rather than guessed when the
+axis never saturated or its knee has no accompanying resource sample. An extrapolated
+point never carries a resource sample in either the structured report or the summary —
+labelling every point `measured`/`extrapolated` in both is how the reporter avoids
+presenting a projection as a measurement, per #323's PRD.
+`tools/e2e/test/test_curve_reporter.py` covers all of this against synthetic run data
+alone. The topology composer #323 describes alongside these four modules is the one
+not-yet-implemented piece of that epic.
 
 ## Layout
 
@@ -360,6 +380,11 @@ covers it entirely with in-process fakes, including the ramp-policy boundary cas
   #323): given a driver, a probe, and an ascending `RampPolicy`, drives load level by
   level until the probe trips and reports the knee, or `BOUND_NOT_FOUND` if it never
   does. No I/O, no container; unit-tested with fake drivers/probes alone.
+- `scripts/curve_reporter.py` — the limits harness's curve reporter (#380, part of
+  #323): a pure function turning a set of per-axis runs into a stable, diffable
+  structured report plus a human-readable summary naming the binding constraint (CPU,
+  memory, or disk) at saturation, with every point labelled measured or extrapolated.
+  No I/O, no container; unit-tested against synthetic run data alone.
 
 ## `.dockerignore`
 

--- a/tools/e2e/scripts/curve_reporter.py
+++ b/tools/e2e/scripts/curve_reporter.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Curve reporter (#380): turns a set of ramp runs into a stable, diffable structured
+report plus a human-readable summary, for #323's limits harness.
+
+A "run" is one axis's ramp (shipper fan-in, single-robot ceiling, uploader concurrency,
+drain rate, ...): the ascending sequence of levels tried, whether each was actually
+driven and measured or is a modelled point beyond what was run, the real-vs-synthetic
+composition behind each level (per the PRD: "every reported figure states its
+real-versus-synthetic composition"), and the CPU/memory/disk usage sampled at each
+measured level. `build_report()` is a pure function of that data — no I/O, no
+containers, no dependency on `ramp_controller`/`saturation_probe` — matching this
+module's siblings in the epic.
+
+Two things the PRD calls out as load-bearing:
+
+- **Stability.** Identical input must produce identical output, and the report's axis
+  order must not depend on the order runs were handed in — a diff between two runs
+  should only ever show a real change. `build_report()` sorts axes by name for this.
+- **Honesty.** A measured point and an extrapolated (projected) one must never look
+  alike. Every `LevelResult` carries its own `PointKind`, both the structured report and
+  `render_summary()` print it next to the level, and an extrapolated point never carries
+  a resource sample — there is nothing measured to report for a level that wasn't run.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+
+class PointKind(StrEnum):
+    MEASURED = "measured"
+    EXTRAPOLATED = "extrapolated"
+
+
+class ResourceKind(StrEnum):
+    CPU = "cpu"
+    MEMORY = "memory"
+    DISK = "disk"
+
+
+class RunOutcome(StrEnum):
+    """Mirrors ramp_controller.RampOutcome's values without importing that module —
+    same decoupling the ramp controller uses for saturation_probe.Verdict."""
+
+    KNEE_FOUND = "knee_found"
+    BOUND_NOT_FOUND = "bound_not_found"
+
+
+@dataclass(frozen=True)
+class ResourceSample:
+    """CPU/memory/disk usage accompanying one measured level, from the existing
+    resource sampler. Percentages, not clamped to 100 — `podman stats`' CPU figure can
+    exceed 100% on a multi-core container."""
+
+    cpu_percent: float
+    mem_percent: float
+    disk_percent: float
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("cpu_percent", self.cpu_percent),
+            ("mem_percent", self.mem_percent),
+            ("disk_percent", self.disk_percent),
+        ):
+            if value < 0:
+                raise ValueError(f"{name} cannot be negative, got {value}")
+
+
+@dataclass(frozen=True)
+class RunComposition:
+    """How many real DC stacks vs. synthetic senders made up one reported level."""
+
+    real_stacks: int
+    synthetic_senders: int
+
+    def __post_init__(self) -> None:
+        if self.real_stacks < 0 or self.synthetic_senders < 0:
+            raise ValueError("composition counts cannot be negative")
+
+    @property
+    def total(self) -> int:
+        return self.real_stacks + self.synthetic_senders
+
+
+@dataclass(frozen=True)
+class LevelResult:
+    """One level tried (or projected) on an axis's ramp.
+
+    `resources` is `None` for an extrapolated point by construction of the reporter's
+    contract: there is no sample to report for a level that was never driven. A measured
+    point normally carries one, but isn't required to (a run whose resource sampler
+    wasn't wired up still reports a level; it just can't back a binding-constraint
+    claim from it).
+    """
+
+    level: float
+    saturated: bool
+    kind: PointKind
+    composition: RunComposition
+    resources: ResourceSample | None = None
+
+
+@dataclass(frozen=True)
+class AxisRun:
+    """One axis's full ramp, as input to `build_report()`."""
+
+    axis: str
+    unit: str
+    outcome: RunOutcome
+    # The highest level tried whose verdict stayed clear; None only when the very
+    # first level tried already saturated. Mirrors ramp_controller.RampResult.
+    highest_clear_level: float | None
+    # None exactly when outcome is BOUND_NOT_FOUND — never a fabricated ceiling.
+    tripped_level: float | None
+    points: Sequence[LevelResult]
+
+    def __post_init__(self) -> None:
+        if not self.axis:
+            raise ValueError("an axis run must name its axis")
+        if len(self.points) == 0:
+            raise ValueError(f"axis run {self.axis!r} must carry at least one point")
+
+
+@dataclass(frozen=True)
+class BindingConstraint:
+    resource: ResourceKind | None
+    percent: float | None
+    reason: str
+
+
+@dataclass(frozen=True)
+class AxisReport:
+    axis: str
+    unit: str
+    outcome: RunOutcome
+    highest_clear_level: float | None
+    tripped_level: float | None
+    binding_constraint: BindingConstraint
+    points: tuple[LevelResult, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class CurveReport:
+    axes: tuple[AxisReport, ...] = field(default_factory=tuple)
+
+
+# CPU checked before memory before disk: both the priority order the PRD lists the
+# three signals in, and the deterministic tie-break when two resources peak at the
+# same percentage.
+_RESOURCE_PRIORITY = (ResourceKind.CPU, ResourceKind.MEMORY, ResourceKind.DISK)
+
+
+def _resource_percent(sample: ResourceSample, kind: ResourceKind) -> float:
+    return {
+        ResourceKind.CPU: sample.cpu_percent,
+        ResourceKind.MEMORY: sample.mem_percent,
+        ResourceKind.DISK: sample.disk_percent,
+    }[kind]
+
+
+def _binding_constraint(run: AxisRun) -> BindingConstraint:
+    """The resource whose usage peaked highest across this run's measured points —
+    "correctly identified from the resource-usage series accompanying a run" per the
+    issue. Never guesses one for a run that didn't saturate, and never reports a
+    constraint sourced from an extrapolated point."""
+    if run.outcome != RunOutcome.KNEE_FOUND:
+        return BindingConstraint(
+            resource=None,
+            percent=None,
+            reason="no saturation observed within tested range; no binding constraint to report",
+        )
+
+    measured = [p for p in run.points if p.kind == PointKind.MEASURED and p.resources is not None]
+    if not measured:
+        return BindingConstraint(
+            resource=None,
+            percent=None,
+            reason="knee found but no measured resource sample accompanies this run",
+        )
+
+    best_kind: ResourceKind | None = None
+    best_percent = -1.0
+    best_level: float | None = None
+    for kind in _RESOURCE_PRIORITY:
+        for point in measured:
+            assert point.resources is not None  # narrowed by the filter above
+            percent = _resource_percent(point.resources, kind)
+            if percent > best_percent:
+                best_kind, best_percent, best_level = kind, percent, point.level
+
+    assert best_kind is not None
+    return BindingConstraint(
+        resource=best_kind,
+        percent=best_percent,
+        reason=f"{best_kind.value} peaked at {best_percent:.1f}% at level {best_level} (measured)",
+    )
+
+
+def build_report(runs: Sequence[AxisRun]) -> CurveReport:
+    """The curve reporter's entry point: a pure function from a set of per-axis runs
+    to a stable report. Axes are sorted by name and each axis's points by level, so the
+    same set of runs always yields the same report regardless of the order they were
+    collected or handed in — required for the report to be diffable between two runs."""
+    axes = tuple(_to_axis_report(run) for run in sorted(runs, key=lambda r: r.axis))
+    return CurveReport(axes=axes)
+
+
+def _to_axis_report(run: AxisRun) -> AxisReport:
+    points = tuple(sorted(run.points, key=lambda p: p.level))
+    return AxisReport(
+        axis=run.axis,
+        unit=run.unit,
+        outcome=run.outcome,
+        highest_clear_level=run.highest_clear_level,
+        tripped_level=run.tripped_level,
+        binding_constraint=_binding_constraint(run),
+        points=points,
+    )
+
+
+def to_json(report: CurveReport) -> str:
+    """The structured report, as stable/diffable JSON: sorted keys so key order can
+    never be the source of a spurious diff, on top of `build_report()`'s own sorting of
+    axes and points."""
+    return json.dumps(dataclasses.asdict(report), indent=2, sort_keys=True)
+
+
+def render_summary(report: CurveReport) -> str:
+    """A human-readable summary naming, per axis, the outcome and the binding
+    constraint at saturation, with every point labelled measured or extrapolated and
+    its real/synthetic composition — never presenting a projection as a measurement."""
+    lines = ["Limits harness curve report", "=" * len("Limits harness curve report"), ""]
+    for axis in report.axes:
+        lines.append(f"{axis.axis} ({axis.unit}):")
+        clear = "none" if axis.highest_clear_level is None else axis.highest_clear_level
+        if axis.outcome == RunOutcome.KNEE_FOUND:
+            lines.append(f"  knee found at {axis.tripped_level} (highest clear: {clear})")
+        else:
+            lines.append(f"  bound not found within tested range (highest clear: {clear})")
+
+        bc = axis.binding_constraint
+        if bc.resource is None:
+            lines.append(f"  binding constraint: none — {bc.reason}")
+        else:
+            lines.append(
+                f"  binding constraint: {bc.resource.value} at {bc.percent:.1f}% ({bc.reason})"
+            )
+
+        lines.append("  points:")
+        for point in axis.points:
+            status = "saturated" if point.saturated else "clear"
+            comp = point.composition
+            composition_text = f"{comp.real_stacks} real + {comp.synthetic_senders} synthetic"
+            if point.resources is None:
+                resource_text = "not measured"
+            else:
+                r = point.resources
+                resource_text = (
+                    f"cpu={r.cpu_percent:.1f}% mem={r.mem_percent:.1f}% disk={r.disk_percent:.1f}%"
+                )
+            lines.append(
+                f"    - {point.level} {axis.unit}: {status} [{point.kind.value}] "
+                f"({composition_text}) {resource_text}"
+            )
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"

--- a/tools/e2e/test/test_curve_reporter.py
+++ b/tools/e2e/test/test_curve_reporter.py
@@ -1,0 +1,368 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/curve_reporter.py (#380): the issue's acceptance
+criteria, driven entirely with synthetic run data (no containers, no network, no
+dependency on ramp_controller/saturation_probe)."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+from curve_reporter import (
+    AxisRun,
+    BindingConstraint,
+    LevelResult,
+    PointKind,
+    ResourceKind,
+    ResourceSample,
+    RunComposition,
+    RunOutcome,
+    build_report,
+    render_summary,
+    to_json,
+)
+
+
+def _measured(
+    level: float,
+    saturated: bool,
+    cpu: float,
+    mem: float,
+    disk: float,
+    real: int = 1,
+    synthetic: int = 0,
+) -> LevelResult:
+    return LevelResult(
+        level=level,
+        saturated=saturated,
+        kind=PointKind.MEASURED,
+        composition=RunComposition(real_stacks=real, synthetic_senders=synthetic),
+        resources=ResourceSample(cpu_percent=cpu, mem_percent=mem, disk_percent=disk),
+    )
+
+
+def _extrapolated(level: float, saturated: bool, real: int = 1, synthetic: int = 0) -> LevelResult:
+    return LevelResult(
+        level=level,
+        saturated=saturated,
+        kind=PointKind.EXTRAPOLATED,
+        composition=RunComposition(real_stacks=real, synthetic_senders=synthetic),
+        resources=None,
+    )
+
+
+def _cpu_bound_run(axis: str = "shipper_fan_in") -> AxisRun:
+    return AxisRun(
+        axis=axis,
+        unit="robots",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=140.0,
+        tripped_level=220.0,
+        points=[
+            _measured(60.0, False, cpu=41.0, mem=30.0, disk=12.0, real=2, synthetic=58),
+            _measured(140.0, False, cpu=68.0, mem=44.0, disk=20.0, real=3, synthetic=137),
+            _measured(220.0, True, cpu=94.2, mem=61.0, disk=33.0, real=4, synthetic=216),
+        ],
+    )
+
+
+# --- Acceptance criterion: identical input -> identical (stable, diffable) output --
+
+
+def test_identical_input_produces_identical_report_and_json():
+    runs = [_cpu_bound_run()]
+
+    report_a = build_report(runs)
+    report_b = build_report(runs)
+
+    assert report_a == report_b
+    assert to_json(report_a) == to_json(report_b)
+
+
+def test_axis_order_in_output_is_stable_regardless_of_input_order():
+    run_a = _cpu_bound_run(axis="shipper_fan_in")
+    run_b = _cpu_bound_run(axis="single_robot_ceiling")
+    run_c = _cpu_bound_run(axis="drain_rate")
+
+    report_forward = build_report([run_a, run_b, run_c])
+    report_shuffled = build_report([run_c, run_a, run_b])
+
+    assert to_json(report_forward) == to_json(report_shuffled)
+    assert [a.axis for a in report_forward.axes] == [
+        "drain_rate",
+        "shipper_fan_in",
+        "single_robot_ceiling",
+    ]
+
+
+def test_points_within_an_axis_are_reported_in_ascending_level_order():
+    run = AxisRun(
+        axis="uploader_concurrency",
+        unit="uploads",
+        outcome=RunOutcome.BOUND_NOT_FOUND,
+        highest_clear_level=30.0,
+        tripped_level=None,
+        points=[
+            _measured(30.0, False, cpu=20.0, mem=10.0, disk=5.0),
+            _measured(10.0, False, cpu=15.0, mem=8.0, disk=4.0),
+            _measured(20.0, False, cpu=18.0, mem=9.0, disk=4.5),
+        ],
+    )
+
+    report = build_report([run])
+
+    assert [p.level for p in report.axes[0].points] == [10.0, 20.0, 30.0]
+
+
+# --- Acceptance criterion: binding constraint correctly identified -----------------
+
+
+def test_binding_constraint_identifies_cpu_when_cpu_peaks_highest():
+    report = build_report([_cpu_bound_run()])
+
+    bc = report.axes[0].binding_constraint
+
+    assert bc.resource == ResourceKind.CPU
+    assert bc.percent == pytest.approx(94.2)
+
+
+def test_binding_constraint_identifies_memory_when_memory_peaks_highest():
+    run = AxisRun(
+        axis="drain_rate",
+        unit="minutes",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=5.0,
+        tripped_level=10.0,
+        points=[
+            _measured(5.0, False, cpu=30.0, mem=40.0, disk=10.0),
+            _measured(10.0, True, cpu=55.0, mem=91.5, disk=20.0),
+        ],
+    )
+
+    report = build_report([run])
+
+    bc = report.axes[0].binding_constraint
+    assert bc.resource == ResourceKind.MEMORY
+    assert bc.percent == pytest.approx(91.5)
+
+
+def test_binding_constraint_identifies_disk_when_disk_peaks_highest():
+    run = AxisRun(
+        axis="uploader_concurrency",
+        unit="uploads",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=8.0,
+        tripped_level=16.0,
+        points=[
+            _measured(8.0, False, cpu=20.0, mem=25.0, disk=40.0),
+            _measured(16.0, True, cpu=45.0, mem=50.0, disk=97.0),
+        ],
+    )
+
+    report = build_report([run])
+
+    bc = report.axes[0].binding_constraint
+    assert bc.resource == ResourceKind.DISK
+    assert bc.percent == pytest.approx(97.0)
+
+
+def test_binding_constraint_tie_break_prefers_cpu_over_memory_over_disk():
+    run = AxisRun(
+        axis="shipper_fan_in",
+        unit="robots",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=None,
+        tripped_level=1.0,
+        points=[_measured(1.0, True, cpu=90.0, mem=90.0, disk=90.0)],
+    )
+
+    report = build_report([run])
+
+    assert report.axes[0].binding_constraint.resource == ResourceKind.CPU
+
+
+def test_binding_constraint_is_none_when_bound_not_found():
+    run = AxisRun(
+        axis="single_robot_ceiling",
+        unit="records_s",
+        outcome=RunOutcome.BOUND_NOT_FOUND,
+        highest_clear_level=500.0,
+        tripped_level=None,
+        points=[_measured(500.0, False, cpu=30.0, mem=20.0, disk=10.0)],
+    )
+
+    report = build_report([run])
+
+    bc = report.axes[0].binding_constraint
+    assert bc == BindingConstraint(
+        resource=None,
+        percent=None,
+        reason="no saturation observed within tested range; no binding constraint to report",
+    )
+
+
+def test_binding_constraint_is_none_when_knee_found_but_no_measured_resources():
+    run = AxisRun(
+        axis="drain_rate",
+        unit="minutes",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=None,
+        tripped_level=5.0,
+        points=[_extrapolated(5.0, True)],
+    )
+
+    report = build_report([run])
+
+    bc = report.axes[0].binding_constraint
+    assert bc.resource is None
+    assert "no measured resource sample" in bc.reason
+
+
+# --- Acceptance criterion: measured vs extrapolated labelled honestly --------------
+
+
+def test_extrapolated_points_never_carry_a_resource_sample_in_the_report():
+    run = AxisRun(
+        axis="shipper_fan_in",
+        unit="robots",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=140.0,
+        tripped_level=220.0,
+        points=[
+            _measured(140.0, False, cpu=68.0, mem=44.0, disk=20.0),
+            _measured(220.0, True, cpu=94.2, mem=61.0, disk=33.0),
+            _extrapolated(500.0, True),
+        ],
+    )
+
+    report = build_report([run])
+    points_by_level = {p.level: p for p in report.axes[0].points}
+
+    assert points_by_level[140.0].kind == PointKind.MEASURED
+    assert points_by_level[140.0].resources is not None
+    assert points_by_level[220.0].kind == PointKind.MEASURED
+    assert points_by_level[500.0].kind == PointKind.EXTRAPOLATED
+    assert points_by_level[500.0].resources is None
+
+
+def test_human_summary_labels_each_point_measured_or_extrapolated():
+    run = AxisRun(
+        axis="shipper_fan_in",
+        unit="robots",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=140.0,
+        tripped_level=220.0,
+        points=[
+            _measured(140.0, False, cpu=68.0, mem=44.0, disk=20.0),
+            _measured(220.0, True, cpu=94.2, mem=61.0, disk=33.0),
+            _extrapolated(500.0, True),
+        ],
+    )
+
+    summary = render_summary(build_report([run]))
+
+    assert "140.0 robots: clear [measured]" in summary
+    assert "220.0 robots: saturated [measured]" in summary
+    assert "500.0 robots: saturated [extrapolated]" in summary
+    # The extrapolated point must never be printed with fabricated resource figures.
+    assert "500.0 robots: saturated [extrapolated] (1 real + 0 synthetic) not measured" in summary
+
+
+def test_human_summary_names_the_binding_constraint_at_saturation():
+    summary = render_summary(build_report([_cpu_bound_run()]))
+
+    assert "binding constraint: cpu at 94.2%" in summary
+
+
+def test_human_summary_states_bound_not_found_without_a_fabricated_ceiling():
+    run = AxisRun(
+        axis="single_robot_ceiling",
+        unit="records_s",
+        outcome=RunOutcome.BOUND_NOT_FOUND,
+        highest_clear_level=500.0,
+        tripped_level=None,
+        points=[_measured(500.0, False, cpu=30.0, mem=20.0, disk=10.0)],
+    )
+
+    summary = render_summary(build_report([run]))
+
+    assert "bound not found within tested range (highest clear: 500.0)" in summary
+    assert "binding constraint: none" in summary
+
+
+# --- Composition (real vs synthetic) is reported per point -------------------------
+
+
+def test_composition_is_reported_per_point():
+    report = build_report([_cpu_bound_run()])
+
+    points_by_level = {p.level: p for p in report.axes[0].points}
+    assert points_by_level[60.0].composition == RunComposition(real_stacks=2, synthetic_senders=58)
+    assert points_by_level[220.0].composition == RunComposition(
+        real_stacks=4, synthetic_senders=216
+    )
+
+
+def test_composition_rejects_negative_counts():
+    with pytest.raises(ValueError, match="cannot be negative"):
+        RunComposition(real_stacks=-1, synthetic_senders=0)
+
+
+# --- Structural validation -----------------------------------------------------------
+
+
+def test_axis_run_rejects_empty_points():
+    with pytest.raises(ValueError, match="at least one point"):
+        AxisRun(
+            axis="shipper_fan_in",
+            unit="robots",
+            outcome=RunOutcome.BOUND_NOT_FOUND,
+            highest_clear_level=None,
+            tripped_level=None,
+            points=[],
+        )
+
+
+def test_axis_run_rejects_an_unnamed_axis():
+    with pytest.raises(ValueError, match="name its axis"):
+        AxisRun(
+            axis="",
+            unit="robots",
+            outcome=RunOutcome.BOUND_NOT_FOUND,
+            highest_clear_level=None,
+            tripped_level=None,
+            points=[_measured(1.0, False, cpu=1.0, mem=1.0, disk=1.0)],
+        )
+
+
+def test_resource_sample_rejects_negative_percentages():
+    with pytest.raises(ValueError, match="cannot be negative"):
+        ResourceSample(cpu_percent=-1.0, mem_percent=0.0, disk_percent=0.0)
+
+
+# --- Multiple axes report independently ---------------------------------------------
+
+
+def test_report_covers_multiple_axes_each_with_its_own_binding_constraint():
+    cpu_run = _cpu_bound_run(axis="shipper_fan_in")
+    disk_run = AxisRun(
+        axis="uploader_concurrency",
+        unit="uploads",
+        outcome=RunOutcome.KNEE_FOUND,
+        highest_clear_level=8.0,
+        tripped_level=16.0,
+        points=[
+            _measured(8.0, False, cpu=20.0, mem=25.0, disk=40.0),
+            _measured(16.0, True, cpu=45.0, mem=50.0, disk=97.0),
+        ],
+    )
+
+    report = build_report([cpu_run, disk_run])
+
+    by_axis = {a.axis: a for a in report.axes}
+    assert by_axis["shipper_fan_in"].binding_constraint.resource == ResourceKind.CPU
+    assert by_axis["uploader_concurrency"].binding_constraint.resource == ResourceKind.DISK


### PR DESCRIPTION
## Summary
- Adds `tools/e2e/scripts/curve_reporter.py`: a pure function turning a set of per-axis ramp runs into a stable, diffable structured report plus a human-readable summary naming the binding constraint (CPU/memory/disk) at saturation.
- Every point is labelled `measured` or `extrapolated` — an extrapolated point never carries a fabricated resource sample — and each point's real-vs-synthetic composition is reported honestly, per #323's PRD.
- Fourth (and last "deep") module of #323's limits harness, after the saturation probe (#377), load driver (#378), and ramp controller (#379). Only the topology composer (integration) remains.

## Test plan
- [x] `uv run pytest tools/e2e/test/test_curve_reporter.py -q` — 19 cases covering the issue's acceptance criteria (stable/diffable output, binding-constraint identification with tie-break, honest measured/extrapolated labelling in both structured and human-readable form) plus structural validation
- [x] `uv run pytest tools/e2e/test/ -q` — full existing suite still green (77 passed)
- [x] `prek run --all-files --skip build-doc` — clean

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXggS8umTXXwMFHzSjXFDi