### PR TITLE
feat(measurements): add mission_nav2_follow_waypoints Measurement

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -167,6 +167,9 @@ list(APPEND dc_measurement_plugin_libs dc_ip_camera_measurement)
 add_library(dc_map_measurement SHARED plugins/measurements/map.cpp)
 list(APPEND dc_measurement_plugin_libs dc_map_measurement)
 
+add_library(dc_mission_nav2_follow_waypoints_measurement SHARED plugins/measurements/mission_nav2_follow_waypoints.cpp)
+list(APPEND dc_measurement_plugin_libs dc_mission_nav2_follow_waypoints_measurement)
+
 add_library(dc_mission_nav2_through_poses_measurement SHARED plugins/measurements/mission_nav2_through_poses.cpp)
 list(APPEND dc_measurement_plugin_libs dc_mission_nav2_through_poses_measurement)
 
@@ -344,6 +347,7 @@ set(tests
   test_measurement_list_string_equal
   test_measurement_map
   test_measurement_memory
+  test_measurement_mission_nav2_follow_waypoints
   test_measurement_mission_nav2_through_poses
   test_measurement_moving
   test_measurement_network
@@ -361,6 +365,7 @@ set(tests
   test_measurement_tcp_health
   test_measurement_thermal
   test_measurement_uptime
+  mission_follow_waypoints_tracker_test
   test_mission_nav2_through_poses_core
 )
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_FOLLOW_WAYPOINTS_TRACKER_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_FOLLOW_WAYPOINTS_TRACKER_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dc_common/state_transition_detector.hpp"
+
+namespace dc_measurements
+{
+
+/// Terminal nav2 GoalStatus values relevant to a mission, expressed with no ROS dependency --
+/// ACCEPTED/EXECUTING/CANCELING never reach the tracker, only what a goal can end on.
+enum class MissionTerminalStatus
+{
+  Succeeded,
+  Canceled,
+  Aborted,
+};
+
+/// The outcome a Record actually reports, per #387's schema. Distinct from MissionTerminalStatus:
+/// a goal that reaches Succeeded with a non-zero error_code is reported as Failed rather than
+/// Succeeded (nav2's WaypointFollower can finish its action goal successfully while still having
+/// missed one or more waypoints).
+enum class MissionOutcome
+{
+  Succeeded,
+  Failed,
+  Cancelled,
+  Aborted,
+};
+
+/// One entry of FollowWaypoints::Result.missed_waypoints (nav2_msgs/msg/WaypointStatus), stripped
+/// of the pose -- not part of #389's schema.
+struct WaypointOutcome
+{
+  std::uint32_t index{ 0 };
+  std::string status;  // "pending" | "completed" | "skipped" | "failed"
+  std::uint16_t error_code{ 0 };
+  std::string error_msg;
+};
+
+struct MissionStartFact
+{
+  std::string mission_id;
+  std::uint64_t sequence{ 0 };
+};
+
+struct MissionEndFact
+{
+  std::string mission_id;
+  std::uint64_t sequence{ 0 };
+  MissionOutcome outcome{ MissionOutcome::Succeeded };
+  double duration_sec{ 0.0 };
+  /// Set exactly when outcome is Failed or Aborted, per #387's schema.
+  std::optional<std::string> reason;
+  std::optional<std::uint16_t> error_code;
+  std::vector<WaypointOutcome> missed_waypoints;
+};
+
+/**
+ * @class dc_measurements::MissionFollowWaypointsTracker
+ * @brief Turns a passively observed FollowWaypoints goal lifecycle (accepted -> terminal) into
+ * mission_start/mission_end facts, with no ROS dependency. Built on
+ * dc_common::StateTransitionDetector<std::string> (#360), the same block `intervention`/`fault`
+ * use, with the tracked "state" being the active goal_id (empty = idle).
+ *
+ * A nav2 WaypointFollower action server processes one goal at a time, so this tracker only ever
+ * follows one mission at once; a second goal accepted before the first's result arrives is
+ * reported by startMission() returning nullopt, for the caller to log and ignore.
+ *
+ * The terminal Result (error_code, error_msg, missed_waypoints) is not available at the moment a
+ * goal reaches a terminal GoalStatus -- a passive watcher (mission_nav2_follow_waypoints.cpp) has
+ * to fetch it with a separate, asynchronous get_result call. endMission() is therefore called once
+ * that response has arrived, not from the status callback directly.
+ */
+class MissionFollowWaypointsTracker
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+
+  /// `at` seeds the tracker as idle since that moment -- without it, the very first mission this
+  /// instance ever observes would be silently absorbed as StateTransitionDetector's baseline
+  /// sample rather than reported as a transition.
+  explicit MissionFollowWaypointsTracker(TimePoint at) : detector_(std::string(), at)
+  {
+  }
+
+  /// A new goal_id was accepted. nullopt when a mission is already tracked, or `goal_id` is
+  /// already the one tracked (a duplicate status-array sighting).
+  std::optional<MissionStartFact> startMission(const std::string& goal_id, TimePoint at)
+  {
+    if (detector_.state().value_or(std::string()) != std::string())
+    {
+      return std::nullopt;
+    }
+    const auto transition = detector_.update(goal_id, at);
+    if (!transition.has_value())
+    {
+      return std::nullopt;
+    }
+    return MissionStartFact{ goal_id, transition->sequence };
+  }
+
+  /// The tracked goal's Result has arrived. nullopt when `goal_id` is not the one currently
+  /// tracked (a stale or foreign result).
+  std::optional<MissionEndFact> endMission(const std::string& goal_id, MissionTerminalStatus status,
+                                           std::uint16_t error_code, std::string error_msg,
+                                           std::vector<WaypointOutcome> missed_waypoints, TimePoint at)
+  {
+    if (detector_.state().value_or(std::string()) != goal_id || goal_id.empty())
+    {
+      return std::nullopt;
+    }
+    const auto transition = detector_.update(std::string(), at);
+    if (!transition.has_value())
+    {
+      return std::nullopt;
+    }
+
+    MissionEndFact fact;
+    fact.mission_id = goal_id;
+    fact.sequence = transition->sequence;
+    fact.duration_sec = std::chrono::duration<double>(transition->dwell).count();
+    fact.missed_waypoints = std::move(missed_waypoints);
+
+    if (status == MissionTerminalStatus::Aborted)
+    {
+      fact.outcome = MissionOutcome::Aborted;
+    }
+    else if (status == MissionTerminalStatus::Canceled)
+    {
+      fact.outcome = MissionOutcome::Cancelled;
+    }
+    else
+    {
+      // Succeeded at the action level, but nav2 still reports a non-zero error_code when it
+      // stopped short of every waypoint -- an application-level failure, not collapsed into
+      // Aborted (mirrors #387's NavigateToPose rule for the same situation).
+      fact.outcome = (error_code != 0) ? MissionOutcome::Failed : MissionOutcome::Succeeded;
+    }
+
+    if (fact.outcome == MissionOutcome::Failed || fact.outcome == MissionOutcome::Aborted)
+    {
+      fact.reason = std::move(error_msg);
+      fact.error_code = error_code;
+    }
+    return fact;
+  }
+
+  /// The goal_id currently tracked, or nullopt while idle -- what onCleanup() checks for a mission
+  /// still open at shutdown.
+  std::optional<std::string> activeMissionId() const
+  {
+    const auto& state = detector_.state();
+    if (!state.has_value() || state->empty())
+    {
+      return std::nullopt;
+    }
+    return state;
+  }
+
+private:
+  dc_common::StateTransitionDetector<std::string> detector_;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_FOLLOW_WAYPOINTS_TRACKER_HPP_

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp
@@ -37,14 +37,15 @@ enum class MissionOutcome
   Aborted,
 };
 
-/// One entry of FollowWaypoints::Result.missed_waypoints (nav2_msgs/msg/WaypointStatus), stripped
-/// of the pose -- not part of #389's schema.
+/// One entry of FollowWaypoints::Result.missed_waypoints (nav2_msgs/msg/MissedWaypoint on Jazzy),
+/// stripped of the goal pose -- not part of #389's schema. Jazzy's MissedWaypoint is just
+/// index/goal/error_code -- no per-waypoint status enum or error_msg the way an older/rolling nav2
+/// has (verified directly against the `jazzy` branch, not `main`, after #388 hit exactly this
+/// mismatch for NavigateThroughPoses).
 struct WaypointOutcome
 {
   std::uint32_t index{ 0 };
-  std::string status;  // "pending" | "completed" | "skipped" | "failed"
   std::uint16_t error_code{ 0 };
-  std::string error_msg;
 };
 
 struct MissionStartFact

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_FOLLOW_WAYPOINTS_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_FOLLOW_WAYPOINTS_HPP_
+
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "action_msgs/msg/goal_status.hpp"
+#include "action_msgs/msg/goal_status_array.hpp"
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp"
+#include "dc_util/node_utils.hpp"
+#include "nav2_msgs/action/follow_waypoints.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "unique_identifier_msgs/msg/uuid.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::MissionNav2FollowWaypoints
+ * @brief The FollowWaypoints sibling of #387's nav2 Mission Measurement, reusing its
+ * mission_start/mission_end Record schema and mission_id/sequence conventions.
+ *
+ * A passive watcher, not a commander: nav2's WaypointFollower action is driven by whatever already
+ * dispatches missions on the robot (nav2_simple_commander, a WMS integration, ...) -- DC never
+ * sends a FollowWaypoints goal of its own, matching every other Measurement's read-only relationship
+ * to the systems it observes. That rules out `rclcpp_action::Client`'s typed goal-tracking API,
+ * which only reports on goals the client itself sent: this subscribes directly to the action's
+ * `_action/status` topic (`action_msgs/msg/GoalStatusArray`, the same type for every action) for
+ * accept/terminal-state boundaries, and calls its `_action/get_result` service directly for the
+ * terminal Result once a goal it is following reaches one -- both public, standard parts of the
+ * ROS 2 action wire protocol that any client may use, sender or not.
+ *
+ * One consequence: `number_of_loops` (#389's acceptance criteria) is a Goal-only field. ROS 2's
+ * action protocol never re-publishes the Goal anywhere a third party can observe it -- only the
+ * sender and the server ever see it, and rclcpp_action::Client has no supported way to attach to a
+ * goal it did not send in order to read it back either. It is therefore not present on the Records
+ * this plugin emits; see doc/src/dc/measurements/mission_nav2_follow_waypoints.md.
+ */
+class MissionNav2FollowWaypoints : public dc_measurements::Measurement
+{
+public:
+  using GetResultService = nav2_msgs::action::FollowWaypoints::Impl::GetResultService;
+
+  MissionNav2FollowWaypoints();
+  ~MissionNav2FollowWaypoints() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void statusCb(const action_msgs::msg::GoalStatusArray& msg);
+  void requestResult(const unique_identifier_msgs::msg::UUID& uuid, const std::string& goal_id,
+                     const rclcpp::Time& terminal_at);
+  void handleResultResponse(const std::string& goal_id, const rclcpp::Time& terminal_at,
+                            const GetResultService::Response::SharedPtr& response);
+  // Caller holds mutex_.
+  void enqueue(json data, const rclcpp::Time& stamp);
+  static json missionStartJson(const MissionStartFact& fact);
+  static json missionEndJson(const MissionEndFact& fact);
+
+  std::string action_name_;
+  rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr status_sub_;
+  rclcpp::Client<GetResultService>::SharedPtr result_client_;
+
+  // The status callback and the get_result response callback run on different callback groups
+  // than the polling timer under a multi-threaded executor, so everything they share is guarded.
+  mutable std::mutex mutex_;
+  std::optional<MissionFollowWaypointsTracker> tracker_;
+  // Which goal_ids a get_result request is already in flight for, so a terminal status repeated
+  // across several status-array publishes doesn't fire the service call more than once.
+  std::set<std::string> result_requested_;
+  // Records wait here for a poll to carry them out, one per poll, so they travel the same publish
+  // path (Conditions, buffering, Group) as every other Record.
+  std::deque<std::pair<json, rclcpp::Time>> pending_records_;
+
+protected:
+  void onConfigure() override;
+  void onCleanup() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_FOLLOW_WAYPOINTS_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -116,6 +116,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_mission_nav2_follow_waypoints_measurement">
+        <class name="dc_measurements/MissionNav2FollowWaypoints" type="dc_measurements::MissionNav2FollowWaypoints" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_mission_nav2_follow_waypoints
+            </description>
+        </class>
+    </library>
+
     <library path="dc_network_measurement">
         <class name="dc_measurements/Network" type="dc_measurements::Network" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/json/mission_nav2_follow_waypoints.json
+++ b/dc_measurements/plugins/measurements/json/mission_nav2_follow_waypoints.json
@@ -55,7 +55,7 @@
     },
     "missed_waypoints": {
       "description":
-          "One entry per waypoint FollowWaypoints::Result.missed_waypoints reports -- which specific stops were not completed and why",
+          "One entry per waypoint FollowWaypoints::Result.missed_waypoints reports -- which specific stops were not completed, and nav2's per-waypoint error code for each",
       "type": "array",
       "items": {
         "type": "object",
@@ -65,28 +65,15 @@
             "type": "integer",
             "minimum": 0
           },
-          "status": {
-            "type": "string",
-            "enum": [
-              "pending",
-              "completed",
-              "skipped",
-              "failed"
-            ]
-          },
           "error_code": {
+            "description": "nav2's MissedWaypoint.error_code for this waypoint",
             "type": "integer",
             "minimum": 0
-          },
-          "error_msg": {
-            "type": "string"
           }
         },
         "required": [
           "index",
-          "status",
-          "error_code",
-          "error_msg"
+          "error_code"
         ]
       }
     }

