### PR TITLE
feat(tools/e2e): add limits harness drain-rate axis (#385)

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -8411,6 +8411,81 @@ reading the code (the repo's established verification standard):
 - `tools/e2e/README.md` gained an "Uploader concurrency axis (#384)" section (after the
   Shipper fan-in axis's #382 section — the last of the three merged this way, so it
   gets the "ninth piece" framing, before Layout) plus Layout entries for the new files.
+
+### #385 - Limits harness: drain-rate axis
+
+- Added `tools/e2e/scripts/drain_rate_axis.py`: "how long does a backlog take to clear
+  once connectivity returns, as a function of load and outage length." Split along the
+  epic's own deep/integration line: `evaluate_cycle()` (pure, no I/O) runs each cycle's
+  outage-phase buffer-size window through `saturation_probe.evaluate()` with
+  `outage_declared=True` and raises `OutageMisreportedError` if that window is ever
+  reported saturated — a growing buffer during a declared outage is expected and must
+  never trip, and this is the *same* module and disk-buffer signal #377 defines, not a
+  bespoke check (one of #385's two acceptance criteria). The recovery-phase window reuses
+  the identical signal with `outage_declared=False` to decide the ramp's knee — except a
+  backlog that never fully drains (`drain_time_s is None`) is always reported saturated,
+  since a buffer that merely plateaus rather than growing wouldn't otherwise trip the
+  growth-trend check. `find_drain_rate_curve()` wires this into
+  `ramp_controller.find_knee()` unmodified, ramping ascending outage lengths at a fixed
+  stated load (callers vary load across invocations, `run_limits_two_tier.sh`'s own
+  REAL_STACKS/SYNTH_CONNECTIONS convention) and reporting the knee: the shortest outage
+  length whose backlog failed to drain within the wait bound (never fabricated —
+  `RunOutcome.BOUND_NOT_FOUND` when every tried outage length drains cleanly, matching
+  #379's rule). `build_axis_run()` turns that into curve_reporter's own `AxisRun` shape
+  unmodified (#385's other acceptance criterion) — `level` is the outage length in
+  seconds tried, matching the unit `tripped_level`/`highest_clear_level` are reported in;
+  the per-level *drain time* this axis exists to report has no field of its own in that
+  shared shape, so `main()` writes it alongside the curve report as a companion JSON
+  keyed by the same outage-length levels.
+- Added `tools/e2e/scripts/run_limits_drain_rate.sh`, the integration scenario: a
+  standalone Shipper under test (bare Vector, `fluent` source + `aws_s3` sink with a disk
+  buffer, no dc_bridge/ROS — same convention the two-tier composer's aggregating Shipper
+  and the load-driver byte-compatibility test both use) plus RustFS as the Destination it
+  can lose, on their own dedicated bridge network (`dc-e2e-drain-net`) rather than
+  `--network host` — RustFS never needs to be host-reachable at all here (only the
+  Shipper talks to it, over container-name DNS), so this sidesteps host port 9000
+  contention with any other scenario script's own RustFS entirely (found this the hard
+  way: a concurrent podman session on this dev machine was squatting host ports 9000 and
+  24224 mid-development, which is what motivated moving RustFS off the host network and
+  giving the Shipper's own fluent/metrics ports non-default values, 24236/9648, both
+  overridable). Induces each outage with the exact `podman stop` / wait / `podman start`
+  recipe `run.sh` itself uses on its own Postgres/RustFS containers — called directly via
+  `drain_rate_axis.py`'s subprocess calls rather than shelling out to `run.sh`, since
+  `run.sh`'s outage window is one step inside a much larger zero-loss run with its own
+  fixed gates; the *recipe* is reused, `run.sh` itself is untouched, satisfying #385's
+  "existing incident/outage scenario scaffolding, reused unmodified" acceptance
+  criterion literally.
+- **Real discovery, made empirically while building this and worth recording rather than
+  working around silently**: buffer size cannot be read as a filesystem stat on Vector's
+  buffer directory. `du -sb` on it was tried first; a live test run here showed the
+  `.dat` segment file staying pinned at its post-outage peak for over a minute of
+  continuous real deliveries to RustFS after the outage ended — Vector's on-disk buffer
+  format (a segment-based mmap log) does not shrink the file as events are acked, so
+  every drain would have looked like it never happened. Switched to scraping Vector's own
+  `internal_metrics` + `prometheus_exporter` sink (`vector_buffer_byte_size`), added to
+  the standalone Vector config (not a DC code change — #323's PRD already anticipates
+  exactly this: "the harness injects a metrics source and exporter ... for the duration
+  of a run"); verified against the same live buildup that this gauge tracks actual
+  pending bytes and reaches ~0 within seconds of the Destination coming back.
+- **Verified end-to-end for real**, not just read through: podman was available with
+  images already cached, so the full scenario was run repeatedly against real RustFS +
+  Vector containers. Confirmed both ramp outcomes for real: a short (20s) outage with a
+  generous wait bound produced `BOUND_NOT_FOUND` with a genuine measured drain time
+  (~752KB backlog, drained in ~8.1s); the same setup with a deliberately tiny wait bound
+  (3s) produced `KNEE_FOUND` at the first outage length tried, with the ramp correctly
+  never driving the second, longer outage length once the first tripped. In every run the
+  outage-phase window's real buffer growth (hundreds of KB) was correctly not
+  misreported as saturation. Confirmed clean teardown (no leftover containers/network)
+  after both success and forced-failure runs.
+- Added `tools/e2e/test/test_drain_rate_axis.py`: unit tests for the pure parts
+  (`evaluate_cycle`, `build_axis_run`, `find_drain_rate_curve`) with synthetic
+  `DrainCycleResult`/`Observation` data and fake drivers, no containers — mirroring
+  `test_ramp_controller.py`'s fakes-based approach, including a direct
+  `ramp_controller.find_knee()` comparison to confirm `find_drain_rate_curve()` is really
+  delegating to it rather than reimplementing ramp semantics.
+- `tools/e2e/README.md` gained a "Drain-rate axis (#385)" section (the tenth piece,
+  after the Uploader concurrency axis's #384 section — the last of #382/#383/#384 to
+  land — before Layout) plus a Layout entry for the two new scripts.
 - Not wired into `ci.yaml`, same as every other narrow scenario script.
 
 ### #388 - Add the Mission Measurement: NavigateThroughPoses adapter

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -514,6 +514,61 @@ expected file count. A violation raises immediately and aborts the whole ramp.
 
 Not wired into `ci.yaml`, same as every other narrow scenario above.
 
+## Drain-rate axis (#385)
+
+The tenth piece of #323's limits harness (developed in parallel with #382/#383/#384):
+"how long does a backlog take to clear once connectivity returns, as a function of load
+and outage length."
+
+```sh
+./tools/e2e/scripts/run_limits_drain_rate.sh
+```
+
+Brings up a standalone Shipper under test (a bare Vector instance on its own bridge
+network, `fluent` source + `aws_s3` sink with a disk buffer — same convention the
+two-tier composer's aggregating Shipper and the load-driver byte-compatibility test both
+use) plus RustFS as the Destination it can lose, then drives `scripts/drain_rate_axis.py`
+through an ascending ramp of outage lengths at a stated synthetic connection
+count/rate. For each outage length it induces the outage with the exact `podman stop` /
+wait / `podman start` recipe `run.sh` itself uses on its own Postgres/RustFS containers
+(#385's "existing incident/outage scenario scaffolding, reused unmodified" acceptance
+criterion), drives `load_driver.py` for the outage's duration, then polls the Shipper's
+buffer size until it clears or a wait bound expires and records that elapsed time as the
+drain time.
+
+Buffer size comes from Vector's own `internal_metrics` + `prometheus_exporter`
+(`vector_buffer_byte_size`), not a filesystem stat on the buffer directory — a discovery
+made empirically while building this: Vector's on-disk buffer format (a segment-based
+mmap log) does not shrink its `.dat` segment file as events are acked, so `du -sb` on the
+buffer directory stays pinned at its post-outage peak indefinitely, which would make
+every drain look like it never happened. The metrics gauge, by contrast, tracks the
+buffer's actual pending bytes and reaches ~0 once the backlog genuinely clears. Injecting
+a metrics source/sink into this standalone Vector config is not a DC code change — #323's
+PRD anticipates exactly this ("observability comes from configuration, not code
+changes").
+
+Every outage-phase observation window is run through `saturation_probe.evaluate()`
+(#377) with `outage_declared=True`, and the whole run hard-fails
+(`OutageMisreportedError`) if that window is ever reported saturated — a growing buffer
+during a declared outage must never be misreported, and this is the same module and the
+same disk-buffer signal #377 defines, not a bespoke check. The *recovery*-phase window
+reuses the identical signal with `outage_declared=False` to decide whether an outage
+length is the ramp's knee — the shortest outage length whose backlog failed to drain
+within the wait bound (never fabricated: a backlog that always drains within the tested
+range is reported as `BOUND_NOT_FOUND`, matching #379's own rule). Output feeds
+`curve_reporter.py` in the same stable `AxisRun`/`CurveReport` shape the other axes use;
+`AxisRun.points[].level` is the outage length in seconds (the same unit
+`tripped_level`/`highest_clear_level` come in) — the per-level *drain time* this axis
+exists to report has no field of its own in that shared shape, so it travels alongside
+the curve report as a companion JSON keyed by the same outage-length levels.
+`tools/e2e/test/test_drain_rate_axis.py` covers the pure parts (`evaluate_cycle`,
+`build_axis_run`, `find_drain_rate_curve`) with fake drivers and synthetic observation
+windows, no containers; the real podman/`load_driver.py` orchestration is exercised by
+running the scenario script itself, not unit-tested, matching the two-tier composer's own
+testing decision.
+
+Not wired into `ci.yaml`, same as the scenarios above.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -640,6 +695,14 @@ Not wired into `ci.yaml`, same as every other narrow scenario above.
   #323) described above: calls `ramp_controller.find_knee()` unchanged, ramping N
   Bridge/Uploader containers against shared Postgres/RustFS and asserting
   delete-after-verify ordering plus Group completion correctness at every level.
+- `scripts/drain_rate_axis.py` / `scripts/run_limits_drain_rate.sh` — the drain-rate axis
+  (#385, part of #323) described above: an induced-outage-then-recovery ramp over outage
+  length at a fixed synthetic load, reusing run.sh's own outage-inducing recipe and
+  saturation_probe.py's outage-aware disk-buffer signal, reporting into
+  curve_reporter.py's stable shape. `evaluate_cycle()`/`build_axis_run()`/
+  `find_drain_rate_curve()` are pure and unit-tested with fakes
+  (`test_drain_rate_axis.py`); the podman/load_driver.py orchestration is exercised by
+  running the scenario script.
 
 ## `.dockerignore`
 

--- a/tools/e2e/scripts/drain_rate_axis.py
+++ b/tools/e2e/scripts/drain_rate_axis.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Drain-rate axis (#385, part of #323's limits harness): "how long does a backlog take
+to clear once connectivity returns, as a function of load and outage length."
+
+An **outage cycle** drives synthetic load (tools/e2e/scripts/load_driver.py, #378) at a
+stated connection count and per-connection rate against a Shipper under test while its
+downstream Destination is unreachable — reusing tools/e2e/scripts/run.sh's own
+outage-inducing recipe (`podman stop`, wait, `podman start`) unmodified rather than
+inventing a second way to simulate an outage — then, once the Destination is restored,
+polls the Shipper's buffer size until it clears (or a wait bound expires) and reports
+that elapsed time as the drain time.
+
+**Buffer size comes from Vector's own `internal_metrics` + `prometheus_exporter`
+(`vector_buffer_byte_size{buffer_id=...}`), not a filesystem stat on the buffer
+directory.** Verified empirically while building this module: Vector's on-disk buffer
+format (a segment-based mmap log) does not shrink its `.dat` segment file as events are
+acked — `du -sb` on the buffer directory stayed pinned at its post-outage peak for over a
+minute of continuous real deliveries in a live test run here, which would have made
+every drain look like it never happened. The `vector_buffer_byte_size` gauge, by
+contrast, tracks the buffer's actual pending bytes and dropped to 0 within ~8s of the
+Destination coming back in the same test. This is exactly the mechanism #323's PRD
+anticipates ("the harness injects a metrics source and exporter into either tier for the
+duration of a run" — "Observability comes from configuration, not code changes"):
+run_limits_drain_rate.sh's own Vector config carries no dc_bridge/DC involvement to
+begin with, so adding `internal_metrics`/`prometheus_exporter` to it is not a DC code
+change at all.
+
+This module splits cleanly along the epic's own line between "deep" (pure, no I/O,
+unit-tested with fakes) and "integration" (real subprocess/podman, exercised by actually
+running it) modules:
+
+- `evaluate_cycle()` / `find_drain_rate_curve()` are pure functions over
+  `DrainCycleResult` data and are unit-tested the same way ramp_controller's find_knee()
+  is: with a fake driver, no containers, no network (test_drain_rate_axis.py).
+- `make_real_cycle_driver()` / `main()` do the actual podman/subprocess/load_driver.py
+  work and are exercised by tools/e2e/scripts/run_limits_drain_rate.sh, not unit-tested,
+  matching the epic's "the topology composer and the scenario script are not
+  unit-tested; running them is the test" testing decision.
+
+**The axis reuses saturation_probe.evaluate() itself for the outage-aware signal rather
+than a bespoke check** (#385's own acceptance criterion): every cycle's outage-phase
+buffer-size samples are run through the exact same disk-buffer-growth signal #377
+defines, with `outage_declared=True`, and the cycle raises `OutageMisreportedError` if
+that ever trips — the growth is real and expected here, so a trip would mean the
+outage-aware suppression in saturation_probe.py itself is broken, not that this axis
+found a legitimate result. The recovery-phase samples reuse the identical signal with
+`outage_declared=False`: a backlog that is still growing (or has stopped shrinking)
+after connectivity returns is exactly what that signal is built to catch, so no second
+implementation of "is the buffer trending up" exists in this module.
+
+ack_latency_s and unacked_window_depth are fixed at 0.0 for every Observation this
+module builds — deliberately inert (always below any positive bound), because this
+axis's job is to exercise the disk-buffer signal specifically; the other two signals are
+the fan-in/single-robot-ceiling axes' concern.
+
+**Ramping.** At a fixed stated load (a script parameter — callers vary it across
+invocations, the same convention run_limits_two_tier.sh uses for REAL_STACKS /
+SYNTH_CONNECTIONS rather than sweeping them in one run), `find_drain_rate_curve()` reuses
+ramp_controller.find_knee() to drive an ascending list of outage lengths and reports the
+knee: the shortest outage length whose backlog failed to drain within the wait bound
+(never fabricated — a policy whose every outage length drains cleanly is reported as
+`RunOutcome.BOUND_NOT_FOUND`, matching #379's own "never fabricate a ceiling" rule).
+`AxisRun.points[].level` is therefore the ramped **outage length in seconds**, matching
+the unit `tripped_level`/`highest_clear_level` are reported in (they come straight out of
+`RampResult`, which is defined in the policy's own unit) — the per-level *drain time*
+this axis exists to report is a different number and doesn't fit any existing
+curve_reporter field, so it is written alongside the curve report as a companion JSON
+(see `main()`), keyed by the same outage-length levels the report's points use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.request
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from curve_reporter import (
+    AxisRun,
+    LevelResult,
+    PointKind,
+    RunComposition,
+    RunOutcome,
+    build_report,
+    render_summary,
+    to_json,
+)
+from ramp_controller import RampOutcome, RampPolicy, RampResult, find_knee
+from saturation_probe import (
+    Observation,
+    SaturationBounds,
+    Verdict,
+    VerdictStatus,
+    evaluate,
+)
+
+
+class OutageMisreportedError(RuntimeError):
+    """Raised when a cycle's outage-phase window trips SATURATED (or can't be assessed
+    at all) — a correctness bug in the outage-aware suppression itself, never an ordinary
+    ramp result. find_knee() must never see this as "level N saturated"; the whole run
+    aborts instead of silently reporting a knee that isn't really one."""
+
+
+@dataclass(frozen=True)
+class DrainCycleResult:
+    """One induced-outage-then-recovery cycle at a fixed load. `drain_time_s` is `None`
+    exactly when the backlog never cleared within the wait bound — never coerced to the
+    bound itself, since "still draining slowly" and "never came close" are different
+    findings for whoever reads the report."""
+
+    outage_length_s: float
+    connections: int
+    rate_hz: float
+    peak_buffer_bytes: float
+    drain_time_s: float | None
+    outage_window: tuple[Observation, ...]
+    recovery_window: tuple[Observation, ...]
+
+
+@dataclass(frozen=True)
+class CycleVerdict:
+    """The `SaturationVerdict` ramp_controller.find_knee() needs (a `.saturated`
+    property), plus both probe evaluations that produced it, for the caller to log or
+    persist."""
+
+    outage_verdict: Verdict
+    recovery_verdict: Verdict | None
+    saturated: bool
+    reason: str
+
+
+def evaluate_cycle(
+    cycle: DrainCycleResult, bounds: SaturationBounds = SaturationBounds()
+) -> CycleVerdict:
+    """Pure function, no I/O: the module's own acceptance-criterion proof that the
+    outage-aware signal is exercised, not reimplemented. Raises `OutageMisreportedError`
+    if the outage-phase window is ever reported saturated (or can't be assessed) despite
+    `outage_declared=True` throughout it — a real growth in that window is expected and
+    must never trip. Otherwise the *recovery*-phase window (`outage_declared=False`) is
+    evaluated with the identical signal, and its verdict decides whether this outage
+    length is the ramp's knee — except when the backlog never drained at all
+    (`drain_time_s is None`): that is always reported saturated, since a buffer that has
+    merely plateaued rather than grown would not otherwise trip the growth-trend check,
+    and "never fabricate a clear result" is #379's own rule for this ramp too.
+    """
+    outage_verdict = evaluate(cycle.outage_window, bounds)
+    if outage_verdict.status == VerdictStatus.INSUFFICIENT_DATA:
+        raise OutageMisreportedError(
+            f"only {len(cycle.outage_window)} buffer sample(s) were captured during the "
+            f"{cycle.outage_length_s}s outage — too few to exercise the outage-aware "
+            "signal at all; shorten the poll interval or lengthen the outage"
+        )
+    if outage_verdict.saturated:
+        raise OutageMisreportedError(
+            f"buffer growth during the declared {cycle.outage_length_s}s outage was "
+            f"reported as saturation ({outage_verdict.reason}) — the outage-aware "
+            "suppression in saturation_probe.py is broken"
+        )
+
+    if cycle.drain_time_s is None:
+        return CycleVerdict(
+            outage_verdict=outage_verdict,
+            recovery_verdict=None,
+            saturated=True,
+            reason=(
+                f"backlog did not drain within the wait bound after the "
+                f"{cycle.outage_length_s}s outage ended"
+            ),
+        )
+
+    recovery_verdict = evaluate(cycle.recovery_window, bounds)
+    return CycleVerdict(
+        outage_verdict=outage_verdict,
+        recovery_verdict=recovery_verdict,
+        saturated=recovery_verdict.saturated,
+        reason=recovery_verdict.reason,
+    )
+
+
+def build_axis_run(
+    ramp_result: RampResult,
+    cycles_by_level: dict[float, DrainCycleResult],
+    connections: int,
+    rate_hz: float,
+) -> AxisRun:
+    """Pure function: turns one find_knee() run plus the cycles it drove into an
+    `AxisRun` in curve_reporter's own shape (#385's "same stable report format as the
+    other axes" acceptance criterion) — no new fields, no schema change. `level` is the
+    outage length in seconds tried at that point (see the module docstring for why the
+    per-level *drain time* travels in a companion JSON instead)."""
+    points = [
+        LevelResult(
+            level=level,
+            saturated=(level == ramp_result.tripped_level),
+            kind=PointKind.MEASURED,
+            composition=RunComposition(real_stacks=0, synthetic_senders=connections),
+        )
+        for level in ramp_result.levels_tried
+    ]
+    outcome = (
+        RunOutcome.KNEE_FOUND
+        if ramp_result.outcome == RampOutcome.KNEE_FOUND
+        else RunOutcome.BOUND_NOT_FOUND
+    )
+    return AxisRun(
+        axis="drain_rate",
+        unit=f"seconds (outage length @ {connections} synthetic connection(s) x {rate_hz}Hz)",
+        outcome=outcome,
+        highest_clear_level=ramp_result.highest_clear_level,
+        tripped_level=ramp_result.tripped_level,
+        points=points,
+    )
+
+
+def find_drain_rate_curve(
+    driver: Callable[[float], DrainCycleResult],
+    outage_lengths_s: Sequence[float],
+    connections: int,
+    rate_hz: float,
+    bounds: SaturationBounds = SaturationBounds(),
+) -> tuple[AxisRun, dict[float, DrainCycleResult]]:
+    """Wires `driver` (real or fake) into ramp_controller.find_knee() via
+    `evaluate_cycle()`, ascending through `outage_lengths_s`, and returns both the
+    resulting `AxisRun` and the raw per-level cycle data (for the companion drain-time
+    JSON `main()` writes). No I/O of its own — `driver` supplies all of it — so this is
+    the seam test_drain_rate_axis.py exercises with a fake driver, the same pattern
+    test_ramp_controller.py uses for find_knee() itself."""
+    cycles_by_level: dict[float, DrainCycleResult] = {}
+
+    def wrapped_driver(level: float) -> DrainCycleResult:
+        cycle = driver(level)
+        cycles_by_level[level] = cycle
+        return cycle
+
+    def probe(cycle: DrainCycleResult) -> CycleVerdict:
+        return evaluate_cycle(cycle, bounds)
+
+    ramp_result = find_knee(wrapped_driver, probe, RampPolicy(levels=outage_lengths_s))
+    axis_run = build_axis_run(ramp_result, cycles_by_level, connections, rate_hz)
+    return axis_run, cycles_by_level
+
+
+# --- integration: the real driver (subprocess/podman), not unit-tested -------------------
+
+
+def _podman(*args: str) -> None:
+    subprocess.run(["podman", *args], check=True, stdout=subprocess.DEVNULL)
+
+
+_BUFFER_BYTE_SIZE_RE = re.compile(
+    r'^vector_buffer_byte_size\{[^}]*buffer_id="(?P<buffer_id>[^"]+)"[^}]*\}\s+(?P<value>[0-9.eE+-]+)',
+    re.MULTILINE,
+)
+
+
+def _buffer_bytes(metrics_url: str, buffer_id: str) -> float:
+    """Scrapes Vector's own `vector_buffer_byte_size` gauge for `buffer_id` from its
+    `prometheus_exporter` sink — see the module docstring for why this replaces a
+    filesystem stat on the buffer directory. Reads as 0 before the buffer has ever held
+    an event (the gauge series doesn't exist yet at that point, which is a legitimate
+    empty-buffer reading, not a scrape failure)."""
+    with urllib.request.urlopen(metrics_url, timeout=5) as response:
+        body = response.read().decode("utf-8")
+    for match in _BUFFER_BYTE_SIZE_RE.finditer(body):
+        if match.group("buffer_id") == buffer_id:
+            return float(match.group("value"))
+    return 0.0
+
+
+def make_real_cycle_driver(
+    *,
+    rustfs_container: str,
+    metrics_url: str,
+    buffer_id: str,
+    shipper_host: str,
+    shipper_port: int,
+    connections: int,
+    rate_hz: float,
+    poll_interval_s: float,
+    max_drain_wait_s: float,
+    repo_root: str,
+    min_observations: int,
+) -> Callable[[float], DrainCycleResult]:
+    """The real driver: induces an outage on `rustfs_container` with the exact same
+    `podman stop` / wait / `podman start` recipe run.sh itself uses (#385's "existing
+    incident/outage scenario scaffolding, reused unmodified" acceptance criterion — this
+    calls podman directly rather than shelling out to run.sh, since run.sh's outage
+    window is only one step inside a much larger zero-loss run; the *recipe* is what's
+    reused, run.sh itself is untouched), drives load_driver.py at the stated connections
+    and rate for the outage's duration, then polls the Shipper's `buffer_id` buffer via
+    `metrics_url` until it drains or `max_drain_wait_s` elapses."""
+
+    if poll_interval_s * min_observations > 0 and poll_interval_s <= 0:
+        raise ValueError("poll_interval_s must be positive")
+
+    def driver(outage_length_s: float) -> DrainCycleResult:
+        if outage_length_s < poll_interval_s * min_observations:
+            raise ValueError(
+                f"outage length {outage_length_s}s is too short to collect "
+                f"{min_observations} samples at a {poll_interval_s}s poll interval — "
+                "raise the outage length or lower the poll interval"
+            )
+
+        _podman("stop", rustfs_container)
+
+        driver_proc = subprocess.Popen(
+            [
+                "uv",
+                "run",
+                "--frozen",
+                "python3",
+                os.path.join(repo_root, "tools/e2e/scripts/load_driver.py"),
+                shipper_host,
+                str(shipper_port),
+                "--connections",
+                str(connections),
+                "--rate",
+                str(rate_hz),
+                "--duration",
+                str(outage_length_s),
+                "--tag",
+                "dc.e2e.drain_rate",
+            ],
+            cwd=repo_root,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+        outage_window: list[Observation] = []
+        peak_bytes = 0.0
+        deadline = time.monotonic() + outage_length_s
+        while time.monotonic() < deadline:
+            size = _buffer_bytes(metrics_url, buffer_id)
+            peak_bytes = max(peak_bytes, size)
+            outage_window.append(
+                Observation(
+                    ack_latency_s=0.0,
+                    unacked_window_depth=0.0,
+                    disk_buffer_bytes=size,
+                    outage_declared=True,
+                )
+            )
+            time.sleep(poll_interval_s)
+        driver_proc.wait(timeout=max(poll_interval_s * 4, 30))
+
+        _podman("start", rustfs_container)
+
+        # A small absolute floor, not a fraction of the peak: unlike a filesystem stat
+        # on the buffer directory, vector_buffer_byte_size genuinely reaches (very close
+        # to) 0 once every pending event has been acked by the real Destination —
+        # verified empirically while building this module.
+        drained_threshold_bytes = 4_096.0
+        recovery_window: list[Observation] = []
+        drain_time_s: float | None = None
+        recovery_start = time.monotonic()
+        while time.monotonic() - recovery_start < max_drain_wait_s:
+            size = _buffer_bytes(metrics_url, buffer_id)
+            recovery_window.append(
+                Observation(
+                    ack_latency_s=0.0,
+                    unacked_window_depth=0.0,
+                    disk_buffer_bytes=size,
+                    outage_declared=False,
+                )
+            )
+            if size <= drained_threshold_bytes:
+                drain_time_s = time.monotonic() - recovery_start
+                break
+            time.sleep(poll_interval_s)
+
+        return DrainCycleResult(
+            outage_length_s=outage_length_s,
+            connections=connections,
+            rate_hz=rate_hz,
+            peak_buffer_bytes=peak_bytes,
+            drain_time_s=drain_time_s,
+            outage_window=tuple(outage_window),
+            recovery_window=tuple(recovery_window),
+        )
+
+    return driver
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rustfs-container", required=True)
+    parser.add_argument("--shipper-host", default="127.0.0.1")
+    parser.add_argument("--shipper-port", type=int, default=24224)
+    parser.add_argument(
+        "--metrics-url",
+        default="http://127.0.0.1:9598/metrics",
+        help="the Shipper-under-test's prometheus_exporter scrape URL",
+    )
+    parser.add_argument("--buffer-id", default="to_object_storage")
+    parser.add_argument("--connections", type=int, default=20)
+    parser.add_argument("--rate", type=float, default=10.0, help="per-connection Records/s")
+    parser.add_argument(
+        "--outage-lengths",
+        default="30,60",
+        help="comma-separated ascending outage lengths in seconds",
+    )
+    parser.add_argument("--poll-interval", type=float, default=5.0)
+    parser.add_argument("--max-drain-wait", type=float, default=120.0)
+    parser.add_argument(
+        "--disk-buffer-growth-threshold-bytes",
+        type=float,
+        default=500_000.0,
+        help="overrides saturation_probe's default 1MB — tuned down so a short "
+        "synthetic-load outage reliably produces a detectable growth trend",
+    )
+    parser.add_argument("--repo-root", default=os.getcwd())
+    parser.add_argument("--report-json", required=True)
+    parser.add_argument("--summary-txt", required=True)
+    parser.add_argument("--measurements-json", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    outage_lengths = [float(x) for x in args.outage_lengths.split(",") if x.strip()]
+
+    driver = make_real_cycle_driver(
+        rustfs_container=args.rustfs_container,
+        metrics_url=args.metrics_url,
+        buffer_id=args.buffer_id,
+        shipper_host=args.shipper_host,
+        shipper_port=args.shipper_port,
+        connections=args.connections,
+        rate_hz=args.rate,
+        poll_interval_s=args.poll_interval,
+        max_drain_wait_s=args.max_drain_wait,
+        repo_root=args.repo_root,
+        min_observations=SaturationBounds().min_observations,
+    )
+    bounds = SaturationBounds(
+        disk_buffer_growth_threshold_bytes=args.disk_buffer_growth_threshold_bytes
+    )
+
+    try:
+        axis_run, cycles_by_level = find_drain_rate_curve(
+            driver, outage_lengths, args.connections, args.rate, bounds
+        )
+    except OutageMisreportedError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    report = build_report([axis_run])
+    with open(args.report_json, "w") as f:
+        f.write(to_json(report))
+    with open(args.summary_txt, "w") as f:
+        f.write(render_summary(report))
+
+    measurements = {
+        str(level): {
+            "outage_length_s": cycle.outage_length_s,
+            "connections": cycle.connections,
+            "rate_hz": cycle.rate_hz,
+            "peak_buffer_bytes": cycle.peak_buffer_bytes,
+            "drain_time_s": cycle.drain_time_s,
+        }
+        for level, cycle in cycles_by_level.items()
+    }
+    with open(args.measurements_json, "w") as f:
+        json.dump(measurements, f, indent=2, sort_keys=True)
+
+    print(render_summary(report))
+    print(json.dumps(measurements, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/e2e/scripts/run_limits_drain_rate.sh
+++ b/tools/e2e/scripts/run_limits_drain_rate.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Limits harness: drain-rate axis (#385, part of #323's epic). From the repo root:
+#
+#   ./tools/e2e/scripts/run_limits_drain_rate.sh
+#
+# Answers "how long does a backlog take to clear once connectivity returns, as a
+# function of load and outage length": brings up a standalone Shipper under test (a bare
+# Vector instance, `fluent` source + `aws_s3` sink with a disk buffer, no dc_bridge/ROS
+# involved — same convention run_limits_two_tier.sh's aggregating Shipper and
+# run_load_driver_shipper_test.sh's bare Vector both use) plus RustFS as the Destination
+# it can lose, then hands off to scripts/drain_rate_axis.py, which drives
+# scripts/load_driver.py (#378) at a stated connection count/rate through an ascending
+# ramp of outage lengths, inducing each outage with the exact `podman stop` / wait /
+# `podman start` recipe run.sh itself uses on its own Postgres/RustFS containers (#385's
+# "existing incident/outage scenario scaffolding, reused unmodified" acceptance
+# criterion — this script calls podman directly with that same recipe rather than
+# shelling out to run.sh, since run.sh's outage window is one step inside a much larger
+# zero-loss run with its own fixed gates).
+#
+# For each outage length, drain_rate_axis.py:
+#   1. stops RustFS, drives load for the outage's duration, sampling the Shipper's
+#      buffer size throughout via its own `internal_metrics` + `prometheus_exporter`
+#      (`vector_buffer_byte_size`) — not a filesystem stat on the buffer directory,
+#      which was tried first and found not to work: Vector's on-disk buffer segment
+#      file does not shrink as events are acked (see drain_rate_axis.py's module
+#      docstring for the empirical finding). Injecting a metrics source/sink into this
+#      standalone Vector config is not a DC code change — see #323's PRD note that
+#      "observability comes from configuration, not code changes";
+#   2. runs that sample window through saturation_probe.evaluate() (#377) with
+#      `outage_declared=True` and hard-fails the whole run if it is ever reported
+#      saturated — a growing buffer during a declared outage must never be misreported,
+#      and this is the same module and the same disk-buffer signal #377 defines, not a
+#      bespoke check (#385's other acceptance criterion);
+#   3. restarts RustFS, polls the buffer size until it clears (or a wait bound expires),
+#      and records that elapsed time as the drain time;
+#   4. evaluates the *recovery* window with the identical probe/signal
+#      (`outage_declared=False`) to decide whether this outage length is the ramp's knee
+#      — the shortest outage length whose backlog failed to drain.
+#
+# Output feeds curve_reporter.py (#380) in the same stable AxisRun/CurveReport shape the
+# other axes use; the per-level drain times themselves (curve_reporter has no field for
+# them — see drain_rate_axis.py's module docstring) land in a companion JSON.
+#
+# Env vars (all optional):
+#   DC_E2E_DRAIN_CONNECTIONS      synthetic load_driver.py connection count -- the
+#                                 "stated load" (default 20)
+#   DC_E2E_DRAIN_RATE_HZ          per-connection Records/s (default 10)
+#   DC_E2E_DRAIN_OUTAGE_LENGTHS   comma-separated ascending outage lengths in seconds to
+#                                 ramp through (default "30,60")
+#   DC_E2E_DRAIN_POLL_INTERVAL_SECONDS   buffer-size sampling interval (default 5)
+#   DC_E2E_DRAIN_MAX_WAIT_SECONDS        how long to wait for the backlog to clear after
+#                                        RustFS comes back before giving up on this
+#                                        outage length (default 120)
+#   DC_E2E_DRAIN_SHIPPER_PORT / DC_E2E_DRAIN_METRICS_PORT   the Shipper-under-test's
+#                                 host-published fluent/metrics ports (default 24236 /
+#                                 9648 -- deliberately not the conventional 24224/9598,
+#                                 to avoid colliding with another scenario script's own
+#                                 Shipper on a shared host)
+#   DC_E2E_KEEP                  "true" to leave the stack up after a failure for debugging
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$E2E_DIR/../.." && pwd)"
+RUN_DIR="$E2E_DIR/.run/limits_drain_rate"
+
+CONNECTIONS="${DC_E2E_DRAIN_CONNECTIONS:-20}"
+RATE_HZ="${DC_E2E_DRAIN_RATE_HZ:-10}"
+OUTAGE_LENGTHS="${DC_E2E_DRAIN_OUTAGE_LENGTHS:-30,60}"
+POLL_INTERVAL_SECONDS="${DC_E2E_DRAIN_POLL_INTERVAL_SECONDS:-5}"
+MAX_WAIT_SECONDS="${DC_E2E_DRAIN_MAX_WAIT_SECONDS:-120}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+# A dedicated bridge network, not --network host (unlike run.sh et al.): this scenario's
+# RustFS never needs to be host-reachable at all (only the Shipper talks to it, over
+# container-name DNS), so keeping it off the host namespace entirely avoids contending
+# with any other scenario script's own RustFS for host port 9000 — the same reasoning
+# run_limits_two_tier.sh's own bridge network is built on. Only the Shipper's fluent and
+# metrics ports are published to the host, for this script's own load_driver.py/curl
+# calls.
+NET=dc-e2e-drain-net
+RUSTFS_C=dc-e2e-drain-rustfs
+SHIPPER_C=dc-e2e-drain-shipper
+# Not the conventional 24224/9598: this Shipper under test is a self-contained loop
+# (only this script's own load_driver.py invocation ever connects to it), so a
+# less-contended port pair avoids colliding with any other scenario script's own
+# Shipper/exporter published on this host, even though RustFS itself no longer needs a
+# host port at all (see $NET above).
+SHIPPER_PORT="${DC_E2E_DRAIN_SHIPPER_PORT:-24236}"
+METRICS_PORT="${DC_E2E_DRAIN_METRICS_PORT:-9648}"
+BUFFER_ID=to_object_storage
+BUCKET=dc-e2e
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-drain-rate $(date -u +%H:%M:%S)] $*"; }
+
+remove_stack() {
+  podman rm -f --ignore "$SHIPPER_C" "$RUSTFS_C" >/dev/null
+  if podman volume exists dc_e2e_drain_rustfs_data; then
+    podman volume rm dc_e2e_drain_rustfs_data >/dev/null
+  fi
+  podman network rm "$NET" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  if podman container exists "$SHIPPER_C"; then
+    podman logs "$SHIPPER_C" > "$RUN_DIR/shipper.log" 2>&1 || true
+  fi
+  remove_stack
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# The exact Vector version dc_bridge is built and tested against, same as
+# run_limits_two_tier.sh / run_load_driver_shipper_test.sh -- read out of the file that
+# pins it, not duplicated as a second source of truth.
+VECTOR_VERSION="$(grep -oP 'set\(VECTOR_VERSION "\K[^"]+' "$REPO_ROOT/vector_vendor/CMakeLists.txt")"
+VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
+
+remove_stack
+
+log "creating the bridge network ($NET)"
+podman network create "$NET" >/dev/null
+
+# --- RustFS: the Destination this scenario induces an outage on, internal-only --------
+log "starting RustFS on $NET (no host port published)"
+podman run -d --network "$NET" --name "$RUSTFS_C" \
+  -v dc_e2e_drain_rustfs_data:/data \
+  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+
+log "waiting for RustFS to accept TCP connections on $NET"
+timeout 60 bash -c "
+  until podman run --rm --network $NET --entrypoint bash '$VECTOR_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
+    sleep 1
+  done
+" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+
+log "creating the RustFS bucket"
+podman run --rm --network "$NET" \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url "http://$RUSTFS_C:9000" s3 mb "s3://$BUCKET"
+
+# --- Shipper under test: bare Vector, fluent source + aws_s3 sink with a disk buffer ---
+log "rendering the Shipper-under-test's Vector config"
+cat > "$RUN_DIR/shipper_vector.toml" <<EOF
+data_dir = "/var/lib/vector"
+
+[acknowledgements]
+enabled = true
+
+[sources.load]
+type = "fluent"
+address = "0.0.0.0:${SHIPPER_PORT}"
+
+[sources.internal_metrics]
+type = "internal_metrics"
+
+[sinks.${BUFFER_ID}]
+type = "aws_s3"
+inputs = ["load"]
+bucket = "${BUCKET}"
+endpoint = "http://${RUSTFS_C}:9000"
+region = "us-east-1"
+force_path_style = true
+key_prefix = "drain-rate/"
+
+[sinks.${BUFFER_ID}.auth]
+access_key_id = "rustfsadmin"
+secret_access_key = "rustfsadmin"
+
+[sinks.${BUFFER_ID}.batch]
+timeout_secs = 2
+
+[sinks.${BUFFER_ID}.buffer]
+type = "disk"
+max_size = 268435488
+
+[sinks.${BUFFER_ID}.encoding]
+codec = "json"
+
+[sinks.expose_metrics]
+type = "prometheus_exporter"
+inputs = ["internal_metrics"]
+address = "0.0.0.0:${METRICS_PORT}"
+EOF
+
+log "starting the Shipper under test ($SHIPPER_C, Vector $VECTOR_VERSION)"
+podman run -d --network "$NET" -p "${SHIPPER_PORT}:${SHIPPER_PORT}" -p "${METRICS_PORT}:${METRICS_PORT}" \
+  --name "$SHIPPER_C" \
+  -v "$RUN_DIR/shipper_vector.toml:/etc/vector/vector.toml:Z" \
+  "$VECTOR_IMAGE" -c /etc/vector/vector.toml >/dev/null
+
+log "waiting for the Shipper's fluent source to accept connections"
+if ! timeout 30 bash -c "until (exec 3<>/dev/tcp/127.0.0.1/${SHIPPER_PORT}) 2>/dev/null; do sleep 0.5; done"; then
+  log "FAIL: the Shipper under test never started listening on port $SHIPPER_PORT"
+  exit 1
+fi
+
+log "waiting for the Shipper's metrics endpoint to respond"
+if ! timeout 30 bash -c "until curl -sf http://127.0.0.1:${METRICS_PORT}/metrics >/dev/null 2>&1; do sleep 0.5; done"; then
+  log "FAIL: the Shipper under test's prometheus_exporter never came up on port $METRICS_PORT"
+  exit 1
+fi
+
+# --- drive the ramp -----------------------------------------------------------------
+log "running the drain-rate axis: $CONNECTIONS synthetic connection(s) @ ${RATE_HZ}Hz, outage lengths [$OUTAGE_LENGTHS]s"
+if ! (cd "$REPO_ROOT" && uv run --frozen python3 tools/e2e/scripts/drain_rate_axis.py \
+  --rustfs-container "$RUSTFS_C" \
+  --shipper-host 127.0.0.1 \
+  --shipper-port "$SHIPPER_PORT" \
+  --metrics-url "http://127.0.0.1:${METRICS_PORT}/metrics" \
+  --buffer-id "$BUFFER_ID" \
+  --connections "$CONNECTIONS" \
+  --rate "$RATE_HZ" \
+  --outage-lengths "$OUTAGE_LENGTHS" \
+  --poll-interval "$POLL_INTERVAL_SECONDS" \
+  --max-drain-wait "$MAX_WAIT_SECONDS" \
+  --repo-root "$REPO_ROOT" \
+  --report-json "$RUN_DIR/curve_report.json" \
+  --summary-txt "$RUN_DIR/curve_summary.txt" \
+  --measurements-json "$RUN_DIR/drain_measurements.json"); then
+  log "FAIL: the drain-rate axis run failed — see output above"
+  exit 1
+fi
+
+log "PASS: drain-rate axis (#385) — report: $RUN_DIR/curve_report.json, measurements: $RUN_DIR/drain_measurements.json"
+cat "$RUN_DIR/curve_summary.txt"

--- a/tools/e2e/test/test_drain_rate_axis.py
+++ b/tools/e2e/test/test_drain_rate_axis.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/drain_rate_axis.py (#385): the pure parts
+(evaluate_cycle, build_axis_run, find_drain_rate_curve), driven entirely with synthetic
+DrainCycleResult data and fake drivers — no containers, no subprocess, no network. The
+real podman/load_driver.py orchestration in make_real_cycle_driver()/main() is exercised
+by tools/e2e/scripts/run_limits_drain_rate.sh instead, matching the epic's "the topology
+composer and the scenario script are not unit-tested; running them is the test" decision.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+from curve_reporter import PointKind, RunOutcome
+from drain_rate_axis import (
+    DrainCycleResult,
+    OutageMisreportedError,
+    build_axis_run,
+    evaluate_cycle,
+    find_drain_rate_curve,
+)
+from ramp_controller import RampOutcome, RampPolicy, RampResult, find_knee
+from saturation_probe import Observation, SaturationBounds
+
+
+def _observations(n: int, *, disk_buffer_bytes, outage_declared: bool) -> tuple[Observation, ...]:
+    """`disk_buffer_bytes` may be a constant or a callable(i) -> float, so tests can
+    describe growth/shrink trends without repeating an Observation() call per sample."""
+    values = disk_buffer_bytes if callable(disk_buffer_bytes) else (lambda i: disk_buffer_bytes)
+    return tuple(
+        Observation(
+            ack_latency_s=0.0,
+            unacked_window_depth=0.0,
+            disk_buffer_bytes=values(i),
+            outage_declared=outage_declared,
+        )
+        for i in range(n)
+    )
+
+
+_GROWTH_STEP_BYTES = 500_000.0  # crosses SaturationBounds' default 1MB growth threshold
+_PEAK_BYTES = 3_000_000.0
+
+
+def _growing_outage_cycle(outage_length_s: float, drain_time_s: float | None) -> DrainCycleResult:
+    """A cycle whose buffer visibly grows during the (correctly declared) outage —
+    growth that *would* trip the disk-buffer signal on its own, past
+    SaturationBounds' default threshold, which is what makes "not misreported while
+    outage_declared=True" a real proof rather than a trend too small to trip either
+    way — and whose recovery window either shrinks back to ~0 (drained) or stays flat
+    at the peak (not drained), depending on `drain_time_s`."""
+    outage_window = _observations(
+        6, disk_buffer_bytes=lambda i: _GROWTH_STEP_BYTES * (i + 1), outage_declared=True
+    )
+    if drain_time_s is not None:
+        recovery_window = _observations(
+            6,
+            disk_buffer_bytes=lambda i: _PEAK_BYTES - _GROWTH_STEP_BYTES * i,
+            outage_declared=False,
+        )
+    else:
+        recovery_window = _observations(6, disk_buffer_bytes=_PEAK_BYTES, outage_declared=False)
+    return DrainCycleResult(
+        outage_length_s=outage_length_s,
+        connections=20,
+        rate_hz=10.0,
+        peak_buffer_bytes=_PEAK_BYTES,
+        drain_time_s=drain_time_s,
+        outage_window=outage_window,
+        recovery_window=recovery_window,
+    )
+
+
+# --- evaluate_cycle: the outage-aware-signal acceptance criterion -------------------
+
+
+def test_a_growing_buffer_during_a_declared_outage_is_not_misreported_as_saturation():
+    cycle = _growing_outage_cycle(outage_length_s=30.0, drain_time_s=5.0)
+
+    verdict = evaluate_cycle(cycle)
+
+    assert verdict.outage_verdict.saturated is False
+    assert verdict.saturated is False
+
+
+def test_a_backlog_that_drains_after_the_outage_is_reported_not_saturated():
+    cycle = _growing_outage_cycle(outage_length_s=30.0, drain_time_s=12.0)
+
+    verdict = evaluate_cycle(cycle)
+
+    assert verdict.saturated is False
+    assert verdict.recovery_verdict is not None
+
+
+def test_a_backlog_that_never_drains_is_reported_saturated_even_if_the_buffer_only_plateaus():
+    # Recovery window is flat (600_000 the whole way through) -- growth-based trend
+    # detection alone would call this "not saturated" (no growth), which would be wrong:
+    # the backlog never actually cleared. drain_time_s=None must override that.
+    cycle = _growing_outage_cycle(outage_length_s=30.0, drain_time_s=None)
+
+    verdict = evaluate_cycle(cycle)
+
+    assert verdict.saturated is True
+    assert verdict.recovery_verdict is None
+    assert "did not drain" in verdict.reason
+
+
+def test_a_still_growing_recovery_window_is_reported_saturated():
+    outage_window = _observations(
+        6, disk_buffer_bytes=lambda i: _GROWTH_STEP_BYTES * (i + 1), outage_declared=True
+    )
+    still_growing_recovery = _observations(
+        6, disk_buffer_bytes=lambda i: _PEAK_BYTES + _GROWTH_STEP_BYTES * i, outage_declared=False
+    )
+    cycle = DrainCycleResult(
+        outage_length_s=30.0,
+        connections=20,
+        rate_hz=10.0,
+        peak_buffer_bytes=_PEAK_BYTES,
+        drain_time_s=90.0,  # a caller-supplied "it eventually stopped growing" value...
+        outage_window=outage_window,
+        recovery_window=still_growing_recovery,
+    )
+
+    verdict = evaluate_cycle(cycle)
+
+    # ...is irrelevant: the recovery window itself still shows growth, so the disk-buffer
+    # signal (not drain_time_s) is what trips this one.
+    assert verdict.saturated is True
+    assert verdict.recovery_verdict.saturated is True
+
+
+def test_outage_window_reported_saturated_raises_instead_of_being_treated_as_a_ramp_result():
+    # A window that trips SATURATED despite outage_declared=True throughout can only mean
+    # the outage-aware suppression itself is broken -- this must never surface as an
+    # ordinary "level N saturated" ramp result.
+    bad_outage_window = _observations(
+        6,
+        disk_buffer_bytes=lambda i: _GROWTH_STEP_BYTES * (i + 1),
+        outage_declared=False,  # bug: not declared
+    )
+    cycle = DrainCycleResult(
+        outage_length_s=30.0,
+        connections=20,
+        rate_hz=10.0,
+        peak_buffer_bytes=600_000.0,
+        drain_time_s=5.0,
+        outage_window=bad_outage_window,
+        recovery_window=_observations(6, disk_buffer_bytes=0.0, outage_declared=False),
+    )
+
+    with pytest.raises(OutageMisreportedError, match="outage-aware suppression"):
+        evaluate_cycle(cycle)
+
+
+def test_too_few_outage_samples_raises_rather_than_defaulting_to_healthy():
+    cycle = DrainCycleResult(
+        outage_length_s=5.0,
+        connections=20,
+        rate_hz=10.0,
+        peak_buffer_bytes=1_000.0,
+        drain_time_s=1.0,
+        outage_window=_observations(2, disk_buffer_bytes=1_000.0, outage_declared=True),
+        recovery_window=_observations(6, disk_buffer_bytes=0.0, outage_declared=False),
+    )
+
+    with pytest.raises(OutageMisreportedError, match="too few"):
+        evaluate_cycle(cycle)
+
+
+# --- find_drain_rate_curve / build_axis_run: fake-driver ramp, no I/O ----------------
+
+
+def _fake_driver_draining_up_to(threshold_s: float):
+    """A fake driver: cycles at an outage length below `threshold_s` drain in 5s; at or
+    above it, the backlog never clears."""
+
+    def driver(outage_length_s: float) -> DrainCycleResult:
+        drains = outage_length_s < threshold_s
+        return _growing_outage_cycle(outage_length_s, drain_time_s=5.0 if drains else None)
+
+    return driver
+
+
+def test_the_knee_is_the_shortest_outage_length_whose_backlog_never_drains():
+    driver = _fake_driver_draining_up_to(threshold_s=100.0)
+
+    axis_run, cycles = find_drain_rate_curve(
+        driver, outage_lengths_s=[30.0, 60.0, 120.0], connections=20, rate_hz=10.0
+    )
+
+    assert axis_run.outcome == RunOutcome.KNEE_FOUND
+    assert axis_run.tripped_level == 120.0
+    assert axis_run.highest_clear_level == 60.0
+    assert set(cycles) == {30.0, 60.0, 120.0}
+
+
+def test_a_backlog_that_always_drains_reports_bound_not_found_never_a_fabricated_ceiling():
+    driver = _fake_driver_draining_up_to(threshold_s=10_000.0)
+
+    axis_run, _cycles = find_drain_rate_curve(
+        driver, outage_lengths_s=[30.0, 60.0], connections=20, rate_hz=10.0
+    )
+
+    assert axis_run.outcome == RunOutcome.BOUND_NOT_FOUND
+    assert axis_run.tripped_level is None
+    assert axis_run.highest_clear_level == 60.0
+
+
+def test_axis_run_uses_the_stable_curve_reporter_shape():
+    driver = _fake_driver_draining_up_to(threshold_s=100.0)
+
+    axis_run, _cycles = find_drain_rate_curve(
+        driver, outage_lengths_s=[30.0, 60.0, 120.0], connections=20, rate_hz=10.0
+    )
+
+    assert axis_run.axis == "drain_rate"
+    assert len(axis_run.points) == 3
+    assert all(p.kind == PointKind.MEASURED for p in axis_run.points)
+    assert all(p.composition.synthetic_senders == 20 for p in axis_run.points)
+    assert all(p.composition.real_stacks == 0 for p in axis_run.points)
+    saturated_levels = {p.level for p in axis_run.points if p.saturated}
+    assert saturated_levels == {120.0}
+
+
+def test_build_axis_run_records_the_tripped_level_as_the_only_saturated_point():
+    ramp_result = RampResult(
+        outcome=RampOutcome.KNEE_FOUND,
+        highest_clear_level=60.0,
+        tripped_level=120.0,
+        tripped_verdict=None,
+        levels_tried=(30.0, 60.0, 120.0),
+    )
+    cycles = {
+        30.0: _growing_outage_cycle(30.0, drain_time_s=5.0),
+        60.0: _growing_outage_cycle(60.0, drain_time_s=8.0),
+        120.0: _growing_outage_cycle(120.0, drain_time_s=None),
+    }
+
+    axis_run = build_axis_run(ramp_result, cycles, connections=20, rate_hz=10.0)
+
+    assert [p.level for p in axis_run.points] == [30.0, 60.0, 120.0]
+    assert [p.saturated for p in axis_run.points] == [False, False, True]
+
+
+def test_find_knee_stops_driving_once_a_cycle_fails_to_drain():
+    driver = _fake_driver_draining_up_to(threshold_s=50.0)
+    calls = []
+
+    def counting_driver(outage_length_s: float) -> DrainCycleResult:
+        calls.append(outage_length_s)
+        return driver(outage_length_s)
+
+    find_drain_rate_curve(
+        counting_driver, outage_lengths_s=[30.0, 60.0, 120.0], connections=20, rate_hz=10.0
+    )
+
+    assert calls == [30.0, 60.0]
+
+
+def test_find_knee_is_reused_unmodified_for_the_ramp():
+    # Sanity check that find_drain_rate_curve is really delegating to
+    # ramp_controller.find_knee() rather than reimplementing ramp semantics -- same
+    # outcome, tripped/highest-clear levels, for the same driver/probe shape.
+    driver = _fake_driver_draining_up_to(threshold_s=100.0)
+
+    axis_run, cycles = find_drain_rate_curve(
+        driver, outage_lengths_s=[30.0, 60.0, 120.0], connections=20, rate_hz=10.0
+    )
+
+    direct_result = find_knee(
+        lambda level: cycles[level],
+        lambda cycle: evaluate_cycle(cycle, SaturationBounds()),
+        RampPolicy(levels=[30.0, 60.0, 120.0]),
+    )
+    assert direct_result.outcome.value == axis_run.outcome.value
+    assert direct_result.tripped_level == axis_run.tripped_level
+    assert direct_result.highest_clear_level == axis_run.highest_clear_level


### PR DESCRIPTION
## Summary

Adds the drain-rate axis to #323's limits harness: induces an outage of a stated
length at a stated synthetic load against a standalone Shipper under test (reusing
`run.sh`'s own `podman stop`/`start` outage recipe unmodified), then measures how long
the resulting backlog takes to clear once connectivity returns, ramping outage length
via `ramp_controller.find_knee()` until the backlog fails to drain within a wait bound.

- Buffer size is sampled from Vector's own `internal_metrics`/`prometheus_exporter`
  gauge (`vector_buffer_byte_size`) rather than a filesystem stat on the buffer
  directory — discovered empirically that Vector's on-disk buffer segment file does not
  shrink as events are acked, which would have made every drain look like it never
  happened.
- Every outage-phase window is run through `saturation_probe.evaluate()` with
  `outage_declared=True`, hard-failing the run if it is ever misreported as saturated —
  the same disk-buffer signal #377 defines, not a bespoke check.
- Output feeds `curve_reporter.py` in the same stable `AxisRun`/`CurveReport` shape the
  other axes use, with per-level drain times in a companion JSON.
- `drain_rate_axis.py`'s pure logic (`evaluate_cycle`/`build_axis_run`/
  `find_drain_rate_curve`) is unit-tested with fakes; the podman/`load_driver.py`
  orchestration was verified by running `run_limits_drain_rate.sh` end to end against
  real containers (both the `BOUND_NOT_FOUND` and `KNEE_FOUND` ramp outcomes).

Closes #385

## Test plan

- [x] `uv run --frozen pytest tools/e2e/test/` — 110 passed (12 new)
- [x] `prek run --all-files --skip build-doc` — all hooks pass
- [x] `./tools/e2e/scripts/run_limits_drain_rate.sh` run end to end against real
      RustFS + Vector containers: confirmed a genuine measured drain time
      (`BOUND_NOT_FOUND`) and a genuine tripped knee (`KNEE_FOUND`), with clean
      teardown in both cases and no outage-phase buffer growth ever misreported as
      saturation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HrRetdC6XktnR2A6GfwM3o