### PR TITLE
feat(dc_measurements): add Mission Measurement NavigateThroughPoses adapter

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.8)
 project(dc_measurements)
 
 set(dependencies
+  action_msgs
   cv_bridge
   dc_common
   dc_core
@@ -13,17 +14,20 @@ set(dependencies
   diagnostic_msgs
   geometry_msgs
   lifecycle_msgs
+  nav2_msgs
   nav2_util
   nlohmann_json
   nlohmann_json_schema_validator
   PkgConfig
   pluginlib
+  rclcpp_action
   rclcpp_components
   rclcpp_lifecycle
   sensor_msgs
   std_msgs
   tf2
   tf2_geometry_msgs
+  unique_identifier_msgs
   yaml_cpp_vendor
 )
 
@@ -162,6 +166,9 @@ list(APPEND dc_measurement_plugin_libs dc_ip_camera_measurement)
 
 add_library(dc_map_measurement SHARED plugins/measurements/map.cpp)
 list(APPEND dc_measurement_plugin_libs dc_map_measurement)
+
+add_library(dc_mission_nav2_through_poses_measurement SHARED plugins/measurements/mission_nav2_through_poses.cpp)
+list(APPEND dc_measurement_plugin_libs dc_mission_nav2_through_poses_measurement)
 
 add_library(dc_memory_measurement SHARED
   plugins/measurements/memory.cpp
@@ -337,6 +344,7 @@ set(tests
   test_measurement_list_string_equal
   test_measurement_map
   test_measurement_memory
+  test_measurement_mission_nav2_through_poses
   test_measurement_moving
   test_measurement_network
   test_measurement_os
@@ -353,6 +361,7 @@ set(tests
   test_measurement_tcp_health
   test_measurement_thermal
   test_measurement_uptime
+  test_mission_nav2_through_poses_core
 )
 
 if(BUILD_TESTING)

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses.hpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_HPP_
+
+#include <array>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "action_msgs/msg/goal_status_array.hpp"
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp"
+#include "dc_util/node_utils.hpp"
+#include "nav2_msgs/action/navigate_through_poses.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "unique_identifier_msgs/msg/uuid.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::MissionNav2ThroughPoses
+ * @brief The nav2 adapter of the Mission Measurement (#396) for `NavigateThroughPoses`: the action
+ * a deployment issues when a mission is a single job through several hard-constraint poses in one
+ * call, rather than a chain of separate `NavigateToPose` goals (#387). Emits `mission_start` when a
+ * goal is first observed and `mission_end` once it reaches a terminal state, in the same Record
+ * schema #387 defines with `mission_type: "navigate_through_poses"`.
+ *
+ * A passive observer, not a second client competing for the action server's single active goal:
+ * it subscribes to the action's own status (`_action/status`) and feedback (`_action/feedback`)
+ * topics and calls its `_action/get_result` service directly for whichever goal_id just reached a
+ * terminal status -- the same standard per-action topics/services every `rclcpp_action::Server`
+ * exposes, rather than `rclcpp_action::Client`'s higher-level API, which has no supported way to
+ * attach to a goal this Measurement did not itself send.
+ */
+class MissionNav2ThroughPoses : public dc_measurements::Measurement
+{
+public:
+  using ActionT = nav2_msgs::action::NavigateThroughPoses;
+  using GetResultSrv = ActionT::Impl::GetResultService;
+  using FeedbackMsg = ActionT::Impl::FeedbackMessage;
+
+  MissionNav2ThroughPoses();
+  ~MissionNav2ThroughPoses() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void statusCb(const action_msgs::msg::GoalStatusArray& msg);
+  void feedbackCb(const FeedbackMsg& msg);
+  void requestResult(const std::string& goal_id_hex, const unique_identifier_msgs::msg::UUID& goal_id, GoalPhase phase,
+                     const rclcpp::Time& detected_at);
+  void handleResult(const std::string& goal_id_hex, GoalPhase phase, const rclcpp::Time& detected_at,
+                    const GetResultSrv::Response::SharedPtr& response);
+  void emit(json data, const rclcpp::Time& stamp);
+
+  std::string action_name_;
+  rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr status_sub_;
+  rclcpp::Subscription<FeedbackMsg>::SharedPtr feedback_sub_;
+  rclcpp::Client<GetResultSrv>::SharedPtr get_result_client_;
+
+  // The status/feedback callbacks and the polling timer run in different callback groups under a
+  // multi-threaded executor, so everything they share is guarded -- same reasoning as
+  // Battery/Fault.
+  mutable std::mutex mutex_;
+  MissionNav2ThroughPosesCore core_;
+  // Last-seen `number_of_recoveries` per goal_id, from the feedback topic -- there is no recovery
+  // count on the terminal Result, only on Feedback, so it has to be captured live and carried
+  // forward to whichever mission_end Record eventually asks for it.
+  std::map<std::string, int> last_recoveries_;
+  // Records wait here for a poll to carry them out, one per poll, so they travel the same publish
+  // path (Conditions, buffering, Group) as every other Record.
+  std::deque<std::pair<json, rclcpp::Time>> pending_records_;
+
+protected:
+  void onConfigure() override;
+  void onCleanup() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_HPP_

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp
@@ -1,0 +1,225 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_CORE_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_CORE_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace dc_measurements
+{
+
+/// Mirrors action_msgs::msg::GoalStatus's STATUS_* constants numerically, so this header (and its
+/// unit test) stay free of any action_msgs/ROS include -- the plugin static_casts the real message
+/// field into this enum.
+enum class GoalPhase : std::uint8_t
+{
+  Unknown = 0,
+  Accepted = 1,
+  Executing = 2,
+  Canceling = 3,
+  Succeeded = 4,
+  Canceled = 5,
+  Aborted = 6,
+};
+
+enum class MissionOutcome
+{
+  Succeeded,
+  Failed,
+  Cancelled,
+  Aborted,
+};
+
+struct MissionStartFact
+{
+  std::string mission_id;
+  std::uint64_t sequence;
+};
+
+struct WaypointStatusCounts
+{
+  std::uint32_t total{ 0 };
+  std::uint32_t completed{ 0 };
+  std::uint32_t skipped{ 0 };
+  std::uint32_t failed{ 0 };
+};
+
+struct MissionEndFact
+{
+  std::string mission_id;
+  std::uint64_t sequence;
+  MissionOutcome outcome;
+  double duration_sec;
+  std::optional<std::string> reason;
+  std::optional<std::uint16_t> error_code;
+  std::optional<int> recoveries;
+  std::optional<WaypointStatusCounts> waypoint_statuses;
+};
+
+/**
+ * @class dc_measurements::MissionNav2ThroughPosesCore
+ * @brief ROS-free interpretation of a NavigateThroughPoses goal's lifecycle, following #360's
+ * split precedent (dc_common::BatteryCycleAccumulator/StateTransitionDetector): which goal_id is
+ * new (a mission_start fact) and, once its terminal status and result are known, what its
+ * mission_end fact looks like (outcome, duration, reason). Owns no clock and no ROS types, so a
+ * unit test drives a whole mission in microseconds with no node or action server involved.
+ *
+ * Unlike dc_common::StateTransitionDetector, a mission's "start" is the very first sample seen for
+ * a goal_id, not a transition away from some prior baseline -- there is no natural idle state a
+ * goal_id holds before it exists -- so this is a small bespoke tracker rather than a
+ * StateTransitionDetector<GoalPhase> instantiation.
+ */
+class MissionNav2ThroughPosesCore
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+
+  /**
+   * @brief Feed one observed status sample for `goal_id`. Returns a MissionStartFact the first
+   * time this goal_id is seen and nullopt on every later sample for the same goal_id -- only the
+   * boundary is reported, matching every other tracker in this codebase.
+   */
+  std::optional<MissionStartFact> observe(const std::string& goal_id, TimePoint at)
+  {
+    if (missions_.find(goal_id) != missions_.end())
+    {
+      return std::nullopt;
+    }
+    missions_.emplace(goal_id, Active{ at, false, false });
+    order_.push_back(goal_id);
+    prune();
+    return MissionStartFact{ goal_id, ++sequence_ };
+  }
+
+  /**
+   * @brief Whether the caller should fetch `goal_id`'s result now that it has reached a terminal
+   * phase. True only the first time a terminal phase is observed for a goal_id, so a status topic
+   * that keeps republishing a finished goal's last entry doesn't queue duplicate result fetches.
+   */
+  bool shouldRequestResult(const std::string& goal_id)
+  {
+    auto it = missions_.find(goal_id);
+    if (it == missions_.end() || it->second.finished || it->second.result_requested)
+    {
+      return false;
+    }
+    it->second.result_requested = true;
+    return true;
+  }
+
+  /**
+   * @brief `goal_id`'s mission_end fact, once its terminal phase and result are known. `outcome`
+   * follows #387/#388's contract: CANCELED maps to cancelled, ABORTED to aborted (both carrying
+   * `error_msg`/`error_code` as `reason`/`error_code`), and SUCCEEDED maps to succeeded unless
+   * `error_code` is non-zero, in which case it is failed (also carrying reason/error_code) -- an
+   * application-level failure nav2 reported without aborting the goal status itself.
+   */
+  MissionEndFact end(const std::string& goal_id, GoalPhase terminal_phase, std::uint16_t error_code,
+                     const std::string& error_msg, std::optional<int> recoveries,
+                     std::optional<WaypointStatusCounts> waypoint_statuses, TimePoint at)
+  {
+    MissionEndFact fact;
+    fact.mission_id = goal_id;
+    fact.sequence = ++sequence_;
+    fact.recoveries = recoveries;
+    fact.waypoint_statuses = waypoint_statuses;
+
+    auto it = missions_.find(goal_id);
+    const TimePoint started_at = (it != missions_.end()) ? it->second.started_at : at;
+    fact.duration_sec =
+        std::chrono::duration<double>(at > started_at ? at - started_at : TimePoint::duration::zero()).count();
+
+    switch (terminal_phase)
+    {
+      case GoalPhase::Canceled:
+        fact.outcome = MissionOutcome::Cancelled;
+        break;
+      case GoalPhase::Aborted:
+        fact.outcome = MissionOutcome::Aborted;
+        fact.reason = error_msg;
+        fact.error_code = error_code;
+        break;
+      case GoalPhase::Succeeded:
+      default:
+        if (error_code != 0)
+        {
+          fact.outcome = MissionOutcome::Failed;
+          fact.reason = error_msg;
+          fact.error_code = error_code;
+        }
+        else
+        {
+          fact.outcome = MissionOutcome::Succeeded;
+        }
+        break;
+    }
+
+    if (it != missions_.end())
+    {
+      it->second.finished = true;
+    }
+    return fact;
+  }
+
+  /// goal_ids still open (mission_start emitted, no mission_end yet) -- for onCleanup()'s shutdown
+  /// warning, mirroring Fault's fault_started_at_ map.
+  std::vector<std::string> openMissionIds() const
+  {
+    std::vector<std::string> open;
+    for (const auto& [id, active] : missions_)
+    {
+      if (!active.finished)
+      {
+        open.push_back(id);
+      }
+    }
+    return open;
+  }
+
+private:
+  // goal_ids never repeat in practice (they're UUIDs), so a long-running instance's map would
+  // otherwise grow without bound; only ever prunes finished missions, oldest first.
+  static constexpr std::size_t kMaxTracked = 256;
+
+  struct Active
+  {
+    TimePoint started_at;
+    bool finished{ false };
+    bool result_requested{ false };
+  };
+
+  void prune()
+  {
+    while (order_.size() > kMaxTracked)
+    {
+      const auto& oldest = order_.front();
+      auto it = missions_.find(oldest);
+      if (it != missions_.end() && it->second.finished)
+      {
+        missions_.erase(it);
+        order_.pop_front();
+      }
+      else
+      {
+        // The oldest tracked goal_id is still open (a very long-running mission) -- leave it
+        // rather than dropping an active mission's tracking state.
+        break;
+      }
+    }
+  }
+
+  std::map<std::string, Active> missions_;
+  std::deque<std::string> order_;
+  std::uint64_t sequence_{ 0 };
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_THROUGH_POSES_CORE_HPP_

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp
@@ -43,14 +43,6 @@ struct MissionStartFact
   std::uint64_t sequence;
 };
 
-struct WaypointStatusCounts
-{
-  std::uint32_t total{ 0 };
-  std::uint32_t completed{ 0 };
-  std::uint32_t skipped{ 0 };
-  std::uint32_t failed{ 0 };
-};
-
 struct MissionEndFact
 {
   std::string mission_id;
@@ -60,7 +52,6 @@ struct MissionEndFact
   std::optional<std::string> reason;
   std::optional<std::uint16_t> error_code;
   std::optional<int> recoveries;
-  std::optional<WaypointStatusCounts> waypoint_statuses;
 };
 
 /**
@@ -122,14 +113,12 @@ public:
    * application-level failure nav2 reported without aborting the goal status itself.
    */
   MissionEndFact end(const std::string& goal_id, GoalPhase terminal_phase, std::uint16_t error_code,
-                     const std::string& error_msg, std::optional<int> recoveries,
-                     std::optional<WaypointStatusCounts> waypoint_statuses, TimePoint at)
+                     const std::string& error_msg, std::optional<int> recoveries, TimePoint at)
   {
     MissionEndFact fact;
     fact.mission_id = goal_id;
     fact.sequence = ++sequence_;
     fact.recoveries = recoveries;
-    fact.waypoint_statuses = waypoint_statuses;
 
     auto it = missions_.find(goal_id);
     const TimePoint started_at = (it != missions_.end()) ? it->second.started_at : at;

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -100,6 +100,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_mission_nav2_through_poses_measurement">
+        <class name="dc_measurements/MissionNav2ThroughPoses" type="dc_measurements::MissionNav2ThroughPoses" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_mission_nav2_through_poses
+            </description>
+        </class>
+    </library>
+
     <library path="dc_memory_measurement">
         <class name="dc_measurements/Memory" type="dc_measurements::Memory" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -15,6 +15,7 @@ SPDX-License-Identifier: MPL-2.0
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>action_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>dc_common</depend>
   <depend>dc_core</depend>
@@ -25,16 +26,19 @@ SPDX-License-Identifier: MPL-2.0
   <depend>ffmpeg</depend>
   <depend>geometry_msgs</depend>
   <depend>lifecycle_msgs</depend>
+  <depend>nav2_msgs</depend>
   <depend>nav2_util</depend>
   <depend>nlohmann-json-dev</depend>
   <depend>nlohmann_json_schema_validator_vendor</depend>
   <depend>pkg-config</depend>
   <depend>pluginlib</depend>
+  <depend>rclcpp_action</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>tf2_ros</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>yaml_cpp_vendor</depend>
   <depend>zxing-cpp</depend>
 

--- a/dc_measurements/plugins/measurements/json/mission_nav2_through_poses.json
+++ b/dc_measurements/plugins/measurements/json/mission_nav2_through_poses.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2ThroughPoses",
+  "description":
+      "One nav2 NavigateThroughPoses mission's lifecycle: a mission_start Record when the goal is first observed, a mission_end Record once it reaches a terminal state. Shares #387's NavigateToPose Record contract; mission_type distinguishes the source action",
+  "properties": {
+    "event": {
+      "description": "Which boundary of the mission this Record reports",
+      "type": "string",
+      "enum": [
+        "mission_start",
+        "mission_end"
+      ]
+    },
+    "mission_id": {
+      "description": "The nav2 goal UUID, stringified as lowercase hex",
+      "type": "string"
+    },
+    "mission_type": {
+      "description": "What kind of mission this was; the nav2 adapter always sets 'navigate_through_poses'",
+      "type": "string"
+    },
+    "sequence": {
+      "description":
+          "Monotonically increasing number of this Record, across every mission this Measurement instance has seen (not per mission_id), so a dropped Record is detectable",
+      "type": "integer",
+      "minimum": 1
+    },
+    "outcome": {
+      "description":
+          "How the mission ended. 'failed' is a non-zero NavigateThroughPoses::Result.error_code on an otherwise-succeeded goal status, distinct from 'aborted' (the goal status itself)",
+      "type": "string",
+      "enum": [
+        "succeeded",
+        "failed",
+        "cancelled",
+        "aborted"
+      ]
+    },
+    "reason": {
+      "description": "NavigateThroughPoses::Result.error_msg, verbatim. Present when outcome is 'failed' or 'aborted'",
+      "type": "string"
+    },
+    "error_code": {
+      "description": "NavigateThroughPoses::Result.error_code, carried through verbatim. Present alongside 'reason'",
+      "type": "integer",
+      "minimum": 0
+    },
+    "duration_sec": {
+      "description": "How long the mission ran, from when the goal was first observed to its terminal status",
+      "type": "number",
+      "minimum": 0
+    },
+    "recoveries": {
+      "description": "NavigateThroughPoses::Feedback.number_of_recoveries at mission completion, when feedback was seen",
+      "type": "integer",
+      "minimum": 0
+    },
+    "waypoint_statuses": {
+      "description":
+          "Aggregate counts of NavigateThroughPoses::Result.waypoint_statuses -- which poses in the job succeeded, were skipped, or failed -- kept as counts rather than the raw per-pose array to keep the Record flat",
+      "type": "object",
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "completed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "skipped": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "failed": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "required": [
+        "total",
+        "completed",
+        "skipped",
+        "failed"
+      ]
+    }
+  },
+  "required": [
+    "event",
+    "mission_id",
+    "sequence"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "mission_end"
+          }
+        },
+        "required": [
+          "event"
+        ]
+      },
+      "then": {
+        "required": [
+          "outcome",
+          "duration_sec"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "mission_end"
+          },
+          "outcome": {
+            "enum": [
+              "failed",
+              "aborted"
+            ]
+          }
+        },
+        "required": [
+          "event",
+          "outcome"
+        ]
+      },
+      "then": {
+        "required": [
+          "reason",
+          "error_code"
+        ]
+      }
+    }
+  ],
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/json/mission_nav2_through_poses.json
+++ b/dc_measurements/plugins/measurements/json/mission_nav2_through_poses.json
@@ -55,35 +55,6 @@
       "description": "NavigateThroughPoses::Feedback.number_of_recoveries at mission completion, when feedback was seen",
       "type": "integer",
       "minimum": 0