--- a/dc_measurements/plugins/measurements/json/mission_nav2_follow_waypoints.json
+++ b/dc_measurements/plugins/measurements/json/mission_nav2_follow_waypoints.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2FollowWaypoints",
+  "description":
+      "One nav2 FollowWaypoints goal's lifecycle, watched passively: a mission_start Record when it is accepted, a mission_end Record when it reaches a terminal state",
+  "properties": {
+    "event": {
+      "description": "What this Record is: a mission being accepted, or one reaching a terminal state",
+      "type": "string",
+      "enum": [
+        "mission_start",
+        "mission_end"
+      ]
+    },
+    "mission_id": {
+      "description": "The FollowWaypoints goal UUID, stringified",
+      "type": "string"
+    },
+    "mission_type": {
+      "description":
+          "Always 'follow_waypoints' for this adapter -- other Mission Measurement adapters set their own value",
+      "type": "string",
+      "const": "follow_waypoints"
+    },
+    "sequence": {
+      "description":
+          "Monotonically increasing transition number for this Measurement instance, so a dropped Record is detectable rather than silently corrupting a duration",
+      "type": "integer",
+      "minimum": 1
+    },
+    "outcome": {
+      "description":
+          "How the mission ended. 'failed' is a goal that reached GoalStatus SUCCEEDED but still carried a non-zero error_code (nav2's WaypointFollower can finish having missed a waypoint without the action itself aborting)",
+      "type": "string",
+      "enum": [
+        "succeeded",
+        "failed",
+        "cancelled",
+        "aborted"
+      ]
+    },
+    "reason": {
+      "description": "Human-readable failure reason, verbatim from FollowWaypoints::Result.error_msg",
+      "type": "string"
+    },
+    "error_code": {
+      "description": "nav2's own numeric FollowWaypoints::Result.error_code, carried through verbatim",
+      "type": "integer",
+      "minimum": 0
+    },
+    "duration_sec": {
+      "description": "How long the mission ran, from acceptance to its terminal state",
+      "type": "number",
+      "minimum": 0
+    },
+    "missed_waypoints": {
+      "description":
+          "One entry per waypoint FollowWaypoints::Result.missed_waypoints reports -- which specific stops were not completed and why",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "description": "Position of this waypoint in the goal's pose list",
+            "type": "integer",
+            "minimum": 0
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "completed",
+              "skipped",
+              "failed"
+            ]
+          },
+          "error_code": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "error_msg": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "index",
+          "status",
+          "error_code",
+          "error_msg"
+        ]
+      }
+    }
+  },
+  "required": [
+    "event",
+    "mission_id",
+    "mission_type",
+    "sequence"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "mission_end"
+          }
+        },
+        "required": [
+          "event"
+        ]
+      },
+      "then": {
+        "required": [
+          "outcome",
+          "duration_sec",
+          "missed_waypoints"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "enum": [
+              "failed",
+              "aborted"
+            ]
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "required": [
+          "reason",
+          "error_code"
+        ]
+      }
+    }
+  ],
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
@@ -163,7 +163,7 @@ void MissionNav2FollowWaypoints::statusCb(const action_msgs::msg::GoalStatusArra
   const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(now.nanoseconds()) };
 
   const std::lock_guard<std::mutex> lock(mutex_);
