### PR TITLE
feat(dc_measurements): add the slam_toolbox quality Measurement

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -26,7 +26,6 @@ set(dependencies
   rclcpp_components
   rclcpp_lifecycle
   sensor_msgs
-  slam_toolbox
   std_msgs
   tf2
   tf2_geometry_msgs

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -26,6 +26,7 @@ set(dependencies
   rclcpp_components
   rclcpp_lifecycle
   sensor_msgs
+  slam_toolbox
   std_msgs
   tf2
   tf2_geometry_msgs
@@ -234,6 +235,9 @@ list(APPEND dc_measurement_plugin_libs dc_ros2_control_status_measurement)
 add_library(dc_serial_interface_measurement SHARED plugins/measurements/serial_interface.cpp)
 list(APPEND dc_measurement_plugin_libs dc_serial_interface_measurement)
 
+add_library(dc_slam_toolbox_quality_measurement SHARED plugins/measurements/slam_toolbox_quality.cpp)
+list(APPEND dc_measurement_plugin_libs dc_slam_toolbox_quality_measurement)
+
 add_library(dc_speed_measurement SHARED plugins/measurements/speed.cpp)
 list(APPEND dc_measurement_plugin_libs dc_speed_measurement)
 
@@ -392,6 +396,7 @@ set(tests
   test_measurement_same_as_previous
   test_measurement_serial_interface
   test_measurement_shared_flush
+  test_measurement_slam_toolbox_quality
   test_measurement_speed
   test_measurement_storage
   test_measurement_string_match

--- a/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
@@ -12,8 +12,9 @@
 #include "dc_measurements/measurement.hpp"
 #include "dc_util/node_utils.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "rclcpp/generic_subscription.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "slam_toolbox/msg/loop_closure_event.hpp"
+#include "rclcpp/serialized_message.hpp"
 
 namespace dc_measurements
 {
@@ -26,6 +27,18 @@ namespace dc_measurements
  * source event carries no data beyond its own arrival, so loop closures per hour and time since
  * the last one -- a localization-drift risk indicator -- come entirely from Record timing
  * downstream, the same way battery's charging sessions do (#394).
+ *
+ * The loop-closure topic is subscribed generically (`create_generic_subscription`, the same
+ * runtime-discovery mechanism dc_bridge's raw mode uses), not with a compile-time
+ * `slam_toolbox::msg::LoopClosureEvent`: that message is declared on slam_toolbox's `ros2`
+ * branch but isn't part of any released binary yet (verified against the actual
+ * `ros-jazzy-slam-toolbox` package contents -- no `LoopClosureEvent` there, only in
+ * unreleased source), so a compile-time dependency on it can't build against a real
+ * installation today. A generic subscription needs no message headers at all: the content is
+ * never decoded, since the Record only needs to know an occurrence happened, not what the
+ * message carried. The topic's type is discovered once it appears on the graph, so this
+ * Measurement still works whenever slam_toolbox does start publishing it, regardless of which
+ * release adds it or what the message's fields end up being.
  */
 class SlamToolboxQuality : public dc_measurements::Measurement
 {
@@ -36,16 +49,23 @@ public:
 
 private:
   void poseCb(const geometry_msgs::msg::PoseWithCovarianceStamped& msg);
-  void loopClosureCb(const slam_toolbox::msg::LoopClosureEvent& msg);
+  // A generic subscription's callback only ever gets the raw serialized bytes; this
+  // Measurement doesn't decode them; the message's mere arrival is the Record.
+  void loopClosureCb(std::shared_ptr<const rclcpp::SerializedMessage> msg);
+  // Looks for loop_closure_topic_ on the graph and subscribes once its type is known.
+  // Retried on discovery_timer_ until it succeeds, so startup order with slam_toolbox
+  // doesn't matter.
+  void tryCreateLoopClosureSubscription();
   json sampleRecord() const;
 
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_subscription_;
-  rclcpp::Subscription<slam_toolbox::msg::LoopClosureEvent>::SharedPtr loop_closure_subscription_;
+  rclcpp::GenericSubscription::SharedPtr loop_closure_subscription_;
+  rclcpp::TimerBase::SharedPtr loop_closure_discovery_timer_;
   std::string pose_topic_;
   std::string loop_closure_topic_;
 
-  // The pose callback and the polling timer run in different callback groups under a
-  // multi-threaded executor, so everything they share is guarded.
+  // The pose/loop-closure callbacks and the polling timer run in different callback groups
+  // under a multi-threaded executor, so everything they share is guarded.
   mutable std::mutex mutex_;
   geometry_msgs::msg::PoseWithCovarianceStamped last_pose_;
   bool has_pose_{ false };

--- a/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__SLAM_TOOLBOX_QUALITY_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__SLAM_TOOLBOX_QUALITY_HPP_
+
+#include <deque>
+#include <mutex>
+#include <string>
+
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "slam_toolbox/msg/loop_closure_event.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::SlamToolboxQuality
+ * @brief Localization quality from two of slam_toolbox's native topics: `/pose` on the polling
+ * interval for a `sample` Record carrying the pose covariance, and
+ * `/slam_toolbox/loop_closure_event` for a single-shot `loop_closure` Record per occurrence. The
+ * source event carries no data beyond its own arrival, so loop closures per hour and time since
+ * the last one -- a localization-drift risk indicator -- come entirely from Record timing
+ * downstream, the same way battery's charging sessions do (#394).
+ */
+class SlamToolboxQuality : public dc_measurements::Measurement
+{
+public:
+  SlamToolboxQuality();
+  ~SlamToolboxQuality() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void poseCb(const geometry_msgs::msg::PoseWithCovarianceStamped& msg);
+  void loopClosureCb(const slam_toolbox::msg::LoopClosureEvent& msg);
+  json sampleRecord() const;
+
+  rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_subscription_;
+  rclcpp::Subscription<slam_toolbox::msg::LoopClosureEvent>::SharedPtr loop_closure_subscription_;
+  std::string pose_topic_;
+  std::string loop_closure_topic_;
+
+  // The pose callback and the polling timer run in different callback groups under a
+  // multi-threaded executor, so everything they share is guarded.
+  mutable std::mutex mutex_;
+  geometry_msgs::msg::PoseWithCovarianceStamped last_pose_;
+  bool has_pose_{ false };
+  // Loop closures wait here for a poll to carry them out, one Record per poll, so they travel
+  // the same publish path (Conditions, buffering, Group) as every other Record.
+  std::deque<rclcpp::Time> pending_loop_closures_;
+
+protected:
+  /**
+   * @brief Configuration of behavior action
+   */
+  void onConfigure() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__SLAM_TOOLBOX_QUALITY_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -200,6 +200,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_slam_toolbox_quality_measurement">
+        <class name="dc_measurements/SlamToolboxQuality" type="dc_measurements::SlamToolboxQuality" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_slam_toolbox_quality
+            </description>
+        </class>
+    </library>
+
     <library path="dc_speed_measurement">
         <class name="dc_measurements/Speed" type="dc_measurements::Speed" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -41,6 +41,7 @@ SPDX-License-Identifier: MPL-2.0
   <depend>pluginlib</depend>
   <depend>rclcpp_action</depend>
   <depend>sensor_msgs</depend>
+  <depend>slam_toolbox</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -41,7 +41,6 @@ SPDX-License-Identifier: MPL-2.0
   <depend>pluginlib</depend>
   <depend>rclcpp_action</depend>
   <depend>sensor_msgs</depend>
-  <depend>slam_toolbox</depend>
   <depend>std_msgs</depend>
   <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>

--- a/dc_measurements/plugins/measurements/json/slam_toolbox_quality.json
+++ b/dc_measurements/plugins/measurements/json/slam_toolbox_quality.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SlamToolboxQuality",
+  "description":
+      "Localization quality from slam_toolbox: a pose sample with covariance on the polling interval, plus a Record on every loop closure",
+  "properties": {
+    "event": {
+      "description": "What this Record is: a periodic pose sample, or a loop closure occurrence",
+      "type": "string",
+      "enum": [
+        "sample",
+        "loop_closure"
+      ]
+    },
+    "x": {
+      "description": "Robot x position in the pose topic's frame, metres",
+      "type": "number"
+    },
+    "y": {
+      "description": "Robot y position in the pose topic's frame, metres",
+      "type": "number"
+    },
+    "yaw": {
+      "description": "Robot heading in the pose topic's frame, radians",
+      "type": "number"
+    },
+    "covariance_x": {
+      "description":
+          "Pose covariance diagonal term for x, metres squared. Localization confidence: higher is less certain",
+      "type": "number",
+      "minimum": 0
+    },
+    "covariance_y": {
+      "description": "Pose covariance diagonal term for y, metres squared",
+      "type": "number",
+      "minimum": 0
+    },
+    "covariance_yaw": {
+      "description": "Pose covariance diagonal term for yaw, radians squared",
+      "type": "number",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "event"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "sample"
+          }
+        },
+        "required": [
+          "event"
+        ]
+      },
+      "then": {
+        "required": [
+          "x",
+          "y",
+          "yaw",
+          "covariance_x",
+          "covariance_y",
+          "covariance_yaw"
+        ]
+      }
+    }
+  ],
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
+++ b/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/slam_toolbox_quality.hpp"
+
+namespace dc_measurements
+{
+
+namespace
+{
+constexpr size_t kMaxPendingLoopClosures = 64;
+}  // namespace
+
+SlamToolboxQuality::SlamToolboxQuality() : dc_measurements::Measurement()
+{
+}
+
+SlamToolboxQuality::~SlamToolboxQuality() = default;
+
+void SlamToolboxQuality::onConfigure()
+{
+  auto node = getNode();
+  pose_topic_ = dc_util::get_str_type_param(node, measurement_name_, "pose_topic", "/pose");
+  loop_closure_topic_ =
+      dc_util::get_str_type_param(node, measurement_name_, "loop_closure_topic", "/slam_toolbox/loop_closure_event");
+
+  pose_subscription_ = node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
+      pose_topic_, rclcpp::SensorDataQoS(), std::bind(&SlamToolboxQuality::poseCb, this, std::placeholders::_1));
+  loop_closure_subscription_ = node->create_subscription<slam_toolbox::msg::LoopClosureEvent>(
+      loop_closure_topic_, rclcpp::SystemDefaultsQoS(),
+      std::bind(&SlamToolboxQuality::loopClosureCb, this, std::placeholders::_1));
+}
+
+void SlamToolboxQuality::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "slam_toolbox_quality.json");
+  }
+}
+
+void SlamToolboxQuality::poseCb(const geometry_msgs::msg::PoseWithCovarianceStamped& msg)
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  last_pose_ = msg;
+  has_pose_ = true;
+}
+
+void SlamToolboxQuality::loopClosureCb(const slam_toolbox::msg::LoopClosureEvent& msg)
+{
+  // slam_toolbox/msg/LoopClosureEvent carries only its own stamp; the occurrence is the Record,
+  // so this Measurement's own clock -- not the message's stamp -- is what pairs it with the
+  // pose samples around it.
+  (void)msg;
+  const auto now = getNode()->get_clock()->now();
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  pending_loop_closures_.push_back(now);
+
+  // One event leaves per poll, so loop closures arriving far faster than the polling interval
+  // would otherwise queue without bound. The oldest goes first: the recent ones are the ones
+  // still worth reporting.
+  while (pending_loop_closures_.size() > kMaxPendingLoopClosures)
+  {
+    pending_loop_closures_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_
+                                               << ": loop closures are arriving faster than the polling interval "
+                                                  "can report them; dropping the oldest.");
+  }
+}
+
+json SlamToolboxQuality::sampleRecord() const
+{
+  json data;
+  data["event"] = "sample";
+  data["x"] = last_pose_.pose.pose.position.x;
+  data["y"] = last_pose_.pose.pose.position.y;
+
+  tf2::Quaternion q(last_pose_.pose.pose.orientation.x, last_pose_.pose.pose.orientation.y,
+                    last_pose_.pose.pose.orientation.z, last_pose_.pose.pose.orientation.w);
+  tf2::Matrix3x3 m(q);
+  double roll, pitch, yaw;
+  m.getRPY(roll, pitch, yaw);
+  data["yaw"] = yaw;
+
+  // PoseWithCovariance's 6x6 row-major covariance: index 0 is x-x, 7 is y-y, 35 is yaw-yaw --
+  // the diagonal terms that read as localization confidence on their own axis, the same ones
+  // AMCL/robot_localization dashboards already chart.
+  data["covariance_x"] = last_pose_.pose.covariance[0];
+  data["covariance_y"] = last_pose_.pose.covariance[7];
+  data["covariance_yaw"] = last_pose_.pose.covariance[35];
+  return data;
+}
+
+dc_interfaces::msg::StringStamped SlamToolboxQuality::collect()
+{
+  auto node = getNode();
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+
+  // A loop closure takes the poll it lands on: it is a fact about a moment, so it keeps the
+  // timestamp of that moment rather than this poll's.
+  if (!pending_loop_closures_.empty())
+  {
+    const auto stamp = pending_loop_closures_.front();
+    pending_loop_closures_.pop_front();
+    msg.header.stamp = stamp;
+    json event;
+    event["event"] = "loop_closure";
+    msg.data = event.dump(-1, ' ', true);
+    return msg;
+  }
+
+  // Nothing on /pose yet: report nothing rather than a Record with no localization data.
+  if (!has_pose_)
+  {
+    return msg;
+  }
+
+  msg.header.stamp = node->get_clock()->now();
+  msg.data = sampleRecord().dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::SlamToolboxQuality, dc_core::Measurement)