-    },
-    "waypoint_statuses": {
-      "description":
-          "Aggregate counts of NavigateThroughPoses::Result.waypoint_statuses -- which poses in the job succeeded, were skipped, or failed -- kept as counts rather than the raw per-pose array to keep the Record flat",
-      "type": "object",
-      "properties": {
-        "total": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "completed": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "skipped": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "failed": {
-          "type": "integer",
-          "minimum": 0
-        }
-      },
-      "required": [
-        "total",
-        "completed",
-        "skipped",
-        "failed"
-      ]
     }
   },
   "required": [

--- a/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
@@ -6,8 +6,6 @@
 #include <iomanip>
 #include <sstream>
 
-#include "nav2_msgs/msg/waypoint_status.hpp"
-
 namespace dc_measurements
 {
 
@@ -40,34 +38,6 @@ std::string outcomeName(MissionOutcome outcome)
     default:
       return "aborted";
   }
-}
-
-std::optional<WaypointStatusCounts> countWaypointStatuses(const std::vector<nav2_msgs::msg::WaypointStatus>& statuses)
-{
-  if (statuses.empty())
-  {
-    return std::nullopt;
-  }
-  WaypointStatusCounts counts;
-  counts.total = static_cast<std::uint32_t>(statuses.size());
-  for (const auto& status : statuses)
-  {
-    switch (status.waypoint_status)
-    {
-      case nav2_msgs::msg::WaypointStatus::COMPLETED:
-        ++counts.completed;
-        break;
-      case nav2_msgs::msg::WaypointStatus::SKIPPED:
-        ++counts.skipped;
-        break;
-      case nav2_msgs::msg::WaypointStatus::FAILED:
-        ++counts.failed;
-        break;
-      default:
-        break;
-    }
-  }
-  return counts;
 }
 
 }  // namespace
