### PR TITLE
feat(tools/e2e): add limits harness Uploader concurrency axis (#384)

### DIFF
--- a/progress.txt
+++ b/progress.txt
@@ -8301,3 +8301,114 @@ not-yet-implemented piece of #323.
 - Not wired into `ci.yaml`, same as every other narrow scenario script, and — like
   `run_limits_two_tier.sh` — needs that script's own topology bring-up working before it
   can run at all.
+
+## #384 - Limits harness: Uploader concurrency axis
+
+`tools/e2e/scripts/run_upload_concurrency_axis.py` + `run_limits_upload_concurrency.sh` +
+`params/e2e_limits_upload_params.yaml`: the ninth piece of #323's epic (#383 and #382
+merged first and already call `ramp_controller.find_knee()` end to end for their own
+axes — this was developed in parallel, not aware of that landing first) — ramps the
+number of concurrent Bridge/Uploader processes against one shared object-storage
+Destination until verify-then-delete falls behind, reporting the last sustainable
+concurrency level.
+
+**Why "process count" is the axis**: read `dc_bridge/src/uploader/uploader.hpp` and
+`bridge_node.cpp`'s full param schema before designing anything — the Uploader has no
+internal concurrency knob at all ("Synchronous (aws-sdk-cpp is blocking) — no async
+runtime", one `uploader_thread_` per Bridge process, no `concurrency`/`worker_count`
+param anywhere). Ramping "concurrency" therefore means starting N separate Bridge
+containers against shared Postgres/RustFS — the same topology `run_limits_two_tier.sh`
+(#381) already proved works for Files, whose header explicitly recorded that Files
+bypass that scenario's two-tier Shipper-relay chain (no Vector hop for the Uploader at
+all) and left true two-tier File coverage as a follow-up. This ticket is the
+single-tier concurrency-and-custody scenario #381 punted, not that follow-up.
+
+**`scripts/upload_saturation_probe.py`** (its own pure module, unit-tested alone, 11
+cases in `test/test_upload_saturation_probe.py`): a sibling to `saturation_probe.py`,
+not a reuse of it — that module's `Observation`/`evaluate()` are hard-wired to
+Shipper-specific fields (ack latency, unacked-window depth, disk-buffer bytes), and
+Files never touch the Shipper, so there is no ack latency to plug in. This axis's own
+two signals, checked in priority order with the same head/tail-mean-growth (not
+snapshot-threshold) discipline and the same outage-suppression rule as the original:
+(1) **upload queue depth** — `IntentQueue::size()`, already exposed by the Bridge's
+`~/ready` service (#265's existing "cheap observability hook" — no DC code changed to
+read it) — trending upward; (2) **verify-then-delete backlog** — files verified in
+`dc_files` (ADR-0005) with no later delete row for the same `local_path` yet — growing
+at steady state, suppressed while an outage is declared.
+
+**The driver** (`run_upload_concurrency_axis.py`, plugged into `find_knee()` unchanged
+per the acceptance criteria): per level, starts N Bridge containers (staggered, same
+reasoning as #381), waits for each one's `~/ready` service to respond, then samples
+queue depth (summed across the N containers via `podman exec ... ros2 service call
+/dc_bridge/ready std_srvs/srv/Trigger`) and the outstanding-verified-backlog count
+(queried via `verify_zero_loss.py`'s own `psql()`/`scalar_int()` helpers, reused rather
+than a second Postgres client) every few seconds for a steady-state window, tears the
+level's containers down, and returns the observation window to `find_knee()`. The
+result feeds `curve_reporter.build_report()` in its stable format (`AxisRun`/
+`LevelResult`/`RunComposition(real_stacks=N, synthetic_senders=0)`), same as every other
+already-landed module in the epic.
+
+**The two hard gates** (acceptance criteria 2): at every level actually driven, before
+that level's containers are torn down, two correctness checks run against `dc_files` —
+never folded into the saturation verdict, since a level can be correctness-broken
+without ever looking like a backpressure ceiling: (1) no `deleted=true` row for a
+`local_path` may exist without an earlier-or-equal `uploaded=true, deleted=false` row
+for the same path (delete-after-verify ordering, checked empirically across N
+concurrently-uploading processes writing to the shared table, not assumed from one
+process's own in-order code path); (2) every `group_complete` marker for the camera
+group names the expected file count. A violation raises immediately and aborts the
+whole ramp.
+
+**Deliberately synthetic/reduced scale** (acceptance criterion 3): file size stays the
+same 64x64 solid-color ~12KB image `workload_generator.py` already produces for every
+E2E scenario — untouched. Only capture *cadence* is sped up: `workload_generator.py`
+gained a `DC_E2E_CAMERA_PERIOD_S` env-var override on its `camera_period_s` ROS param
+(default 15.0s unchanged for every other scenario — it's started as a plain `python3`
+process by `entrypoint.sh`, not through `ros2 launch`, so there is no `--ros-args -p`
+hook to reach into it without either a code change or an env var, matching the file's
+own pre-existing `DC_E2E_LEDGER` convention), so N concurrent processes produce enough
+uploads inside a short steady-state window to show a trend at all. Any byte-volume
+implication of a reported ceiling is arithmetic, never presented as measured — same
+principle #323's PRD states explicitly for this axis.
+
+**Two real bugs found and fixed by actually running this against podman**, not by
+reading the code (the repo's established verification standard):
+1. The first "verify-then-delete backlog" query counted `uploaded=true AND
+   deleted=false` rows directly — wrong, because `dc_files` is an append-only event log
+   (Vector's `postgres` sink only ever `INSERT`s; a file's upload/verify row never
+   changes, and a later delete is a *separate* row for the same `local_path`). That
+   query therefore counted every verify event ever recorded, including ones long since
+   deleted — a figure that only ever grew, on a run that was actually healthy
+   throughout (delete_when_sent was firing correctly the whole time). Fixed to count
+   distinct `local_path`s verified with *no later delete row at all* for that path
+   (`_outstanding_verified_count()`).
+2. At concurrency 4, the delete-after-verify gate genuinely tripped — investigated
+   before accepting it as a finding, per #381's own precedent of not silently working
+   around a surprising result. Traced `Camera::getLocalPath()`/`getSavePath()`
+   (`dc_measurements/plugins/measurements/camera.cpp`) and confirmed a captured file's
+   `local_path` is built purely from wall-clock time truncated to whole seconds — no
+   PID, hostname, or counter of any kind. Every container in this axis runs the
+   identical params file and cadence, so two containers capturing within the same
+   wall-clock second produced byte-identical `local_path` strings — confirmed directly
+   against Postgres (`dc_files` showed a single path with 7 file_status rows across 4
+   containers). Not a DC-level Uploader bug: each container's own upload/verify/delete
+   sequence was internally correct: two independent lifecycles were indistinguishable
+   by `local_path` alone, a scenario-harness gap, not a pipeline one. Fixed with **no DC
+   code change** — `dc_util::expand_env()` is a generic `$VARNAME` expander (not
+   `$HOME`-specific), so `params/e2e_limits_upload_params.yaml`'s
+   `save_local_base_path` now includes `$DC_E2E_STACK_ID`, set per container by the
+   driver script; re-verified clean at concurrency 4 afterward (real dc_files rows
+   showed the correct `uploaded` → `deleted` ordering, `IntentQueue` retry/backoff
+   producing intermediate `missing_row` status entries before the real verify+delete
+   pair, exactly as designed).
+- **Verified end-to-end for real**, repeatedly, against the cached `dc-e2e:latest`
+  image (rebuilt once, cheaply — `Containerfile.e2e` is a thin layer over the cached
+  workspace image, so picking up the `workload_generator.py` env-var change needed no
+  colcon recompile): single-level and multi-level (1, 2, 4-way concurrency) runs, both
+  the pre-fix failure and the post-fix clean pass at concurrency 4, direct Postgres
+  inspection of `dc_files` to confirm the collision hypothesis and the fix. All 88
+  `tools/e2e/test/` cases (11 new) and `prek` (ruff/shellcheck/codespell/etc.) pass.
+- `tools/e2e/README.md` gained an "Uploader concurrency axis (#384)" section (after the
+  Shipper fan-in axis's #382 section — the last of the three merged this way, so it
+  gets the "ninth piece" framing, before Layout) plus Layout entries for the new files.
+- Not wired into `ci.yaml`, same as every other narrow scenario script.

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -452,6 +452,68 @@ Not wired into `ci.yaml`, same as the other scenario scripts above — and, like
 `run_limits_two_tier.sh`'s own dependents, this axis needs that script's own topology
 bring-up already established working before it can run at all.
 
+## Uploader concurrency axis (#384)
+
+The ninth piece of #323's limits harness (developed in parallel with #383/#382, which
+merged first and already call `ramp_controller.find_knee()` end to end for their own
+axes): ramps the number of concurrent Bridge/Uploader processes against one shared
+object-storage Destination until verify-then-delete falls behind, reporting the last
+sustainable concurrency level.
+
+```sh
+./tools/e2e/scripts/run_limits_upload_concurrency.sh
+```
+
+The Uploader has no internal concurrency knob — `dc_bridge/src/uploader/uploader.hpp`
+says so directly ("Synchronous (aws-sdk-cpp is blocking) — no async runtime"), one
+`uploader_thread_` per Bridge process, and `bridge_node.cpp`'s full param schema declares
+none. "Concurrency" on this axis therefore means starting N separate Bridge/Uploader
+containers against a shared Postgres + RustFS on a dedicated bridge network — the same
+topology #381 already proved works for Files, whose header recorded that Files bypass
+that scenario's two-tier Shipper-relay chain entirely (no Vector hop at all) and left true
+two-tier File coverage as a follow-up. This axis is the single-tier concurrency-and-custody
+scenario #381 punted, not that follow-up.
+
+`scripts/run_upload_concurrency_axis.py` owns the ramp itself: it calls
+`ramp_controller.find_knee()` **unchanged**, driving load by starting/stopping N
+containers per level against `params/e2e_limits_upload_params.yaml` (a minimal params
+file carrying only the camera Measurement — this axis's claim is File concurrency and
+custody, not Record delivery), and feeds the result to `curve_reporter.build_report()` in
+its stable format. Per #384's acceptance criteria, file size stays the same deliberately
+synthetic 64x64 solid-color image every E2E scenario already produces (~12KB via
+`workload_generator.py`); only capture *cadence* is sped up per container
+(`DC_E2E_CAMERA_PERIOD_S`, a new env-var override on `workload_generator.py` — default
+15s is unchanged for every other scenario) so N processes produce enough uploads inside a
+short steady-state window to show a trend at all. Any byte-volume implication of a
+reported ceiling is arithmetic, never presented as measured.
+
+Since Files never touch the Shipper, `saturation_probe.py`'s ack-latency/unacked-window/
+disk-buffer signals don't apply here — `scripts/upload_saturation_probe.py` is this
+axis's own pure verdict function (unit-tested alone, no container, same structure and
+priority-ordering/outage-suppression discipline as its sibling) over two observables that
+exist for Files instead: the Bridge's own `~/ready` service, which already exposes its
+upload queue depth (#265's existing "cheap observability hook" — no DC code changed to
+add it) trending upward as the primary signal, and the verify-then-delete backlog —
+files verified in `dc_files` (ADR-0005) with no later delete row for the same
+`local_path` yet — growing at steady state (suppressed during a declared outage) as the
+secondary one. `dc_files` is an append-only event log, not a current-state table (Vector's
+`postgres` sink only ever `INSERT`s), so computing that backlog correctly means "verified
+with no *later* delete row exists", not "the verify row itself still says
+`deleted=false`" — the first version of this script got that wrong and reported a
+backlog that only ever grew, on a run that was actually healthy throughout; caught by
+running the script for real against a live stack, not by reading the code.
+
+At every level actually driven, two hard gates run against `dc_files` before that level's
+containers are torn down, never folded into the saturation verdict since they are
+correctness properties, not backpressure signals: no `deleted=true` row for a
+`local_path` may exist without an earlier-or-equal `uploaded=true, deleted=false` row for
+the same path (delete-after-verify ordering, checked empirically across N concurrently-
+uploading processes writing to the shared table, not just assumed from one process's own
+in-order code path), and every `group_complete` marker for the camera group names the
+expected file count. A violation raises immediately and aborts the whole ramp.
+
+Not wired into `ci.yaml`, same as every other narrow scenario above.
+
 ## Layout
 
 - `Containerfile` — builds the full DC workspace (every `dc_*` package, all C++ since
@@ -569,6 +631,15 @@ bring-up already established working before it can run at all.
   Shipper fan-in axis (#382, part of #323) described above: ramping robot count against
   #381's two-tier topology to the knee and proving the instrument itself against a
   deliberately constrained aggregating Shipper.
+- `scripts/upload_saturation_probe.py` — the Uploader concurrency axis's own saturation
+  verdict (#384, part of #323): a pure function, sibling to `saturation_probe.py` but
+  over queue-depth/verify-delete-backlog observations instead of ack latency, since
+  Files never touch the Shipper. No I/O, no container; unit-tested alone.
+- `scripts/run_upload_concurrency_axis.py` / `scripts/run_limits_upload_concurrency.sh` /
+  `params/e2e_limits_upload_params.yaml` — the Uploader concurrency axis (#384, part of
+  #323) described above: calls `ramp_controller.find_knee()` unchanged, ramping N
+  Bridge/Uploader containers against shared Postgres/RustFS and asserting
+  delete-after-verify ordering plus Group completion correctness at every level.
 
 ## `.dockerignore`
 

--- a/tools/e2e/params/e2e_limits_upload_params.yaml
+++ b/tools/e2e/params/e2e_limits_upload_params.yaml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The limits harness's Uploader concurrency axis scenario (#384, part of #323's epic).
+# Trimmed to only what this axis needs — the camera Measurement's File pipeline — rather
+# than the full Measurement suite params/e2e_params.yaml/e2e_limits_params.yaml carry:
+# this axis's claim is concurrency and custody of File uploads against one
+# object-storage Destination, not Record delivery, so there is nothing for the other
+# Measurements to add here (dc_bridge still renders a valid config with just
+# `pgsql_files`/`rustfs` declared — a Destination's own `receives`/`inputs` are what
+# create route branches, not the number of Measurement plugins enabled).
+#
+# Differs from e2e_limits_params.yaml (#381) in exactly the two ways this axis needs:
+#
+# - `files.delete_when_sent: true` — #381's two-tier scenario left this false (it never
+#   asserted delete-after-verify); this axis's whole point is asserting delete only
+#   fires after verification, so there is nothing to assert without it.
+# - `camera.polling_interval` (2s, not 15s) paired with `DC_E2E_CAMERA_PERIOD_S=2`
+#   (tools/e2e/scripts/run_upload_concurrency_axis.py sets this per container) — a
+#   faster capture cadence so N concurrent Bridge/Uploader processes produce enough
+#   uploads inside a short steady-state window to show a queue-depth/backlog trend at
+#   all. The image itself stays the same deliberately synthetic 64x64 solid-color
+#   picture workload_generator.py already produces (~12KB) — per #384's acceptance
+#   criteria, file *size* stays reduced-scale; only capture *rate* changes here.
+#
+# `pgsql_files`/`rustfs` point at the shared Postgres/RustFS containers
+# run_limits_upload_concurrency.sh stands up (dc-e2e-upload-postgres/
+# dc-e2e-upload-rustfs) — the same "Uploader bypasses Vector, talks to the Destination
+# host directly" bypass #381 already discovered and pointed e2e_limits_params.yaml's
+# equivalent block at.
+
+measurement_server:
+  ros__parameters:
+    # $DC_E2E_STACK_ID (set per container by run_upload_concurrency_axis.py, via
+    # dc_util::expand_env's generic $VARNAME expansion — not a DC code change) is
+    # load-bearing here, not cosmetic: Camera::getSavePath() (dc_measurements/plugins/
+    # measurements/camera.cpp) builds a capture's filename from wall-clock time
+    # truncated to whole seconds, with no PID/hostname/counter of its own. Every
+    # container in this axis runs the identical params file and the identical
+    # camera_period_s cadence, so without a per-container path component, two
+    # containers capturing within the same wall-clock second produce the exact same
+    # `local_path` string — verified empirically: run_upload_concurrency_axis.py's
+    # delete-after-verify assertion (keyed on local_path) tripped a false violation at
+    # concurrency 4 before this was added, because dc_files rows from two different
+    # containers' independent upload/verify/delete lifecycles were indistinguishable by
+    # local_path alone.
+    save_local_base_path: "$HOME/.dc/e2e/data/$DC_E2E_STACK_ID/%Y/%M/%D/%H"
+    all_base_path: "e2e"
+    measurement_plugins: ["camera"]
+
+    camera:
+      plugin: "dc_measurements/Camera"
+      polling_interval: 2000
+      cam_name: "e2e_camera"
+      cam_topic: "/dc/e2e/camera/image_raw"
+      draw_det_barcodes: false
+      save_raw_img: true
+      save_rotated_img: false
+      save_detections_img: false
+      save_raw_base64: false
+      save_rotated_base64: false
+      save_inspected_base64: false
+      remote_keys: ["rustfs"]
+      remote_prefixes: ["camera"]
+      group_key: "camera"
+
+dc_bridge:
+  ros__parameters:
+    shipper:
+      data_dir: "$HOME/.dc/e2e/buffer"
+    destinations: ["pgsql_files", "rustfs"]
+
+    pgsql_files:
+      type: postgres
+      receives: records
+      # dc-e2e-upload-postgres, not 127.0.0.1: the Uploader writes File metadata
+      # directly over libpq, with no Vector hop, straight to
+      # run_limits_upload_concurrency.sh's shared Postgres over its own bridge network.
+      host: "dc-e2e-upload-postgres"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_files"
+      time_key: "date"
+
+    rustfs:
+      type: s3
+      receives: files
+      inputs: ["/dc/measurement/camera"]
+      bucket: "dc-e2e"
+      # Same bypass as pgsql_files above — the Uploader's own AWS SDK client, not Vector.
+      endpoint: "http://dc-e2e-upload-rustfs:9000"
+      region: "us-east-1"
+      access_key_id: "rustfsadmin"
+      secret_access_key: "rustfsadmin"
+      force_path_style: true
+
+    files:
+      # The load-bearing difference from e2e_limits_params.yaml (#381): this axis
+      # asserts delete only fires after verification, which needs deletes to happen.
+      delete_when_sent: true
+      metadata_destination: "pgsql_files"
+
+    # Same-container loopback — never leaves the container regardless of topology.
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224
+
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]

--- a/tools/e2e/scripts/run_limits_upload_concurrency.sh
+++ b/tools/e2e/scripts/run_limits_upload_concurrency.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Limits harness: Uploader concurrency axis (#384, part of #323's epic). From the repo
+# root:
+#
+#   ./tools/e2e/scripts/run_limits_upload_concurrency.sh
+#
+# Stands up a shared Postgres + RustFS (the one object-storage Destination this axis
+# ramps concurrent Uploaders against) on a dedicated podman bridge network, then hands
+# off to tools/e2e/scripts/run_upload_concurrency_axis.py, which owns the ramp itself:
+# it calls tools/e2e/scripts/ramp_controller.py's find_knee() unchanged, driving load by
+# starting N Bridge/Uploader containers per level (the Uploader has no internal
+# concurrency knob — see that script's own header for why "concurrency" means process
+# count) against params/e2e_limits_upload_params.yaml, and feeds the result to
+# tools/e2e/scripts/curve_reporter.py's build_report().
+#
+# Per #384's acceptance criteria, file sizes stay the deliberately synthetic/reduced-scale
+# 64x64 solid-color image workload_generator.py already produces for every E2E scenario
+# (~12KB) — the claim under test is concurrency and custody (delete-after-verify
+# ordering, Group completion correctness), not byte volume, and any byte-volume
+# implication of the reported ceiling is arithmetic, never presented as measured.
+#
+# Env vars (all optional):
+#   DC_E2E_UPLOAD_LEVELS              comma-separated ascending concurrency levels
+#                                      (default "1,2,4,8" — kept modest per #323's PRD's
+#                                      own dev-machine note: 8 real DC stacks concurrently
+#                                      starting is already a meaningful load)
+#   DC_E2E_UPLOAD_CAMERA_PERIOD_S     capture cadence fed to each container via
+#                                      DC_E2E_CAMERA_PERIOD_S (default 2 — see
+#                                      workload_generator.py and the params file's own
+#                                      header for why the default 15s cadence is too slow
+#                                      to build a queue-depth/backlog trend inside a short
+#                                      steady-state window)
+#   DC_E2E_UPLOAD_STEADY_STATE_SECONDS  per-level sampling window (default 60 — covers
+#                                      workload_generator.py's own fixed ~30s
+#                                      subscription-wait fallback before its first
+#                                      publish, verified empirically, plus enough
+#                                      real capture cycles afterward at
+#                                      DC_E2E_UPLOAD_CAMERA_PERIOD_S to form a trend)
+#   DC_E2E_UPLOAD_SAMPLE_INTERVAL_SECONDS  seconds between observations (default 5)
+#   DC_E2E_KEEP                       "true" to leave the stack (and its network) up
+#                                      after a failure for debugging
+#   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE   same meaning as run.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+E2E_DIR="$(dirname "$SCRIPT_DIR")"
+RUN_DIR="$E2E_DIR/.run/upload_concurrency"
+
+LEVELS="${DC_E2E_UPLOAD_LEVELS:-1,2,4,8}"
+CAMERA_PERIOD_S="${DC_E2E_UPLOAD_CAMERA_PERIOD_S:-2}"
+STEADY_STATE_SECONDS="${DC_E2E_UPLOAD_STEADY_STATE_SECONDS:-60}"
+SAMPLE_INTERVAL_SECONDS="${DC_E2E_UPLOAD_SAMPLE_INTERVAL_SECONDS:-5}"
+KEEP="${DC_E2E_KEEP:-false}"
+
+# Hyphens, not underscores — same reasoning as run_limits_two_tier.sh's PG_C/RUSTFS_C:
+# these names are embedded in URLs (RustFS/Postgres endpoints), and aws-cli 2.36's
+# --endpoint-url parser rejects a hostname with an underscore outright.
+NET=dc-e2e-upload-net
+PG_C=dc-e2e-upload-postgres
+RUSTFS_C=dc-e2e-upload-rustfs
+
+mkdir -p "$RUN_DIR"
+cd "$E2E_DIR"
+
+log() { echo "[e2e-upload-axis $(date -u +%H:%M:%S)] $*"; }
+
+remove_stack() {
+  # Any per-level Bridge containers/volumes are already cleaned up by
+  # run_upload_concurrency_axis.py's own driver as each level finishes — only the
+  # shared storage + network this script itself started remain here.
+  podman rm -f --ignore "$PG_C" "$RUSTFS_C" >/dev/null
+  for v in dc_e2e_upload_pgdata dc_e2e_upload_rustfs_data; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+  podman network rm "$NET" >/dev/null 2>&1 || true
+}
+
+cleanup() {
+  local exit_code=$?
+  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the shared storage up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down shared storage"
+  if podman container exists "$PG_C"; then
+    podman logs "$PG_C" > "$RUN_DIR/postgres.log" 2>&1
+  fi
+  if podman container exists "$RUSTFS_C"; then
+    podman logs "$RUSTFS_C" > "$RUN_DIR/rustfs.log" 2>&1
+  fi
+  remove_stack
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- obtain the DC stack image (shared with run.sh — see its header) ------------------
+if [ -n "${DC_E2E_IMAGE:-}" ]; then
+  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+  DC_IMAGE="$DC_E2E_IMAGE"
+else
+  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
+  else
+    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+    "$SCRIPT_DIR/build.sh"
+    WORKSPACE_IMAGE="dc-workspace:latest"
+  fi
+  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
+  DC_IMAGE="dc-e2e:latest"
+fi
+
+# Clean any leftovers from a previous (possibly DC_E2E_KEEP=true) run.
+remove_stack
+
+# --- bridge network + the one shared object-storage Destination this axis ramps -------
+log "creating the bridge network ($NET)"
+podman network create "$NET" >/dev/null
+
+log "starting the shared Postgres + RustFS on $NET"
+podman run -d --network "$NET" --name "$PG_C" \
+  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+  -v dc_e2e_upload_pgdata:/var/lib/postgresql/data \
+  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+  docker.io/library/postgres:13 >/dev/null
+podman run -d --network "$NET" --name "$RUSTFS_C" \
+  -v dc_e2e_upload_rustfs_data:/data \
+  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+
+timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_files')\" 2>/dev/null | grep -q dc_files; do sleep 2; done" \
+  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+
+log "waiting for RustFS to accept TCP connections on $NET"
+# --entrypoint bash: the image's own ENTRYPOINT (entrypoint.sh) launches the full DC
+# stack and appends any extra args to `ros2 launch` rather than running them as a
+# separate command, so a one-off diagnostic run needs an explicit override — same
+# reasoning and probe run_limits_two_tier.sh uses.
+timeout 60 bash -c "
+  until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
+    sleep 1
+  done
+" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+
+log "creating the RustFS bucket"
+podman run --rm --network "$NET" \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+
+# --- the ramp itself: run_upload_concurrency_axis.py owns everything from here --------
+log "running the Uploader concurrency ramp (levels: $LEVELS)"
+uv run --frozen python3 "$SCRIPT_DIR/run_upload_concurrency_axis.py" \
+  --image "$DC_IMAGE" \
+  --network "$NET" \
+  --postgres-container "$PG_C" \
+  --params-file "$E2E_DIR/params/e2e_limits_upload_params.yaml" \
+  --run-dir "$RUN_DIR" \
+  --levels "$LEVELS" \
+  --camera-period-s "$CAMERA_PERIOD_S" \
+  --steady-state-seconds "$STEADY_STATE_SECONDS" \
+  --sample-interval-seconds "$SAMPLE_INTERVAL_SECONDS" \
+  --report "$RUN_DIR/curve_report.json"
+
+log "PASS: Uploader concurrency axis (#384)"

--- a/tools/e2e/scripts/run_upload_concurrency_axis.py
+++ b/tools/e2e/scripts/run_upload_concurrency_axis.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Uploader concurrency axis (#384, part of #323's limits harness epic): ramps the
+number of concurrent Bridge/Uploader processes against one shared object-storage
+Destination until verify-then-delete falls behind, reporting the last sustainable
+concurrency level.
+
+Run through tools/e2e/scripts/run_limits_upload_concurrency.sh, which stands up the
+shared Postgres + RustFS this script points every level's Bridge containers at and tears
+them down afterwards; this script owns only the ramp itself, calling
+tools/e2e/scripts/ramp_controller.py's find_knee() unchanged (#384's acceptance
+criterion) with this axis's own driver and
+tools/e2e/scripts/upload_saturation_probe.py's evaluate() as the probe, then feeding the
+result to tools/e2e/scripts/curve_reporter.py's build_report() in its stable format.
+
+The Uploader has no internal concurrency knob (dc_bridge/src/uploader/uploader.hpp:
+"Synchronous (aws-sdk-cpp is blocking) — no async runtime", one uploader_thread_ per
+Bridge process) — confirmed by reading dc_bridge/src/bridge_node.cpp's full param
+schema, which declares none. Ramping "concurrency" therefore means starting N separate
+Bridge/Uploader processes, each with its own serial uploader thread, all pointed at the
+same shared RustFS/Postgres — the same topology run_limits_two_tier.sh (#381) already
+proved works for Files, whose header recorded that Files bypass that scenario's two-tier
+Shipper-relay chain entirely (the Uploader's own AWS SDK/libpq calls, no Vector hop) and
+left "true two-tier coverage" for Files as a follow-up; this script is the single-tier
+concurrency-and-custody axis #381 punted, not that follow-up.
+
+Two observables stand in for saturation_probe.py's Shipper-specific ack
+latency/unacked-window/disk-buffer signals, since Files never touch the Shipper at all
+(see upload_saturation_probe.py's own docstring for why a File-specific probe exists
+instead of reusing that one): the Bridge's own `~/ready` service, which already exposes
+its upload queue depth (#265's "cheap observability hook", bridge_node.cpp) as an
+existing observability hook — no DC code changed to add it — and the shared `dc_files`
+table's verify/delete rows (ADR-0005), which this script queries via
+verify_zero_loss.py's own podman-exec `psql()`/`scalar_int()` helpers rather than a
+second Postgres client.
+
+At every level actually driven, before that level's containers are torn down, two hard
+gates run against `dc_files` — never merged into the saturation verdict, since they are
+correctness properties, not backpressure signals:
+
+1. **Delete-after-verify ordering** — no `deleted=true` row for a local_path may exist
+   without an earlier-or-equal `uploaded=true, deleted=false` row for the same path.
+2. **Group completion correctness** — every `group_complete` marker for the camera group
+   names the expected file count, and at least one landed.
+
+A violation raises immediately and aborts the whole ramp (fails loudly, per #323's PRD:
+"a verification that silently did not run must never look identical to one that
+passed") rather than being folded into "saturated" — a concurrency level can be
+correctness-broken without ever looking like a backpressure ceiling, and the two must
+never be confused.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+import curve_reporter
+import ramp_controller
+import upload_saturation_probe
+import verify_zero_loss
+
+READY_SERVICE = "/dc_bridge/ready"
+
+
+def log(msg: str) -> None:
+    print(f"[upload-axis {time.strftime('%H:%M:%S', time.gmtime())}] {msg}", flush=True)
+
+
+def _podman(*args: str, timeout: float = 30.0) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["podman", *args], capture_output=True, text=True, check=True, timeout=timeout
+    )
+
+
+def _queue_depth(container: str, attempts: int = 3) -> int:
+    """Sums Bridge's own `~/ready` observability hook's upload queue depth for one
+    container. Raises only once every attempt has failed — `ros2 service call`'s own
+    DDS-discovery step occasionally takes longer than one 20s attempt under load
+    (verified empirically), and a transient CLI hiccup reading a monitoring probe must
+    not abort an otherwise-healthy ramp the way a real infra failure should."""
+    last_error: str = ""
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                [
+                    "podman",
+                    "exec",
+                    container,
+                    "bash",
+                    "-lc",
+                    "source /root/ws/install/setup.bash >/dev/null 2>&1; "
+                    f"ros2 service call {READY_SERVICE} std_srvs/srv/Trigger '{{}}'",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=20,
+            )
+        except subprocess.TimeoutExpired:
+            last_error = f"attempt {attempt + 1}/{attempts} timed out after 20s"
+            continue
+        if result.returncode != 0:
+            last_error = f"attempt {attempt + 1}/{attempts} failed: {result.stderr.strip()}"
+            continue
+        match = re.search(r"upload queue depth:\s*(\d+)", result.stdout)
+        if match is None:
+            last_error = (
+                f"attempt {attempt + 1}/{attempts} carried no upload queue depth figure "
+                f"(stdout: {result.stdout.strip()!r})"
+            )
+            continue
+        return int(match.group(1))
+    raise RuntimeError(
+        f"readiness probe failed on {container} after {attempts} attempt(s): {last_error}"
+    )
+
+
+def _wait_for_containers_ready(names: list[str], timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    for name in names:
+        while True:
+            try:
+                _queue_depth(name)
+                break
+            except RuntimeError:
+                if time.monotonic() >= deadline:
+                    raise RuntimeError(
+                        f"{name} never became ready (upload queue depth probe) within {timeout_s}s"
+                    ) from None
+                time.sleep(1)
+
+
+def _volume_names(prefix: str, n: int, i: int) -> tuple[str, str]:
+    return f"{prefix}_buffer_{n}_{i}", f"{prefix}_data_{n}_{i}"
+
+
+def _start_level_containers(
+    image: str,
+    network: str,
+    params_file: str,
+    stack_prefix: str,
+    volume_prefix: str,
+    n: int,
+    camera_period_s: float,
+    stagger_s: float,
+) -> list[str]:
+    names = []
+    for i in range(n):
+        stack_id = f"l{n}-{i}"
+        name = f"{stack_prefix}-{stack_id}"
+        buf_vol, data_vol = _volume_names(volume_prefix, n, i)
+        _podman("volume", "create", buf_vol)
+        _podman("volume", "create", data_vol)
+        _podman(
+            "run",
+            "-d",
+            "--network",
+            network,
+            "--name",
+            name,
+            "-e",
+            f"DC_E2E_CAMERA_PERIOD_S={camera_period_s}",
+            # Makes each container's captured-file local_path genuinely unique — see
+            # params/e2e_limits_upload_params.yaml's own comment on
+            # save_local_base_path for why this is load-bearing, not cosmetic.
+            "-e",
+            f"DC_E2E_STACK_ID={stack_id}",
+            "-v",
+            f"{buf_vol}:/root/.dc/e2e/buffer",
+            "-v",
+            f"{data_vol}:/root/.dc/e2e/data",
+            "-v",
+            f"{params_file}:/opt/e2e/e2e_params.yaml:ro",
+            image,
+        )
+        names.append(name)
+        # Staggered, not all at once: same reasoning as run_limits_two_tier.sh — reduces
+        # simultaneous ROS/DDS-discovery contention across N concurrently-starting stacks.
+        if i < n - 1:
+            time.sleep(stagger_s)
+    return names
+
+
+def _stop_level_containers(names: list[str], volume_prefix: str, n: int, run_dir: str) -> None:
+    for name in names:
+        try:
+            with open(f"{run_dir}/{name}.log", "w") as f:
+                subprocess.run(
+                    ["podman", "logs", name], stdout=f, stderr=subprocess.STDOUT, check=False
+                )
+        except OSError:
+            pass
+    if names:
+        subprocess.run(["podman", "rm", "-f", *names], check=False, capture_output=True)
+    for i in range(n):
+        buf_vol, data_vol = _volume_names(volume_prefix, n, i)
+        for v in (buf_vol, data_vol):
+            subprocess.run(["podman", "volume", "rm", v], check=False, capture_output=True)
+
+
+def _outstanding_verified_count(pg_container: str, level_start: float) -> int:
+    """Files verified since `level_start` with no matching delete row yet.
+
+    `dc_files` is an append-only event log (Vector's postgres sink does INSERT, not
+    UPDATE — ADR-0005): the row a file's upload/verify writes never changes, and a later
+    delete is a *separate* row for the same local_path, not an update of the first one.
+    Naively counting `uploaded=true AND deleted=false` rows therefore counts every
+    verify event ever recorded, including ones already long deleted — always growing,
+    never draining, regardless of whether delete-then-verify is actually keeping up
+    (caught empirically running this script for real: a healthy single-Uploader run
+    that logged "1 verified, 1 deleted" every cycle still showed this figure climbing
+    monotonically before the fix). The backlog that actually matters is verified files
+    with *no later delete row at all* for the same local_path.
+    """
+    return verify_zero_loss.scalar_int(
+        pg_container,
+        f"""
+        SELECT count(*) FROM (
+          SELECT DISTINCT local_path FROM dc_files
+          WHERE kind='file_status' AND uploaded=true AND deleted=false
+            AND updated_at >= {level_start}
+        ) u
+        WHERE NOT EXISTS (
+          SELECT 1 FROM dc_files d
+          WHERE d.kind='file_status' AND d.local_path = u.local_path AND d.deleted=true
+        )
+        """,
+    )
+
+
+def _assert_delete_after_verify(pg_container: str, level_start: float) -> None:
+    """Every `deleted=true` row must have an earlier-or-equal `uploaded=true,
+    deleted=false` row for the same local_path — the empirical, DB-level proof that
+    delete-after-verify held under N concurrently-uploading processes, not just an
+    assumption that a single process's own in-order code path generalizes."""
+    violations = verify_zero_loss.scalar_int(
+        pg_container,
+        f"""
+        SELECT count(*) FROM dc_files d
+        WHERE d.kind='file_status' AND d.deleted=true AND d.updated_at >= {level_start}
+          AND NOT EXISTS (
+            SELECT 1 FROM dc_files u
+            WHERE u.kind='file_status' AND u.local_path = d.local_path
+              AND u.uploaded=true AND u.deleted=false AND u.updated_at <= d.updated_at
+          )
+        """,
+    )
+    if violations > 0:
+        raise RuntimeError(
+            f"{violations} file(s) at this level were deleted with no preceding "
+            "verified-upload row — delete fired before/without verification"
+        )
+
+
+def _assert_group_completion(
+    pg_container: str, level_start: float, expected_file_count: int
+) -> None:
+    complete_count = verify_zero_loss.scalar_int(
+        pg_container,
+        "SELECT count(*) FROM dc_files WHERE kind='group_complete' AND group_name='camera' "
+        f"AND updated_at >= {level_start}",
+    )
+    if complete_count == 0:
+        raise RuntimeError("zero group_complete markers landed for the camera group at this level")
+    bad_count = verify_zero_loss.scalar_int(
+        pg_container,
+        "SELECT count(*) FROM dc_files WHERE kind='group_complete' AND group_name='camera' "
+        f"AND updated_at >= {level_start} AND file_count != {expected_file_count}",
+    )
+    if bad_count > 0:
+        raise RuntimeError(
+            f"{bad_count} group_complete marker(s) at this level reported a file_count "
+            f"other than the expected {expected_file_count}"
+        )
+
+
+@dataclass
+class LevelRun:
+    level: float
+    window: list = field(default_factory=list)
+
+
+def build_driver(
+    *,
+    image: str,
+    network: str,
+    pg_container: str,
+    params_file: str,
+    stack_prefix: str,
+    volume_prefix: str,
+    run_dir: str,
+    camera_period_s: float,
+    steady_state_s: float,
+    sample_interval_s: float,
+    startup_stagger_s: float,
+    startup_timeout_s: float,
+    expected_file_count: int,
+) -> tuple[ramp_controller.Driver, dict[float, LevelRun]]:
+    runs: dict[float, LevelRun] = {}
+    min_observations = upload_saturation_probe.SaturationBounds().min_observations
+    sample_count = max(min_observations, math.ceil(steady_state_s / sample_interval_s))
+
+    def driver(level: float) -> list:
+        n = int(level)
+        log(f"level {level}: starting {n} Bridge/Uploader container(s)")
+        names = _start_level_containers(
+            image,
+            network,
+            params_file,
+            stack_prefix,
+            volume_prefix,
+            n,
+            camera_period_s,
+            startup_stagger_s,
+        )
+        try:
+            _wait_for_containers_ready(names, startup_timeout_s)
+            level_start = time.time()
+            window = []
+            log(f"level {level}: sampling {sample_count} observation(s) every {sample_interval_s}s")
+            for _ in range(sample_count):
+                time.sleep(sample_interval_s)
+                queue_depth = sum(_queue_depth(name) for name in names)
+                backlog = _outstanding_verified_count(pg_container, level_start)
+                window.append(
+                    upload_saturation_probe.Observation(
+                        queue_depth=queue_depth, verify_delete_backlog=backlog
+                    )
+                )
+                log(
+                    f"level {level}: observation queue_depth={queue_depth} "
+                    f"verify_delete_backlog={backlog}"
+                )
+            verdict = upload_saturation_probe.evaluate(window)
+            log(
+                f"level {level}: verdict={verdict.status.value} reason={verdict.reason!r} "
+                f"figures={verdict.figures}"
+            )
+            log(f"level {level}: asserting delete-after-verify ordering and group completion")
+            _assert_delete_after_verify(pg_container, level_start)
+            _assert_group_completion(pg_container, level_start, expected_file_count)
+            runs[level] = LevelRun(level=level, window=window)
+            return window
+        finally:
+            _stop_level_containers(names, volume_prefix, n, run_dir)
+            time.sleep(2)
+
+    return driver, runs
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", default="dc-e2e:latest")
+    parser.add_argument("--network", required=True)
+    parser.add_argument("--postgres-container", required=True)
+    parser.add_argument("--params-file", required=True)
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--stack-prefix", default="dc-e2e-upload-stack")
+    parser.add_argument("--volume-prefix", default="dc_e2e_upload")
+    parser.add_argument(
+        "--levels", default="1,2,4,8", help="comma-separated ascending concurrency levels"
+    )
+    parser.add_argument("--camera-period-s", type=float, default=2.0)
+    parser.add_argument("--steady-state-seconds", type=float, default=60.0)
+    parser.add_argument("--sample-interval-seconds", type=float, default=5.0)
+    parser.add_argument("--startup-stagger-seconds", type=float, default=3.0)
+    parser.add_argument("--startup-timeout-seconds", type=float, default=90.0)
+    parser.add_argument("--expected-file-count", type=int, default=1)
+    parser.add_argument("--report", default=None, help="write the curve_reporter JSON report here")
+    args = parser.parse_args()
+
+    levels = tuple(float(x) for x in args.levels.split(","))
+    policy = ramp_controller.RampPolicy(levels=levels)
+
+    driver, runs = build_driver(
+        image=args.image,
+        network=args.network,
+        pg_container=args.postgres_container,
+        params_file=args.params_file,
+        stack_prefix=args.stack_prefix,
+        volume_prefix=args.volume_prefix,
+        run_dir=args.run_dir,
+        camera_period_s=args.camera_period_s,
+        steady_state_s=args.steady_state_seconds,
+        sample_interval_s=args.sample_interval_seconds,
+        startup_stagger_s=args.startup_stagger_seconds,
+        startup_timeout_s=args.startup_timeout_seconds,
+        expected_file_count=args.expected_file_count,
+    )
+
+    try:
+        result = ramp_controller.find_knee(driver, upload_saturation_probe.evaluate, policy)
+    except Exception as exc:  # any failure here is a hard scenario failure
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    points = []
+    for level in result.levels_tried:
+        run = runs[level]
+        verdict = upload_saturation_probe.evaluate(run.window)
+        points.append(
+            curve_reporter.LevelResult(
+                level=level,
+                saturated=verdict.saturated,
+                kind=curve_reporter.PointKind.MEASURED,
+                composition=curve_reporter.RunComposition(
+                    real_stacks=int(level), synthetic_senders=0
+                ),
+            )
+        )
+
+    axis_run = curve_reporter.AxisRun(
+        axis="upload_concurrency",
+        unit="concurrent Bridge/Uploader processes",
+        outcome=curve_reporter.RunOutcome(result.outcome.value),
+        highest_clear_level=result.highest_clear_level,
+        tripped_level=result.tripped_level,
+        points=points,
+    )
+    report = curve_reporter.build_report([axis_run])
+    print(curve_reporter.render_summary(report))
+    if args.report:
+        with open(args.report, "w") as f:
+            f.write(curve_reporter.to_json(report))
+
+    log(f"PASS: ramp completed cleanly, outcome={result.outcome.value}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/e2e/scripts/upload_saturation_probe.py
+++ b/tools/e2e/scripts/upload_saturation_probe.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Upload-concurrency saturation probe (#384): a pure verdict function for #323's
+limits harness, sibling to saturation_probe.py but for the Uploader concurrency axis.
+
+Files bypass the Shipper entirely — the Bridge's Uploader writes them to object storage
+directly over its own AWS SDK client, with no Vector hop (#381's recorded discovery) —
+so saturation_probe.py's Observation (ack latency, unacked-window depth, disk-buffer
+bytes) doesn't apply here: there is no acknowledgement latency to sample, because there
+is no acknowledging Shipper in this path. What the Uploader has instead is its own
+backpressure statement, taken straight from dc_bridge/src/bridge_node.cpp's readiness
+service and its own Postgres file_status/group_complete rows (ADR-0005):
+
+1. **Upload queue depth** trending upward — `IntentQueue::size()`, sampled from the
+   Bridge's own `~/ready` service (#265's "cheap observability hook"). The Uploader is a
+   single synchronous thread per Bridge process; a queue that keeps growing across the
+   window is that thread telling callers it cannot drain incoming Files as fast as they
+   arrive, exactly the same "trend, not a snapshot" reasoning saturation_probe.py uses
+   for unacked-window depth. The primary signal, since it is the axis's most direct
+   backpressure statement (there is no Uploader-side acknowledgement latency to check
+   first, unlike the Shipper's Record path).
+2. **Verify-then-delete backlog** growing at steady state — the count of File rows that
+   have verified (`uploaded=true`) but not yet cleared (`deleted=false`) in `dc_files`.
+   Checked only once queue depth hasn't already decided the verdict, and suppressed for
+   the whole window if `outage_declared` is set anywhere in it, mirroring
+   saturation_probe.py's disk-buffer check: a growing backlog during a declared outage
+   (the object-storage Destination is down) is expected, not a capacity signal; the same
+   growth at steady state means delete-after-verify is falling behind the upload rate —
+   this axis's namesake failure mode.
+
+An observation window shorter than `min_observations` returns `INSUFFICIENT_DATA` rather
+than any healthy/saturated verdict, same contract as saturation_probe.py.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from enum import StrEnum
+from statistics import fmean
+
+
+class VerdictStatus(StrEnum):
+    NOT_SATURATED = "not_saturated"
+    SATURATED = "saturated"
+    INSUFFICIENT_DATA = "insufficient_data"
+
+
+class Signal(StrEnum):
+    QUEUE_DEPTH = "queue_depth"
+    VERIFY_DELETE_BACKLOG = "verify_delete_backlog"
+
+
+@dataclass(frozen=True)
+class Observation:
+    """One sample in the window. Every check below assumes oldest-to-newest order."""
+
+    queue_depth: float
+    verify_delete_backlog: float
+    outage_declared: bool = False
+
+
+@dataclass(frozen=True)
+class SaturationBounds:
+    # Fewer than this many observations can't support a trend judgement at all.
+    min_observations: int = 4
+    # Minimum growth (mean of the window's second half minus its first half) in queue
+    # depth to count as "trending upward". Small relative to saturation_probe.py's
+    # unacked_window_depth_growth_threshold (20.0): this axis ramps single-digit
+    # concurrent Bridge processes, not hundreds of connections, so its queue depth lives
+    # on a correspondingly smaller scale.
+    queue_depth_growth_threshold: float = 2.0
+    # Same head/tail growth split, for the verified-but-undeleted backlog.
+    verify_delete_backlog_growth_threshold: float = 2.0
+
+
+@dataclass(frozen=True)
+class Verdict:
+    status: VerdictStatus
+    binding_signal: Signal | None
+    reason: str
+    figures: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def saturated(self) -> bool:
+        return self.status == VerdictStatus.SATURATED
+
+
+def evaluate(
+    window: Sequence[Observation], bounds: SaturationBounds = SaturationBounds()
+) -> Verdict:
+    """The saturation verdict for one observation window. Never raises on a short or
+    empty window — that's INSUFFICIENT_DATA, not an error, since a limits-harness ramp
+    controller calls this on every poll, including before the window has filled."""
+    if len(window) < bounds.min_observations:
+        return Verdict(
+            status=VerdictStatus.INSUFFICIENT_DATA,
+            binding_signal=None,
+            reason=(
+                f"window has {len(window)} observation(s), fewer than the "
+                f"{bounds.min_observations} required to assess a trend"
+            ),
+        )
+
+    for signal_check in (_queue_depth_signal, _verify_delete_backlog_signal):
+        verdict = signal_check(window, bounds)
+        if verdict is not None:
+            return verdict
+
+    return Verdict(
+        status=VerdictStatus.NOT_SATURATED,
+        binding_signal=None,
+        reason="no signal crossed its bound",
+    )
+
+
+def _split_halves(
+    window: Sequence[Observation],
+) -> tuple[Sequence[Observation], Sequence[Observation]]:
+    midpoint = len(window) // 2
+    return window[:midpoint], window[midpoint:]
+
+
+def _queue_depth_signal(window: Sequence[Observation], bounds: SaturationBounds) -> Verdict | None:
+    head, tail = _split_halves(window)
+    if not head or not tail:
+        return None
+    head_mean = fmean(o.queue_depth for o in head)
+    tail_mean = fmean(o.queue_depth for o in tail)
+    growth = tail_mean - head_mean
+    if growth < bounds.queue_depth_growth_threshold:
+        return None
+    return Verdict(
+        status=VerdictStatus.SATURATED,
+        binding_signal=Signal.QUEUE_DEPTH,
+        reason=(
+            f"upload queue depth grew by {growth:.1f} file(s) from the window's first "
+            f"half to its second, at or above the {bounds.queue_depth_growth_threshold} "
+            f"bound"
+        ),
+        figures={
+            "queue_depth_head_mean": head_mean,
+            "queue_depth_tail_mean": tail_mean,
+            "queue_depth_growth": growth,
+        },
+    )
+
+
+def _verify_delete_backlog_signal(
+    window: Sequence[Observation], bounds: SaturationBounds
+) -> Verdict | None:
+    # A growing verify-then-delete backlog during a declared outage (the object-storage
+    # Destination is down) is expected, not a capacity signal — see the module
+    # docstring. Suppressed for the whole window, same reasoning as
+    # saturation_probe.py's disk-buffer check.
+    if any(o.outage_declared for o in window):
+        return None
+    head, tail = _split_halves(window)
+    if not head or not tail:
+        return None
+    head_mean = fmean(o.verify_delete_backlog for o in head)
+    tail_mean = fmean(o.verify_delete_backlog for o in tail)
+    growth = tail_mean - head_mean
+    if growth < bounds.verify_delete_backlog_growth_threshold:
+        return None
+    return Verdict(
+        status=VerdictStatus.SATURATED,
+        binding_signal=Signal.VERIFY_DELETE_BACKLOG,
+        reason=(
+            f"verify-then-delete backlog grew by {growth:.1f} file(s) at steady state "
+            f"(no outage declared in the window), at or above the "
+            f"{bounds.verify_delete_backlog_growth_threshold} bound"
+        ),
+        figures={
+            "verify_delete_backlog_head_mean": head_mean,
+            "verify_delete_backlog_tail_mean": tail_mean,
+            "verify_delete_backlog_growth": growth,
+        },
+    )

--- a/tools/e2e/scripts/workload_generator.py
+++ b/tools/e2e/scripts/workload_generator.py
@@ -67,7 +67,16 @@ class WorkloadGenerator(Node):
         super().__init__("e2e_workload_generator")
         self.declare_parameter("num_synth_topics", NUM_SYNTH_TOPICS)
         self.declare_parameter("rate_hz", 1.0)
-        self.declare_parameter("camera_period_s", 15.0)
+        # Same env-var-override convention as LEDGER_PATH above: entrypoint.sh runs this
+        # generator as a plain python3 process, not through `ros2 launch`, so an
+        # E2E scenario has no `--ros-args -p` hook to reach into it — an env var is the
+        # only knob available without a code change per run. Default unchanged (15.0s)
+        # so every existing scenario's capture cadence is untouched; the upload
+        # concurrency axis (#384) needs a much shorter period to build meaningful
+        # Uploader backlog inside a short steady-state window.
+        self.declare_parameter(
+            "camera_period_s", float(os.environ.get("DC_E2E_CAMERA_PERIOD_S", 15.0))
+        )
 
         num_topics = self.get_parameter("num_synth_topics").value
         rate_hz = self.get_parameter("rate_hz").value

--- a/tools/e2e/test/test_upload_saturation_probe.py
+++ b/tools/e2e/test/test_upload_saturation_probe.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for tools/e2e/scripts/upload_saturation_probe.py (#384): the Uploader
+concurrency axis's saturation verdict, mirroring test_saturation_probe.py's coverage —
+signal priority, trend-not-utilisation, outage suppression, and the insufficient-data
+contract — for this axis's own two signals (queue depth, verify-then-delete backlog).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+from upload_saturation_probe import (
+    Observation,
+    Signal,
+    VerdictStatus,
+    evaluate,
+)
+
+DEFAULT_QUEUE_DEPTH = 1.0
+DEFAULT_BACKLOG = 0.0
+
+
+def _window(
+    queue_depths: list[float] | None = None,
+    backlogs: list[float] | None = None,
+    outages: list[bool] | None = None,
+    length: int = 8,
+) -> list[Observation]:
+    """Builds a window from per-field lists, defaulting any omitted field to a flat,
+    healthy series so a test only has to state the field(s) it cares about."""
+    queue_depths = queue_depths if queue_depths is not None else [DEFAULT_QUEUE_DEPTH] * length
+    backlogs = backlogs if backlogs is not None else [DEFAULT_BACKLOG] * length
+    n = len(queue_depths)
+    outages = outages if outages is not None else [False] * n
+    assert len(backlogs) == len(outages) == n
+    return [
+        Observation(
+            queue_depth=queue_depths[i],
+            verify_delete_backlog=backlogs[i],
+            outage_declared=outages[i],
+        )
+        for i in range(n)
+    ]
+
+
+def test_a_steady_healthy_window_returns_not_saturated():
+    verdict = evaluate(_window())
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.saturated is False
+    assert verdict.binding_signal is None
+
+
+def test_a_monotonic_queue_depth_climb_returns_saturated_with_queue_depth_named():
+    depths = [1.0, 1.0, 2.0, 4.0, 6.0, 9.0]
+    verdict = evaluate(_window(queue_depths=depths, length=len(depths)))
+    assert verdict.status == VerdictStatus.SATURATED
+    assert verdict.binding_signal == Signal.QUEUE_DEPTH
+    assert verdict.figures["queue_depth_growth"] >= 2.0
+
+
+def test_a_flat_queue_depth_does_not_trip_the_verdict():
+    depths = [2.0, 3.0, 2.0, 3.0, 2.0, 3.0]
+    verdict = evaluate(_window(queue_depths=depths, length=len(depths)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.binding_signal is None
+
+
+def test_a_high_but_flat_queue_depth_does_not_trip_the_verdict():
+    # Depth measured by trend, not by a level threshold — a queue that is deep but not
+    # growing is not this axis's saturation signal, same rejection of utilisation-alone
+    # saturation_probe.py makes for the disk buffer.
+    verdict = evaluate(_window(queue_depths=[500.0] * 8))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+
+
+def test_verify_delete_backlog_growth_trips_the_verdict_as_the_secondary_signal():
+    backlogs = [0.0, 0.0, 1.0, 3.0, 5.0, 8.0]
+    verdict = evaluate(_window(backlogs=backlogs, length=len(backlogs)))
+    assert verdict.status == VerdictStatus.SATURATED
+    assert verdict.binding_signal == Signal.VERIFY_DELETE_BACKLOG
+
+
+def test_a_flat_verify_delete_backlog_does_not_trip_the_verdict():
+    backlogs = [1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
+    verdict = evaluate(_window(backlogs=backlogs, length=len(backlogs)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+
+
+def test_identical_backlog_growth_during_a_declared_outage_does_not_trip_the_verdict():
+    backlogs = [0.0, 0.0, 1.0, 3.0, 5.0, 8.0]
+    outages = [True] * len(backlogs)
+    verdict = evaluate(_window(backlogs=backlogs, outages=outages, length=len(backlogs)))
+    assert verdict.status == VerdictStatus.NOT_SATURATED
+    assert verdict.binding_signal is None
+
+
+def test_queue_depth_takes_priority_over_a_concurrently_growing_backlog():
+    depths = [1.0, 1.0, 2.0, 4.0, 6.0, 9.0]
+    backlogs = [0.0, 0.0, 1.0, 3.0, 5.0, 8.0]
+    verdict = evaluate(_window(queue_depths=depths, backlogs=backlogs, length=len(depths)))
+    assert verdict.binding_signal == Signal.QUEUE_DEPTH
+
+
+def test_an_observation_window_with_insufficient_data_returns_an_explicit_result():
+    verdict = evaluate(_window(length=2))
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA
+    assert verdict.saturated is False
+    assert verdict.binding_signal is None
+
+
+def test_insufficient_data_is_returned_even_when_the_few_samples_look_saturated():
+    verdict = evaluate(_window(queue_depths=[50.0, 90.0], length=2))
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA
+
+
+def test_an_empty_window_returns_insufficient_data_not_an_error():
+    verdict = evaluate([])
+    assert verdict.status == VerdictStatus.INSUFFICIENT_DATA


### PR DESCRIPTION
## Summary

- Adds the Uploader concurrency axis to #323's limits harness epic: ramps N concurrent Bridge/Uploader processes against one shared object-storage Destination until verify-then-delete falls behind, reporting the last sustainable concurrency level. Calls `ramp_controller.find_knee()` **unchanged** and feeds `curve_reporter.build_report()` in its stable format, per the acceptance criteria.
- The Uploader has no internal concurrency knob (`dc_bridge/src/uploader/uploader.hpp`: synchronous, one thread per Bridge process) — so "concurrency" here means starting N separate Bridge/Uploader containers against shared Postgres/RustFS, reusing the topology #381 already proved works for Files.
- New `upload_saturation_probe.py`: a sibling to `saturation_probe.py` (not a reuse — that module is Shipper-ack-latency-specific and Files never touch the Shipper) over two File-specific signals: Bridge's own `~/ready` upload queue depth, and a verify-then-delete backlog computed from `dc_files`.
- At every level, two hard gates run against `dc_files`: delete-after-verify ordering, and Group completion correctness (expected file count). A violation aborts the ramp.
- File size stays the same deliberately synthetic ~12KB image every E2E scenario already produces; only capture cadence is sped up per container via a new `DC_E2E_CAMERA_PERIOD_S` env-var override on `workload_generator.py` (default unchanged for every other scenario).
- Found and fixed two real bugs by running this against real podman containers rather than just reading the code: (1) the backlog query initially counted cumulative historical verify events instead of currently-outstanding ones (`dc_files` is an append-only event log, not a current-state table); (2) at concurrency 4, Camera capture filenames collided across containers (no per-process uniqueness, second-granularity wall-clock only) — fixed with a params-template env var (`DC_E2E_STACK_ID`), no DC code changed.

## Test plan

- [x] `tools/e2e/test/test_upload_saturation_probe.py` (11 new cases: signal priority, trend-not-utilisation, outage suppression, insufficient-data) — all 88 `tools/e2e/test/` cases pass
- [x] `prek run --all-files --skip build-doc` passes on the changed files
- [x] Ran `./tools/e2e/scripts/run_limits_upload_concurrency.sh` end to end against real podman containers multiple times: single-level, and multi-level (1, 2, 4-way) ramps, including the pre-fix failure and post-fix clean pass at concurrency 4, with direct Postgres inspection confirming both bugs and their fixes
- [ ] Not wired into `ci.yaml`, same as every other narrow E2E scenario script

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D84zRZohWXdBSom6w33AJR