-  for (const auto& entry : msg.status)
+  for (const auto& entry : msg.status_list)
   {
     const std::string goal_id = uuidToString(entry.goal_info.goal_id);
 

--- a/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
@@ -1,0 +1,295 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+#include "nav2_msgs/msg/waypoint_status.hpp"
+
+namespace dc_measurements
+{
+
+namespace
+{
+
+constexpr size_t kMaxPendingRecords = 64;
+
+std::string uuidToString(const unique_identifier_msgs::msg::UUID& uuid)
+{
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < uuid.uuid.size(); ++i)
+  {
+    oss << std::setw(2) << static_cast<int>(uuid.uuid[i]);
+    if (i == 3 || i == 5 || i == 7 || i == 9)
+    {
+      oss << '-';
+    }
+  }
+  return oss.str();
+}
+
+std::string waypointStatusName(uint8_t status)
+{
+  switch (status)
+  {
+    case nav2_msgs::msg::WaypointStatus::PENDING:
+      return "pending";
+    case nav2_msgs::msg::WaypointStatus::COMPLETED:
+      return "completed";
+    case nav2_msgs::msg::WaypointStatus::SKIPPED:
+      return "skipped";
+    case nav2_msgs::msg::WaypointStatus::FAILED:
+      return "failed";
+    default:
+      return "unknown";
+  }
+}
+
+std::string outcomeName(MissionOutcome outcome)
+{
+  switch (outcome)
+  {
+    case MissionOutcome::Succeeded:
+      return "succeeded";
+    case MissionOutcome::Failed:
+      return "failed";
+    case MissionOutcome::Cancelled:
+      return "cancelled";
+    case MissionOutcome::Aborted:
+      return "aborted";
+  }
+  return "unknown";
+}
+
+MissionTerminalStatus terminalStatusOf(int8_t action_status)
+{
+  switch (action_status)
+  {
+    case action_msgs::msg::GoalStatus::STATUS_CANCELED:
+      return MissionTerminalStatus::Canceled;
+    case action_msgs::msg::GoalStatus::STATUS_ABORTED:
+      return MissionTerminalStatus::Aborted;
+    default:
+      return MissionTerminalStatus::Succeeded;
+  }
+}
+
+}  // namespace
+
+MissionNav2FollowWaypoints::MissionNav2FollowWaypoints() : dc_measurements::Measurement()
+{
+}
+
+MissionNav2FollowWaypoints::~MissionNav2FollowWaypoints() = default;
+
+void MissionNav2FollowWaypoints::onConfigure()
+{
+  auto node = getNode();
+  action_name_ = dc_util::get_str_type_param(node, measurement_name_, "action_name", "follow_waypoints");
+
+  const rclcpp::Time now = node->get_clock()->now();
+  tracker_.emplace(std::chrono::system_clock::time_point(std::chrono::nanoseconds(now.nanoseconds())));
+
+  // Matches the QoS an action server publishes its status topic with (reliable, transient_local):
+  // a late-joining watcher still gets the current goal's last-known status rather than waiting for
+  // the next change.
+  status_sub_ = node->create_subscription<action_msgs::msg::GoalStatusArray>(
+      action_name_ + "/_action/status", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local(),
+      std::bind(&MissionNav2FollowWaypoints::statusCb, this, std::placeholders::_1));
+  result_client_ = node->create_client<GetResultService>(action_name_ + "/_action/get_result");
+}
+
+void MissionNav2FollowWaypoints::onCleanup()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (tracker_.has_value())
+  {
+    if (const auto active = tracker_->activeMissionId())
+    {
+      RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with mission '" << *active
+                                                    << "' still active; no closing Record will be published");
+    }
+  }
+  status_sub_.reset();
+  result_client_.reset();
+}
+
+void MissionNav2FollowWaypoints::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "mission_nav2_follow_waypoints.json");
+  }
+}
+
+json MissionNav2FollowWaypoints::missionStartJson(const MissionStartFact& fact)
+{
+  json data;
+  data["event"] = "mission_start";
+  data["mission_id"] = fact.mission_id;
+  data["mission_type"] = "follow_waypoints";
+  data["sequence"] = fact.sequence;
+  return data;
+}
+
+json MissionNav2FollowWaypoints::missionEndJson(const MissionEndFact& fact)
+{
+  json data;
+  data["event"] = "mission_end";
+  data["mission_id"] = fact.mission_id;
+  data["mission_type"] = "follow_waypoints";
+  data["sequence"] = fact.sequence;
+  data["outcome"] = outcomeName(fact.outcome);
+  data["duration_sec"] = fact.duration_sec;
+  if (fact.reason.has_value())
+  {
+    data["reason"] = *fact.reason;
+  }
+  if (fact.error_code.has_value())
+  {
+    data["error_code"] = *fact.error_code;
+  }
+  json missed = json::array();
+  for (const auto& waypoint : fact.missed_waypoints)
+  {
+    missed.push_back({ { "index", waypoint.index },
+                       { "status", waypoint.status },
+                       { "error_code", waypoint.error_code },
+                       { "error_msg", waypoint.error_msg } });
+  }
+  data["missed_waypoints"] = missed;
+  return data;
+}
+
+void MissionNav2FollowWaypoints::enqueue(json data, const rclcpp::Time& stamp)
+{
+  pending_records_.emplace_back(std::move(data), stamp);
+  while (pending_records_.size() > kMaxPendingRecords)
+  {
+    pending_records_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_
+                                               << ": mission Records are arriving faster than the polling interval "
+                                                  "can report them; dropping the oldest.");
+  }
+}
+
+void MissionNav2FollowWaypoints::statusCb(const action_msgs::msg::GoalStatusArray& msg)
+{
+  const rclcpp::Time now = getNode()->get_clock()->now();
+  const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(now.nanoseconds()) };
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& entry : msg.status)
+  {
+    const std::string goal_id = uuidToString(entry.goal_info.goal_id);
+
+    if (entry.status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ||
+        entry.status == action_msgs::msg::GoalStatus::STATUS_EXECUTING ||
+        entry.status == action_msgs::msg::GoalStatus::STATUS_CANCELING)
+    {
+      const auto start = tracker_->startMission(goal_id, at);
+      if (start.has_value())
+      {
+        enqueue(missionStartJson(*start), now);
+      }
+      else if (!tracker_->activeMissionId().has_value() || *tracker_->activeMissionId() != goal_id)
+      {
+        RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                    "Measurement " << measurement_name_ << ": goal '" << goal_id << "' accepted on '"
+                                                   << action_name_
+                                                   << "' while another mission is already being tracked; ignoring it.");
+      }
+      continue;
+    }
+
+    const bool is_terminal = entry.status == action_msgs::msg::GoalStatus::STATUS_SUCCEEDED ||
+                             entry.status == action_msgs::msg::GoalStatus::STATUS_CANCELED ||
+                             entry.status == action_msgs::msg::GoalStatus::STATUS_ABORTED;
+    if (!is_terminal)
+    {
+      continue;
+    }
+    if (!tracker_->activeMissionId().has_value() || *tracker_->activeMissionId() != goal_id)
+    {
+      // Not the mission this instance is following (or already closed) -- most likely this same
+      // terminal status republished after its get_result response already ended it.
+      continue;
+    }
+    if (!result_requested_.insert(goal_id).second)
+    {
+      continue;
+    }
+    requestResult(entry.goal_info.goal_id, goal_id, now);
+  }
+}
+
+void MissionNav2FollowWaypoints::requestResult(const unique_identifier_msgs::msg::UUID& uuid,
+                                               const std::string& goal_id, const rclcpp::Time& terminal_at)
+{
+  if (!result_client_->service_is_ready())
+  {
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_ << ": '" << action_name_
+                                               << "/_action/get_result' is not ready; will retry on the next terminal "
+                                                  "status for '"
+                                               << goal_id << "'.");
+    result_requested_.erase(goal_id);
+    return;
+  }
+
+  auto request = std::make_shared<GetResultService::Request>();
+  request->goal_id = uuid;
+  result_client_->async_send_request(request, [this, goal_id,
+                                               terminal_at](rclcpp::Client<GetResultService>::SharedFuture future) {
+    handleResultResponse(goal_id, terminal_at, future.get());
+  });
+}
+
+void MissionNav2FollowWaypoints::handleResultResponse(const std::string& goal_id, const rclcpp::Time& terminal_at,
+                                                      const GetResultService::Response::SharedPtr& response)
+{
+  std::vector<WaypointOutcome> missed;
+  missed.reserve(response->result.missed_waypoints.size());
+  for (const auto& waypoint : response->result.missed_waypoints)
+  {
+    missed.push_back({ waypoint.waypoint_index, waypointStatusName(waypoint.waypoint_status), waypoint.error_code,
+                       waypoint.error_msg });
+  }
+
+  const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(terminal_at.nanoseconds()) };
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  result_requested_.erase(goal_id);
+  const auto end = tracker_->endMission(goal_id, terminalStatusOf(response->status), response->result.error_code,
+                                        response->result.error_msg, std::move(missed), at);
+  if (end.has_value())
+  {
+    enqueue(missionEndJson(*end), terminal_at);
+  }
+}
+
+dc_interfaces::msg::StringStamped MissionNav2FollowWaypoints::collect()
+{
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_records_.empty())
+  {
+    return msg;
+  }
+  auto record = std::move(pending_records_.front());
+  pending_records_.pop_front();
+  msg.header.stamp = record.second;
+  msg.data = record.first.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::MissionNav2FollowWaypoints, dc_core::Measurement)