--- a/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
+++ b/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
@@ -26,9 +26,56 @@ void SlamToolboxQuality::onConfigure()
 
   pose_subscription_ = node->create_subscription<geometry_msgs::msg::PoseWithCovarianceStamped>(
       pose_topic_, rclcpp::SensorDataQoS(), std::bind(&SlamToolboxQuality::poseCb, this, std::placeholders::_1));
-  loop_closure_subscription_ = node->create_subscription<slam_toolbox::msg::LoopClosureEvent>(
-      loop_closure_topic_, rclcpp::SystemDefaultsQoS(),
-      std::bind(&SlamToolboxQuality::loopClosureCb, this, std::placeholders::_1));
+
+  // The loop-closure topic's type isn't known until slam_toolbox actually advertises it (it
+  // may not even be running yet), so the generic subscription can't be created up front the
+  // way the typed pose one is -- tryCreateLoopClosureSubscription() retries until it appears.
+  tryCreateLoopClosureSubscription();
+  if (!loop_closure_subscription_)
+  {
+    loop_closure_discovery_timer_ =
+        node->create_wall_timer(std::chrono::seconds(1), [this] { tryCreateLoopClosureSubscription(); });
+  }
+}
+
+void SlamToolboxQuality::tryCreateLoopClosureSubscription()
+{
+  auto node = getNode();
+  const auto topics = node->get_topic_names_and_types();
+  const auto topic_it = topics.find(loop_closure_topic_);
+  if (topic_it == topics.end() || topic_it->second.empty())
+  {
+    return;
+  }
+  if (topic_it->second.size() > 1)
+  {
+    // Genuinely ambiguous: one generic subscription carries exactly one type, and picking
+    // arbitrarily would silently drop whichever publisher's messages don't match.
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *node->get_clock(), 10000,
+                                "Measurement " << measurement_name_ << ": " << loop_closure_topic_ << " advertises "
+                                               << topic_it->second.size()
+                                               << " types; cannot pick one to subscribe with.");
+    return;
+  }
+
+  try
+  {
+    loop_closure_subscription_ =
+        node->create_generic_subscription(loop_closure_topic_, topic_it->second.front(), rclcpp::SystemDefaultsQoS(),
+                                          std::bind(&SlamToolboxQuality::loopClosureCb, this, std::placeholders::_1));
+  }
+  catch (const std::exception& e)
+  {
+    // Most likely the message package's type support isn't loadable on this machine.
+    // Logged once via throttle; the discovery timer will keep retrying regardless, since a
+    // transient cause (the package finishing an install) is exactly as plausible as a
+    // permanent one, and there's no cheap way to tell them apart from here.
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *node->get_clock(), 10000,
+                                "Measurement " << measurement_name_ << ": could not subscribe to "
+                                               << loop_closure_topic_ << ": " << e.what());
+    return;
+  }
+  loop_closure_discovery_timer_.reset();
 }
 
 void SlamToolboxQuality::setValidationSchema()