@@ -204,8 +174,7 @@ void MissionNav2ThroughPoses::handleResult(const std::string& goal_id_hex, GoalP
       recoveries = recoveries_it->second;
       last_recoveries_.erase(recoveries_it);
     }
-    fact = core_.end(goal_id_hex, phase, response->result.error_code, response->result.error_msg, recoveries,
-                     countWaypointStatuses(response->result.waypoint_statuses), at);
+    fact = core_.end(goal_id_hex, phase, response->result.error_code, response->result.error_msg, recoveries, at);
   }
 
   json data;
@@ -226,13 +195,6 @@ void MissionNav2ThroughPoses::handleResult(const std::string& goal_id_hex, GoalP
   if (fact.recoveries.has_value())
   {
     data["recoveries"] = *fact.recoveries;
-  }
-  if (fact.waypoint_statuses.has_value())
-  {
-    data["waypoint_statuses"] = { { "total", fact.waypoint_statuses->total },
-                                  { "completed", fact.waypoint_statuses->completed },
-                                  { "skipped", fact.waypoint_statuses->skipped },
-                                  { "failed", fact.waypoint_statuses->failed } };
   }
 
   const std::lock_guard<std::mutex> lock(mutex_);

--- a/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
@@ -1,0 +1,263 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/mission_nav2_through_poses.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+#include "nav2_msgs/msg/waypoint_status.hpp"
+
+namespace dc_measurements
+{
+
+namespace
+{
+
+constexpr size_t kMaxPendingRecords = 64;
+
+std::string uuidToHex(const std::array<uint8_t, 16>& uuid)
+{
+  std::ostringstream oss;
+  for (auto byte : uuid)
+  {
+    oss << std::hex << std::setfill('0') << std::setw(2) << static_cast<int>(byte);
+  }
+  return oss.str();
+}
+
+std::string outcomeName(MissionOutcome outcome)
+{
+  switch (outcome)
+  {
+    case MissionOutcome::Succeeded:
+      return "succeeded";
+    case MissionOutcome::Failed:
+      return "failed";
+    case MissionOutcome::Cancelled:
+      return "cancelled";
+    case MissionOutcome::Aborted:
+    default:
+      return "aborted";
+  }
+}
+
+std::optional<WaypointStatusCounts> countWaypointStatuses(const std::vector<nav2_msgs::msg::WaypointStatus>& statuses)
+{
+  if (statuses.empty())
+  {
+    return std::nullopt;
+  }
+  WaypointStatusCounts counts;
+  counts.total = static_cast<std::uint32_t>(statuses.size());
+  for (const auto& status : statuses)
+  {
+    switch (status.waypoint_status)
+    {
+      case nav2_msgs::msg::WaypointStatus::COMPLETED:
+        ++counts.completed;
+        break;
+      case nav2_msgs::msg::WaypointStatus::SKIPPED:
+        ++counts.skipped;
+        break;
+      case nav2_msgs::msg::WaypointStatus::FAILED:
+        ++counts.failed;
+        break;
+      default:
+        break;
+    }
+  }
+  return counts;
+}
+
+}  // namespace
+
+MissionNav2ThroughPoses::MissionNav2ThroughPoses() : dc_measurements::Measurement()
+{
+}
+
+MissionNav2ThroughPoses::~MissionNav2ThroughPoses() = default;
+
+void MissionNav2ThroughPoses::onConfigure()
+{
+  auto node = getNode();
+  action_name_ = dc_util::get_str_type_param(node, measurement_name_, "action_name", "navigate_through_poses");
+
+  status_sub_ = node->create_subscription<action_msgs::msg::GoalStatusArray>(
+      action_name_ + "/_action/status", rclcpp::QoS(10),
+      std::bind(&MissionNav2ThroughPoses::statusCb, this, std::placeholders::_1));
+  feedback_sub_ = node->create_subscription<FeedbackMsg>(action_name_ + "/_action/feedback", rclcpp::QoS(10),
+                                                         std::bind(&MissionNav2ThroughPoses::feedbackCb, this,
+                                                                   std::placeholders::_1));
+  get_result_client_ =
+      node->create_client<GetResultSrv>(action_name_ + "/_action/get_result", rclcpp::ServicesQoS(), client_cb_group_);
+}
+
+void MissionNav2ThroughPoses::onCleanup()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& mission_id : core_.openMissionIds())
+  {
+    RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with mission '" << mission_id
+                                                  << "' still running; no mission_end Record will be published");
+  }
+}
+
+void MissionNav2ThroughPoses::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "mission_nav2_through_poses.json");
+  }
+}
+
+void MissionNav2ThroughPoses::emit(json data, const rclcpp::Time& stamp)
+{
+  pending_records_.emplace_back(std::move(data), stamp);
+  // One Record leaves per poll, so missions starting/ending far faster than the polling interval
+  // would otherwise queue without bound. The oldest goes first: the recent boundaries are the ones
+  // still worth reporting.
+  while (pending_records_.size() > kMaxPendingRecords)
+  {
+    pending_records_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_
+                                               << ": mission Records are arriving faster than the polling interval "
+                                                  "can report them; dropping the oldest.");
+  }
+}
+
+void MissionNav2ThroughPoses::statusCb(const action_msgs::msg::GoalStatusArray& msg)
+{
+  const rclcpp::Time stamp = getNode()->get_clock()->now();
+  const std::chrono::system_clock::time_point now{ std::chrono::nanoseconds(stamp.nanoseconds()) };
+
+  for (const auto& status : msg.status_list)
+  {
+    const std::string goal_id_hex = uuidToHex(status.goal_info.goal_id.uuid);
+
+    std::optional<MissionStartFact> start;
+    {
+      const std::lock_guard<std::mutex> lock(mutex_);
+      start = core_.observe(goal_id_hex, now);
+    }
+    if (start.has_value())
+    {
+      json data;
+      data["event"] = "mission_start";
+      data["mission_id"] = start->mission_id;
+      data["mission_type"] = "navigate_through_poses";
+      data["sequence"] = start->sequence;
+      const std::lock_guard<std::mutex> lock(mutex_);
+      emit(std::move(data), stamp);
+    }
+
+    const auto phase = static_cast<GoalPhase>(status.status);
+    if (phase == GoalPhase::Succeeded || phase == GoalPhase::Canceled || phase == GoalPhase::Aborted)
+    {
+      requestResult(goal_id_hex, status.goal_info.goal_id, phase, stamp);
+    }
+  }
+}
+
+void MissionNav2ThroughPoses::feedbackCb(const FeedbackMsg& msg)
+{
+  const std::string goal_id_hex = uuidToHex(msg.goal_id.uuid);
+  const std::lock_guard<std::mutex> lock(mutex_);
+  last_recoveries_[goal_id_hex] = msg.feedback.number_of_recoveries;
+}
+
+void MissionNav2ThroughPoses::requestResult(const std::string& goal_id_hex,
+                                            const unique_identifier_msgs::msg::UUID& goal_id, GoalPhase phase,
+                                            const rclcpp::Time& detected_at)
+{
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (!core_.shouldRequestResult(goal_id_hex))
+    {
+      return;
+    }
+  }
+
+  auto request = std::make_shared<GetResultSrv::Request>();
+  request->goal_id = goal_id;
+
+  get_result_client_->async_send_request(request, [this, goal_id_hex, phase,
+                                                   detected_at](rclcpp::Client<GetResultSrv>::SharedFuture future) {
+    handleResult(goal_id_hex, phase, detected_at, future.get());
+  });
+}
+
+void MissionNav2ThroughPoses::handleResult(const std::string& goal_id_hex, GoalPhase phase,
+                                           const rclcpp::Time& detected_at,
+                                           const GetResultSrv::Response::SharedPtr& response)
+{
+  const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(detected_at.nanoseconds()) };
+
+  std::optional<int> recoveries;
+  MissionEndFact fact;
+  {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    auto recoveries_it = last_recoveries_.find(goal_id_hex);
+    if (recoveries_it != last_recoveries_.end())
+    {
+      recoveries = recoveries_it->second;
+      last_recoveries_.erase(recoveries_it);
+    }
+    fact = core_.end(goal_id_hex, phase, response->result.error_code, response->result.error_msg, recoveries,
+                     countWaypointStatuses(response->result.waypoint_statuses), at);
+  }
+
+  json data;
+  data["event"] = "mission_end";
+  data["mission_id"] = fact.mission_id;
+  data["mission_type"] = "navigate_through_poses";
+  data["sequence"] = fact.sequence;
+  data["outcome"] = outcomeName(fact.outcome);
+  data["duration_sec"] = fact.duration_sec;
+  if (fact.reason.has_value())
+  {
+    data["reason"] = *fact.reason;
+  }
+  if (fact.error_code.has_value())
+  {
+    data["error_code"] = *fact.error_code;
+  }
+  if (fact.recoveries.has_value())
+  {
+    data["recoveries"] = *fact.recoveries;
+  }
+  if (fact.waypoint_statuses.has_value())
+  {
+    data["waypoint_statuses"] = { { "total", fact.waypoint_statuses->total },
+                                  { "completed", fact.waypoint_statuses->completed },
+                                  { "skipped", fact.waypoint_statuses->skipped },
+                                  { "failed", fact.waypoint_statuses->failed } };
+  }
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  emit(std::move(data), detected_at);
+}
+
+dc_interfaces::msg::StringStamped MissionNav2ThroughPoses::collect()
+{
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_records_.empty())
+  {
+    return msg;
+  }
+
+  auto record = std::move(pending_records_.front());
+  pending_records_.pop_front();
+  msg.header.stamp = record.second;
+  msg.data = record.first.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::MissionNav2ThroughPoses, dc_core::Measurement)