--- a/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
@@ -6,7 +6,7 @@
 #include <iomanip>
 #include <sstream>
 
-#include "nav2_msgs/msg/waypoint_status.hpp"
+#include "nav2_msgs/msg/missed_waypoint.hpp"
 
 namespace dc_measurements
 {
@@ -29,23 +29,6 @@ std::string uuidToString(const unique_identifier_msgs::msg::UUID& uuid)
     }
   }
   return oss.str();
-}
-
-std::string waypointStatusName(uint8_t status)
-{
-  switch (status)
-  {
-    case nav2_msgs::msg::WaypointStatus::PENDING:
-      return "pending";
-    case nav2_msgs::msg::WaypointStatus::COMPLETED:
-      return "completed";
-    case nav2_msgs::msg::WaypointStatus::SKIPPED:
-      return "skipped";
-    case nav2_msgs::msg::WaypointStatus::FAILED:
-      return "failed";
-    default:
-      return "unknown";
-  }
 }
 
 std::string outcomeName(MissionOutcome outcome)
@@ -155,10 +138,7 @@ json MissionNav2FollowWaypoints::missionEndJson(const MissionEndFact& fact)
   json missed = json::array();
   for (const auto& waypoint : fact.missed_waypoints)
   {
-    missed.push_back({ { "index", waypoint.index },
-                       { "status", waypoint.status },
-                       { "error_code", waypoint.error_code },
-                       { "error_msg", waypoint.error_msg } });
+    missed.push_back({ { "index", waypoint.index }, { "error_code", waypoint.error_code } });
   }
   data["missed_waypoints"] = missed;
   return data;
@@ -256,8 +236,7 @@ void MissionNav2FollowWaypoints::handleResultResponse(const std::string& goal_id
   missed.reserve(response->result.missed_waypoints.size());
   for (const auto& waypoint : response->result.missed_waypoints)
   {
-    missed.push_back({ waypoint.waypoint_index, waypointStatusName(waypoint.waypoint_status), waypoint.error_code,
-                       waypoint.error_msg });
+    missed.push_back({ waypoint.index, waypoint.error_code });
   }
 
   const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(terminal_at.nanoseconds()) };

--- a/dc_measurements/test/mission_follow_waypoints_tracker_test.cpp
+++ b/dc_measurements/test/mission_follow_waypoints_tracker_test.cpp
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_measurements::MissionFollowWaypointsTracker (#389). No action server, no
+// node: goal_id/status/result all arrive as arguments, mirroring
+// dc_common/test/battery_cycle_accumulator_test.cpp's standalone coverage of
+// BatteryCycleAccumulator. rclcpp::init()/shutdown() in main() below is only for link
+// compatibility with this package's CMakeLists.txt test registration, which does not pass
+// SKIP_LINKING_MAIN_LIBRARIES to ament_add_gtest.
+
+#include "dc_measurements/plugins/measurements/mission_follow_waypoints_tracker.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+#include <vector>
+
+#include "rclcpp/rclcpp.hpp"
+
+using dc_measurements::MissionFollowWaypointsTracker;
+using dc_measurements::MissionOutcome;
+using dc_measurements::MissionTerminalStatus;
+using dc_measurements::WaypointOutcome;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+}  // namespace
+
+TEST(MissionFollowWaypointsTracker, StartsIdle)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  EXPECT_FALSE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionFollowWaypointsTracker, AcceptedGoalProducesAMissionStart)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+
+  const auto start = tracker.startMission("goal-1", at(5));
+  ASSERT_TRUE(start.has_value());
+  EXPECT_EQ(start->mission_id, "goal-1");
+  EXPECT_EQ(start->sequence, 1u);
+  ASSERT_TRUE(tracker.activeMissionId().has_value());
+  EXPECT_EQ(*tracker.activeMissionId(), "goal-1");
+}
+
+TEST(MissionFollowWaypointsTracker, SecondGoalWhileOneIsActiveIsIgnored)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  ASSERT_TRUE(tracker.startMission("goal-1", at(5)).has_value());
+
+  EXPECT_FALSE(tracker.startMission("goal-2", at(6)).has_value());
+  EXPECT_EQ(*tracker.activeMissionId(), "goal-1");
+}
+
+TEST(MissionFollowWaypointsTracker, SucceededResultProducesAMissionEndWithNoReason)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  tracker.startMission("goal-1", at(5));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 0, "", {}, at(35));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->mission_id, "goal-1");
+  EXPECT_EQ(end->sequence, 2u);
+  EXPECT_EQ(end->outcome, MissionOutcome::Succeeded);
+  EXPECT_DOUBLE_EQ(end->duration_sec, 30.0);
+  EXPECT_FALSE(end->reason.has_value());
+  EXPECT_FALSE(end->error_code.has_value());
+  EXPECT_FALSE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionFollowWaypointsTracker, SucceededStatusWithNonZeroErrorCodeIsReportedAsFailed)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  tracker.startMission("goal-1", at(5));
+
+  std::vector<WaypointOutcome> missed{ { 3, "skipped", 603, "waypoint skipped" } };
+  const auto end =
+      tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 603, "stopped on missed waypoint", missed, at(20));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Failed);
+  ASSERT_TRUE(end->reason.has_value());
+  EXPECT_EQ(*end->reason, "stopped on missed waypoint");
+  ASSERT_TRUE(end->error_code.has_value());
+  EXPECT_EQ(*end->error_code, 603u);
+  ASSERT_EQ(end->missed_waypoints.size(), 1u);
+  EXPECT_EQ(end->missed_waypoints[0].index, 3u);
+  EXPECT_EQ(end->missed_waypoints[0].status, "skipped");
+}
+
+TEST(MissionFollowWaypointsTracker, CanceledStatusIsReportedAsCancelled)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Canceled, 0, "", {}, at(10));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Cancelled);
+  EXPECT_FALSE(end->reason.has_value());
+}
+
+TEST(MissionFollowWaypointsTracker, AbortedStatusCarriesReasonAndErrorCode)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Aborted, 601, "task executor failed", {}, at(2));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Aborted);
+  ASSERT_TRUE(end->reason.has_value());
+  EXPECT_EQ(*end->reason, "task executor failed");
+  ASSERT_TRUE(end->error_code.has_value());
+  EXPECT_EQ(*end->error_code, 601u);
+}
+
+TEST(MissionFollowWaypointsTracker, ResultForAForeignGoalIdIsIgnored)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  EXPECT_FALSE(tracker.endMission("goal-stale", MissionTerminalStatus::Succeeded, 0, "", {}, at(10)).has_value());
+  EXPECT_TRUE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionFollowWaypointsTracker, SequenceIncrementsAcrossMultipleMissions)
+{
+  MissionFollowWaypointsTracker tracker(at(0));
+
+  const auto first_start = tracker.startMission("goal-1", at(0));
+  const auto first_end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 0, "", {}, at(10));
+  const auto second_start = tracker.startMission("goal-2", at(20));
+  const auto second_end = tracker.endMission("goal-2", MissionTerminalStatus::Succeeded, 0, "", {}, at(30));
+
+  ASSERT_TRUE(first_start.has_value());
+  ASSERT_TRUE(first_end.has_value());
+  ASSERT_TRUE(second_start.has_value());
+  ASSERT_TRUE(second_end.has_value());
+  EXPECT_EQ(first_start->sequence, 1u);
+  EXPECT_EQ(first_end->sequence, 2u);
+  EXPECT_EQ(second_start->sequence, 3u);
+  EXPECT_EQ(second_end->sequence, 4u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const bool all_successful = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return all_successful;
+}

--- a/dc_measurements/test/mission_follow_waypoints_tracker_test.cpp
+++ b/dc_measurements/test/mission_follow_waypoints_tracker_test.cpp
@@ -81,18 +81,18 @@ TEST(MissionFollowWaypointsTracker, SucceededStatusWithNonZeroErrorCodeIsReporte
   MissionFollowWaypointsTracker tracker(at(0));
   tracker.startMission("goal-1", at(5));
 
-  std::vector<WaypointOutcome> missed{ { 3, "skipped", 603, "waypoint skipped" } };
+  std::vector<WaypointOutcome> missed{ { 3, 601 } };  // 601 = TASK_EXECUTOR_FAILED on Jazzy
   const auto end =
-      tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 603, "stopped on missed waypoint", missed, at(20));
+      tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 601, "task executor failed", missed, at(20));
   ASSERT_TRUE(end.has_value());
   EXPECT_EQ(end->outcome, MissionOutcome::Failed);
   ASSERT_TRUE(end->reason.has_value());