@@ -46,11 +93,12 @@ void SlamToolboxQuality::poseCb(const geometry_msgs::msg::PoseWithCovarianceStam
   has_pose_ = true;
 }
 
-void SlamToolboxQuality::loopClosureCb(const slam_toolbox::msg::LoopClosureEvent& msg)
+void SlamToolboxQuality::loopClosureCb(std::shared_ptr<const rclcpp::SerializedMessage> msg)
 {
-  // slam_toolbox/msg/LoopClosureEvent carries only its own stamp; the occurrence is the Record,
-  // so this Measurement's own clock -- not the message's stamp -- is what pairs it with the
-  // pose samples around it.
+  // A generic subscription only ever hands over the raw serialized bytes, undecoded; the
+  // occurrence is the Record regardless of what the message carries, so this Measurement's
+  // own clock -- not any stamp the message might have -- is what pairs it with the pose
+  // samples around it.
   (void)msg;
   const auto now = getNode()->get_clock()->now();
 

--- a/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
+++ b/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
@@ -1,0 +1,232 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
+#include "slam_toolbox/msg/loop_closure_event.hpp"
+
+class MeasurementSlamToolboxQualityTest : public ::testing::Test
+{
+protected:
+  MeasurementSlamToolboxQualityTest()
+  {
+    SetUp();
+  }
+
+  ~MeasurementSlamToolboxQualityTest() override
+  {
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "slam_quality" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/slam_quality", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementSlamToolboxQualityTest::dataCallback, this, std::placeholders::_1));
+    pose_pub_ = ms_node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/test/pose",
+                                                                                          rclcpp::SensorDataQoS());
+    loop_closure_pub_ = ms_node_->create_publisher<slam_toolbox::msg::LoopClosureEvent>("/test/loop_closure_event",
+                                                                                        rclcpp::SystemDefaultsQoS());
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("slam_quality.plugin", std::string("dc_measurements/SlamToolboxQuality"));
+    ms_node_->declare_parameter("slam_quality.group_key", std::string("slam_quality"));
+    ms_node_->declare_parameter("slam_quality.topic_output", std::string("/dc/measurement/slam_quality"));
+    ms_node_->declare_parameter("slam_quality.pose_topic", std::string("/test/pose"));
+    ms_node_->declare_parameter("slam_quality.loop_closure_topic", std::string("/test/loop_closure_event"));
+    ms_node_->declare_parameter("slam_quality.polling_interval", 50);
+    ms_node_->declare_parameter("slam_quality.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  void waitForSubscriber(const std::string& topic)
+  {
+    while (ms_node_->count_subscribers(topic) == 0)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  // Republishes `msg` until a *new* Record matching `predicate` shows up, so a best-effort sample
+  // lost before the plugin subscribed doesn't make the test flaky.
+  nlohmann::json publishUntilRecord(const geometry_msgs::msg::PoseWithCovarianceStamped& msg,
+                                    const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = records_.size();
+    for (int i = 0; i < 400; ++i)
+    {
+      pose_pub_->publish(msg);
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  // A loop closure is single-shot: republishing it would report several occurrences instead of
+  // one, so this only sends it once and waits for the Record it causes.
+  nlohmann::json publishLoopClosureAndWaitForRecord()
+  {
+    const size_t first_new = records_.size();
+    slam_toolbox::msg::LoopClosureEvent msg;
+    msg.stamp = ms_node_->get_clock()->now();
+    loop_closure_pub_->publish(msg);
+    for (int i = 0; i < 400; ++i)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (isEvent("loop_closure")(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No loop_closure Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  // The schema the plugin itself validates against, applied here directly so a Record that only
+  // half fills it fails the test rather than only logging.
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path = ament_index_cpp::get_package_share_directory("dc_measurements") +
+                             "/plugins/measurements/json/slam_toolbox_quality.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
+  rclcpp::Publisher<slam_toolbox::msg::LoopClosureEvent>::SharedPtr loop_closure_pub_;
+  std::vector<nlohmann::json> records_;
+};
+
+TEST_F(MeasurementSlamToolboxQualityTest, ReportsPoseAndCovarianceOnThePollingInterval)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/pose");
+
+  geometry_msgs::msg::PoseWithCovarianceStamped msg;
+  msg.pose.pose.position.x = 1.5;
+  msg.pose.pose.position.y = -2.25;
+  msg.pose.pose.orientation.w = 1.0;
+  msg.pose.covariance[0] = 0.01;
+  msg.pose.covariance[7] = 0.02;
+  msg.pose.covariance[35] = 0.03;
+
+  const auto record = publishUntilRecord(msg, isEvent("sample"));
+
+  EXPECT_NEAR(record["x"].get<double>(), 1.5, 1e-6);
+  EXPECT_NEAR(record["y"].get<double>(), -2.25, 1e-6);
+  EXPECT_NEAR(record["yaw"].get<double>(), 0.0, 1e-6);
+  EXPECT_NEAR(record["covariance_x"].get<double>(), 0.01, 1e-9);
+  EXPECT_NEAR(record["covariance_y"].get<double>(), 0.02, 1e-9);
+  EXPECT_NEAR(record["covariance_yaw"].get<double>(), 0.03, 1e-9);
+  expectValidatesAgainstSchema(record);
+}
+
+TEST_F(MeasurementSlamToolboxQualityTest, ReportsNothingWhilePoseNeverPublishes)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/pose");
+
+  // Several polling intervals with nothing on /pose: no Record at all beats a Record with no
+  // localization data.
+  spinFor(std::chrono::milliseconds(500));
+
+  EXPECT_TRUE(records_.empty()) << records_.size() << " Record(s) published without any pose";
+}
+
+TEST_F(MeasurementSlamToolboxQualityTest, EmitsASingleShotRecordPerLoopClosure)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/pose");
+  waitForSubscriber("/test/loop_closure_event");
+
+  const auto record = publishLoopClosureAndWaitForRecord();
+
+  EXPECT_EQ(record["event"], "loop_closure");
+  // The source topic carries only a timestamp -- nothing else belongs in the Record body.
+  EXPECT_EQ(record.size(), 1u);
+  expectValidatesAgainstSchema(record);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
+++ b/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
@@ -212,8 +212,14 @@ TEST_F(MeasurementSlamToolboxQualityTest, EmitsASingleShotRecordPerLoopClosure)
   const auto record = publishLoopClosureAndWaitForRecord();
 
   EXPECT_EQ(record["event"], "loop_closure");
-  // The source topic carries only a timestamp -- nothing else belongs in the Record body.
-  EXPECT_EQ(record.size(), 1u);
+  // The source topic carries only a timestamp -- no localization data belongs in the Record
+  // body. (Every Record picks up a few enrichment keys -- flattened/nested and friends -- from
+  // the shared publish() pipeline regardless of Measurement, so this checks absence of the
+  // sample-specific fields rather than an exact key count.)
+  for (const auto& key : { "x", "y", "yaw", "covariance_x", "covariance_y", "covariance_yaw" })
+  {
+    EXPECT_FALSE(record.contains(key)) << key << " should be absent on a loop_closure Record";
+  }
   expectValidatesAgainstSchema(record);
 }
 

--- a/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
+++ b/dc_measurements/test/test_measurement_slam_toolbox_quality.cpp
@@ -16,7 +16,7 @@
 #include "dc_measurements/measurement_server.hpp"
 #include "dc_util/json_utils.hpp"
 #include "geometry_msgs/msg/pose_with_covariance_stamped.hpp"
-#include "slam_toolbox/msg/loop_closure_event.hpp"
+#include "std_msgs/msg/empty.hpp"
 
 class MeasurementSlamToolboxQualityTest : public ::testing::Test
 {
@@ -39,8 +39,11 @@ protected:
         std::bind(&MeasurementSlamToolboxQualityTest::dataCallback, this, std::placeholders::_1));
     pose_pub_ = ms_node_->create_publisher<geometry_msgs::msg::PoseWithCovarianceStamped>("/test/pose",
                                                                                           rclcpp::SensorDataQoS());
-    loop_closure_pub_ = ms_node_->create_publisher<slam_toolbox::msg::LoopClosureEvent>("/test/loop_closure_event",
-                                                                                        rclcpp::SystemDefaultsQoS());
+    // Stands in for whatever slam_toolbox itself eventually publishes: the plugin subscribes
+    // generically and never decodes the message, so the type here doesn't have to match a
+    // real slam_toolbox one -- only its *arrival* is exercised.
+    loop_closure_pub_ =
+        ms_node_->create_publisher<std_msgs::msg::Empty>("/test/loop_closure_event", rclcpp::SystemDefaultsQoS());
   }
 
   void TearDown() override
@@ -124,9 +127,7 @@ protected:
   nlohmann::json publishLoopClosureAndWaitForRecord()
   {
     const size_t first_new = records_.size();
-    slam_toolbox::msg::LoopClosureEvent msg;
-    msg.stamp = ms_node_->get_clock()->now();
-    loop_closure_pub_->publish(msg);
+    loop_closure_pub_->publish(std_msgs::msg::Empty());
     for (int i = 0; i < 400; ++i)
     {
       rclcpp::spin_some(ms_node_->get_node_base_interface());
@@ -159,7 +160,7 @@ protected:
   std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
   rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
   rclcpp::Publisher<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr pose_pub_;
-  rclcpp::Publisher<slam_toolbox::msg::LoopClosureEvent>::SharedPtr loop_closure_pub_;
+  rclcpp::Publisher<std_msgs::msg::Empty>::SharedPtr loop_closure_pub_;
   std::vector<nlohmann::json> records_;
 };
 

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -45,6 +45,7 @@
   - [Random](./dc/measurements/random.md)
   - [ROS2 control status](./dc/measurements/ros2_control_status.md)
   - [Serial interface](./dc/measurements/serial_interface.md)
+  - [slam_toolbox quality](./dc/measurements/slam_toolbox_quality.md)
   - [Speed](./dc/measurements/speed.md)
   - [Storage](./dc/measurements/storage.md)
   - [String stamped](./dc/measurements/string_stamped.md)

--- a/doc/src/dc/kpi_views.md
+++ b/doc/src/dc/kpi_views.md
@@ -4,9 +4,10 @@ DC collects Records; the numbers an operations team reports on are computed from
 Records in SQL, on the database, never on the robot. The window is a query parameter, so
 changing a KPI definition is re-applying one file — not redeploying a fleet.
 
-The set covers **availability and uptime**, **utilisation**, **intervention rate** and
-**MTBF/MTTR**. It lives in `tools/infrastructure/sql/kpi_views.sql` and reads the `dc`
-table the [PostgreSQL](./infrastructure_setup/postgresql.md) Destination writes into.
+The set covers **availability and uptime**, **utilisation**, **intervention rate**,
+**MTBF/MTTR** and **loop closure rate**. It lives in `tools/infrastructure/sql/kpi_views.sql`
+and reads the `dc` table the [PostgreSQL](./infrastructure_setup/postgresql.md) Destination
+writes into.
 
 ## What it defines
 
@@ -24,6 +25,9 @@ table the [PostgreSQL](./infrastructure_setup/postgresql.md) Destination writes 
 | `dc_kpi_fault_events`                                 | view     | One row per fault Record: `component`, `from_level`, `to_level`, `previous_duration`, `sequence`, `reason`, `open`                                     |
 | `dc_kpi_reliability(from, to [, failure_levels])`     | function | Per component: `failures`, `repairs`, `open_faults`, `operating_seconds`, `downtime_seconds`, `mtbf_seconds`, `mttr_seconds`                           |
 | `dc_kpi_faults_1h`                                    | view     | Failures, repairs and downtime in 1-hour buckets                                                                                                      |
+| `dc_kpi_loop_closure_events`                          | view     | One row per slam_toolbox_quality `loop_closure` Record ([#394])                                                                                        |
+| `dc_kpi_loop_closure_rate(from, to)`                  | function | Per robot: `loop_closures`, `window_seconds`, `per_hour`, `last_loop_closure`, `seconds_since_last`                                                     |
+| `dc_kpi_loop_closures_1h`                             | view     | Loop closures in 1-hour buckets                                                                                                                       |
 | `dc_kpi_max_gap()`                                    | function | The grace period every definition above shares (30 s)                                                                                                 |
 | `dc_kpi_min_speed()`                                  | function | The speed at or above which the robot counts as moving (0.05 m/s)                                                                                     |
 | `dc_kpi_failure_levels()`                             | function | The diagnostic levels that count as broken (`ERROR`, `STALE`)                                                                                         |
@@ -147,6 +151,30 @@ What it deliberately does not claim:
   after eight healthy hours reports eight hours of MTBF in a one-hour window; the window
   chooses which events count, not how long their intervals were.
 
+## Loop closure rate
+
+Reads the `slam_toolbox_quality` Measurement ([#394]). `slam_toolbox/LoopClosureEvent` carries
+nothing but its own occurrence, so the KPI value is entirely in Record timing:
+
+```text
+per_hour = loop_closures / (window_seconds / 3600)
+```
+
+alongside `seconds_since_last` — how long it's been since the most recent loop closure as of
+`window_end`, a localization-drift risk indicator distinct from the rate: a robot can have a
+healthy rate over a long window and still be mid-drift right now if its last correction was a
+while ago.
+
+What it deliberately does not claim:
+
+- **`seconds_since_last` looks past `window_start`.** Clipped to the window it would read a
+  robot with no loop closure yet in a short window as "just corrected" instead of "never
+  corrected" — the other rate functions clip strictly to the window, this one deliberately
+  doesn't, for this one column.
+- **A robot with no loop closure Record at all, ever, is absent from the result** — same as
+  every other rate function here: nothing distinguishes "never ran slam_toolbox" from "ran it
+  and never closed a loop" without a fleet registry.
+
 ## Mission success rate is not here yet
 
 The fourth starter metric — completed, failed, cancelled and aborted missions as a share of
@@ -174,6 +202,7 @@ them:
 | Utilisation         | `driving_type`, `speed`                                   |
 | Intervention rate   | `intervention` ([#362]), `driving_type`, `distance_traveled` |
 | MTBF / MTTR         | `fault` ([#365])                                          |
+| Loop closure rate   | `slam_toolbox_quality` ([#394])                            |
 
 `dc_demos/params/tb3_simulation_pgsql_minio.yaml` is a working example of everything that
 exists today. The `intervention` and `fault` Measurements do not, so their views return no
@@ -230,11 +259,13 @@ Then, on the reporting side:
   ```sql
   GRANT SELECT ON dc_kpi_uptime_samples, dc_kpi_availability_5m, dc_kpi_driving_samples,
                   dc_kpi_utilisation_5m, dc_kpi_intervention_events, dc_kpi_interventions_1h,
-                  dc_kpi_fault_events, dc_kpi_faults_1h TO grafana;
+                  dc_kpi_fault_events, dc_kpi_faults_1h, dc_kpi_loop_closure_events,
+                  dc_kpi_loop_closures_1h TO grafana;
   GRANT EXECUTE ON FUNCTION dc_kpi_availability(timestamptz, timestamptz, interval),
                             dc_kpi_utilisation(timestamptz, timestamptz, interval, double precision),
                             dc_kpi_intervention_rate(timestamptz, timestamptz, interval),
-                            dc_kpi_reliability(timestamptz, timestamptz, text[]) TO grafana;
+                            dc_kpi_reliability(timestamptz, timestamptz, text[]),
+                            dc_kpi_loop_closure_rate(timestamptz, timestamptz) TO grafana;
   ```
 
 - **Records stored elsewhere** — another schema, another table name — only affect the four
@@ -259,3 +290,4 @@ a dashboard later. Add a case for every definition you add.
 [#305]: https://github.com/Minipada/ros2_data_collection/issues/305
 [#362]: https://github.com/Minipada/ros2_data_collection/issues/362
 [#365]: https://github.com/Minipada/ros2_data_collection/issues/365
+[#394]: https://github.com/Minipada/ros2_data_collection/issues/394

--- a/doc/src/dc/measurements/slam_toolbox_quality.md
+++ b/doc/src/dc/measurements/slam_toolbox_quality.md
@@ -1,0 +1,116 @@
+# slam_toolbox quality
+
+## Description
+
+Localization quality from two of [slam_toolbox](https://github.com/SteveMacenski/slam_toolbox)'s
+native ROS 2 topics: `/pose` (`geometry_msgs/PoseWithCovarianceStamped`), polled on the same
+interval as every other Measurement, for a `sample` Record carrying the pose and its covariance;
+and `/slam_toolbox/loop_closure_event` (`slam_toolbox/LoopClosureEvent`) for a single-shot
+`loop_closure` Record per occurrence.
+
+`LoopClosureEvent` carries nothing but its own timestamp — slam_toolbox doesn't say which nodes
+closed the loop or by how much, only that one happened. The Record reflects that: `loop_closure`
+has no fields beyond `event`. The KPI value is entirely in the timing of these Records against
+each other and against the samples: **loop closures per hour** is a rate over how often
+`loop_closure` Records land, and **time since the last loop closure** — how long the map has gone
+without a correction — is a localization-drift risk indicator on its own, the way a growing gap
+between battery samples reads as data loss rather than a battery at 0 %.
+
+Every Record carries an `event` field naming which of the two it is:
+
+| `event`         | When                                  | Carries                                              |
+| ---------------- | -------------------------------------- | ------------------------------------------------------- |
+| `sample`         | Every polling interval, once `/pose` has published | `x`, `y`, `yaw`, and the diagonal covariance terms for each |
+| `loop_closure`   | slam_toolbox reports one on `/slam_toolbox/loop_closure_event` | Nothing else — the occurrence is the fact |
+
+The covariance terms are the diagonal of `PoseWithCovariance`'s 6x6 matrix at the indices for x, y
+and yaw — the same terms AMCL/`robot_localization` dashboards already chart, and the ones that read
+as confidence on their own axis without needing the off-diagonal correlations.
+
+Until `/pose` publishes at all, no `sample` Record is emitted: a gap means no localization data,
+not a robot at the origin. A loop closure is queued the moment it's reported and leaves on the
+next poll, one Record per poll, so it travels the same path as every other Record (Conditions,
+incident buffering, Group) — the same convention [Battery](./battery.md)'s charging-session
+boundaries and [Intervention](./intervention.md)'s takeovers use.
+
+```admonish info title="slam_toolbox is a runtime dependency, not a build one this plugin adds weight to"
+`slam_toolbox/LoopClosureEvent` is defined inside the `slam_toolbox` package itself — it ships no
+separate, lighter `_msgs` package the way nav2 does. This Measurement only makes sense on a robot
+already running slam_toolbox for real SLAM, so depending on the real package (rather than working
+around it with a raw/generic subscription) is the plain choice: the dependency is already present
+wherever this Measurement is.
+```
+
+## Parameters
+
+| Parameter               | Description                                                                 | Type | Default                              |
+| ------------------------ | ----------------------------------------------------------------------------- | ---- | --------------------------------------- |
+| **pose_topic**           | Topic (`geometry_msgs/PoseWithCovarianceStamped`) to read localization pose from | str  | "/pose" (Optional)                    |
+| **loop_closure_topic**   | Topic (`slam_toolbox/LoopClosureEvent`) slam_toolbox reports loop closures on | str  | "/slam_toolbox/loop_closure_event" (Optional) |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "SlamToolboxQuality",
+  "description": "Localization quality from slam_toolbox: a pose sample with covariance on the polling interval, plus a Record on every loop closure",
+  "properties": {
+    "event": { "type": "string", "enum": ["sample", "loop_closure"] },
+    "x": { "type": "number" },
+    "y": { "type": "number" },
+    "yaw": { "type": "number" },
+    "covariance_x": { "type": "number", "minimum": 0 },
+    "covariance_y": { "type": "number", "minimum": 0 },
+    "covariance_yaw": { "type": "number", "minimum": 0 }
+  },
+  "required": ["event"],
+  "type": "object"
+}
+```
+
+The full file (`plugins/measurements/json/slam_toolbox_quality.json`) also requires `x`, `y`,
+`yaw` and all three covariance terms on a `sample` — `loop_closure` requires nothing beyond
+`event`.
+
+## Measurement configuration
+
+```yaml
+...
+slam_quality:
+  plugin: "dc_measurements/SlamToolboxQuality"
+  topic_output: "/dc/measurement/slam_quality"
+  polling_interval: 1000
+  pose_topic: "/pose"
+  loop_closure_topic: "/slam_toolbox/loop_closure_event"
+```
+
+Example Record data, one sample:
+
+```json
+{
+  "event": "sample",
+  "x": 1.42,
+  "y": -0.63,
+  "yaw": 0.71,
+  "covariance_x": 0.008,
+  "covariance_y": 0.011,
+  "covariance_yaw": 0.004
+}
+```
+
+A loop closure:
+
+```json
+{
+  "event": "loop_closure"
+}
+```
+
+## KPIs
+
+`tools/infrastructure/sql/kpi_views.sql` defines `dc_kpi_loop_closure_rate()` (loop closures per
+hour and seconds since the last one, over an arbitrary window) and `dc_kpi_loop_closures_1h` (the
+same count bucketed hourly for charting) over this Measurement's `loop_closure` Records, following
+the same convention as `dc_kpi_intervention_rate()`. The demo Grafana KPI dashboard charts loop
+closures per hour; the robot dashboard charts the covariance trend directly from `sample` Records.

--- a/doc/src/dc/measurements/slam_toolbox_quality.md
+++ b/doc/src/dc/measurements/slam_toolbox_quality.md
@@ -5,8 +5,9 @@
 Localization quality from two of [slam_toolbox](https://github.com/SteveMacenski/slam_toolbox)'s
 native ROS 2 topics: `/pose` (`geometry_msgs/PoseWithCovarianceStamped`), polled on the same
 interval as every other Measurement, for a `sample` Record carrying the pose and its covariance;
-and `/slam_toolbox/loop_closure_event` (`slam_toolbox/LoopClosureEvent`) for a single-shot
-`loop_closure` Record per occurrence.
+and `/slam_toolbox/loop_closure_event` (`slam_toolbox/LoopClosureEvent` on slam_toolbox's
+development branch — see the note below on why this Measurement doesn't depend on that type
+directly) for a single-shot `loop_closure` Record per occurrence.
 
 `LoopClosureEvent` carries nothing but its own timestamp — slam_toolbox doesn't say which nodes
 closed the loop or by how much, only that one happened. The Record reflects that: `loop_closure`
@@ -33,12 +34,17 @@ next poll, one Record per poll, so it travels the same path as every other Recor
 incident buffering, Group) — the same convention [Battery](./battery.md)'s charging-session
 boundaries and [Intervention](./intervention.md)'s takeovers use.
 
-```admonish info title="slam_toolbox is a runtime dependency, not a build one this plugin adds weight to"
-`slam_toolbox/LoopClosureEvent` is defined inside the `slam_toolbox` package itself — it ships no
-separate, lighter `_msgs` package the way nav2 does. This Measurement only makes sense on a robot
-already running slam_toolbox for real SLAM, so depending on the real package (rather than working
-around it with a raw/generic subscription) is the plain choice: the dependency is already present
-wherever this Measurement is.
+```admonish info title="Why loop_closure_topic is subscribed generically"
+`slam_toolbox/LoopClosureEvent` is declared on slam_toolbox's `ros2` development branch but isn't
+part of any released binary yet — verified directly against the actual `ros-jazzy-slam-toolbox`
+package contents, which ship no `msg/` interface headers for it at all, only the `srv/` ones. A
+compile-time dependency on that message can't build against a real installation today, so this
+Measurement subscribes to `loop_closure_topic` with `create_generic_subscription` instead — the
+same runtime-discovery mechanism dc_bridge's raw mode uses. The content is never decoded (the
+Record only needs to know an occurrence happened, not what the message carried), and the topic's
+actual type is discovered from the ROS graph once slam_toolbox starts advertising it, so this
+Measurement keeps working whichever release adds the topic and whatever fields it ends up
+carrying — no dc_measurements rebuild required.
 ```
 
 ## Parameters
@@ -46,7 +52,7 @@ wherever this Measurement is.
 | Parameter               | Description                                                                 | Type | Default                              |
 | ------------------------ | ----------------------------------------------------------------------------- | ---- | --------------------------------------- |
 | **pose_topic**           | Topic (`geometry_msgs/PoseWithCovarianceStamped`) to read localization pose from | str  | "/pose" (Optional)                    |
-| **loop_closure_topic**   | Topic (`slam_toolbox/LoopClosureEvent`) slam_toolbox reports loop closures on | str  | "/slam_toolbox/loop_closure_event" (Optional) |
+| **loop_closure_topic**   | Topic slam_toolbox reports loop closures on, subscribed generically (type discovered at runtime) | str  | "/slam_toolbox/loop_closure_event" (Optional) |
 
 ## Schema
 

--- a/progress.txt
+++ b/progress.txt
@@ -9127,3 +9127,22 @@ the new tests, not that they were run and passed.
   generic and content is never inspected). Doc page's admonish block rewritten to match.
   Genuinely forward-compatible: whichever release slam_toolbox eventually ships this topic
   on, and whatever fields it carries, this Measurement picks it up without a rebuild.
+- **CI follow-up 2 (kpi-views failure, also caught landing the PR)**: `psycopg2.errors.
+  DuplicateColumn: column "event" specified more than once`. Cause: #392 (Fast DDS
+  statistics Measurement) landed on `jazzy` around the same time and *also* added its own
+  `event text,` column to the `dc` table in `tools/infrastructure/docker/config/postgresql/
+  init.sql` -- textually far enough from this ticket's own `event text,` addition that
+  `git rebase`'s line-based merge saw no conflict and silently kept both. Fixed by dropping
+  the duplicate declaration and pointing fastdds_stats' own comment at the column this
+  ticket (and battery.cpp) already declares, rather than redeclaring it. Verified for real
+  this time, not just via `prek`: ran `tools/infrastructure/scripts/test_kpi_views.sh`
+  locally against a throwaway Podman PostgreSQL -- the actual CI harness, available in this
+  sandbox even though `colcon`/ROS are not -- all 33 fixture tests (including the 4 new
+  loop-closure-rate cases) passed. Also swept every other file two-or-more concurrently
+  merged PRs touched for the same silent-duplicate risk (plugin registrations, CMake
+  dependency/test lists, package.xml depends, Grafana panel ids/titles, SQL view/function
+  names, SUMMARY.md doc entries) -- none found. Lesson for next time landing a PR into a
+  fast-moving base: a clean rebase only proves no *textual* conflict, not no *semantic* one
+  between concurrently-merged PRs that both touch a shared append-only file in different
+  places; worth an explicit duplicate-declaration sweep whenever a rebase pulls in another
+  PR that touched the same generated/shared file.

--- a/progress.txt
+++ b/progress.txt
@@ -9038,3 +9038,69 @@ the new tests, not that they were run and passed.
   close the "colcon build succeeds" and "gtest suite passes" acceptance criteria formally. `prek
   run --all-files --skip build-doc` passed for every changed file (JSON/YAML/XML syntax,
   clang-format, copyright headers, ROS package metadata) as a substitute check.
+
+### #394 - Add the slam_toolbox quality Measurement
+
+- Added `dc_measurements/SlamToolboxQuality` (`slam_toolbox_quality.{hpp,cpp}`), combining
+  two of slam_toolbox's native ROS 2 topics into one plugin: `/pose`
+  (`geometry_msgs/PoseWithCovarianceStamped`), polled on the ordinary interval for a
+  `sample` Record carrying `x`/`y`/`yaw` and the pose covariance diagonal
+  (`covariance_x`/`covariance_y`/`covariance_yaw`, indices 0/7/35 of the 6x6 matrix); and
+  `/slam_toolbox/loop_closure_event` (`slam_toolbox/LoopClosureEvent`) for a single-shot
+  `loop_closure` Record per occurrence. Followed `battery.cpp`'s pending-events convention
+  exactly: the loop closure callback queues a timestamp, `collect()` drains one queued event
+  per poll ahead of the periodic sample, so it travels the same publish path (Conditions,
+  incident buffering, Group) as every other Record.
+- `LoopClosureEvent` carries only its own stamp (`builtin_interfaces/Time stamp` — verified
+  against the real message definition on the `ros2` branch of
+  github.com/SteveMacenski/slam_toolbox, not guessed), so the Record body has nothing beyond
+  `event`; the plugin uses its own clock at callback time rather than the message's stamp,
+  since the two are close enough in practice and the Record only needs to say *that* a
+  closure happened, matching the acceptance criterion's "timestamp only" framing.
+- **Real dependency, not a workaround**: `slam_toolbox` (the full package — it ships no
+  lighter `_msgs`-only split the way nav2 does) is a plain `<depend>`/`find_package` in
+  `dc_measurements`, linked only to the new plugin's own target the way `ZXing`/ffmpeg
+  already are for camera/ip_camera. Considered a `rclcpp::GenericSubscription` to dodge the
+  heavy transitive deps (ceres, suitesparse, Qt5, rviz) instead, but that only defers the
+  same dependency to runtime dlopen of slam_toolbox's own typesupport library — this
+  Measurement is only meaningful on a robot already running slam_toolbox for real SLAM, so
+  the dependency is already present wherever it would run, and the generic-subscription
+  route would only have made *this repo's* tests harder to write for no real decoupling.
+- Test (`test_measurement_slam_toolbox_quality.cpp`) follows the `battery` test's structure:
+  a `MeasurementServer` with two publishers (`/test/pose`, `/test/loop_closure_event`),
+  covering the periodic sample (pose + covariance), the "nothing published yet" gap, and the
+  single-shot loop-closure Record (published once, not republished, since it must produce
+  exactly one Record) — every case validated against the installed JSON Schema.
+- Registered everywhere a Measurement plugin needs it: `CMakeLists.txt` (library target,
+  `dependencies` list, test list), `measurement_plugin.xml`, `package.xml`.
+- **KPI value wired through, not left for later** (this issue's acceptance criteria asked
+  for it explicitly, unlike battery's own event Records, which have no KPI view yet):
+  added `dc_kpi_loop_closure_events`/`dc_kpi_loop_closure_rate(from, to)`/
+  `dc_kpi_loop_closures_1h` to `tools/infrastructure/sql/kpi_views.sql`, following the
+  `intervention`/`fault` views' conventions. `seconds_since_last` deliberately looks past
+  `window_start` (unlike every other rate function here) — clipped to the window it would
+  read a robot with no loop closure yet in a short window as "just corrected" instead of
+  "never corrected". Added a fixture-test section to
+  `tools/infrastructure/test/test_kpi_views.py` (`loop_closure()`/`loop_closure_rate()`
+  helpers + 4 cases), and `event`/`x`/`y`/`yaw`/`covariance_x`/`covariance_y`/`covariance_yaw`
+  columns to `tools/infrastructure/docker/config/postgresql/init.sql` (reusing `event` from
+  `battery.cpp` and `x`/`y`/`yaw` names already implied-but-unused by `position.cpp`, told
+  apart by `name = 'slam_toolbox_quality'` the same way every other Measurement sharing a
+  column name is).
+- Grafana: added "Loop closures per hour" (`dc_kpi_loop_closures_1h`) and "Time since last
+  loop closure" (`dc_kpi_loop_closure_rate`) panels to the KPI dashboard
+  (`dashboards/kpi.json`), and a "Localization covariance trend" panel querying `dc` directly
+  (`dashboards/robot.json`), matching that dashboard's existing raw-telemetry panels
+  (speed/cmd_vel) rather than going through a view, since it's a plain trend with no
+  aggregation.
+- Doc page `doc/src/dc/measurements/slam_toolbox_quality.md` added and linked from
+  `SUMMARY.md`; `doc/src/dc/kpi_views.md` gained a "Loop closure rate" section, a row in the
+  "What it defines" table, the grants list, and the "What the data has to look like" table,
+  matching every other KPI already documented there.
+- **Not done**: no live demo runs slam_toolbox in this repo yet, so the new dashboard panels
+  are blank until one does (labeled as such in their panel descriptions, matching how the
+  `intervention`/`fault` panels already read before those Measurements existed) — wiring an
+  actual slam_toolbox-based demo is out of scope for this ticket, which asked for the
+  Measurement plus KPI/panel wiring, not a new demo. `colcon build`/`colcon test` could not
+  be run in this sandbox (no ROS install, same constraint noted since #242); `prek run
+  --all-files --skip build-doc` passed clean on every changed file instead.

--- a/progress.txt
+++ b/progress.txt
@@ -9104,3 +9104,26 @@ the new tests, not that they were run and passed.
   Measurement plus KPI/panel wiring, not a new demo. `colcon build`/`colcon test` could not
   be run in this sandbox (no ROS install, same constraint noted since #242); `prek run
   --all-files --skip build-doc` passed clean on every changed file instead.
+- **CI follow-up (build-workspace failure, caught landing the PR)**: `colcon build` (which
+  the sandbox above genuinely could not run) failed with `fatal error:
+  slam_toolbox/msg/loop_closure_event.hpp: No such file or directory`. Downloaded and
+  inspected the actual `ros-jazzy-slam-toolbox_2.8.5` `.deb` CI installs: it ships no `msg/`
+  interface headers at all (only `srv/`), and the release tag `2.8.5` on GitHub has no
+  `msg/` directory either -- `LoopClosureEvent.msg` only exists on the unreleased `ros2`
+  branch tip, added after 2.8.5. The original design (a compile-time
+  `slam_toolbox::msg::LoopClosureEvent` typed subscription, `slam_toolbox` as a real
+  `find_package`/`<depend>`) was verified against that branch tip, not against what's
+  actually installable -- a real gap in the earlier verification, not a rebase artifact.
+  Fixed by switching `loop_closure_topic_` to a `create_generic_subscription` (the same
+  runtime-discovery mechanism `dc_bridge/raw_subscriptions.cpp`'s raw mode already uses in
+  this repo): `tryCreateLoopClosureSubscription()` looks the topic up via
+  `get_topic_names_and_types()`, subscribes once its type is known (skips ambiguous
+  multi-type topics, catches an unloadable typesupport), and a 1 s discovery timer retries
+  until it succeeds, so this Measurement's startup order relative to slam_toolbox's doesn't
+  matter. The callback never decodes the payload -- occurrence is the Record, not content --
+  so there's no compile-time dependency on the message at all any more: dropped
+  `slam_toolbox` from `package.xml`/`CMakeLists.txt` entirely, and the test's stand-in
+  publisher now uses `std_msgs::msg::Empty` (any type works, since the subscription is
+  generic and content is never inspected). Doc page's admonish block rewritten to match.
+  Genuinely forward-compatible: whichever release slam_toolbox eventually ships this topic
+  on, and whatever fields it carries, this Measurement picks it up without a rebuild.

--- a/tools/infrastructure/docker/config/grafana/dashboards/kpi.json
+++ b/tools/infrastructure/docker/config/grafana/dashboards/kpi.json
@@ -1225,6 +1225,128 @@
       ],
       "title": "Faults per hour",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "dc_kpi_loop_closures_1h — slam_toolbox_quality loop closures per hour (#394). Blank until the Measurement lands.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto",
+            "spanNulls": false
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 60
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql":
+              "SELECT bucket_start AS \"time\", robot_name AS metric, loop_closures FROM dc_kpi_loop_closures_1h WHERE $__timeFilter(bucket_start) ORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Loop closures per hour",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "dc_kpi_loop_closure_rate() — seconds since the last loop closure, a localization-drift risk indicator: a growing gap means the map has gone without a correction.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s",
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 60
+      },
+      "id": 18,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "limit": 10,
+          "values": true
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT robot_name, seconds_since_last FROM dc_kpi_loop_closure_rate($__timeFrom(), $__timeTo())",
+          "refId": "A"
+        }
+      ],
+      "title": "Time since last loop closure",
+      "type": "stat"
     }
   ],
   "refresh": "30s",

--- a/tools/infrastructure/docker/config/grafana/dashboards/robot.json
+++ b/tools/infrastructure/docker/config/grafana/dashboards/robot.json
@@ -150,6 +150,56 @@
       ],
       "title": "Group completion status",
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "postgres",
+        "uid": "dc_postgres"
+      },
+      "description":
+          "slam_toolbox_quality's pose covariance diagonal (#394) — localization confidence over time. Blank until the Measurement lands.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "auto"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "postgres",
+            "uid": "dc_postgres"
+          },
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql":
+              "SELECT to_timestamp(date / 1e9) AS \"time\", covariance_x, covariance_y, covariance_yaw FROM dc WHERE name = 'slam_toolbox_quality' AND event = 'sample' ORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "title": "Localization covariance trend",
+      "type": "timeseries"
     }
   ],
   "refresh": "",

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -89,6 +89,19 @@ CREATE TABLE IF NOT EXISTS dc (
   previous_duration double precision,
   sequence bigint,
   open boolean,
+  -- slam_toolbox_quality.cpp's Records (#394): `event` tags which of the two Record shapes a
+  -- row is (shared with battery.cpp's own `event`, told apart by `name`), and
+  -- x/y/yaw/covariance_* carry the `sample` shape -- distinct columns from position.cpp's own
+  -- x/y/yaw (never enumerated above, see the note at the top of this file) only in the sense
+  -- that the postgres sink maps by column name regardless of `name`, so both are told apart by
+  -- `name = 'slam_toolbox_quality'` in the KPI views that read them.
+  event text,
+  x double precision,
+  y double precision,
+  yaw double precision,
+  covariance_x double precision,
+  covariance_y double precision,
+  covariance_yaw double precision,
   -- Infrastructure (tcp_health.cpp)
   host text,
   port integer,

--- a/tools/infrastructure/docker/config/postgresql/init.sql
+++ b/tools/infrastructure/docker/config/postgresql/init.sql
@@ -90,11 +90,11 @@ CREATE TABLE IF NOT EXISTS dc (
   sequence bigint,
   open boolean,
   -- slam_toolbox_quality.cpp's Records (#394): `event` tags which of the two Record shapes a
-  -- row is (shared with battery.cpp's own `event`, told apart by `name`), and
-  -- x/y/yaw/covariance_* carry the `sample` shape -- distinct columns from position.cpp's own
-  -- x/y/yaw (never enumerated above, see the note at the top of this file) only in the sense
-  -- that the postgres sink maps by column name regardless of `name`, so both are told apart by
-  -- `name = 'slam_toolbox_quality'` in the KPI views that read them.
+  -- row is -- a column battery.cpp and fastdds_stats.cpp also populate their own `event` into,
+  -- told apart by `name` -- and x/y/yaw/covariance_* carry the `sample` shape, distinct columns
+  -- from position.cpp's own x/y/yaw (never enumerated above, see the note at the top of this
+  -- file) only in the sense that the postgres sink maps by column name regardless of `name`, so
+  -- both are told apart by `name = 'slam_toolbox_quality'` in the KPI views that read them.
   event text,
   x double precision,
   y double precision,
@@ -107,11 +107,10 @@ CREATE TABLE IF NOT EXISTS dc (
   port integer,
   server_name text,
   active boolean,
-  -- Fast DDS statistics (fastdds_stats.cpp, #392, fastdds_stats_pgsql_grafana demo). `event` is
-  -- always "sample" for this Measurement -- listed for querying, unlike the Measurements above
-  -- that never populate it, none of which use this column. process_names (not `processes`,
-  -- which cpu.cpp above already owns for its total process count) is a jsonb array of names.
-  event text,
+  -- Fast DDS statistics (fastdds_stats.cpp, #392, fastdds_stats_pgsql_grafana demo). Reuses the
+  -- `event` column declared above (always "sample" for this Measurement -- listed for querying).
+  -- process_names (not `processes`, which cpu.cpp above already owns for its total process
+  -- count) is a jsonb array of names.
   domain_id integer,
   participant_count integer,
   datawriter_count integer,

--- a/tools/infrastructure/sql/kpi_views.sql
+++ b/tools/infrastructure/sql/kpi_views.sql
@@ -485,5 +485,77 @@ FROM dc_kpi_fault_events e
 WHERE e.from_level IS NOT NULL
 GROUP BY 1, 2, 3;
 
+-- The wide `dc` table narrowed to the slam_toolbox_quality Measurement's single-shot
+-- loop-closure Records (#394). The source topic carries nothing but its own occurrence, so
+-- there is nothing more to project than when it happened.
+CREATE OR REPLACE VIEW dc_kpi_loop_closure_events AS
+SELECT
+  COALESCE(d.robot_name, 'unknown') AS robot_name,
+  to_timestamp(d.date / 1e9) AS event_time
+FROM dc d
+WHERE d.name = 'slam_toolbox_quality'
+  AND d.event = 'loop_closure'
+  AND d.date IS NOT NULL;
+
+-- Loop closures per hour of the window, per robot, plus how long it's been since the last one
+-- as of window_end -- a growing gap is a localization-drift risk indicator on its own, distinct
+-- from the rate. last_loop_closure looks past window_start (unlike the interventions/faults
+-- rate functions) because "how long since" is meaningless clipped to the window: a robot with no
+-- loop closure yet in a short window would otherwise read as recently corrected instead of never.
+CREATE OR REPLACE FUNCTION dc_kpi_loop_closure_rate(
+  window_start timestamptz,
+  window_end timestamptz
+)
+RETURNS TABLE (
+  robot_name text,
+  loop_closures bigint,
+  window_seconds double precision,
+  per_hour double precision,
+  last_loop_closure timestamptz,
+  seconds_since_last double precision
+)
+LANGUAGE sql
+STABLE
+AS $$
+  WITH counted AS (
+    SELECT e.robot_name, count(*)::bigint AS loop_closures
+    FROM dc_kpi_loop_closure_events e
+    WHERE e.event_time >= window_start AND e.event_time <= window_end
+    GROUP BY e.robot_name
+  ),
+  last_seen AS (
+    SELECT e.robot_name, max(e.event_time) AS last_loop_closure
+    FROM dc_kpi_loop_closure_events e
+    WHERE e.event_time <= window_end
+    GROUP BY e.robot_name
+  ),
+  robots AS (
+    SELECT counted.robot_name FROM counted
+    UNION SELECT last_seen.robot_name FROM last_seen
+  )
+  SELECT
+    r.robot_name,
+    COALESCE(c.loop_closures, 0),
+    EXTRACT(EPOCH FROM (window_end - window_start))::double precision,
+    (
+      COALESCE(c.loop_closures, 0) /
+      NULLIF(EXTRACT(EPOCH FROM (window_end - window_start)) / 3600.0, 0)
+    )::double precision,
+    l.last_loop_closure,
+    EXTRACT(EPOCH FROM (window_end - l.last_loop_closure))::double precision
+  FROM robots r
+  LEFT JOIN counted c ON c.robot_name = r.robot_name
+  LEFT JOIN last_seen l ON l.robot_name = r.robot_name
+$$;
+
+-- Loop closures bucketed hourly for charting, the same bucket size interventions and faults use.
+CREATE OR REPLACE VIEW dc_kpi_loop_closures_1h AS
+SELECT
+  to_timestamp(floor(EXTRACT(EPOCH FROM e.event_time) / 3600) * 3600) AS bucket_start,
+  e.robot_name,
+  count(*)::bigint AS loop_closures
+FROM dc_kpi_loop_closure_events e
+GROUP BY 1, 2;
+
 -- The lookup every object above starts from.
 CREATE INDEX IF NOT EXISTS dc_name_date_idx ON dc (name, date);

--- a/tools/infrastructure/test/test_kpi_views.py
+++ b/tools/infrastructure/test/test_kpi_views.py
@@ -437,6 +437,62 @@ def test_the_bucketed_intervention_view_charts_the_same_events(db):
     assert buckets[0]["mean_intervention_seconds"] == pytest.approx(60.0)
 
 
+# --- Loop closure rate ------------------------------------------------------------------
+
+
+def loop_closure(db, offset):
+    """One slam_toolbox_quality loop_closure Record (#394): a single-shot occurrence."""
+    db.execute(
+        "INSERT INTO dc (date, name, robot_name, event) VALUES (%s, %s, %s, %s)",
+        (int(at(offset).timestamp()) * 10**9, "slam_toolbox_quality", ROBOT, "loop_closure"),
+    )
+
+
+def loop_closure_rate(db, start, end):
+    """dc_kpi_loop_closure_rate() over [start, end], keyed by robot."""
+    db.execute("SELECT * FROM dc_kpi_loop_closure_rate(%s, %s)", (at(start), at(end)))
+    return {row["robot_name"]: row for row in db.fetchall()}
+
+
+def test_loop_closure_rate_is_per_hour(db):
+    loop_closure(db, 400)
+    loop_closure(db, 700)
+    loop_closure(db, 1900)  # outside the window
+
+    kpi = loop_closure_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["loop_closures"] == 2
+    assert kpi["window_seconds"] == pytest.approx(600.0)
+    assert kpi["per_hour"] == pytest.approx(12.0)
+
+
+def test_seconds_since_last_looks_past_the_window_start(db):
+    # The only loop closure is well before the window: "how long since" would be meaningless
+    # clipped to the window, so it looks at everything up to window_end instead.
+    loop_closure(db, 100)
+
+    kpi = loop_closure_rate(db, 300, 900)[ROBOT]
+
+    assert kpi["loop_closures"] == 0
+    assert kpi["last_loop_closure"] == at(100)
+    assert kpi["seconds_since_last"] == pytest.approx(800.0)
+
+
+def test_a_robot_with_no_loop_closures_ever_reports_nothing(db):
+    assert loop_closure_rate(db, 300, 900) == {}
+
+
+def test_the_bucketed_loop_closure_view_charts_the_same_events(db):
+    loop_closure(db, 400)
+    loop_closure(db, 460)
+    loop_closure(db, 4000)  # the next hour bucket
+
+    db.execute("SELECT * FROM dc_kpi_loop_closures_1h ORDER BY bucket_start")
+    buckets = db.fetchall()
+
+    assert [row["loop_closures"] for row in buckets] == [2, 1]
+
+
 # --- MTBF and MTTR ---------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- Add `dc_measurements/SlamToolboxQuality`, combining slam_toolbox's `/pose` (periodic `sample` Record with pose covariance) and `/slam_toolbox/loop_closure_event` (single-shot `loop_closure` Record) into one Measurement plugin, following `battery.cpp`'s pending-events convention.
- Wire the KPI value through: `dc_kpi_loop_closure_rate()`/`dc_kpi_loop_closures_1h` in `kpi_views.sql` (with a fixture-test section), demo Postgres columns, and two Grafana panels (loop closures per hour, time since last loop closure) plus a localization covariance trend panel.
- Add the doc page and register the plugin everywhere a Measurement needs it (`CMakeLists.txt`, `measurement_plugin.xml`, `package.xml`).

## Test plan
- [x] `prek run --all-files --skip build-doc` passes clean on every changed file (clang-format, JSON/XML validation, ROS package metadata checks, etc.)
- [x] New unit test `test_measurement_slam_toolbox_quality.cpp` covers the periodic sample (pose + covariance), the "nothing published yet" gap, and the single-shot loop-closure Record, each validated against the installed JSON Schema — follows the existing `battery` test's structure and harness.
- [x] New fixture-test section in `tools/infrastructure/test/test_kpi_views.py` covers `dc_kpi_loop_closure_rate()`'s rate, its window-independent `seconds_since_last`, the no-loop-closure-ever case, and the hourly bucketed view.
- [ ] `colcon build` / `colcon test` — not runnable in this sandbox (no ROS install); needs CI or a machine with `ament_cmake`.
- [ ] Live Grafana verification — no demo in this repo runs slam_toolbox yet, so the new panels are unpopulated until one does (same state `intervention`/`fault` panels were in before those Measurements existed).

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012L9kNdTWQBMy6pDsbVyyo5