--- a/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
@@ -18,7 +18,6 @@
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
 #include "nav2_msgs/action/navigate_through_poses.hpp"
-#include "nav2_msgs/msg/waypoint_status.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
 namespace
@@ -179,20 +178,17 @@ protected:
     waitForActiveGoal()->publish_feedback(feedback);
   }
 
-  static ActionT::Result::SharedPtr makeResult(uint16_t error_code, const std::string& error_msg,
-                                               std::vector<nav2_msgs::msg::WaypointStatus> waypoint_statuses = {})
+  static ActionT::Result::SharedPtr makeResult(uint16_t error_code, const std::string& error_msg)
   {
     auto result = std::make_shared<ActionT::Result>();
     result->error_code = error_code;
     result->error_msg = error_msg;
-    result->waypoint_statuses = std::move(waypoint_statuses);
     return result;
   }
 
-  void succeedActiveGoal(uint16_t error_code = 0, const std::string& error_msg = "",
-                         std::vector<nav2_msgs::msg::WaypointStatus> waypoint_statuses = {})
+  void succeedActiveGoal(uint16_t error_code = 0, const std::string& error_msg = "")
   {
-    waitForActiveGoal()->succeed(makeResult(error_code, error_msg, std::move(waypoint_statuses)));
+    waitForActiveGoal()->succeed(makeResult(error_code, error_msg));
   }
 
   void abortActiveGoal(uint16_t error_code, const std::string& error_msg)
@@ -361,28 +357,6 @@ TEST_F(MeasurementMissionNav2ThroughPosesTest, RecoveriesFromFeedbackAreCarriedO
   const auto end = waitForRecord(isEvent("mission_end"));
   ASSERT_TRUE(end.contains("recoveries"));
   EXPECT_EQ(end["recoveries"], 3);
-}
-
-TEST_F(MeasurementMissionNav2ThroughPosesTest, WaypointStatusesAreAggregatedOntoMissionEnd)
-{
-  declareCommonParameters();
-  startLifecycleNode();
-
-  sendGoal();
-  waitForRecord(isEvent("mission_start"));
-
-  std::vector<nav2_msgs::msg::WaypointStatus> waypoints(3);
-  waypoints[0].waypoint_status = nav2_msgs::msg::WaypointStatus::COMPLETED;
-  waypoints[1].waypoint_status = nav2_msgs::msg::WaypointStatus::COMPLETED;
-  waypoints[2].waypoint_status = nav2_msgs::msg::WaypointStatus::FAILED;
-  succeedActiveGoal(0, "", waypoints);
-
-  const auto end = waitForRecord(isEvent("mission_end"));
-  ASSERT_TRUE(end.contains("waypoint_statuses"));
-  EXPECT_EQ(end["waypoint_statuses"]["total"], 3);
-  EXPECT_EQ(end["waypoint_statuses"]["completed"], 2);
-  EXPECT_EQ(end["waypoint_statuses"]["failed"], 1);
-  expectValidatesAgainstSchema(end);
 }
 
 TEST_F(MeasurementMissionNav2ThroughPosesTest, SequenceIsMonotonicAcrossSeveralMissions)

--- a/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
@@ -103,14 +103,14 @@ protected:
 
   void handleAccepted(const std::shared_ptr<ServerGoalHandleT>& goal_handle)
   {
-    {
-      const std::lock_guard<std::mutex> lock(goal_mutex_);
-      active_goal_ = goal_handle;
-    }
-    // Standing in for a real action server that starts working immediately on acceptance -- moves
-    // the goal from ACCEPTED straight to EXECUTING so succeed()/abort() below are valid calls, and
-    // so a client-initiated cancel lands in CANCELING rather than being rejected outright.
-    goal_handle->execute();
+    const std::lock_guard<std::mutex> lock(goal_mutex_);
+    active_goal_ = goal_handle;
+    // No goal_handle->execute() here: returning ACCEPT_AND_EXECUTE from the goal-request callback
+    // already moves rcl_action's state machine straight from ACCEPTED to EXECUTING before this
+    // callback runs, so succeed()/abort() below are already valid calls, and a client-initiated
+    // cancel already lands in CANCELING rather than being rejected outright. Calling execute()
+    // again here is a second EXECUTE event on an already-EXECUTING goal handle -- rcl_action
+    // throws ("invalid transition from state EXECUTING with event EXECUTE") rather than no-op it.
   }
 
   void spinFor(std::chrono::milliseconds duration)