-  EXPECT_EQ(*end->reason, "stopped on missed waypoint");
+  EXPECT_EQ(*end->reason, "task executor failed");
   ASSERT_TRUE(end->error_code.has_value());
-  EXPECT_EQ(*end->error_code, 603u);
+  EXPECT_EQ(*end->error_code, 601u);
   ASSERT_EQ(end->missed_waypoints.size(), 1u);
   EXPECT_EQ(end->missed_waypoints[0].index, 3u);
-  EXPECT_EQ(end->missed_waypoints[0].status, "skipped");
+  EXPECT_EQ(end->missed_waypoints[0].error_code, 601u);
 }
 
 TEST(MissionFollowWaypointsTracker, CanceledStatusIsReportedAsCancelled)

--- a/dc_measurements/test/test_measurement_mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2_follow_waypoints.cpp
@@ -1,0 +1,332 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav2_msgs/action/follow_waypoints.hpp"
+#include "nav2_msgs/msg/waypoint_status.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+using FollowWaypoints = nav2_msgs::action::FollowWaypoints;
+using FollowWaypointsGoalHandle = rclcpp_action::ServerGoalHandle<FollowWaypoints>;
+
+// Stands in for whatever nav2's WaypointFollower action server and its commander (nav2_simple_commander,
+// a WMS integration, ...) really are: a real rclcpp_action::Server the plugin under test watches, and a
+// real rclcpp_action::Client that drives it, completely independent of dc_measurements::MissionNav2FollowWaypoints
+// -- exactly the passive-watcher relationship the plugin has to the real thing.
+class MeasurementMissionNav2FollowWaypointsTest : public ::testing::Test
+{
+protected:
+  MeasurementMissionNav2FollowWaypointsTest()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "mission" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/mission", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMissionNav2FollowWaypointsTest::dataCallback, this, std::placeholders::_1));
+
+    server_node_ = std::make_shared<rclcpp::Node>("fake_nav2_" + std::to_string(instance_++));
+    action_server_ = rclcpp_action::create_server<FollowWaypoints>(
+        server_node_, kActionName,
+        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const FollowWaypoints::Goal>) {
+          return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+        },
+        [](const std::shared_ptr<FollowWaypointsGoalHandle>&) { return rclcpp_action::CancelResponse::ACCEPT; },
+        [this](const std::shared_ptr<FollowWaypointsGoalHandle>& goal_handle) { goal_handle_ = goal_handle; });
+
+    commander_node_ = std::make_shared<rclcpp::Node>("fake_commander_" + std::to_string(instance_++));
+    commander_client_ = rclcpp_action::create_client<FollowWaypoints>(commander_node_, kActionName);
+  }
+
+  void TearDown() override
+  {
+    stopCollection();
+  }
+
+  // Idempotent: one test stops collection mid-mission on purpose.
+  void stopCollection()
+  {
+    if (stopped_)
+    {
+      return;
+    }
+    stopped_ = true;
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("mission.plugin", std::string("dc_measurements/MissionNav2FollowWaypoints"));
+    ms_node_->declare_parameter("mission.group_key", std::string("mission"));
+    ms_node_->declare_parameter("mission.topic_output", std::string("/dc/measurement/mission"));
+    ms_node_->declare_parameter("mission.action_name", std::string(kActionName));
+    ms_node_->declare_parameter("mission.polling_interval", 50);
+    ms_node_->declare_parameter("mission.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+  }
+
+  void spinAll()
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    rclcpp::spin_some(server_node_);
+    rclcpp::spin_some(commander_node_);
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  // Sends a goal through the fake commander and spins until the fake server's handle_accepted has
+  // fired, so the test controls exactly when (and how) the goal completes.
+  void sendGoalAndWaitForAcceptance()
+  {
+    ASSERT_TRUE(commander_client_->wait_for_action_server(std::chrono::seconds(5)));
+    FollowWaypoints::Goal goal;
+    client_goal_handle_future_ = commander_client_->async_send_goal(goal);
+    for (int i = 0; i < 400 && !goal_handle_; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(goal_handle_) << "Fake nav2 action server never reported the goal as accepted";
+  }
+
+  // Drives a real cancel request through the commander so the server-side goal handle legally
+  // reaches CANCELING before the test completes it -- succeed()/abort() are reachable directly
+  // from EXECUTING, but canceled() is only a legal transition out of CANCELING.
+  void requestCancelAndWaitForCanceling()
+  {
+    for (int i = 0;
+         i < 400 && client_goal_handle_future_.wait_for(std::chrono::seconds(0)) != std::future_status::ready; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_EQ(client_goal_handle_future_.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    commander_client_->async_cancel_goal(client_goal_handle_future_.get());
+    for (int i = 0; i < 400 && !goal_handle_->is_canceling(); ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(goal_handle_->is_canceling());
+  }
+
+  nlohmann::json waitForRecord(const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = records_.size();
+    for (int i = 0; i < 600; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path = ament_index_cpp::get_package_share_directory("dc_measurements") +
+                             "/plugins/measurements/json/mission_nav2_follow_waypoints.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  static constexpr const char* kActionName = "/test/follow_waypoints";
+  static int instance_;
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+
+  rclcpp::Node::SharedPtr server_node_;
+  rclcpp_action::Server<FollowWaypoints>::SharedPtr action_server_;
+  std::shared_ptr<FollowWaypointsGoalHandle> goal_handle_;
+
+  rclcpp::Node::SharedPtr commander_node_;
+  rclcpp_action::Client<FollowWaypoints>::SharedPtr commander_client_;
+  std::shared_future<rclcpp_action::ClientGoalHandle<FollowWaypoints>::SharedPtr> client_goal_handle_future_;
+
+  std::vector<nlohmann::json> records_;
+  bool stopped_{ false };
+};
+
+int MeasurementMissionNav2FollowWaypointsTest::instance_ = 0;
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, AcceptedGoalProducesAMissionStartRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+
+  const auto start = waitForRecord(isEvent("mission_start"));
+  EXPECT_EQ(start["mission_type"], "follow_waypoints");
+  EXPECT_GT(start["sequence"].get<uint64_t>(), 0u);
+  EXPECT_FALSE(start["mission_id"].get<std::string>().empty());
+  expectValidatesAgainstSchema(start);
+}
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, SucceededGoalProducesAMissionEndWithNoReason)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  const auto start = waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<FollowWaypoints::Result>();
+  result->error_code = 0;
+  goal_handle_->succeed(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["mission_id"], start["mission_id"]);
+  EXPECT_EQ(end["mission_type"], "follow_waypoints");
+  EXPECT_EQ(end["sequence"].get<uint64_t>(), start["sequence"].get<uint64_t>() + 1);
+  EXPECT_EQ(end["outcome"], "succeeded");
+  EXPECT_GE(end["duration_sec"].get<double>(), 0.0);
+  EXPECT_FALSE(end.contains("reason"));
+  EXPECT_FALSE(end.contains("error_code"));
+  EXPECT_TRUE(end["missed_waypoints"].empty());
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, SucceededStatusWithNonZeroErrorCodeIsReportedAsFailed)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<FollowWaypoints::Result>();
+  result->error_code = 603;  // STOP_ON_MISSED_WAYPOINT
+  result->error_msg = "stopped on missed waypoint";
+  nav2_msgs::msg::WaypointStatus missed;
+  missed.waypoint_index = 2;
+  missed.waypoint_status = nav2_msgs::msg::WaypointStatus::SKIPPED;
+  missed.error_code = 603;
+  missed.error_msg = "skipped";
+  result->missed_waypoints.push_back(missed);
+  goal_handle_->succeed(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "failed");
+  EXPECT_EQ(end["reason"], "stopped on missed waypoint");
+  EXPECT_EQ(end["error_code"].get<int>(), 603);
+  ASSERT_EQ(end["missed_waypoints"].size(), 1u);
+  EXPECT_EQ(end["missed_waypoints"][0]["index"].get<int>(), 2);
+  EXPECT_EQ(end["missed_waypoints"][0]["status"], "skipped");
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, CanceledGoalIsReportedAsCancelled)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+  requestCancelAndWaitForCanceling();
+
+  auto result = std::make_shared<FollowWaypoints::Result>();
+  goal_handle_->canceled(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "cancelled");
+  EXPECT_FALSE(end.contains("reason"));
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, AbortedGoalCarriesReasonAndErrorCode)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<FollowWaypoints::Result>();
+  result->error_code = 601;  // TASK_EXECUTOR_FAILED
+  result->error_msg = "task executor failed";
+  goal_handle_->abort(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "aborted");
+  EXPECT_EQ(end["reason"], "task executor failed");
+  EXPECT_EQ(end["error_code"].get<int>(), 601);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2FollowWaypointsTest, MissionOpenAtShutdownGetsNoClosingRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  stopCollection();
+  spinFor(std::chrono::milliseconds(200));
+
+  ASSERT_EQ(records_.size(), 1u) << "Shutdown must not invent a closing Record";
+  EXPECT_EQ(records_.back()["event"], "mission_start");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2_follow_waypoints.cpp
@@ -17,7 +17,7 @@
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
 #include "nav2_msgs/action/follow_waypoints.hpp"
-#include "nav2_msgs/msg/waypoint_status.hpp"
+#include "nav2_msgs/msg/missed_waypoint.hpp"
 #include "rclcpp_action/rclcpp_action.hpp"
 
 using FollowWaypoints = nav2_msgs::action::FollowWaypoints;
@@ -248,23 +248,21 @@ TEST_F(MeasurementMissionNav2FollowWaypointsTest, SucceededStatusWithNonZeroErro
   waitForRecord(isEvent("mission_start"));
 
   auto result = std::make_shared<FollowWaypoints::Result>();
-  result->error_code = 603;  // STOP_ON_MISSED_WAYPOINT
-  result->error_msg = "stopped on missed waypoint";
-  nav2_msgs::msg::WaypointStatus missed;
-  missed.waypoint_index = 2;
-  missed.waypoint_status = nav2_msgs::msg::WaypointStatus::SKIPPED;
-  missed.error_code = 603;
-  missed.error_msg = "skipped";
+  result->error_code = FollowWaypoints::Result::TASK_EXECUTOR_FAILED;
+  result->error_msg = "task executor failed";
+  nav2_msgs::msg::MissedWaypoint missed;
+  missed.index = 2;
+  missed.error_code = FollowWaypoints::Result::TASK_EXECUTOR_FAILED;
   result->missed_waypoints.push_back(missed);
   goal_handle_->succeed(result);
 
   const auto end = waitForRecord(isEvent("mission_end"));
   EXPECT_EQ(end["outcome"], "failed");
-  EXPECT_EQ(end["reason"], "stopped on missed waypoint");
-  EXPECT_EQ(end["error_code"].get<int>(), 603);
+  EXPECT_EQ(end["reason"], "task executor failed");
+  EXPECT_EQ(end["error_code"].get<int>(), FollowWaypoints::Result::TASK_EXECUTOR_FAILED);
   ASSERT_EQ(end["missed_waypoints"].size(), 1u);
   EXPECT_EQ(end["missed_waypoints"][0]["index"].get<int>(), 2);
-  EXPECT_EQ(end["missed_waypoints"][0]["status"], "skipped");
+  EXPECT_EQ(end["missed_waypoints"][0]["error_code"].get<int>(), FollowWaypoints::Result::TASK_EXECUTOR_FAILED);
   expectValidatesAgainstSchema(end);
 }
 
@@ -293,14 +291,14 @@ TEST_F(MeasurementMissionNav2FollowWaypointsTest, AbortedGoalCarriesReasonAndErr
   waitForRecord(isEvent("mission_start"));
 
   auto result = std::make_shared<FollowWaypoints::Result>();
-  result->error_code = 601;  // TASK_EXECUTOR_FAILED
-  result->error_msg = "task executor failed";
+  result->error_code = FollowWaypoints::Result::UNKNOWN;
+  result->error_msg = "unknown failure";
   goal_handle_->abort(result);
 
   const auto end = waitForRecord(isEvent("mission_end"));
   EXPECT_EQ(end["outcome"], "aborted");
-  EXPECT_EQ(end["reason"], "task executor failed");
-  EXPECT_EQ(end["error_code"].get<int>(), 601);
+  EXPECT_EQ(end["reason"], "unknown failure");
+  EXPECT_EQ(end["error_code"].get<int>(), FollowWaypoints::Result::UNKNOWN);
   expectValidatesAgainstSchema(end);
 }
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -33,6 +33,7 @@
   - [IP Camera](./dc/measurements/ip_camera.md)
   - [Map](./dc/measurements/map.md)
   - [Memory](./dc/measurements/memory.md)
+  - [Mission (nav2 FollowWaypoints)](./dc/measurements/mission_nav2_follow_waypoints.md)
   - [Mission Nav2 (NavigateThroughPoses)](./dc/measurements/mission_nav2_through_poses.md)
   - [Network](./dc/measurements/network.md)
   - [OS](./dc/measurements/os.md)

--- a/doc/src/dc/measurements/mission_nav2_follow_waypoints.md
+++ b/doc/src/dc/measurements/mission_nav2_follow_waypoints.md
@@ -1,0 +1,135 @@
+# Mission (nav2 FollowWaypoints)
+
+## Description
+
+Reports the outcome of a nav2 `FollowWaypoints` mission -- a patrol or waypoint-following run,
+including nav2's own per-waypoint failure reporting -- as one `mission_start` Record when a goal is
+accepted and one `mission_end` Record when it reaches a terminal state. It is the `FollowWaypoints`
+sibling of the `NavigateToPose` Mission Measurement (#387): same Record schema, same
+`mission_id`/`sequence` conventions, its own `mission_type`.
+
+This Measurement is a **passive watcher, not a commander**: it never sends a `FollowWaypoints` goal
+itself. Whatever already dispatches waypoint-following missions on the robot --
+[`nav2_simple_commander`](https://docs.nav2.org/commander_api/index.html), a WMS integration, a
+teleop panel -- keeps doing exactly that; this Measurement only observes. That is a deliberate
+match to every other Measurement's read-only relationship to the systems it reports on, and it is
+also why it does not use `rclcpp_action::Client`'s typed goal-tracking API: that API only reports
+on goals the client itself sent. Instead it subscribes directly to the action's `_action/status`
+topic (`action_msgs/msg/GoalStatusArray`, the same message type for every action) to see a goal get
+accepted or reach a terminal state, and calls the action's `_action/get_result` service directly
+once it does, to fetch the Result -- both standard, public parts of the ROS 2 action wire protocol
+that any client may use, sender or not.
+
+## Known limitation: `number_of_loops`
+
+nav2's `FollowWaypoints` goal carries a `number_of_loops` field (how many times to repeat the
+route), but the goal itself is never re-published anywhere a third party can observe it -- only the
+sender and the action server ever see it, and nothing in the ROS 2 action protocol (nor
+`rclcpp_action::Client`'s public API) lets a client that did not send a goal read it back. A
+passive watcher therefore cannot report `number_of_loops`, and this Measurement's Records do not
+carry it. Sending the goal itself instead of watching it would make this Measurement responsible
+for driving navigation, contradicting DC's role as a telemetry pipeline (see `CONTEXT.md`) and
+directly competing with whatever else already commands the same action -- e.g.
+`dc_demos/dc_demos/qrcodes_waypoint_follower.py`, which already sends `FollowWaypoints` goals of
+its own. If a deployment needs `number_of_loops` on this Record, it has to come from the mission
+commander via a documented escape hatch (#305's territory), not from this adapter.
+
+## Parameters
+
+| Parameter     | Type   | Default             | Description                                                        |
+| ------------- | ------ | -------------------- | -------------------------------------------------------------------- |
+| `action_name` | string | `follow_waypoints`   | The nav2 `FollowWaypoints` action to watch                          |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2FollowWaypoints",
+  "properties": {
+    "event": { "type": "string", "enum": ["mission_start", "mission_end"] },
+    "mission_id": { "type": "string" },
+    "mission_type": { "type": "string", "const": "follow_waypoints" },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "outcome": { "type": "string", "enum": ["succeeded", "failed", "cancelled", "aborted"] },
+    "reason": { "type": "string" },
+    "error_code": { "type": "integer", "minimum": 0 },
+    "duration_sec": { "type": "number", "minimum": 0 },
+    "missed_waypoints": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "index": { "type": "integer", "minimum": 0 },
+          "status": { "type": "string", "enum": ["pending", "completed", "skipped", "failed"] },
+          "error_code": { "type": "integer", "minimum": 0 },
+          "error_msg": { "type": "string" }
+        },
+        "required": ["index", "status", "error_code", "error_msg"]
+      }
+    }
+  },
+  "required": ["event", "mission_id", "mission_type", "sequence"],
+  "type": "object"
+}
+```
+
+`outcome`, `duration_sec` and `missed_waypoints` are required on `mission_end` only. `reason` and
+`error_code` are required on `mission_end` when `outcome` is `failed` or `aborted`: `failed` is a
+goal that reached nav2's `GoalStatus.SUCCEEDED` but whose `FollowWaypoints::Result.error_code` is
+still non-zero -- nav2's `WaypointFollower` can finish a route having missed a waypoint without the
+action itself aborting.
+
+## Measurement configuration
+
+```yaml
+...
+mission:
+  plugin: "dc_measurements/MissionNav2FollowWaypoints"
+  topic_output: "/dc/measurement/mission"
+  group_key: "mission"
+  action_name: "follow_waypoints"
+```
+
+Example Record data, start:
+
+```json
+{
+  "event": "mission_start",
+  "mission_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "mission_type": "follow_waypoints",
+  "sequence": 5
+}
+```
+
+end, succeeded:
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "mission_type": "follow_waypoints",
+  "sequence": 6,
+  "outcome": "succeeded",
+  "duration_sec": 184.2,
+  "missed_waypoints": []
+}
+```
+
+and end, failed on a missed waypoint:
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "6c9f6a3e-2d1a-4e3a-9f7a-1b2c3d4e5f60",
+  "mission_type": "follow_waypoints",
+  "sequence": 8,
+  "outcome": "failed",
+  "reason": "stopped on missed waypoint",
+  "error_code": 603,
+  "duration_sec": 92.6,
+  "missed_waypoints": [
+    { "index": 2, "status": "skipped", "error_code": 603, "error_msg": "stopped on missed waypoint" }
+  ]
+}
+```

--- a/doc/src/dc/measurements/mission_nav2_follow_waypoints.md
+++ b/doc/src/dc/measurements/mission_nav2_follow_waypoints.md
@@ -61,11 +61,9 @@ commander via a documented escape hatch (#305's territory), not from this adapte
         "type": "object",
         "properties": {
           "index": { "type": "integer", "minimum": 0 },
-          "status": { "type": "string", "enum": ["pending", "completed", "skipped", "failed"] },
-          "error_code": { "type": "integer", "minimum": 0 },
-          "error_msg": { "type": "string" }
+          "error_code": { "type": "integer", "minimum": 0 }
         },
-        "required": ["index", "status", "error_code", "error_msg"]
+        "required": ["index", "error_code"]
       }
     }
   },
@@ -125,11 +123,13 @@ and end, failed on a missed waypoint:
   "mission_type": "follow_waypoints",
   "sequence": 8,
   "outcome": "failed",
-  "reason": "stopped on missed waypoint",
-  "error_code": 603,
+  "reason": "task executor failed",
+  "error_code": 601,
   "duration_sec": 92.6,
   "missed_waypoints": [
-    { "index": 2, "status": "skipped", "error_code": 603, "error_msg": "stopped on missed waypoint" }
+    { "index": 2, "error_code": 601 }
   ]
 }
 ```
