### PR TITLE
feat(tools/e2e): add limits harness Shipper fan-in axis + instrument proof (#382)

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -8222,3 +8222,82 @@ not-yet-implemented piece of #323.
   built image is available (CI, or a machine with more disk/`colcon`) is still needed to
   close the loop on the podman/`ros2 param set`/`psql` seam itself.
 - Not wired into `ci.yaml`, same as every other narrow scenario script.
+
+### #382 - Limits harness: Shipper fan-in axis + instrument proof
+
+- Added `tools/e2e/scripts/run_limits_shipper_fanin.py`, the orchestrator wiring #323's
+  four deep modules together for real: `ramp_controller.find_knee()` drives synthetic
+  connection count via `load_driver.py` against #381's aggregating Shipper, one ramp
+  level built from several short back-to-back `load_driver` sub-runs (no mid-run
+  introspection hook exists, so a sustained level is approximated as fresh short bursts
+  rather than one held connection) each turned into one `saturation_probe.Observation`
+  (ack-latency p95, unacked-window depth, aggregating-Shipper disk-buffer bytes via
+  `podman exec`/`du`); `saturation_probe.evaluate()` judges the window; `curve_reporter`
+  turns the result into a stable report plus the PRD's required closing sentence. None
+  of the four modules were modified.
+- Zero loss is asserted **at every sustainable level**, not once at the end, by hooking
+  into `find_knee()`'s own driver/probe seam: the `probe` first asks the saturation
+  probe for a verdict, and only when a level stays clear does it also run
+  `verify_zero_loss.py` ("the existing verifier," reused unmodified, same as #381)
+  against a snapshot of the ledger-checked real stack's still-running output. A
+  violation is a hard, immediate failure of the whole ramp.
+- Added `tools/e2e/scripts/run_limits_shipper_fanin.sh`, a sibling scenario script (own
+  topology bring-up, own gates — not a mode bolted onto the zero-loss run) that reuses
+  #381's topology verbatim: the same `params/e2e_limits_params.yaml`,
+  `params/e2e_limits_forward_sink.toml`, and the exact container names those files
+  hard-code (`dc-e2e-limits-postgres`/`rustfs`/`agg`), since the two-tier chain they
+  compose is exactly what this ramp drives. It runs the ramp twice — once against an
+  unconstrained aggregating Shipper (the flagship number), then again (after truncating
+  `dc_records`/`dc_files` and tearing down just that phase's Shipper + real stacks, with
+  Postgres/RustFS/network kept up) against a deliberately CPU/memory-constrained one
+  (`--cpus`/`--memory`, `DC_E2E_FANIN_CONSTRAINED_CPUS`/`_MEMORY`) — and hard-fails
+  unless the constrained ceiling comes in at or below half the unconstrained one
+  (`DC_E2E_FANIN_CEILING_DROP_RATIO`, default 0.5), proving the harness detects an
+  induced limit per #323's PRD ("a limits harness that cannot demonstrate detecting an
+  induced limit has not been shown to work"). Either phase reporting `BOUND_NOT_FOUND`
+  is itself a hard failure, never a skip: an unconstrained run with no measured ceiling
+  has nothing for the PRD's closing sentence to state, and a constrained run that never
+  saturates has failed to demonstrate the induced limit.
+- **Verified against real infrastructure**, not just unit-level reasoning: ran the full
+  two-phase scenario against the pre-built `dc-e2e:latest` image several times on this
+  machine. One run (`DC_E2E_FANIN_LEVELS="100 400"`, only 2 levels) correctly *failed*
+  the instrument-proof gate — both phases happened to saturate at the same coarse tested
+  level, and the harness refused to claim a false pass rather than fabricate success at
+  that resolution. A finer-grained run (`"50 100 200 400"`) drove real synthetic load
+  through a real aggregating Shipper, found a real knee via `ramp_controller`, asserted
+  real zero-loss via `verify_zero_loss.py` at clear levels, and produced a correct
+  closing sentence and curve report — confirmed level-by-level before the run was cut
+  short by an external background-task limit at level 200 of the second (constrained)
+  phase, after both earlier levels had already passed cleanly with the fix below in
+  place. A full unattended pass of both phases end-to-end (a run of several minutes) is
+  still worth doing once outside this sandbox's per-command constraints, but the
+  mechanism was exercised for real, not just smoke-tested against fakes.
+- **Recorded discovery, found and root-caused from that real run, not simulated**: the
+  live-volume snapshot `verify_zero_loss_at_level()` reads from (the ledger-checked real
+  stack keeps running across the whole ramp — restarting it between every level would be
+  far too slow) raced a specific, precisely diagnosed mechanism, not a vague "torn
+  write": `entrypoint.sh` starts `dc_mcap_writer` with `--max-duration-secs 15`, and
+  (per `RotatingMcapWriter._open_next_file()`'s own docstring) a `.mcap` file only
+  becomes readable once its 15s rotation finishes and `Writer.finish()` runs — so a
+  snapshot taken mid-rotation reports the handful of most-recent Records as "never
+  reached dc_mcap_writer" even though they are sitting safely on disk, about to become
+  readable a few seconds later. First hit this at real ramp level 400: a clean,
+  well-formed "ZERO-LOSS VERIFICATION FAILED" (`mcap/synth02`/`synth03`, "away from any
+  kill point") that manually re-running the exact same check against the same
+  still-live containers, moments later, reported as a clean pass with zero violations —
+  proving it was a snapshot-timing race, not real loss. The original retry logic only
+  retried failures that *looked like* a parse crash (kept a real "ZERO-LOSS
+  VERIFICATION FAILED" message as an immediate hard failure); fixed to retry *any*
+  failure shape once, after a pause (`_ZERO_LOSS_RETRY_SLEEP_S = 18.0`, comfortably past
+  the 15s rotation boundary) before hard-failing — a genuine violation is expected to
+  reproduce well past any rotation boundary, so this costs nothing on real loss.
+  Re-verified directly against the same live containers that had failed under the
+  original 5s retry: the fixed 18s retry passed within its two-attempt budget
+  (`VERIFY OK in 84.4s`).
+- `tools/e2e/README.md` gained a "Shipper fan-in axis (#382)" section (after the
+  single-robot ceiling axis's #383 section, before Layout — #383 merged first and
+  already claimed the "seventh piece" framing, so this one is the eighth) plus a Layout
+  entry for the two new files.
+- Not wired into `ci.yaml`, same as every other narrow scenario script, and — like
+  `run_limits_two_tier.sh` — needs that script's own topology bring-up working before it
+  can run at all.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -395,6 +395,63 @@ the test"), the real-I/O `PodmanRealStackHandle` itself and the shell script are
 exercised by actually running the scenario, not unit tests. Not wired into `ci.yaml`,
 same as the other scenario scripts above.
 
+## Shipper fan-in axis (#382)
+
+The eighth piece, and the epic's flagship axis: how many robots does one aggregating
+Shipper serve before it applies backpressure?
+
+```sh
+./tools/e2e/scripts/run_limits_shipper_fanin.sh
+```
+
+A sibling of `run_limits_two_tier.sh` — its own gates, not a mode bolted onto the
+zero-loss run — but it reuses that ticket's topology verbatim, since the two-tier chain
+it composes is exactly what this ramp drives: the same `params/e2e_limits_params.yaml`,
+`params/e2e_limits_forward_sink.toml`, and the same hard-coded container names those
+files address (`dc-e2e-limits-postgres`/`rustfs`/`agg`). `scripts/run_limits_shipper_fanin.py`
+is where the pieces actually meet: `ramp_controller.find_knee()` (#379) drives synthetic
+connection count upward via `load_driver.py` (#378) against the aggregating Shipper,
+`saturation_probe.evaluate()` (#377) judges each level from a short window of
+ack-latency/unacked-window-depth/disk-buffer-growth observations, and `curve_reporter`
+(#380) turns the result into a stable report plus the PRD's required closing sentence.
+None of the four are modified — this axis is exactly the "one axis costs one thin
+scenario" the epic's PRD called for.
+
+Zero loss is asserted by hooking straight into the ramp controller's own driver/probe
+seam: the `probe` handed to `find_knee()` first asks the saturation probe for a verdict,
+and only when a level's verdict stays clear does it also run `verify_zero_loss.py` — "the
+existing verifier," reused unmodified, same as `run_limits_two_tier.sh` — against a
+snapshot of the ledger-checked real stack's still-running output. A violation there is a
+hard failure of the whole ramp, immediately: a throughput figure obtained from a
+configuration that was dropping Records is never reported. Recorded discovery, verified
+against a real run: because the real stack keeps running (and its output files keep
+growing) across the whole ramp rather than being restarted between every level, the
+snapshot the verifier reads occasionally races that still-running container. One instance
+of that race has a precise, diagnosed cause — `entrypoint.sh` runs `dc_mcap_writer` with
+`--max-duration-secs 15`, and a `.mcap` file only becomes readable once its rotation
+finishes, so a snapshot taken mid-rotation can report the handful of most-recent Records
+as "never reached dc_mcap_writer" even though they are safely on disk. The check retries
+any failure shape once, after a pause comfortably longer than that 15s rotation window,
+before treating it as a hard failure like any other — never silently skipped, never given
+more than one extra chance.
+
+The scenario then proves the instrument itself, per the PRD's "a limits harness that
+cannot demonstrate detecting an induced limit has not been shown to work": having found
+the unconstrained ceiling, it truncates `dc_records`/`dc_files`, tears down that phase's
+aggregating Shipper and real stacks (Postgres/RustFS/the network stay up), and re-runs the
+identical ramp against a deliberately CPU/memory-constrained aggregating Shipper
+(`--cpus`/`--memory`, `DC_E2E_FANIN_CONSTRAINED_CPUS`/`_MEMORY`). The constrained run's
+ceiling must come in at or below half the unconstrained one
+(`DC_E2E_FANIN_CEILING_DROP_RATIO`, default `0.5`) — a hard gate, not informational.
+Either phase reporting `BOUND_NOT_FOUND` (never saturating within the tested levels) is
+itself a hard failure: an unconstrained run with no measured ceiling has nothing for the
+PRD's closing sentence to state, and a constrained run that never saturates has failed to
+demonstrate the induced limit, never fabricated as a pass either way.
+
+Not wired into `ci.yaml`, same as the other scenario scripts above — and, like
+`run_limits_two_tier.sh`'s own dependents, this axis needs that script's own topology
+bring-up already established working before it can run at all.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -508,6 +565,10 @@ same as the other scenario scripts above.
   #323): the real-I/O `RealStackHandle`, the find_knee-result-to-`AxisRun` folding, and
   the one-real-stack podman topology, reusing `verify_zero_loss.py` unmodified after a
   post-ramp drain.
+- `scripts/run_limits_shipper_fanin.sh` / `scripts/run_limits_shipper_fanin.py` — the
+  Shipper fan-in axis (#382, part of #323) described above: ramping robot count against
+  #381's two-tier topology to the knee and proving the instrument itself against a
+  deliberately constrained aggregating Shipper.
 
 ## `.dockerignore`
 

--- a/tools/e2e/scripts/run_limits_shipper_fanin.py
+++ b/tools/e2e/scripts/run_limits_shipper_fanin.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Limits harness: Shipper fan-in axis (#382, the flagship axis of #323's epic).
+
+Drives #379's ramp controller over #381's two-tier topology, using #378's synthetic
+load driver as the injected driver and #377's saturation probe as the injected verdict
+function, and reports through #380's curve reporter. One process handles one topology
+instance (one aggregating Shipper, one set of real stacks) — `run_limits_shipper_fanin.sh`
+invokes it twice, once per instance, for the unconstrained run and the deliberately
+resource-constrained control the PRD's "prove the instrument itself" requirement calls
+for; this module does not know which one it is beyond the `--label` it stamps on its
+report.
+
+The ramp varies only the synthetic sender count — the connection count is exactly the
+"how many robots does one Shipper serve" axis (#323's PRD). A small fixed number of real
+DC stacks (`--real-stacks`, default 1, matching #381's own discovered default) run
+alongside every level for fidelity, per the PRD's hybrid load-generation decision.
+
+One ramp level = a handful of short back-to-back load_driver.py sub-runs at that
+connection count, each contributing one `saturation_probe.Observation` (ack-latency
+p95, unacked-window depth, and the aggregating Shipper's own disk-buffer growth,
+sampled via `podman exec`/`du`) to the window `saturation_probe.evaluate()` judges.
+`load_driver.run()` has no mid-run introspection hook — it blocks for its whole
+duration and returns one final summary — so a sustained level is approximated as
+several fresh short bursts rather than one continuous connection; this is judged
+sufficient for a fan-in load test, since what saturates an aggregating Shipper's ingest
+listener is connection count and aggregate byte rate, not any one connection's
+lifetime.
+
+Zero loss is asserted **at every sustainable level**, not just once at the end, by
+hooking straight into `ramp_controller.find_knee()`'s own driver/probe seam: the
+`probe` handed to `find_knee()` first asks `saturation_probe.evaluate()` for the
+verdict, and only when that verdict is NOT saturated does it also run
+`verify_zero_loss.py` — "the existing verifier," reused unmodified, exactly as #381's
+own two-tier composer already does — against a snapshot of the ledger-checked real
+stack's output. A violation there is a hard failure of the whole ramp, immediately,
+before any higher level is ever tried: a throughput figure obtained from a
+configuration that was dropping Records must never be reported (#323's PRD).
+
+Recorded discovery, in the same spirit as #381's own two: the snapshot verify_zero_loss.py
+checks against is extracted from the real stack's *still-running* data volume (the
+ledger-checked real stack keeps running across the whole ramp — stopping and restarting
+it between every level would be far too slow, and would also break the "one continuous
+real-stack run backs every sustainable level" property this check exists to establish).
+A named-volume read while another container is still appending to the same files races
+that container, and one instance of that race has a precise, diagnosed cause rather than
+a vague "torn write": `entrypoint.sh` starts `dc_mcap_writer` with `--max-duration-secs
+15`, and (per that writer's own `RotatingMcapWriter._open_next_file()` docstring) a
+`.mcap` file only becomes readable once its 15s rotation finishes and the writer calls
+`Writer.finish()` — the handful of most-recent Records always sit in a *currently open,
+unfinished* file that `mcap_summary.py` cannot parse at all yet. A live snapshot taken
+mid-rotation therefore reports those Records as "never reached dc_mcap_writer" even
+though they are sitting safely on disk, about to become readable a few seconds later.
+Verified empirically against a real run (see #382's progress.txt entry): a level's check
+failed with a clean, well-formed "ZERO-LOSS VERIFICATION FAILED" (not a parse crash) that
+the exact same check, re-run against the same still-live containers a bit later, no
+longer reproduced. So `verify_zero_loss_at_level()` retries *any* failure shape once,
+after a pause comfortably longer than that 15s rotation window
+(`_ZERO_LOSS_RETRY_SLEEP_S`), before treating it as a hard failure — a genuine violation
+is expected to reproduce on both attempts (well past any rotation boundary), so this
+costs nothing on real loss, and a failure is never distinguished from a real violation
+beyond that single retry, so it can never silently pass off as "verification didn't
+really run."
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import curve_reporter
+import ramp_controller
+import saturation_probe
+from load_driver import LoadDriverConfig, run_sync
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+# The aggregating Shipper's `sinks.to_postgres.buffer.max_size`
+# (run_limits_two_tier.sh's rendered aggregator_vector.toml) — the denominator disk-buffer
+# growth is expressed as a percent of, for the curve report's ResourceSample. Not itself a
+# saturation threshold (saturation_probe judges growth, never raw utilisation — see its own
+# docstring for why).
+DEFAULT_AGG_BUFFER_MAX_BYTES = 268_435_488
+
+DEFAULT_LEVELS = (25, 50, 100, 200, 400)
+DEFAULT_SYNTH_RATE_HZ = 5.0
+DEFAULT_SUB_WINDOW_SECONDS = 5.0
+DEFAULT_SUB_WINDOWS_PER_LEVEL = 5
+
+# entrypoint.sh runs dc_mcap_writer with `--max-duration-secs 15` — comfortably longer
+# than that, so a retry always lands after the rotation boundary that made the previous
+# attempt's most-recent Records unreadable (see the module docstring's discovery).
+_ZERO_LOSS_RETRY_SLEEP_S = 18.0
+
+
+class ZeroLossViolationError(RuntimeError):
+    """Raised when verify_zero_loss.py reports a real violation (not a transient
+    read race) — a hard, unrecoverable failure of the whole ramp."""
+
+
+def _podman_exec(container: str, *cmd: str) -> str:
+    result = subprocess.run(
+        ["podman", "exec", container, *cmd], capture_output=True, text=True, check=False
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def sample_disk_buffer_bytes(agg_container: str, data_dir: str = "/var/lib/vector") -> float:
+    """Total bytes under the aggregating Shipper's Vector data dir — dominated by
+    `sinks.to_postgres.buffer`, the sink carrying the at-least-once guarantee real
+    stacks' Records depend on. `du` failing (container not up yet) reads as 0 bytes,
+    not an error — sampled only ever alongside other observations that would themselves
+    fail loudly if the container were actually gone."""
+    out = _podman_exec(agg_container, "du", "-sb", data_dir)
+    if not out:
+        return 0.0
+    try:
+        return float(out.split()[0])
+    except (ValueError, IndexError):
+        return 0.0
+
+
+def sample_resource_usage(container: str) -> tuple[float, float]:
+    """(cpu_percent, mem_percent) for `container` via `podman stats`, mirroring
+    measure_resources.sh's own field choice. (0.0, 0.0) if the container has no stats
+    available right now (e.g. still starting) — informational, never a gate by itself."""
+    result = subprocess.run(
+        [
+            "podman",
+            "stats",
+            "--no-stream",
+            "--format",
+            "{{.CPUPerc}},{{.MemPerc}}",
+            "--filter",
+            f"name={container}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    line = result.stdout.strip()
+    if result.returncode != 0 or not line:
+        return (0.0, 0.0)
+    try:
+        cpu_s, mem_s = line.split(",")
+        return (float(cpu_s.rstrip("%")), float(mem_s.rstrip("%")))
+    except ValueError:
+        return (0.0, 0.0)
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = max(0, min(len(ordered) - 1, int(round(pct / 100.0 * (len(ordered) - 1)))))
+    return ordered[idx]
+
+
+@dataclass(frozen=True)
+class LevelConfig:
+    agg_host: str
+    agg_port: int
+    synth_rate_hz: float = DEFAULT_SYNTH_RATE_HZ
+    sub_window_seconds: float = DEFAULT_SUB_WINDOW_SECONDS
+    sub_windows_per_level: int = DEFAULT_SUB_WINDOWS_PER_LEVEL
+    tag: str = "dc.e2e.limits_synth"
+
+
+def drive_level(
+    level: float, agg_container: str, cfg: LevelConfig
+) -> list[saturation_probe.Observation]:
+    """The ramp controller's injected `driver`: runs `cfg.sub_windows_per_level` short
+    load_driver bursts at `level` synthetic connections back to back, turning each into
+    one Observation. Returns the whole window, oldest first, for the probe to judge."""
+    window: list[saturation_probe.Observation] = []
+    for _ in range(cfg.sub_windows_per_level):
+        driver_config = LoadDriverConfig(
+            host=cfg.agg_host,
+            port=cfg.agg_port,
+            connection_count=int(level),
+            record_rate_hz=cfg.synth_rate_hz,
+            duration_s=cfg.sub_window_seconds,
+            tag=cfg.tag,
+        )
+        result = run_sync(driver_config)
+        window.append(
+            saturation_probe.Observation(
+                ack_latency_s=_percentile(result.ack_latencies_s(), 95),
+                unacked_window_depth=float(len(result.unacked_chunk_ids)),
+                disk_buffer_bytes=sample_disk_buffer_bytes(agg_container),
+                outage_declared=False,
+            )
+        )
+    return window
+
+
+@dataclass(frozen=True)
+class VerifyConfig:
+    verify_script: Path
+    dc_image: str
+    data_volume: str
+    postgres_container: str
+    num_synth_topics: int
+    run_dir: Path
+    label: str
+
+
+def _podman_cat(dc_image: str, data_volume: str, path_in_container: str) -> str:
+    result = subprocess.run(
+        [
+            "podman",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "bash",
+            "-v",
+            f"{data_volume}:/vol:ro",
+            dc_image,
+            "-c",
+            f"cat {path_in_container} 2>/dev/null || true",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout
+
+
+def _extract_snapshot(cfg: VerifyConfig, level: float) -> dict[str, Path]:
+    prefix = cfg.run_dir / f"{cfg.label}_level_{level}"
+    paths = {
+        "ledger": prefix.with_suffix(".ledger.txt"),
+        "passthrough": prefix.with_suffix(".passthrough.ndjson"),
+        "raw": prefix.with_suffix(".raw.ndjson"),
+    }
+    paths["ledger"].write_text(
+        _podman_cat(cfg.dc_image, cfg.data_volume, "/vol/workload_ledger.txt")
+    )
+    paths["passthrough"].write_text(
+        _podman_cat(cfg.dc_image, cfg.data_volume, "/vol/passthrough/records.ndjson")
+    )
+    paths["raw"].write_text(_podman_cat(cfg.dc_image, cfg.data_volume, "/vol/raw/records.ndjson"))
+
+    mcap = subprocess.run(
+        [
+            "podman",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "python3",
+            "-v",
+            f"{cfg.data_volume}:/vol:ro",
+            cfg.dc_image,
+            "/opt/e2e/mcap_summary.py",
+            "/vol/mcap",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    mcap_path = prefix.with_suffix(".mcap_summary.json")
+    mcap_path.write_text(mcap.stdout if mcap.stdout.strip() else "{}")
+    paths["mcap"] = mcap_path
+    return paths
+
+
+def _run_verifier_once(
+    cfg: VerifyConfig, level: float, paths: dict[str, Path]
+) -> subprocess.CompletedProcess:
+    report_path = cfg.run_dir / f"{cfg.label}_level_{level}.verification_report.json"
+    return subprocess.run(
+        [
+            sys.executable,
+            str(cfg.verify_script),
+            "--postgres-container",
+            cfg.postgres_container,
+            "--num-synth-topics",
+            str(cfg.num_synth_topics),
+            "--ledger-file",
+            str(paths["ledger"]),
+            "--passthrough-file",
+            str(paths["passthrough"]),
+            "--mcap-summary-file",
+            str(paths["mcap"]),
+            "--raw-file",
+            str(paths["raw"]),
+            "--report",
+            str(report_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def verify_zero_loss_at_level(level: float, cfg: VerifyConfig) -> None:
+    """Runs `verify_zero_loss.py` against a live snapshot of the ledger-checked real
+    stack's output. Raises ZeroLossViolationError on any failure that survives one
+    retry — never a silent skip. See the module docstring for the diagnosed
+    live-snapshot/MCAP-rotation race this retry exists to absorb."""
+    for attempt in range(2):
+        paths = _extract_snapshot(cfg, level)
+        proc = _run_verifier_once(cfg, level, paths)
+        if proc.returncode == 0:
+            return
+        if attempt == 1:
+            raise ZeroLossViolationError(
+                f"verify_zero_loss.py failed at level {level} ({cfg.label}), "
+                f"attempt {attempt + 1}/2:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+            )
+        time.sleep(_ZERO_LOSS_RETRY_SLEEP_S)  # clears the MCAP rotation boundary race
+
+
+def build_axis_run(
+    result: ramp_controller.RampResult,
+    levels_resources: dict[float, tuple[curve_reporter.ResourceSample, bool]],
+    real_stacks: int,
+    label: str,
+) -> curve_reporter.AxisRun:
+    outcome = (
+        curve_reporter.RunOutcome.KNEE_FOUND
+        if result.outcome == ramp_controller.RampOutcome.KNEE_FOUND
+        else curve_reporter.RunOutcome.BOUND_NOT_FOUND
+    )
+    points = []
+    for level in result.levels_tried:
+        resources, saturated = levels_resources[level]
+        points.append(
+            curve_reporter.LevelResult(
+                level=level,
+                saturated=saturated,
+                kind=curve_reporter.PointKind.MEASURED,
+                composition=curve_reporter.RunComposition(
+                    real_stacks=real_stacks, synthetic_senders=int(level)
+                ),
+                resources=resources,
+            )
+        )
+    return curve_reporter.AxisRun(
+        axis=f"shipper_fan_in_{label}",
+        unit="synthetic connections (robots)",
+        outcome=outcome,
+        highest_clear_level=result.highest_clear_level,
+        tripped_level=result.tripped_level,
+        points=points,
+    )
+
+
+def closing_sentence(
+    result: ramp_controller.RampResult, real_stacks: int, synth_rate_hz: float
+) -> str:
+    """#323's PRD's required single defensible sentence, from an UNCONSTRAINED run:
+    'one aggregating Shipper sustains N robots at M Records per second before applying
+    backpressure, measured with X real stacks and Y synthetic senders, extrapolated
+    beyond Z.' Never fabricates a ceiling: BOUND_NOT_FOUND states plainly that the true
+    ceiling lies somewhere past the highest level tested, with no number invented for it."""
+    if result.outcome == ramp_controller.RampOutcome.BOUND_NOT_FOUND:
+        highest = result.highest_clear_level or 0
+        return (
+            f"One aggregating Shipper sustains at least {real_stacks + int(highest)} robots "
+            f"({real_stacks} real + {int(highest)} synthetic) at {synth_rate_hz} Records/s "
+            f"per robot without applying backpressure — the ramp never saturated within "
+            f"the tested range, so no ceiling is reported beyond {int(highest)} synthetic "
+            f"senders (bound not found; never fabricated)."
+        )
+    highest_clear = result.highest_clear_level
+    synthetic_at_knee = int(highest_clear) if highest_clear is not None else 0
+    return (
+        f"One aggregating Shipper sustains {real_stacks + synthetic_at_knee} robots "
+        f"({real_stacks} real + {synthetic_at_knee} synthetic) at {synth_rate_hz} "
+        f"Records/s per robot before applying backpressure, measured with {real_stacks} "
+        f"real stack(s) and {synthetic_at_knee} synthetic sender(s); saturation observed "
+        f"at {int(result.tripped_level)} synthetic senders (not extrapolated — the knee "
+        f"itself was measured, not projected)."
+    )
+
+
+def run(args: argparse.Namespace) -> ramp_controller.RampResult:
+    run_dir = Path(args.run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    level_cfg = LevelConfig(
+        agg_host=args.agg_host,
+        agg_port=args.agg_port,
+        synth_rate_hz=args.synth_rate_hz,
+        sub_window_seconds=args.sub_window_seconds,
+        sub_windows_per_level=args.sub_windows_per_level,
+    )
+    verify_cfg = VerifyConfig(
+        verify_script=SCRIPT_DIR / "verify_zero_loss.py",
+        dc_image=args.dc_image,
+        data_volume=args.data_volume,
+        postgres_container=args.postgres_container,
+        num_synth_topics=args.num_synth_topics,
+        run_dir=run_dir,
+        label=args.label,
+    )
+    bounds = saturation_probe.SaturationBounds()
+    levels_resources: dict[float, tuple[curve_reporter.ResourceSample, bool]] = {}
+
+    def driver(level: float) -> list[saturation_probe.Observation]:
+        print(
+            f"[fanin/{args.label}] level {int(level)}: driving {args.sub_windows_per_level} "
+            f"sub-window(s) of {args.sub_window_seconds}s at {int(level)} synthetic connections",
+            flush=True,
+        )
+        return drive_level(level, args.agg_container, level_cfg)
+
+    levels_seen: list[float] = []
+
+    def probe_and_record(window: list[saturation_probe.Observation]) -> saturation_probe.Verdict:
+        level = levels_seen[-1]
+        verdict = saturation_probe.evaluate(window, bounds)
+        cpu, mem = sample_resource_usage(args.agg_container)
+        disk_bytes = window[-1].disk_buffer_bytes if window else 0.0
+        levels_resources[level] = (
+            curve_reporter.ResourceSample(
+                cpu_percent=cpu,
+                mem_percent=mem,
+                disk_percent=(disk_bytes / args.agg_buffer_max_bytes) * 100.0,
+            ),
+            verdict.saturated,
+        )
+        print(
+            f"[fanin/{args.label}] level {int(level)}: {verdict.status.value} ({verdict.reason})",
+            flush=True,
+        )
+        if not verdict.saturated:
+            print(
+                f"[fanin/{args.label}] level {int(level)}: clear — asserting zero loss "
+                f"via verify_zero_loss.py before continuing",
+                flush=True,
+            )
+            verify_zero_loss_at_level(level, verify_cfg)
+            print(f"[fanin/{args.label}] level {int(level)}: PASS zero-loss", flush=True)
+        return verdict
+
+    def tracking_driver(level: float) -> list[saturation_probe.Observation]:
+        levels_seen.append(level)
+        return driver(level)
+
+    policy = ramp_controller.RampPolicy(levels=tuple(float(v) for v in args.levels))
+    result = ramp_controller.find_knee(tracking_driver, probe_and_record, policy)
+
+    axis_run = build_axis_run(result, levels_resources, args.real_stacks, args.label)
+    report = curve_reporter.build_report([axis_run])
+
+    Path(args.report_json).write_text(curve_reporter.to_json(report))
+    sentence = closing_sentence(result, args.real_stacks, args.synth_rate_hz)
+    summary = curve_reporter.render_summary(report) + "\nClosing statement:\n" + sentence + "\n"
+    Path(args.report_txt).write_text(summary)
+    print(summary)
+
+    print(
+        json.dumps(
+            {
+                "label": args.label,
+                "outcome": result.outcome.value,
+                "highest_clear_level": result.highest_clear_level,
+                "tripped_level": result.tripped_level,
+            }
+        )
+    )
+    return result
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", required=True, help="e.g. 'unconstrained' or 'constrained'")
+    parser.add_argument("--agg-host", required=True)
+    parser.add_argument("--agg-port", type=int, required=True)
+    parser.add_argument("--agg-container", required=True)
+    parser.add_argument("--postgres-container", required=True)
+    parser.add_argument(
+        "--data-volume", required=True, help="the ledger-checked real stack's data volume"
+    )
+    parser.add_argument("--dc-image", required=True)
+    parser.add_argument("--real-stacks", type=int, default=1)
+    parser.add_argument("--num-synth-topics", type=int, default=14)
+    parser.add_argument("--levels", type=int, nargs="+", default=list(DEFAULT_LEVELS))
+    parser.add_argument("--synth-rate-hz", type=float, default=DEFAULT_SYNTH_RATE_HZ)
+    parser.add_argument("--sub-window-seconds", type=float, default=DEFAULT_SUB_WINDOW_SECONDS)
+    parser.add_argument("--sub-windows-per-level", type=int, default=DEFAULT_SUB_WINDOWS_PER_LEVEL)
+    parser.add_argument("--agg-buffer-max-bytes", type=float, default=DEFAULT_AGG_BUFFER_MAX_BYTES)
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--report-json", required=True)
+    parser.add_argument("--report-txt", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    try:
+        run(args)
+    except ZeroLossViolationError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/e2e/scripts/run_limits_shipper_fanin.sh
+++ b/tools/e2e/scripts/run_limits_shipper_fanin.sh
@@ -1,0 +1,383 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Limits harness: Shipper fan-in axis + instrument proof (#382, the flagship axis of
+# #323's epic). From the repo root:
+#
+#   ./tools/e2e/scripts/run_limits_shipper_fanin.sh
+#
+# A sibling of run_limits_two_tier.sh (#381) — its own gates (a ramp to saturation plus
+# the induced-limit instrument proof, not a fixed-load pass/fail) — but reuses that
+# ticket's topology verbatim: the same params/e2e_limits_params.yaml,
+# params/e2e_limits_forward_sink.toml, and the same aggregating-Shipper container names
+# those files hard-code (dc-e2e-limits-postgres/rustfs/agg), since the two-tier chain
+# they compose is exactly what this ramp drives. The two scripts are never meant to run
+# concurrently (same as every other pair of sibling scenario scripts in this harness);
+# each does its own full teardown on start and on exit.
+#
+# What it does, in order:
+#   1. Brings up the shared Postgres + RustFS + aggregating-Shipper topology once.
+#   2. Runs #379's ramp controller over #378's synthetic load driver and #377's
+#      saturation probe (both wired up in scripts/run_limits_shipper_fanin.py) against
+#      an UNCONSTRAINED aggregating Shipper — the flagship number.
+#   3. Truncates dc_records/dc_files, tears down that phase's Shipper + real stacks
+#      (Postgres/RustFS/network stay up), and re-runs the identical ramp against a
+#      deliberately CPU/memory-constrained aggregating Shipper.
+#   4. Asserts the constrained run's ceiling is substantially lower than the
+#      unconstrained one (DC_E2E_FANIN_CEILING_DROP_RATIO, default 0.5) — "a limits
+#      harness that cannot demonstrate detecting an induced limit has not been shown to
+#      work" (#323's PRD). Neither phase is allowed to end BOUND_NOT_FOUND: an
+#      unconstrained run that never saturates has no ceiling to report the PRD's closing
+#      sentence about, and a constrained run that never saturates has failed to
+#      demonstrate the induced limit — both are hard failures, not skips.
+#
+# Zero loss is asserted by the Python orchestrator itself, via #379's own driver/probe
+# injection seam — see run_limits_shipper_fanin.py's module docstring for exactly how
+# (verify_zero_loss.py, reused unmodified, at every level whose verdict stays clear) and
+# the one documented trade-off (a live-volume snapshot mid-run) that entails.
+#
+# Env vars (all optional):
+#   DC_E2E_FANIN_REAL_STACKS            real DC stacks kept running for fidelity through
+#                                        the whole ramp (default 1 — see
+#                                        run_limits_two_tier.sh's own discovery about
+#                                        the aggregating Shipper's shared-sink bottleneck
+#                                        before raising this)
+#   DC_E2E_FANIN_LEVELS                 ascending synthetic-connection levels to ramp
+#                                        through (default "25 50 100 200 400 800")
+#   DC_E2E_FANIN_SYNTH_RATE_HZ          per-connection Record rate (default 5)
+#   DC_E2E_FANIN_SUB_WINDOW_SECONDS     each ramp level's sub-window duration (default 5)
+#   DC_E2E_FANIN_SUB_WINDOWS_PER_LEVEL  sub-windows sampled per level (default 5)
+#   DC_E2E_FANIN_CONSTRAINED_CPUS       constrained-phase --cpus (default 0.5)
+#   DC_E2E_FANIN_CONSTRAINED_MEMORY     constrained-phase --memory (default 256m)
+#   DC_E2E_FANIN_CEILING_DROP_RATIO     constrained ceiling / unconstrained ceiling must
+#                                        be <= this (default 0.5 — "substantially lower")
+#   DC_E2E_KEEP                  "true" to leave the stack (and its network) up after a
+#                                 failure for debugging
+#   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE   same meaning as run.sh / run_limits_two_tier.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(cd "$E2E_DIR/../.." && pwd)"
+RUN_DIR="$E2E_DIR/.run/limits_shipper_fanin"
+
+REAL_STACKS="${DC_E2E_FANIN_REAL_STACKS:-1}"
+LEVELS="${DC_E2E_FANIN_LEVELS:-25 50 100 200 400 800}"
+SYNTH_RATE_HZ="${DC_E2E_FANIN_SYNTH_RATE_HZ:-5}"
+SUB_WINDOW_SECONDS="${DC_E2E_FANIN_SUB_WINDOW_SECONDS:-5}"
+SUB_WINDOWS_PER_LEVEL="${DC_E2E_FANIN_SUB_WINDOWS_PER_LEVEL:-5}"
+CONSTRAINED_CPUS="${DC_E2E_FANIN_CONSTRAINED_CPUS:-0.5}"
+CONSTRAINED_MEMORY="${DC_E2E_FANIN_CONSTRAINED_MEMORY:-256m}"
+CEILING_DROP_RATIO="${DC_E2E_FANIN_CEILING_DROP_RATIO:-0.5}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+NET=dc-e2e-limits-net
+# Same names params/e2e_limits_params.yaml and params/e2e_limits_forward_sink.toml
+# hard-code — see this file's header for why reusing them unmodified requires it.
+PG_C=dc-e2e-limits-postgres
+RUSTFS_C=dc-e2e-limits-rustfs
+AGG_C=dc-e2e-limits-agg
+AGG_VECTOR_PORT=6000
+AGG_FLUENT_PORT=24224
+STACK_PREFIX=dc-e2e-limits-stack-
+LEDGER_STACK_INDEX=0
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-fanin $(date -u +%H:%M:%S)] $*"; }
+
+stack_name() { echo "${STACK_PREFIX}$1"; }
+
+all_stack_names() {
+  local i
+  for ((i = 0; i < REAL_STACKS; i++)); do
+    stack_name "$i"
+  done
+}
+
+remove_phase_containers() {
+  # shellcheck disable=SC2046
+  podman rm -f --ignore $(all_stack_names) "$AGG_C" >/dev/null
+  local i v
+  for ((i = 0; i < REAL_STACKS; i++)); do
+    for v in "dc_e2e_limits_buffer_$i" "dc_e2e_limits_data_$i"; do
+      if podman volume exists "$v"; then
+        podman volume rm "$v" >/dev/null
+      fi
+    done
+  done
+}
+
+remove_all() {
+  remove_phase_containers
+  podman rm -f --ignore "$PG_C" "$RUSTFS_C" >/dev/null
+  for v in dc_e2e_limits_pgdata dc_e2e_limits_rustfs_data; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+  podman network rm "$NET" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  local s
+  for s in $(all_stack_names); do
+    if podman container exists "$s"; then
+      podman logs "$s" > "$RUN_DIR/${s}.log" 2>&1
+    fi
+  done
+  if podman container exists "$AGG_C"; then
+    podman logs "$AGG_C" > "$RUN_DIR/agg.log" 2>&1
+  fi
+  remove_all
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- obtain the DC stack image (shared with run.sh / run_limits_two_tier.sh) ------------
+if [ -n "${DC_E2E_IMAGE:-}" ]; then
+  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+  DC_IMAGE="$DC_E2E_IMAGE"
+else
+  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
+  else
+    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+    "$SCRIPT_DIR/build.sh"
+    WORKSPACE_IMAGE="dc-workspace:latest"
+  fi
+  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
+  DC_IMAGE="dc-e2e:latest"
+fi
+
+VECTOR_VERSION="$(grep -oP 'set\(VECTOR_VERSION "\K[^"]+' "$REPO_ROOT/vector_vendor/CMakeLists.txt")"
+VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
+
+remove_all
+
+# --- bridge network + shared destinations (kept up across both phases) ------------------
+log "creating the bridge network ($NET)"
+podman network create "$NET" >/dev/null
+
+log "starting the shared Postgres + RustFS on $NET"
+podman run -d --network "$NET" --name "$PG_C" \
+  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+  -v dc_e2e_limits_pgdata:/var/lib/postgresql/data \
+  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+  docker.io/library/postgres:13 >/dev/null
+podman run -d --network "$NET" --name "$RUSTFS_C" \
+  -v dc_e2e_limits_rustfs_data:/data \
+  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+
+timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
+  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+
+log "waiting for RustFS to accept TCP connections on $NET"
+timeout 60 bash -c "
+  until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
+    sleep 1
+  done
+" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+
+log "creating the RustFS bucket"
+podman run --rm --network "$NET" \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+
+# --- the aggregating Shipper's Vector config, rendered once and reused across both phases
+cat > "$RUN_DIR/aggregator_vector.toml" <<EOF
+data_dir = "/var/lib/vector"
+
+[acknowledgements]
+enabled = true
+
+[sources.from_tier1]
+type = "vector"
+address = "0.0.0.0:${AGG_VECTOR_PORT}"
+
+[sources.from_synth]
+type = "fluent"
+address = "0.0.0.0:${AGG_FLUENT_PORT}"
+
+[sinks.to_postgres]
+type = "postgres"
+inputs = ["from_tier1"]
+endpoint = "postgres://dc:password@${PG_C}:5432/dc"
+table = "dc_records"
+
+[sinks.to_postgres.buffer]
+type = "disk"
+max_size = 268435488
+
+[sinks.discard_synth]
+type = "blackhole"
+inputs = ["from_synth"]
+EOF
+
+pg_exec() { podman exec "$PG_C" psql -U dc -d dc -tAc "$1"; }
+
+truncate_records() {
+  log "truncating dc_records/dc_files so the next phase starts from a clean baseline"
+  pg_exec "TRUNCATE dc_records, dc_files" >/dev/null
+}
+
+# --- run one phase (unconstrained or constrained) end to end -----------------------------
+run_phase() {
+  local label="$1"
+  shift
+  local agg_extra_args=("$@")
+
+  log "=== phase: $label ==="
+  log "starting the aggregating Shipper ($AGG_C)${agg_extra_args[*]:+ with ${agg_extra_args[*]}}"
+  podman run -d --network "$NET" -p "${AGG_FLUENT_PORT}:${AGG_FLUENT_PORT}" --name "$AGG_C" \
+    "${agg_extra_args[@]}" \
+    -v "$RUN_DIR/aggregator_vector.toml:/etc/vector/vector.toml:Z" \
+    "$VECTOR_IMAGE" -c /etc/vector/vector.toml >/dev/null
+
+  log "waiting for the aggregating Shipper's synthetic-sender ingress to accept connections"
+  if ! timeout 30 bash -c "until (exec 3<>/dev/tcp/127.0.0.1/${AGG_FLUENT_PORT}) 2>/dev/null; do sleep 0.5; done"; then
+    log "FAIL: the aggregating Shipper's fluent source never started listening on port $AGG_FLUENT_PORT"
+    exit 1
+  fi
+  log "waiting for the aggregating Shipper's tier-1 ingress to accept connections"
+  timeout 60 bash -c "
+    until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$AGG_C/$AGG_VECTOR_PORT' >/dev/null 2>&1; do
+      sleep 1
+    done
+  " || { log "FAIL: the aggregating Shipper's vector-protocol source never became reachable on $NET"; exit 1; }
+
+  log "starting $REAL_STACKS real DC stack(s) against params/e2e_limits_params.yaml"
+  local i s
+  for ((i = 0; i < REAL_STACKS; i++)); do
+    s="$(stack_name "$i")"
+    podman volume create "dc_e2e_limits_buffer_$i" >/dev/null
+    podman volume create "dc_e2e_limits_data_$i" >/dev/null
+    podman run -d --network "$NET" --name "$s" \
+      -v "dc_e2e_limits_buffer_$i:/root/.dc/e2e/buffer" \
+      -v "dc_e2e_limits_data_$i:/root/.dc/e2e/data" \
+      -v "$E2E_DIR/params/e2e_limits_params.yaml:/opt/e2e/e2e_params.yaml:ro" \
+      -v "$E2E_DIR/params/e2e_limits_forward_sink.toml:/opt/e2e/e2e_limits_forward_sink.toml:ro" \
+      "$DC_IMAGE" >/dev/null
+    sleep 5
+  done
+
+  log "waiting for the first Record to reach Postgres through the two-tier chain"
+  timeout 90 bash -c "until [ \"\$(podman exec $PG_C psql -U dc -d dc -tAc 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)\" -gt 0 ] 2>/dev/null; do sleep 1; done" \
+    || { log "FAIL: no Record reached Postgres through the two-tier chain within 90s"; exit 1; }
+  log "PASS: real-stack traffic is flowing through the aggregating Shipper — starting the ramp"
+
+  local data_vol="dc_e2e_limits_data_${LEDGER_STACK_INDEX}"
+  local report_json="$RUN_DIR/${label}_report.json"
+  local report_txt="$RUN_DIR/${label}_summary.txt"
+
+  # shellcheck disable=SC2086
+  uv run --frozen python3 "$SCRIPT_DIR/run_limits_shipper_fanin.py" \
+    --label "$label" \
+    --agg-host 127.0.0.1 --agg-port "$AGG_FLUENT_PORT" \
+    --agg-container "$AGG_C" \
+    --postgres-container "$PG_C" \
+    --data-volume "$data_vol" \
+    --dc-image "$DC_IMAGE" \
+    --real-stacks "$REAL_STACKS" \
+    --levels $LEVELS \
+    --synth-rate-hz "$SYNTH_RATE_HZ" \
+    --sub-window-seconds "$SUB_WINDOW_SECONDS" \
+    --sub-windows-per-level "$SUB_WINDOWS_PER_LEVEL" \
+    --run-dir "$RUN_DIR" \
+    --report-json "$report_json" \
+    --report-txt "$report_txt" \
+    | tee "$RUN_DIR/${label}_orchestrator.log"
+
+  log "stopping $label's real DC stack(s)"
+  for s in $(all_stack_names); do
+    podman stop "$s" >/dev/null
+  done
+
+  # The orchestrator's own final line is a single-line JSON summary — see
+  # run_limits_shipper_fanin.py's `run()`.
+  tail -1 "$RUN_DIR/${label}_orchestrator.log" > "$RUN_DIR/${label}_result.json"
+}
+
+stop_phase() {
+  local s
+  for s in $(all_stack_names); do
+    if podman container exists "$s"; then
+      podman logs "$s" > "$RUN_DIR/${s}_$1.log" 2>&1
+    fi
+  done
+  if podman container exists "$AGG_C"; then
+    podman logs "$AGG_C" > "$RUN_DIR/agg_$1.log" 2>&1
+  fi
+  remove_phase_containers
+}
+
+ceiling_of() {
+  # KNEE_FOUND's ceiling is the tripped level (the actual measured saturation point,
+  # never highest_clear_level — that would understate what was actually driven to).
+  python3 -c "
+import json
+r = json.load(open('$1'))
+if r['outcome'] != 'knee_found':
+    print('NONE')
+else:
+    print(r['tripped_level'])
+"
+}
+
+outcome_of() {
+  python3 -c "import json; print(json.load(open('$1'))['outcome'])"
+}
+
+# --- phase 1: unconstrained --------------------------------------------------------------
+run_phase "unconstrained"
+stop_phase "unconstrained"
+
+UNCONSTRAINED_OUTCOME="$(outcome_of "$RUN_DIR/unconstrained_result.json")"
+if [ "$UNCONSTRAINED_OUTCOME" != "knee_found" ]; then
+  log "FAIL: the unconstrained run never saturated within the tested levels ($LEVELS) — no measured ceiling to report the PRD's closing sentence about. Raise DC_E2E_FANIN_LEVELS."
+  exit 1
+fi
+UNCONSTRAINED_CEILING="$(ceiling_of "$RUN_DIR/unconstrained_result.json")"
+log "unconstrained ceiling: $UNCONSTRAINED_CEILING synthetic connections"
+
+truncate_records
+
+# --- phase 2: deliberately constrained ----------------------------------------------------
+run_phase "constrained" --cpus "$CONSTRAINED_CPUS" --memory "$CONSTRAINED_MEMORY"
+stop_phase "constrained"
+
+CONSTRAINED_OUTCOME="$(outcome_of "$RUN_DIR/constrained_result.json")"
+if [ "$CONSTRAINED_OUTCOME" != "knee_found" ]; then
+  log "FAIL: the constrained run (--cpus $CONSTRAINED_CPUS --memory $CONSTRAINED_MEMORY) never saturated within the tested levels ($LEVELS) — the instrument has not demonstrated detecting the induced limit."
+  exit 1
+fi
+CONSTRAINED_CEILING="$(ceiling_of "$RUN_DIR/constrained_result.json")"
+log "constrained ceiling: $CONSTRAINED_CEILING synthetic connections"
+
+# --- the instrument proof: constrained ceiling must be substantially lower ---------------
+RATIO="$(python3 -c "print($CONSTRAINED_CEILING / $UNCONSTRAINED_CEILING)")"
+log "constrained/unconstrained ceiling ratio: $RATIO (must be <= $CEILING_DROP_RATIO)"
+if ! python3 -c "import sys; sys.exit(0 if $RATIO <= $CEILING_DROP_RATIO else 1)"; then
+  log "FAIL: the constrained run's ceiling ($CONSTRAINED_CEILING) is not substantially lower than the unconstrained run's ($UNCONSTRAINED_CEILING) — ratio $RATIO exceeds $CEILING_DROP_RATIO. The instrument has not demonstrated detecting the induced limit."
+  exit 1
+fi
+log "PASS: the constrained aggregating Shipper's ceiling is substantially lower than the unconstrained one — the instrument detects an induced limit"
+
+echo
+echo "=== #323's required closing sentence (unconstrained run) ==="
+tail -2 "$RUN_DIR/unconstrained_summary.txt"
+
+log "PASS: limits harness Shipper fan-in axis + instrument proof (#382)"


### PR DESCRIPTION
## Summary

- Adds `tools/e2e/scripts/run_limits_shipper_fanin.py`, the orchestrator that wires #323's four already-shipped deep modules together for real: `ramp_controller.find_knee()` drives synthetic connection count (via `load_driver.py`) against #381's two-tier topology's aggregating Shipper, `saturation_probe.evaluate()` judges each level from a window of ack-latency/unacked-window-depth/disk-buffer observations, and `curve_reporter` turns the result into a stable report plus the PRD's required closing sentence. None of the four modules are modified.
- Zero loss is asserted **at every sustainable level**, not once at the end, by hooking into the ramp controller's own driver/probe seam: only when a level's verdict stays clear does the probe also run `verify_zero_loss.py` ("the existing verifier," reused unmodified) against a snapshot of the ledger-checked real stack's still-running output. A violation hard-fails the whole ramp immediately.
- Adds `tools/e2e/scripts/run_limits_shipper_fanin.sh`, a sibling scenario script (own topology bring-up, own gates) reusing #381's topology files verbatim. It runs the ramp twice — unconstrained (the flagship number), then against a deliberately CPU/memory-constrained aggregating Shipper — and hard-fails unless the constrained ceiling is substantially lower (`<= 0.5x` by default), proving the harness detects an induced limit per the PRD.

## Verified against real infrastructure

Ran the full scenario against a real `dc-e2e` image on real podman infrastructure multiple times (not just unit-level reasoning against fakes):
- A coarse-ramp run correctly *failed* the instrument-proof gate when both phases happened to saturate at the same tested level — the harness refused to fabricate a pass.
- A finer-grained run drove real synthetic load through a real aggregating Shipper, found a real saturation knee, and asserted real zero-loss at clear levels.
- Found and root-caused a real bug in the process: the live-volume snapshot `verify_zero_loss_at_level()` reads raced `dc_mcap_writer`'s 15s rotation window (`entrypoint.sh --max-duration-secs 15`), surfacing as a false "ZERO-LOSS VERIFICATION FAILED" for Records that were actually safe on disk but not yet in a finished, readable `.mcap` file. Fixed the retry to cover any failure shape (not just parse crashes) with an 18s pause, and re-verified the fix against the same live containers that had failed under the original logic.

Full details in `progress.txt`'s `#382` entry.

Closes #382

## Test plan

- [x] `prek run --all-files --skip build-doc` passes (ruff, shellcheck, codespell, clang-format, etc.)
- [x] `python3 -m py_compile` / CLI `--help` smoke test on the orchestrator
- [x] In-process smoke test against a fake ingest server exercising the full ramp/probe/zero-loss-hook/curve-report/closing-sentence flow
- [x] Multiple real end-to-end runs against a real `dc-e2e` image + real podman containers (Postgres/RustFS/aggregating Shipper/real DC stack), including a run that correctly failed the instrument-proof gate and a run that found a real saturation knee with real zero-loss assertions
- [ ] A full unattended pass of both phases end-to-end in one run, outside this sandbox's per-command time constraints — not run by `ci.yaml`, same as every other narrow scenario script in this harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mh8vrBQibc4B5JqJn5f45Z