--- a/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2_through_poses.cpp
@@ -1,0 +1,430 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav2_msgs/action/navigate_through_poses.hpp"
+#include "nav2_msgs/msg/waypoint_status.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+namespace
+{
+constexpr const char* kActionName = "/test/navigate_through_poses";
+}  // namespace
+
+// A minimal rclcpp_action::Server standing in for nav2's real bt_navigator, driven by a real
+// rclcpp_action::Client the test owns -- the Measurement under test never sends a goal itself, it
+// only watches this server's status/feedback/get_result endpoints (#388's passive-observer
+// design), so something else has to originate the goal the way the real BT would.
+class MeasurementMissionNav2ThroughPosesTest : public ::testing::Test
+{
+protected:
+  using ActionT = nav2_msgs::action::NavigateThroughPoses;
+  using ServerGoalHandleT = rclcpp_action::ServerGoalHandle<ActionT>;
+  using ClientGoalHandleT = rclcpp_action::ClientGoalHandle<ActionT>;
+
+  MeasurementMissionNav2ThroughPosesTest()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "mission" });
+    server_node_ = std::make_shared<rclcpp::Node>("fake_nav2_through_poses_server");
+
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/mission", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMissionNav2ThroughPosesTest::dataCallback, this, std::placeholders::_1));
+
+    action_server_ = rclcpp_action::create_server<ActionT>(
+        server_node_, kActionName,
+        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const ActionT::Goal>) {
+          return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+        },
+        [](const std::shared_ptr<ServerGoalHandleT>&) { return rclcpp_action::CancelResponse::ACCEPT; },
+        std::bind(&MeasurementMissionNav2ThroughPosesTest::handleAccepted, this, std::placeholders::_1));
+    action_client_ = rclcpp_action::create_client<ActionT>(server_node_, kActionName);
+  }
+
+  void TearDown() override
+  {
+    stopCollection();
+  }
+
+  void stopCollection()
+  {
+    if (stopped_)
+    {
+      return;
+    }
+    stopped_ = true;
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("mission.plugin", std::string("dc_measurements/MissionNav2ThroughPoses"));
+    ms_node_->declare_parameter("mission.group_key", std::string("mission"));
+    ms_node_->declare_parameter("mission.topic_output", std::string("/dc/measurement/mission"));
+    ms_node_->declare_parameter("mission.action_name", std::string(kActionName));
+    ms_node_->declare_parameter("mission.polling_interval", 50);
+    ms_node_->declare_parameter("mission.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+    waitForStatusSubscriber();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+  }
+
+  void handleAccepted(const std::shared_ptr<ServerGoalHandleT>& goal_handle)
+  {
+    {
+      const std::lock_guard<std::mutex> lock(goal_mutex_);
+      active_goal_ = goal_handle;
+    }
+    // Standing in for a real action server that starts working immediately on acceptance -- moves
+    // the goal from ACCEPTED straight to EXECUTING so succeed()/abort() below are valid calls, and
+    // so a client-initiated cancel lands in CANCELING rather than being rejected outright.
+    goal_handle->execute();
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  void waitForStatusSubscriber()
+  {
+    const std::string topic = std::string(kActionName) + "/_action/status";
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (server_node_->count_subscribers(topic) == 0 && std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  std::shared_ptr<ClientGoalHandleT> sendGoal()
+  {
+    auto goal_msg = ActionT::Goal();
+    auto goal_handle_future = action_client_->async_send_goal(goal_msg);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (goal_handle_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready &&
+           std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    auto goal_handle = goal_handle_future.get();
+    EXPECT_NE(goal_handle, nullptr) << "Goal was not accepted within the timeout";
+    return goal_handle;
+  }
+
+  std::shared_ptr<ServerGoalHandleT> waitForActiveGoal()
+  {
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      {
+        const std::lock_guard<std::mutex> lock(goal_mutex_);
+        if (active_goal_)
+        {
+          return active_goal_;
+        }
+      }
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ADD_FAILURE() << "No goal was accepted within the timeout";
+    return nullptr;
+  }
+
+  void publishFeedback(int recoveries)
+  {
+    auto feedback = std::make_shared<ActionT::Feedback>();
+    feedback->number_of_recoveries = recoveries;
+    waitForActiveGoal()->publish_feedback(feedback);
+  }
+
+  static ActionT::Result::SharedPtr makeResult(uint16_t error_code, const std::string& error_msg,
+                                               std::vector<nav2_msgs::msg::WaypointStatus> waypoint_statuses = {})
+  {
+    auto result = std::make_shared<ActionT::Result>();
+    result->error_code = error_code;
+    result->error_msg = error_msg;
+    result->waypoint_statuses = std::move(waypoint_statuses);
+    return result;
+  }
+
+  void succeedActiveGoal(uint16_t error_code = 0, const std::string& error_msg = "",
+                         std::vector<nav2_msgs::msg::WaypointStatus> waypoint_statuses = {})
+  {
+    waitForActiveGoal()->succeed(makeResult(error_code, error_msg, std::move(waypoint_statuses)));
+  }
+
+  void abortActiveGoal(uint16_t error_code, const std::string& error_msg)
+  {
+    waitForActiveGoal()->abort(makeResult(error_code, error_msg));
+  }
+
+  void cancelActiveGoal(const std::shared_ptr<ClientGoalHandleT>& client_goal_handle)
+  {
+    auto cancel_future = action_client_->async_cancel_goal(client_goal_handle);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (cancel_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready &&
+           std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    waitForActiveGoal()->canceled(makeResult(0, ""));
+  }
+
+  // Spins both nodes until a Record matching `predicate` shows up, so the async accept/execute/
+  // get_result round trip doesn't make the test flaky.
+  nlohmann::json waitForRecord(const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      rclcpp::spin_some(server_node_);
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path = ament_index_cpp::get_package_share_directory("dc_measurements") +
+                             "/plugins/measurements/json/mission_nav2_through_poses.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Node::SharedPtr server_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp_action::Server<ActionT>::SharedPtr action_server_;
+  rclcpp_action::Client<ActionT>::SharedPtr action_client_;
+  std::vector<nlohmann::json> records_;
+
+  std::mutex goal_mutex_;
+  std::shared_ptr<ServerGoalHandleT> active_goal_;
+
+  bool stopped_{ false };
+};
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, GoalAcceptedEmitsAMissionStartRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  const auto start = waitForRecord(isEvent("mission_start"));
+
+  EXPECT_EQ(start["sequence"], 1);
+  EXPECT_EQ(start["mission_type"], "navigate_through_poses");
+  EXPECT_FALSE(start["mission_id"].get<std::string>().empty());
+  expectValidatesAgainstSchema(start);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, GoalSucceedsEmitsAMissionEndRecordWithSucceededOutcome)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  const auto start = waitForRecord(isEvent("mission_start"));
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  succeedActiveGoal();
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["mission_id"], start["mission_id"]);
+  EXPECT_EQ(end["outcome"], "succeeded");
+  EXPECT_EQ(end["mission_type"], "navigate_through_poses");
+  EXPECT_GE(end["duration_sec"].get<double>(), 0.0);
+  EXPECT_FALSE(end.contains("reason"));
+  EXPECT_FALSE(end.contains("error_code"));
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, GoalAbortedCarriesReasonAndErrorCode)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  waitForRecord(isEvent("mission_start"));
+  abortActiveGoal(9102, "tf timeout");
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "aborted");
+  EXPECT_EQ(end["reason"], "tf timeout");
+  EXPECT_EQ(end["error_code"], 9102);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, GoalCanceledIsOutcomeCancelled)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  auto client_goal_handle = sendGoal();
+  waitForRecord(isEvent("mission_start"));
+  cancelActiveGoal(client_goal_handle);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "cancelled");
+  EXPECT_FALSE(end.contains("reason"));
+  EXPECT_FALSE(end.contains("error_code"));
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, NonZeroErrorCodeOnASucceededStatusIsOutcomeFailed)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  waitForRecord(isEvent("mission_start"));
+  succeedActiveGoal(9101, "failed to load behavior tree");
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "failed");
+  EXPECT_EQ(end["reason"], "failed to load behavior tree");
+  EXPECT_EQ(end["error_code"], 9101);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, RecoveriesFromFeedbackAreCarriedOntoMissionEnd)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  waitForRecord(isEvent("mission_start"));
+  publishFeedback(3);
+  spinFor(std::chrono::milliseconds(100));
+  succeedActiveGoal();
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  ASSERT_TRUE(end.contains("recoveries"));
+  EXPECT_EQ(end["recoveries"], 3);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, WaypointStatusesAreAggregatedOntoMissionEnd)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  waitForRecord(isEvent("mission_start"));
+
+  std::vector<nav2_msgs::msg::WaypointStatus> waypoints(3);
+  waypoints[0].waypoint_status = nav2_msgs::msg::WaypointStatus::COMPLETED;
+  waypoints[1].waypoint_status = nav2_msgs::msg::WaypointStatus::COMPLETED;
+  waypoints[2].waypoint_status = nav2_msgs::msg::WaypointStatus::FAILED;
+  succeedActiveGoal(0, "", waypoints);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  ASSERT_TRUE(end.contains("waypoint_statuses"));
+  EXPECT_EQ(end["waypoint_statuses"]["total"], 3);
+  EXPECT_EQ(end["waypoint_statuses"]["completed"], 2);
+  EXPECT_EQ(end["waypoint_statuses"]["failed"], 1);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2ThroughPosesTest, SequenceIsMonotonicAcrossSeveralMissions)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+
+  sendGoal();
+  const auto start1 = waitForRecord(isEvent("mission_start"));
+  succeedActiveGoal();
+  const auto end1 = waitForRecord([&](const nlohmann::json& r) {
+    return r.value("event", "") == "mission_end" && r["mission_id"] == start1["mission_id"];
+  });
+
+  {
+    const std::lock_guard<std::mutex> lock(goal_mutex_);
+    active_goal_.reset();
+  }
+
+  sendGoal();
+  const auto start2 = waitForRecord([&](const nlohmann::json& r) {
+    return r.value("event", "") == "mission_start" && r["mission_id"] != start1["mission_id"];
+  });
+  abortActiveGoal(9103, "timeout");
+  const auto end2 = waitForRecord([&](const nlohmann::json& r) {
+    return r.value("event", "") == "mission_end" && r["mission_id"] == start2["mission_id"];
+  });
+
+  EXPECT_LT(start1["sequence"].get<uint64_t>(), end1["sequence"].get<uint64_t>());
+  EXPECT_LT(end1["sequence"].get<uint64_t>(), start2["sequence"].get<uint64_t>());
+  EXPECT_LT(start2["sequence"].get<uint64_t>(), end2["sequence"].get<uint64_t>());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_mission_nav2_through_poses_core.cpp
+++ b/dc_measurements/test/test_mission_nav2_through_poses_core.cpp
@@ -16,7 +16,6 @@
 using dc_measurements::GoalPhase;
 using dc_measurements::MissionNav2ThroughPosesCore;
 using dc_measurements::MissionOutcome;
-using dc_measurements::WaypointStatusCounts;
 
 namespace
 {
@@ -74,7 +73,7 @@ TEST(MissionNav2ThroughPosesCore, SucceededWithNoErrorCodeIsOutcomeSucceeded)
 {
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
-  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(10));
+  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, at(10));
 
   EXPECT_EQ(fact.mission_id, "goal-1");
   EXPECT_EQ(fact.sequence, 2u);
@@ -88,8 +87,7 @@ TEST(MissionNav2ThroughPosesCore, SucceededWithNonZeroErrorCodeIsOutcomeFailed)
 {
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
-  const auto fact =
-      core.end("goal-1", GoalPhase::Succeeded, 9100, "unknown failure", std::nullopt, std::nullopt, at(5));
+  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 9100, "unknown failure", std::nullopt, at(5));
 
   EXPECT_EQ(fact.outcome, MissionOutcome::Failed);
   ASSERT_TRUE(fact.reason.has_value());
@@ -102,7 +100,7 @@ TEST(MissionNav2ThroughPosesCore, AbortedCarriesReasonAndErrorCode)
 {
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
-  const auto fact = core.end("goal-1", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, std::nullopt, at(3));
+  const auto fact = core.end("goal-1", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, at(3));
 
   EXPECT_EQ(fact.outcome, MissionOutcome::Aborted);
   ASSERT_TRUE(fact.reason.has_value());
@@ -115,32 +113,22 @@ TEST(MissionNav2ThroughPosesCore, CanceledCarriesNoReasonOrErrorCode)
 {
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
-  const auto fact = core.end("goal-1", GoalPhase::Canceled, 0, "", std::nullopt, std::nullopt, at(2));
+  const auto fact = core.end("goal-1", GoalPhase::Canceled, 0, "", std::nullopt, at(2));
 
   EXPECT_EQ(fact.outcome, MissionOutcome::Cancelled);
   EXPECT_FALSE(fact.reason.has_value());
   EXPECT_FALSE(fact.error_code.has_value());
 }
 
-TEST(MissionNav2ThroughPosesCore, RecoveriesAndWaypointStatusesAreCarriedThrough)
+TEST(MissionNav2ThroughPosesCore, RecoveriesAreCarriedThrough)
 {
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
 
-  WaypointStatusCounts counts;
-  counts.total = 3;
-  counts.completed = 2;
-  counts.skipped = 0;
-  counts.failed = 1;
-
-  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", 2, counts, at(1));
+  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", 2, at(1));
 
   ASSERT_TRUE(fact.recoveries.has_value());
   EXPECT_EQ(*fact.recoveries, 2);
-  ASSERT_TRUE(fact.waypoint_statuses.has_value());
-  EXPECT_EQ(fact.waypoint_statuses->total, 3u);
-  EXPECT_EQ(fact.waypoint_statuses->completed, 2u);
-  EXPECT_EQ(fact.waypoint_statuses->failed, 1u);
 }
 
 TEST(MissionNav2ThroughPosesCore, OpenMissionIdsReportsOnlyUnfinishedMissions)
@@ -148,7 +136,7 @@ TEST(MissionNav2ThroughPosesCore, OpenMissionIdsReportsOnlyUnfinishedMissions)
   MissionNav2ThroughPosesCore core;
   core.observe("goal-1", at(0));
   core.observe("goal-2", at(1));
-  core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(2));
+  core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, at(2));
 
   const auto open = core.openMissionIds();
   ASSERT_EQ(open.size(), 1u);
@@ -159,9 +147,9 @@ TEST(MissionNav2ThroughPosesCore, SequenceIsMonotonicAcrossStartsAndEndsOfSevera
 {
   MissionNav2ThroughPosesCore core;
   const auto start1 = core.observe("goal-1", at(0));
-  const auto end1 = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(1));
+  const auto end1 = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, at(1));
   const auto start2 = core.observe("goal-2", at(2));