+
+`error_code` is `FollowWaypoints::Result.error_code` verbatim -- on the Jazzy `nav2_msgs` this repo targets, its only non-zero values are `UNKNOWN` (600) and `TASK_EXECUTOR_FAILED` (601); `missed_waypoints[].error_code` is nav2's `MissedWaypoint.error_code` for that one waypoint, from the same table. `MissedWaypoint` on Jazzy carries only `index`, the waypoint's goal pose (not part of this schema) and `error_code` -- no per-waypoint status enum or free-text reason the way a newer/rolling nav2 has; `reason`/`error_msg` above are always the mission-level `FollowWaypoints::Result.error_msg`, not anything per-waypoint.

--- a/progress.txt
+++ b/progress.txt
@@ -8544,3 +8544,89 @@ reading the code (the repo's established verification standard):
 - `git add -A && prek run --all-files --skip build-doc` passes clean. Same caveat as
   the last two entries: no `colcon`/ROS 2 toolchain in this sandbox to actually run the
   test locally — the next CI run is what confirms this.
+
+### #389 - Add the Mission Measurement: FollowWaypoints adapter
+
+- New `dc_measurements` plugin `mission_nav2_follow_waypoints` (class
+  `MissionNav2FollowWaypoints`), reusing #387's `mission_start`/`mission_end` Record
+  schema/conventions for nav2's `FollowWaypoints` action instead of `NavigateToPose`.
+  Neither #387 nor #305 (the ADR #387 is blocked by) has landed any code yet — #389 is
+  explicitly not blocked by #387's implementation, so this reads the Record schema
+  straight out of #387's issue body's "Implementation Decisions" section and adapts it to
+  `FollowWaypoints`' own goal/result shape (confirmed against the real
+  `ros-navigation/navigation2` `main` branch: `FollowWaypoints.action` and
+  `WaypointStatus.msg`, not the stale/older definitions cached in another worktree's
+  scratchpad from a previous session).
+- **Design decision, confirmed with the user before implementing**: this Measurement is a
+  passive watcher, not a commander -- it never sends a `FollowWaypoints` goal itself.
+  Whatever already dispatches missions (`nav2_simple_commander`, a WMS, ...) keeps doing
+  that; this only observes, matching every other Measurement's read-only relationship to
+  what it reports on, and not competing with `dc_demos/dc_demos/qrcodes_waypoint_follower.py`
+  (which already sends `FollowWaypoints` goals of its own). Concretely this means
+  `rclcpp_action::Client`'s typed API is unusable here -- it only reports on goals the
+  client itself sent -- so the plugin subscribes directly to `<action>/_action/status`
+  (`action_msgs/msg/GoalStatusArray`, the same type for every action) for accept/terminal
+  boundaries, and calls `<action>/_action/get_result`
+  (`nav2_msgs::action::FollowWaypoints::Impl::GetResultService`) directly for the
+  terminal Result once a goal it is following reaches one -- both public, standard parts
+  of the ROS 2 action wire protocol usable by any client, sender or not.
+- **Known, documented gap versus the issue's literal acceptance criteria**:
+  `number_of_loops` lives only on the Goal, which the ROS 2 action protocol never
+  re-publishes anywhere a third party can read it, and `rclcpp_action::Client` has no
+  supported way to attach to a goal it did not send either. A passive watcher structurally
+  cannot report it, so it is omitted from the Record/schema, with the reasoning recorded
+  in the plugin header's class comment and a "Known limitation" section in the doc page --
+  the alternative (the Measurement sending its own goal) would make a data-collection
+  plugin responsible for driving navigation, which conflicts with `CLAUDE.md`'s framing of
+  DC as a telemetry pipeline.
+- ROS-free core: `dc_measurements::MissionFollowWaypointsTracker`
+  (`mission_follow_waypoints_tracker.hpp`), built on the existing
+  `dc_common::StateTransitionDetector<std::string>` (#360, the same block
+  `intervention`/`fault` use) with the active goal_id as the tracked state (empty = idle).
+  Seeded idle at construction with an explicit timestamp so the very first mission this
+  instance ever observes is reported as a real transition rather than being silently
+  absorbed as the detector's baseline sample. Encapsulates the `outcome` derivation rule
+  from #387 (`SUCCEEDED` status + non-zero `error_code` => `failed`, not `succeeded`) so
+  it's covered by ROS-free unit tests (`mission_follow_waypoints_tracker_test.cpp`,
+  mirroring `battery_cycle_accumulator_test.cpp`'s standalone style) rather than only by
+  the ROS-level integration test.
+- `outcome`/`reason`/`error_code`/`duration_sec`/`missed_waypoints` follow #387's schema
+  conventions exactly (`reason`/`error_code` required together, only when `outcome` is
+  `failed`/`aborted`); `missed_waypoints` is nav2's own `WaypointStatus[]` carried through
+  (index/status/error_code/error_msg, pose dropped -- not part of this schema).
+  `mission_type` is always `"follow_waypoints"` on both Records (JSON Schema `const`).
+- New JSON Schema `dc_measurements/plugins/measurements/json/mission_nav2_follow_waypoints.json`,
+  validated in both the integration test and referenced from the doc page.
+- Integration test (`test_measurement_mission_nav2_follow_waypoints.cpp`) adapts #387's
+  planned "fake action server" pattern to the passive-watcher design: a real
+  `rclcpp_action::Server<FollowWaypoints>` fixture stands in for nav2, and a real
+  `rclcpp_action::Client<FollowWaypoints>` fixture stands in for whatever commands it,
+  completely independent of the plugin under test -- which only ever watches, exactly as
+  in a real deployment. Covers: accepted goal -> `mission_start`; succeeded -> `mission_end`
+  with no `reason`; `SUCCEEDED` status with non-zero `error_code` -> `outcome: failed` with
+  `missed_waypoints` populated; a real cancel request driven through the commander (so the
+  server-side goal handle legally reaches `CANCELING` before `canceled()` is called --
+  `canceled()` is not a legal transition directly out of `EXECUTING`) -> `outcome:
+  cancelled`; `abort()` -> `outcome: aborted` with `reason`/`error_code`; a mission still
+  open at shutdown gets no closing Record. Every emitted Record is validated against the
+  schema.
+- New `dc_measurements` dependencies: `nav2_msgs` (the action definition; `action_msgs`
+  and `unique_identifier_msgs` resolve transitively through it, matching
+  `dc_lifecycle_manager`'s existing precedent of depending on `nav2_msgs` alone for the
+  same kind of transitive message types) and `rclcpp_action` (needed only by the
+  integration test's fake server/client, not by the plugin itself, which uses raw
+  `rclcpp::Subscription`/`rclcpp::Client` -- added to the package's shared `dependencies`
+  list the same way `nav2_util` already is despite most plugins not using it directly).
+- Doc page `doc/src/dc/measurements/mission_nav2_follow_waypoints.md`, linked from
+  `doc/src/SUMMARY.md`, matching `battery.md`/`intervention.md`'s structure plus the
+  `number_of_loops` limitation section.
+- `git add -A && prek run --all-files --skip build-doc` passes clean (clang-format
+  auto-reformatted the new C++ files on the first pass, re-staged after).
+- **Not done / left for CI**: no `colcon build`/`colcon test` run in this sandbox -- no
+  ROS 2 install here (same disk-space constraint noted in #242/#243's entries above), so
+  the exact `nav2_msgs::action::FollowWaypoints::Impl::GetResultService` nested-type usage,
+  the manual `_action/status`/`_action/get_result` wiring, and the fake-action-server
+  test's `rclcpp_action` API calls are unverified by an actual compile. Written against
+  documented, stable ROS 2 action-protocol behavior and cross-checked against this
+  repo's one existing `rclcpp_action` usage (`dc_lifecycle_manager`), but a real build is
+  needed to close the loop.

--- a/progress.txt
+++ b/progress.txt
@@ -8630,3 +8630,40 @@ reading the code (the repo's established verification standard):
   documented, stable ROS 2 action-protocol behavior and cross-checked against this
   repo's one existing `rclcpp_action` usage (`dc_lifecycle_manager`), but a real build is
   needed to close the loop.
+
+### #389 follow-up - Fix `nav2_msgs/msg/waypoint_status.hpp` missing (rebase-time discovery)
+
+- While rebasing #389 onto `jazzy` after #388 landed, found #388's own two follow-up
+  entries above: it hit the exact same mistake this ticket's initial implementation had
+  just made -- fetching `ros-navigation/navigation2` **without pinning a ref** resolves
+  to `main` (rolling/current dev), not the `jazzy` branch this repo's rosdep actually
+  installs. #389's original entry above explicitly (if unknowingly) documents having
+  fetched `FollowWaypoints.action`/`WaypointStatus.msg` from `main`. Re-fetched both with
+  `?ref=jazzy` before finishing the rebase, rather than pushing a branch already known to
+  hit the same CI build failure #388 did.
+- On `jazzy`, `FollowWaypoints::Result.missed_waypoints` is `MissedWaypoint[]`, not
+  `WaypointStatus[]` -- a different message entirely (`nav2_msgs/msg/WaypointStatus.msg`
+  doesn't exist on `jazzy` at all, confirmed 404). `MissedWaypoint` carries only `index`,
+  the waypoint's goal pose, and `error_code` -- no per-waypoint status enum
+  (pending/completed/skipped/failed) and no per-waypoint `error_msg` the way the `main`
+  branch's `WaypointStatus` has. Also, `jazzy`'s error-code table for this action is only
+  `NONE=0`/`UNKNOWN=600`/`TASK_EXECUTOR_FAILED=601` -- `NO_VALID_WAYPOINTS=602` and
+  `STOP_ON_MISSED_WAYPOINT=603`, both used in the original implementation and its tests,
+  don't exist on `jazzy` either.
+- Fix: `WaypointOutcome` (`mission_follow_waypoints_tracker.hpp`) dropped its `status`/
+  `error_msg` fields, keeping only `index`/`error_code`; the plugin's
+  `#include "nav2_msgs/msg/waypoint_status.hpp"` became
+  `"nav2_msgs/msg/missed_waypoint.hpp"` and the now-unused `waypointStatusName()` helper
+  was removed; the JSON schema's `missed_waypoints` item shape dropped `status`/
+  `error_msg`, keeping `index`/`error_code` as the only required fields; both test files
+  and the doc page's schema/examples were updated to match, using the real
+  `FollowWaypoints::Result::TASK_EXECUTOR_FAILED`/`::UNKNOWN` constants instead of the
+  602/603 values that don't exist on this repo's target nav2. `mission_id`/
+  `mission_type`/`sequence`/`outcome`/`reason`/`error_code`/`duration_sec` -- all sourced
+  from fields `jazzy`'s `FollowWaypoints.action` genuinely has -- are unaffected.
+- `git add -A && prek run --all-files --skip build-doc` passes clean after the fix.
+  Same caveat as the original entry: no `colcon`/ROS 2 toolchain in this sandbox, so this
+  was verified by re-reading the `jazzy`-branch `.action`/`.msg` definitions directly
+  (not from memory, and this time with the ref actually pinned) rather than by
+  rebuilding -- the next CI run is what closes the loop, same as #388's own two
+  follow-ups needed.

--- a/progress.txt
+++ b/progress.txt
@@ -8667,3 +8667,28 @@ reading the code (the repo's established verification standard):
   (not from memory, and this time with the ref actually pinned) rather than by
   rebuilding -- the next CI run is what closes the loop, same as #388's own two
   follow-ups needed.
+
+### #389 follow-up 2 - Fix CI build failure (`GoalStatusArray` has no member `status`)
+
+- CI's real Jazzy build failed: `mission_nav2_follow_waypoints.cpp:166: error:
+  'const action_msgs::msg::GoalStatusArray' ... has no member named 'status'`, plus a
+  `-Werror=unused-function` on `uuidToString()` (a knock-on effect of the same error --
+  the compiler couldn't fully check the function body past the bad range-for expression,
+  so it never registered the call site inside that loop as a use).
+- Root cause: `action_msgs::msg::GoalStatusArray`'s array field is `status_list`, not
+  `status` -- exactly the "easy field-name trap" #388's own progress.txt entry above
+  already named as something it had specifically checked and avoided for its own
+  `GoalStatusArray` usage. This ticket's `statusCb()` used the wrong name anyway; the
+  `?ref=jazzy` re-verification the two follow-ups above did was for the nav2-specific
+  `FollowWaypoints`/`MissedWaypoint` shapes, not for this core, nav2-independent
+  `action_msgs` type, which was carried over from the original implementation without a
+  matching re-check.
+- Fix: one-line change, `msg.status` -> `msg.status_list` in
+  `MissionNav2FollowWaypoints::statusCb()`. Cross-checked against
+  `mission_nav2_through_poses.cpp`'s own (correct) `msg.status_list` usage for
+  consistency. No other file in this ticket's diff touches `GoalStatusArray` directly.
+- `git add -A && prek run --all-files --skip build-doc` passes clean. This one came from
+  a real CI build log (not a re-read of definitions), so unlike every prior entry in this
+  ticket, the specific line that failed is now confirmed compiling-clean against the
+  actual error message -- though a full `colcon build`/`colcon test` pass is still owed
+  to CI, since this sandbox still has no ROS 2 toolchain to run one.


### PR DESCRIPTION
## Summary

- New `dc_measurements` plugin `mission_nav2_follow_waypoints` (class `MissionNav2FollowWaypoints`), the `FollowWaypoints` sibling of #387's nav2 Mission Measurement, reusing its `mission_start`/`mission_end` Record schema/conventions.
- Passive watcher, not a commander: it never sends a `FollowWaypoints` goal itself (confirmed with the user before implementing) — it subscribes to `<action>/_action/status` and calls `<action>/_action/get_result` directly, both standard, public parts of the ROS 2 action protocol, since `rclcpp_action::Client`'s typed API only reports on goals it sent itself. This avoids competing with whatever already commands the action (e.g. `dc_demos/dc_demos/qrcodes_waypoint_follower.py`) and matches DC's telemetry-only role.
- One documented, deliberate gap versus the issue's literal spec: `number_of_loops` lives only on the Goal, which a passive third-party watcher structurally cannot observe (no ROS 2 mechanism re-publishes it, and `rclcpp_action::Client` can't attach to a goal it didn't send). Documented in the plugin header and the doc page's "Known limitation" section.
- ROS-free core (`MissionFollowWaypointsTracker`) built on `dc_common::StateTransitionDetector`, unit-tested standalone; `MeasurementServer` integration test drives a real `rclcpp_action::Server`/`Client` pair standing in for nav2 and its commander.

## Test plan

- [x] `git add -A && prek run --all-files --skip build-doc` passes clean
- [ ] `colcon build` / `colcon test` in CI (no ROS 2 install available in the sandbox this was written in — see progress.txt's "Not done / left for CI" note)

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017GPxtiNGQKW2rBGKaCs7n7