-  const auto end2 = core.end("goal-2", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, std::nullopt, at(3));
+  const auto end2 = core.end("goal-2", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, at(3));
 
   EXPECT_EQ(start1->sequence, 1u);
   EXPECT_EQ(end1.sequence, 2u);

--- a/dc_measurements/test/test_mission_nav2_through_poses_core.cpp
+++ b/dc_measurements/test/test_mission_nav2_through_poses_core.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_measurements::MissionNav2ThroughPosesCore (#388). No node, no rclcpp::init():
+// goal_id/status/result all arrive as arguments, mirroring dc_common::BatteryCycleAccumulator's
+// standalone coverage.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <optional>
+#include <string>
+
+#include "dc_measurements/plugins/measurements/mission_nav2_through_poses_core.hpp"
+
+using dc_measurements::GoalPhase;
+using dc_measurements::MissionNav2ThroughPosesCore;
+using dc_measurements::MissionOutcome;
+using dc_measurements::WaypointStatusCounts;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+}  // namespace
+
+TEST(MissionNav2ThroughPosesCore, FirstSampleOfAGoalIdIsAMissionStart)
+{
+  MissionNav2ThroughPosesCore core;
+  const auto start = core.observe("goal-1", at(0));
+  ASSERT_TRUE(start.has_value());
+  EXPECT_EQ(start->mission_id, "goal-1");
+  EXPECT_EQ(start->sequence, 1u);
+}
+
+TEST(MissionNav2ThroughPosesCore, RepeatedSamplesOfTheSameGoalIdProduceNoFurtherStart)
+{
+  MissionNav2ThroughPosesCore core;
+  ASSERT_TRUE(core.observe("goal-1", at(0)).has_value());
+  EXPECT_FALSE(core.observe("goal-1", at(1)).has_value());
+  EXPECT_FALSE(core.observe("goal-1", at(2)).has_value());
+}
+
+TEST(MissionNav2ThroughPosesCore, TwoDifferentGoalIdsEachGetTheirOwnStart)
+{
+  MissionNav2ThroughPosesCore core;
+  const auto first = core.observe("goal-1", at(0));
+  const auto second = core.observe("goal-2", at(1));
+  ASSERT_TRUE(first.has_value());
+  ASSERT_TRUE(second.has_value());
+  EXPECT_EQ(first->sequence, 1u);
+  EXPECT_EQ(second->sequence, 2u);
+}
+
+TEST(MissionNav2ThroughPosesCore, ShouldRequestResultIsTrueOnlyOncePerGoalId)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  EXPECT_TRUE(core.shouldRequestResult("goal-1"));
+  EXPECT_FALSE(core.shouldRequestResult("goal-1"));
+}
+
+TEST(MissionNav2ThroughPosesCore, ShouldRequestResultIsFalseForAnUntrackedGoalId)
+{
+  MissionNav2ThroughPosesCore core;
+  EXPECT_FALSE(core.shouldRequestResult("never-seen"));
+}
+
+TEST(MissionNav2ThroughPosesCore, SucceededWithNoErrorCodeIsOutcomeSucceeded)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(10));
+
+  EXPECT_EQ(fact.mission_id, "goal-1");
+  EXPECT_EQ(fact.sequence, 2u);
+  EXPECT_EQ(fact.outcome, MissionOutcome::Succeeded);
+  EXPECT_DOUBLE_EQ(fact.duration_sec, 10.0);
+  EXPECT_FALSE(fact.reason.has_value());
+  EXPECT_FALSE(fact.error_code.has_value());
+}
+
+TEST(MissionNav2ThroughPosesCore, SucceededWithNonZeroErrorCodeIsOutcomeFailed)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  const auto fact =
+      core.end("goal-1", GoalPhase::Succeeded, 9100, "unknown failure", std::nullopt, std::nullopt, at(5));
+
+  EXPECT_EQ(fact.outcome, MissionOutcome::Failed);
+  ASSERT_TRUE(fact.reason.has_value());
+  EXPECT_EQ(*fact.reason, "unknown failure");
+  ASSERT_TRUE(fact.error_code.has_value());
+  EXPECT_EQ(*fact.error_code, 9100);
+}
+
+TEST(MissionNav2ThroughPosesCore, AbortedCarriesReasonAndErrorCode)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  const auto fact = core.end("goal-1", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, std::nullopt, at(3));
+
+  EXPECT_EQ(fact.outcome, MissionOutcome::Aborted);
+  ASSERT_TRUE(fact.reason.has_value());
+  EXPECT_EQ(*fact.reason, "tf timeout");
+  ASSERT_TRUE(fact.error_code.has_value());
+  EXPECT_EQ(*fact.error_code, 9102);
+}
+
+TEST(MissionNav2ThroughPosesCore, CanceledCarriesNoReasonOrErrorCode)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  const auto fact = core.end("goal-1", GoalPhase::Canceled, 0, "", std::nullopt, std::nullopt, at(2));
+
+  EXPECT_EQ(fact.outcome, MissionOutcome::Cancelled);
+  EXPECT_FALSE(fact.reason.has_value());
+  EXPECT_FALSE(fact.error_code.has_value());
+}
+
+TEST(MissionNav2ThroughPosesCore, RecoveriesAndWaypointStatusesAreCarriedThrough)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+
+  WaypointStatusCounts counts;
+  counts.total = 3;
+  counts.completed = 2;
+  counts.skipped = 0;
+  counts.failed = 1;
+
+  const auto fact = core.end("goal-1", GoalPhase::Succeeded, 0, "", 2, counts, at(1));
+
+  ASSERT_TRUE(fact.recoveries.has_value());
+  EXPECT_EQ(*fact.recoveries, 2);
+  ASSERT_TRUE(fact.waypoint_statuses.has_value());
+  EXPECT_EQ(fact.waypoint_statuses->total, 3u);
+  EXPECT_EQ(fact.waypoint_statuses->completed, 2u);
+  EXPECT_EQ(fact.waypoint_statuses->failed, 1u);
+}
+
+TEST(MissionNav2ThroughPosesCore, OpenMissionIdsReportsOnlyUnfinishedMissions)
+{
+  MissionNav2ThroughPosesCore core;
+  core.observe("goal-1", at(0));
+  core.observe("goal-2", at(1));
+  core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(2));
+
+  const auto open = core.openMissionIds();
+  ASSERT_EQ(open.size(), 1u);
+  EXPECT_EQ(open.front(), "goal-2");
+}
+
+TEST(MissionNav2ThroughPosesCore, SequenceIsMonotonicAcrossStartsAndEndsOfSeveralMissions)
+{
+  MissionNav2ThroughPosesCore core;
+  const auto start1 = core.observe("goal-1", at(0));
+  const auto end1 = core.end("goal-1", GoalPhase::Succeeded, 0, "", std::nullopt, std::nullopt, at(1));
+  const auto start2 = core.observe("goal-2", at(2));
+  const auto end2 = core.end("goal-2", GoalPhase::Aborted, 9102, "tf timeout", std::nullopt, std::nullopt, at(3));
+
+  EXPECT_EQ(start1->sequence, 1u);
+  EXPECT_EQ(end1.sequence, 2u);
+  EXPECT_EQ(start2->sequence, 3u);
+  EXPECT_EQ(end2.sequence, 4u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [IP Camera](./dc/measurements/ip_camera.md)
   - [Map](./dc/measurements/map.md)
   - [Memory](./dc/measurements/memory.md)
+  - [Mission Nav2 (NavigateThroughPoses)](./dc/measurements/mission_nav2_through_poses.md)
   - [Network](./dc/measurements/network.md)
   - [OS](./dc/measurements/os.md)
   - [Permissions](./dc/measurements/permissions.md)

--- a/doc/src/dc/measurements/mission_nav2_through_poses.md
+++ b/doc/src/dc/measurements/mission_nav2_through_poses.md
@@ -1,0 +1,132 @@
+# Mission Nav2 (NavigateThroughPoses)
+
+## Description
+
+The nav2 adapter of the Mission Measurement for nav2's `NavigateThroughPoses` action -- the
+action a deployment issues when a mission is a single job through several hard-constraint poses
+in one call, rather than a chain of separate `NavigateToPose` goals (that sibling adapter is
+`mission_nav2`, #387). Emits a `mission_start` Record when a goal is first observed and a
+`mission_end` Record once it reaches a terminal state, in the same Record schema #387 defines,
+with `mission_type: "navigate_through_poses"`.
+
+This Measurement is a **passive observer, not a second client competing for the action server's
+single active goal**. It never sends a goal itself. Instead it subscribes to the action's own
+`_action/status` and `_action/feedback` topics and calls its `_action/get_result` service
+directly for whichever goal_id just reached a terminal status -- the same standard per-action
+topics/services every `rclcpp_action::Server` (nav2's `bt_navigator` included) exposes. Whatever
+in the deployment actually dispatches missions (a BT navigator, a fleet orchestrator, an
+operator command) keeps doing so exactly as before; this Measurement only watches.
+
+Two Records per mission:
+
+- a **`mission_start`** Record, the first time a goal_id is observed on the action's status topic.
+- a **`mission_end`** Record, once that goal_id reaches a terminal status (`SUCCEEDED`,
+  `CANCELED`, or `ABORTED`) and its result has been fetched.
+
+`outcome` on the end Record is one of `succeeded`, `failed`, `cancelled`, `aborted`:
+`CANCELED` maps to `cancelled`, `ABORTED` to `aborted` (both carrying nav2's own
+`error_msg`/`error_code` as `reason`/`error_code`), and `SUCCEEDED` maps to `succeeded` unless
+`NavigateThroughPoses::Result.error_code` is non-zero, in which case it is `failed` -- an
+application-level failure nav2 reported without aborting the goal status itself.
+
+`recoveries` (from `NavigateThroughPoses::Feedback.number_of_recoveries`, when feedback was seen
+before completion) and `waypoint_statuses` (an aggregate `{total, completed, skipped, failed}`
+count of `NavigateThroughPoses::Result.waypoint_statuses` -- which poses in the job succeeded
+versus were skipped or failed -- kept as counts rather than the raw per-pose array to keep the
+Record flat) are both carried on the end Record when available.
+
+A mission still running when collection stops simply never gets a matching `mission_end` Record:
+nothing downstream can average an interval that was never closed as a zero, because there is no
+`mission_end` Record to average. `sequence` is a monotonically increasing counter across every
+Record this Measurement instance emits (start and end alike, not per mission_id), so a dropped
+Record shows up as a gap rather than silently corrupting a duration or a mission-success-rate
+denominator.
+
+## Parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `action_name` | `navigate_through_poses` | The `NavigateThroughPoses` action to watch. Its `_action/status`, `_action/feedback`, and `_action/get_result` endpoints are subscribed/called directly. |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2ThroughPoses",
+  "properties": {
+    "event": { "type": "string", "enum": ["mission_start", "mission_end"] },
+    "mission_id": { "type": "string" },
+    "mission_type": { "type": "string" },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "outcome": { "type": "string", "enum": ["succeeded", "failed", "cancelled", "aborted"] },
+    "reason": { "type": "string" },
+    "error_code": { "type": "integer", "minimum": 0 },
+    "duration_sec": { "type": "number", "minimum": 0 },
+    "recoveries": { "type": "integer", "minimum": 0 },
+    "waypoint_statuses": {
+      "type": "object",
+      "properties": {
+        "total": { "type": "integer", "minimum": 0 },
+        "completed": { "type": "integer", "minimum": 0 },
+        "skipped": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "required": ["event", "mission_id", "sequence"],
+  "type": "object"
+}
+```
+
+## Measurement configuration
+
+```yaml
+...
+mission_nav2_through_poses:
+  plugin: "dc_measurements/MissionNav2ThroughPoses"
+  topic_output: "/dc/measurement/mission_nav2_through_poses"
+  group_key: "mission"
+  action_name: "navigate_through_poses"
+```
+
+Example Record data, start:
+
+```json
+{
+  "event": "mission_start",
+  "mission_id": "3f2504e04f8911d39a0c0305e82c3301",
+  "mission_type": "navigate_through_poses",
+  "sequence": 7
+}
+```
+
+and end (succeeded, two of three waypoints completed):
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "3f2504e04f8911d39a0c0305e82c3301",
+  "mission_type": "navigate_through_poses",
+  "sequence": 8,
+  "outcome": "succeeded",
+  "duration_sec": 96.4,
+  "recoveries": 1,
+  "waypoint_statuses": { "total": 3, "completed": 2, "skipped": 0, "failed": 1 }
+}
+```
+
+and end (aborted):
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "9f86d081884c7d659a2feaa0c55ad015",
+  "mission_type": "navigate_through_poses",
+  "sequence": 10,
+  "outcome": "aborted",
+  "reason": "tf timeout",
+  "error_code": 9102,
+  "duration_sec": 12.1
+}
+```

--- a/doc/src/dc/measurements/mission_nav2_through_poses.md
+++ b/doc/src/dc/measurements/mission_nav2_through_poses.md
@@ -30,10 +30,20 @@ Two Records per mission:
 application-level failure nav2 reported without aborting the goal status itself.
 
 `recoveries` (from `NavigateThroughPoses::Feedback.number_of_recoveries`, when feedback was seen
-before completion) and `waypoint_statuses` (an aggregate `{total, completed, skipped, failed}`
-count of `NavigateThroughPoses::Result.waypoint_statuses` -- which poses in the job succeeded
-versus were skipped or failed -- kept as counts rather than the raw per-pose array to keep the
-Record flat) are both carried on the end Record when available.
+before completion) is carried on the end Record when available.
+
+**No per-waypoint outcome is reported.** The acceptance criteria this Measurement was built
+against ask for the final `waypoint_statuses` (which poses in the job succeeded versus failed) to
+be represented on `mission_end`, following an upstream nav2 `NavigateThroughPoses.action` result
+field of that name. That field does not exist on the nav2 release this repository actually
+builds against (`nav2_msgs` on the `jazzy` branch of `ros-navigation/navigation2` -- verified
+directly, not assumed): its `NavigateThroughPoses::Result` carries only `error_code`/`error_msg`,
+the same shape as `NavigateToPose::Result`. It was present in an earlier implementation of this
+plugin (written against the upstream default branch without checking the pinned distro branch
+first) and removed once CI's real Jazzy build caught the mismatch (`fatal error:
+nav2_msgs/msg/waypoint_status.hpp: No such file or directory`). Adding it back is a follow-up for
+whenever nav2 backports per-waypoint result reporting to a distro this repository targets, not
+something this Measurement can honestly do today.
 
 A mission still running when collection stops simply never gets a matching `mission_end` Record:
 nothing downstream can average an interval that was never closed as a zero, because there is no
@@ -63,16 +73,7 @@ denominator.
     "reason": { "type": "string" },
     "error_code": { "type": "integer", "minimum": 0 },
     "duration_sec": { "type": "number", "minimum": 0 },
-    "recoveries": { "type": "integer", "minimum": 0 },
-    "waypoint_statuses": {
-      "type": "object",
-      "properties": {
-        "total": { "type": "integer", "minimum": 0 },
-        "completed": { "type": "integer", "minimum": 0 },
-        "skipped": { "type": "integer", "minimum": 0 },
-        "failed": { "type": "integer", "minimum": 0 }
-      }
-    }
+    "recoveries": { "type": "integer", "minimum": 0 }
   },
   "required": ["event", "mission_id", "sequence"],
   "type": "object"
@@ -101,7 +102,7 @@ Example Record data, start:
 }
 ```
 
-and end (succeeded, two of three waypoints completed):
+and end (succeeded):
 
 ```json
 {
@@ -111,8 +112,7 @@ and end (succeeded, two of three waypoints completed):
   "sequence": 8,
   "outcome": "succeeded",
   "duration_sec": 96.4,
-  "recoveries": 1,
-  "waypoint_statuses": { "total": 3, "completed": 2, "skipped": 0, "failed": 1 }
+  "recoveries": 1
 }
 ```
 

--- a/progress.txt
+++ b/progress.txt
@@ -8521,3 +8521,26 @@ reading the code (the repo's established verification standard):
   fix. Same caveat as before: no `colcon`/ROS 2 toolchain in this sandbox, so this was
   verified by re-reading the jazzy-branch definitions directly rather than by
   rebuilding — the next CI run is what actually closes the loop.
+
+### #388 follow-up 2 - Fix CI test failure (double EXECUTE transition in test fixture)
+
+- After the `waypoint_statuses` build fix above, the same CI run's `colcon test` still
+  failed — all 7 `dc_measurements_test_measurement_mission_nav2_through_poses` cases,
+  each in under 100ms (not a timeout). Real error, from the log: `C++ exception with
+  description "goal_handle attempted invalid transition from state EXECUTING with event
+  EXECUTE, at ./src/rcl_action/goal_handle.c:100" thrown in the test body`.
+- Root cause: a bug in the test's own fake action-server fixture, not the plugin under
+  test. The fixture's `handle_goal` callback returns `GoalResponse::ACCEPT_AND_EXECUTE`
+  — which, per `rclcpp_action::Server`'s own semantics, already drives the goal handle
+  straight from ACCEPTED to EXECUTING internally *before* invoking `handle_accepted`.
+  The fixture's `handleAccepted()` then called `goal_handle->execute()` again as a
+  defensive "make sure it's executing" step — a second EXECUTE event on an
+  already-EXECUTING goal handle, which `rcl_action`'s state machine treats as a hard
+  error, not a no-op.
+- Fix: removed the redundant `execute()` call from `handleAccepted()`, with a comment
+  explaining why it was wrong (not just deleting it silently) so a future edit doesn't
+  reintroduce it defensively. `succeed()`/`abort()`/cancel-then-`canceled()` are all
+  still valid from the state ACCEPT_AND_EXECUTE already put the goal in.
+- `git add -A && prek run --all-files --skip build-doc` passes clean. Same caveat as
+  the last two entries: no `colcon`/ROS 2 toolchain in this sandbox to actually run the
+  test locally — the next CI run is what confirms this.

--- a/progress.txt
+++ b/progress.txt
@@ -8412,3 +8412,77 @@ reading the code (the repo's established verification standard):
   Shipper fan-in axis's #382 section — the last of the three merged this way, so it
   gets the "ninth piece" framing, before Layout) plus Layout entries for the new files.
 - Not wired into `ci.yaml`, same as every other narrow scenario script.
+
+### #388 - Add the Mission Measurement: NavigateThroughPoses adapter
+
+- New `dc_measurements` plugin `mission_nav2_through_poses` (class
+  `MissionNav2ThroughPoses`), watching nav2's `NavigateThroughPoses` action and emitting
+  `mission_start`/`mission_end` Records in #387's Record schema, with
+  `mission_type: "navigate_through_poses"`. #387 itself is not implemented in this tree
+  (still open) — #388's own "Blocked by: None" explicitly says it only needs #387's
+  *documented* schema/pattern (written out in #387's issue body), not #387's code, so
+  this was implemented directly against that spec.
+- **Architecture decision, not pre-specified by either issue**: this Measurement is a
+  passive observer, not a second `rclcpp_action::Client` competing for the action
+  server's single active goal. nav2's `SimpleActionServer` (behind `bt_navigator`) only
+  ever runs one goal at a time; a DC plugin that sent its own competing
+  `NavigateThroughPoses` goal to track missions would preempt or fight whatever real
+  navigation stack component (BT navigator, fleet orchestrator) is actually driving the
+  robot. Instead it subscribes directly to the action's own `_action/status`
+  (`action_msgs/msg/GoalStatusArray`) and `_action/feedback` topics and calls its
+  `_action/get_result` service directly for whichever goal_id just reached a terminal
+  status — the same standard per-action topics/services every `rclcpp_action::Server`
+  exposes (verified against the real generated `Impl::GetResultService`/
+  `Impl::FeedbackMessage` codegen pattern), rather than `rclcpp_action::Client`'s
+  higher-level API, which has no supported way to attach to a goal it did not itself
+  send.
+- Verified the real nav2 message shapes against `ros-navigation/navigation2` on GitHub
+  (not from memory) before writing the field mapping: `NavigateThroughPoses.action`'s
+  Result carries `error_code`/`error_msg` (same error-code table as `NavigateToPose`,
+  offset by `+100`) plus `WaypointStatus[] waypoint_statuses`; `action_msgs/msg/
+  GoalStatusArray`'s array field is `status_list`, not `status` (an easy field-name trap
+  had this not been checked directly).
+- ROS-free core (`mission_nav2_through_poses_core.hpp`, header-only, following #360's
+  `StateTransitionDetector`/`BatteryCycleAccumulator` split precedent): tracks which
+  goal_ids are new (`observe()` → a `MissionStartFact` only the first time a goal_id is
+  seen — deliberately *not* built on `StateTransitionDetector<GoalPhase>`, since a
+  mission's start is the very first sample for a goal_id, not a transition away from
+  some prior baseline state the way `intervention`/`fault` have one); `end()` derives
+  `outcome` (`succeeded`/`failed`/`cancelled`/`aborted`) from the terminal phase and
+  `error_code`, matching #387's contract (`SUCCEEDED` + non-zero `error_code` →
+  `failed`, distinct from `ABORTED`). Bounded tracking (`kMaxTracked = 256`, prunes
+  oldest *finished* entries only) since goal UUIDs never repeat, unlike `fault`'s
+  diagnostic-name keys.
+- `waypoint_statuses` on `mission_end` is an aggregate `{total, completed, skipped,
+  failed}` count object, not the raw per-pose array — the acceptance criteria left this
+  choice to the implementer ("whichever is simpler to keep the Record reasonably
+  flat").
+- New JSON Schema `mission_nav2_through_poses.json` (mirrors #387's `battery.json`-style
+  `allOf`/`if`/`then` conditionals: `mission_end` requires `outcome`/`duration_sec`;
+  `outcome` in `[failed, aborted]` additionally requires `reason`/`error_code`).
+- Tests: `test_mission_nav2_through_poses_core.cpp` (ROS-free, no node, no action
+  server — mirrors `battery_cycle_accumulator_test.cpp`) plus
+  `test_measurement_mission_nav2_through_poses.cpp`, a `MeasurementServer` integration
+  test using a real `rclcpp_action::Server<NavigateThroughPoses>` fixture standing in
+  for nav2, driven by a real `rclcpp_action::Client` the *test* owns (since the
+  Measurement under test never sends a goal itself) — covers goal-accepted →
+  `mission_start`, succeeded/aborted/cancelled/failed-via-error-code outcomes,
+  recoveries-from-feedback, `waypoint_statuses` aggregation, schema validation on every
+  emitted Record, and sequence monotonicity across several missions.
+- Doc page `doc/src/dc/measurements/mission_nav2_through_poses.md`, registered in
+  `doc/src/SUMMARY.md` (after Memory, alphabetically among Measurements).
+- New `dc_measurements` deps: `action_msgs`, `nav2_msgs`, `rclcpp_action`,
+  `unique_identifier_msgs` (package.xml + CMakeLists.txt `dependencies`).
+- `git add -A && prek run --all-files --skip build-doc` passes clean (clang-format
+  reformatted the new files on the first pass, re-staged and re-ran clean).
+- **Not done / left for CI**: no `colcon`/ROS 2 toolchain available in this sandbox (no
+  `/opt/ros`, no `colcon` binary) — same constraint noted in #242/#243's entries above.
+  Every generated-message field name used (`GoalStatusArray.status_list`,
+  `GoalStatus.goal_info`/`.status`, `GoalInfo.goal_id`/`.stamp`, `UUID.uuid`,
+  `NavigateThroughPoses` Goal/Result/Feedback/`Impl::GetResultService`/
+  `Impl::FeedbackMessage`, `WaypointStatus.waypoint_status`/`PENDING`/`COMPLETED`/
+  `SKIPPED`/`FAILED`) was cross-checked against the real `.msg`/`.action` definitions
+  fetched from `ros-navigation/navigation2` and `ros2/rcl_interfaces`/
+  `ros2/unique_identifier_msgs` on GitHub rather than from memory, but a real `colcon
+  build`/`colcon test` of `dc_measurements` on Jazzy is still needed to close the loop
+  formally (CI once #249 lands, or a machine with `ament_cmake`/nav2 installed).

--- a/progress.txt
+++ b/progress.txt
@@ -8486,3 +8486,38 @@ reading the code (the repo's established verification standard):
   `ros2/unique_identifier_msgs` on GitHub rather than from memory, but a real `colcon
   build`/`colcon test` of `dc_measurements` on Jazzy is still needed to close the loop
   formally (CI once #249 lands, or a machine with `ament_cmake`/nav2 installed).
+
+### #388 follow-up - Fix CI build failure (`nav2_msgs/msg/waypoint_status.hpp` missing)
+
+- CI's real Jazzy build (`dc_measurements` `colcon build` in the `build-workspace` job)
+  failed: `fatal error: nav2_msgs/msg/waypoint_status.hpp: No such file or directory`.
+  Root cause: the `.action`/`.msg` field verification for #388 above was done by
+  fetching `ros-navigation/navigation2` **without pinning a ref**, which resolves to
+  the repo's default branch (`main`, tracking rolling/current dev) — not the `jazzy`
+  branch CI's rosdep-installed `nav2_msgs` actually ships. Re-fetched
+  `nav2_msgs/action/NavigateThroughPoses.action` and `nav2_msgs/msg` directly with
+  `?ref=jazzy` this time: on `jazzy`, `NavigateThroughPoses::Result` carries only
+  `error_code`/`error_msg` (same shape as `NavigateToPose::Result`) — no
+  `waypoint_statuses` field, and no `WaypointStatus.msg` exists in the package at all
+  yet (`nav2_msgs/msg/` on `jazzy` has no such file; it appears to be an addition to a
+  later/rolling nav2 not yet on the branch this repo builds against). Also confirmed
+  `action_msgs`/`unique_identifier_msgs` (core ROS interfaces, not nav2-versioned) were
+  unaffected — their `jazzy`-branch field names match what was already used
+  (`status_list`, `goal_info`, `goal_id`, `uuid`).
+- Fix: removed `waypoint_statuses` entirely rather than working around it — the
+  acceptance criteria's "final waypoint_statuses... represented on mission_end" item is
+  not satisfiable against the nav2 this repo actually targets, not a bug to patch
+  around. Removed `WaypointStatusCounts`/the `waypoint_statuses` parameter from
+  `MissionNav2ThroughPosesCore::end()`, the `#include "nav2_msgs/msg/waypoint_status.hpp"`
+  and its aggregation helper from the plugin, the `waypoint_statuses` property from the
+  JSON schema, the corresponding test coverage in both test files, and rewrote the
+  affected doc section to state plainly why the field isn't there and what would need
+  to change upstream for it to come back.
+- `mission_id`/`mission_type`/`sequence`/`outcome`/`reason`/`error_code`/
+  `duration_sec`/`recoveries` are all unaffected — those come from
+  `NavigateThroughPoses::Result.error_code`/`.error_msg` and `::Feedback
+  .number_of_recoveries`, all present on both branches.
+- `git add -A && prek run --all-files --skip build-doc` passes clean again after the
+  fix. Same caveat as before: no `colcon`/ROS 2 toolchain in this sandbox, so this was
+  verified by re-reading the jazzy-branch definitions directly rather than by
+  rebuilding — the next CI run is what actually closes the loop.


### PR DESCRIPTION
## Summary

- Adds a new `dc_measurements` plugin, `mission_nav2_through_poses` (class
  `MissionNav2ThroughPoses`), watching nav2's `NavigateThroughPoses` action and emitting
  `mission_start`/`mission_end` Records in #387's Record schema, with
  `mission_type: "navigate_through_poses"`.
- The Measurement is a **passive observer**, not a second `rclcpp_action::Client`
  competing for the action server's single active goal: it subscribes to the action's
  own `_action/status`/`_action/feedback` topics and calls `_action/get_result`
  directly, rather than sending its own goal (which would preempt whatever real
  navigation client — BT navigator, fleet orchestrator — is actually driving the
  robot). All generated-message field names used were cross-checked against the real
  `.msg`/`.action` definitions in `ros-navigation/navigation2` and
  `ros2/rcl_interfaces`/`ros2/unique_identifier_msgs` on GitHub.
- ROS-free core (`mission_nav2_through_poses_core.hpp`) interprets goal-status/result
  into `mission_start`/`mission_end` facts, following #360's
  `StateTransitionDetector`/`BatteryCycleAccumulator` split precedent.
- New JSON Schema (`mission_nav2_through_poses.json`), doc page, and both a ROS-free
  core unit test and a `MeasurementServer` integration test using a real
  `rclcpp_action::Server` fixture standing in for nav2.

Closes #388

## Test plan

- [x] `git add -A && prek run --all-files --skip build-doc` passes clean
- [ ] `colcon build --packages-select dc_measurements` (no ROS 2 toolchain available in
      the sandbox this was written in — see `progress.txt`'s #388 entry for what was
      verified without it)
- [ ] `colcon test --packages-select dc_measurements` (new tests:
      `dc_measurements_test_mission_nav2_through_poses_core`,
      `dc_measurements_test_measurement_mission_nav2_through_poses`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012q87RuoZxzfQEBotiaS88u