### PR TITLE
feat(dc_measurements): add the ros2_control status Measurement

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -6,6 +6,7 @@ project(dc_measurements)
 
 set(dependencies
   action_msgs
+  controller_manager_msgs
   cv_bridge
   dc_common
   dc_core
@@ -203,6 +204,9 @@ list(APPEND dc_measurement_plugin_libs dc_position_measurement)
 add_library(dc_random_measurement SHARED plugins/measurements/random.cpp)
 list(APPEND dc_measurement_plugin_libs dc_random_measurement)
 
+add_library(dc_ros2_control_status_measurement SHARED plugins/measurements/ros2_control_status.cpp)
+list(APPEND dc_measurement_plugin_libs dc_ros2_control_status_measurement)
+
 add_library(dc_serial_interface_measurement SHARED plugins/measurements/serial_interface.cpp)
 list(APPEND dc_measurement_plugin_libs dc_serial_interface_measurement)
 
@@ -356,6 +360,7 @@ set(tests
   test_measurement_permissions
   test_measurement_position
   test_measurement_random
+  test_measurement_ros2_control_status
   test_measurement_same_as_previous
   test_measurement_serial_interface
   test_measurement_shared_flush

--- a/dc_measurements/include/dc_measurements/plugins/measurements/ros2_control_status.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/ros2_control_status.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__ROS2_CONTROL_STATUS_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__ROS2_CONTROL_STATUS_HPP_
+
+#include <cstdint>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include "controller_manager_msgs/msg/controller_manager_activity.hpp"
+#include "controller_manager_msgs/msg/named_lifecycle_state.hpp"
+#include "dc_common/state_transition_detector.hpp"
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_util/node_utils.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::Ros2ControlStatus
+ * @brief One Record per controller/hardware component crossing into or out of `active`, derived
+ * from the controller manager's `~/activity` topic (transient-local, republished on every
+ * lifecycle change) rather than polling `list_controllers`/`list_hardware_components`. Built on
+ * the same dc_common::StateTransitionDetector as Intervention and Fault (#362, #365): one
+ * detector per controller/hardware component, keyed the way Fault keys its per-component map, so
+ * they fault and recover independently; the `start`/`end` boundary it watches for is the same
+ * shape Intervention already reports (#395).
+ */
+class Ros2ControlStatus : public dc_measurements::Measurement
+{
+public:
+  Ros2ControlStatus();
+  ~Ros2ControlStatus() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void activityCb(const controller_manager_msgs::msg::ControllerManagerActivity& msg);
+  void processEntries(const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& entries,
+                      const std::string& component_type, const rclcpp::Time& stamp,
+                      std::map<std::string, dc_common::StateTransitionDetector<uint8_t>>& detectors);
+
+  rclcpp::Subscription<controller_manager_msgs::msg::ControllerManagerActivity>::SharedPtr subscription_;
+  std::string topic_;
+
+  // The activity callback and the polling timer run in different callback groups under a
+  // multi-threaded executor, so everything they share is guarded.
+  mutable std::mutex mutex_;
+  std::map<std::string, dc_common::StateTransitionDetector<uint8_t>> controller_detectors_;
+  std::map<std::string, dc_common::StateTransitionDetector<uint8_t>> hardware_component_detectors_;
+  // Records wait here for a poll to carry them out, one per poll, so they travel the same publish
+  // path (Conditions, buffering, Group) as every other Record.
+  std::deque<std::pair<json, rclcpp::Time>> pending_records_;
+
+  // Per-Record, not per-component: a global counter across every controller and hardware
+  // component, so a consumer can tell a dropped Record apart from one that never changed.
+  std::uint64_t record_seq_{ 0 };
+
+protected:
+  void onConfigure() override;
+  void onCleanup() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__ROS2_CONTROL_STATUS_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -164,6 +164,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_ros2_control_status_measurement">
+        <class name="dc_measurements/Ros2ControlStatus" type="dc_measurements::Ros2ControlStatus" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_ros2_control_status
+            </description>
+        </class>
+    </library>
+
     <library path="dc_serial_interface_measurement">
         <class name="dc_measurements/SerialInterface" type="dc_measurements::SerialInterface" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -16,6 +16,7 @@ SPDX-License-Identifier: MPL-2.0
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>action_msgs</depend>
+  <depend>controller_manager_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>dc_common</depend>
   <depend>dc_core</depend>

--- a/dc_measurements/plugins/measurements/json/ros2_control_status.json
+++ b/dc_measurements/plugins/measurements/json/ros2_control_status.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Ros2ControlStatus",
+  "description":
+      "A controller or hardware component crossing into or out of the ros2_control `active` lifecycle state, derived from the controller manager's `~/activity` topic: one Record when it starts, one when it ends",
+  "properties": {
+    "seq": {
+      "description":
+          "Monotonically increasing number of this Record, across every controller and hardware component, so a dropped Record is detectable rather than silently shortening an outage",
+      "type": "integer",
+      "minimum": 1
+    },
+    "component_type": {
+      "description": "Whether 'component' names a controller or a hardware component",
+      "type": "string",
+      "enum": [
+        "controller",
+        "hardware_component"
+      ]
+    },
+    "component": {
+      "description": "Reporting controller or hardware component name",
+      "type": "string"
+    },
+    "event": {
+      "description": "'start' when the component entered 'active', 'end' when it left 'active'",
+      "type": "string",
+      "enum": [
+        "start",
+        "end"
+      ]
+    },
+    "from_state": {
+      "description": "Lifecycle state the component left",
+      "type": "string",
+      "enum": [
+        "unconfigured",
+        "inactive",
+        "active",
+        "finalized",
+        "configuring",
+        "cleaningup",
+        "shuttingdown",
+        "activating",
+        "deactivating",
+        "errorprocessing",
+        "unknown"
+      ]
+    },
+    "to_state": {
+      "description": "Lifecycle state the component entered",
+      "type": "string",
+      "enum": [
+        "unconfigured",
+        "inactive",
+        "active",
+        "finalized",
+        "configuring",
+        "cleaningup",
+        "shuttingdown",
+        "activating",
+        "deactivating",
+        "errorprocessing",
+        "unknown"
+      ]
+    },
+    "previous_state_duration_s": {
+      "description":
+          "Seconds 'from_state' had been held: on a start Record, how long the component had been out of 'active' before this; on an end Record, how long it had been 'active'",
+      "type": "number",
+      "minimum": 0
+    },
+    "open": {
+      "description":
+          "true on a start Record, false on an end Record -- a component still active when collection stops simply never gets a matching end Record, so it cannot be averaged as a zero",
+      "type": "boolean"
+    }
+  },
+  "required": [
+    "seq",
+    "component_type",
+    "component",
+    "event",
+    "from_state",
+    "to_state",
+    "previous_state_duration_s",
+    "open"
+  ],
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/ros2_control_status.cpp
+++ b/dc_measurements/plugins/measurements/ros2_control_status.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/ros2_control_status.hpp"
+
+#include "lifecycle_msgs/msg/state.hpp"
+
+namespace dc_measurements
+{
+
+namespace
+{
+constexpr size_t kMaxPendingRecords = 64;
+constexpr const char* kControllerType = "controller";
+constexpr const char* kHardwareComponentType = "hardware_component";
+
+double secondsOf(const std::chrono::system_clock::duration& d)
+{
+  return std::chrono::duration<double>(d).count();
+}
+
+// The controller manager's own labels are not reproduced on every sample -- only the current
+// entry's -- so a transition's `from` state is looked up from the id the detector held, the same
+// way Fault turns a DiagnosticStatus level back into a name.
+std::string stateLabel(uint8_t id)
+{
+  switch (id)
+  {
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED:
+      return "unconfigured";
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE:
+      return "inactive";
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE:
+      return "active";
+    case lifecycle_msgs::msg::State::PRIMARY_STATE_FINALIZED:
+      return "finalized";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CONFIGURING:
+      return "configuring";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_CLEANINGUP:
+      return "cleaningup";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_SHUTTINGDOWN:
+      return "shuttingdown";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ACTIVATING:
+      return "activating";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_DEACTIVATING:
+      return "deactivating";
+    case lifecycle_msgs::msg::State::TRANSITION_STATE_ERRORPROCESSING:
+      return "errorprocessing";
+    default:
+      return "unknown";
+  }
+}
+
+}  // namespace
+
+Ros2ControlStatus::Ros2ControlStatus() : dc_measurements::Measurement()
+{
+}
+
+Ros2ControlStatus::~Ros2ControlStatus() = default;
+
+void Ros2ControlStatus::onConfigure()
+{
+  auto node = getNode();
+  topic_ = dc_util::get_str_type_param(node, measurement_name_, "topic", "/controller_manager/activity");
+
+  // Matches the controller manager's own `~/activity` publisher exactly: transient-local so a
+  // late-joining subscriber still gets the current snapshot instead of only future changes.
+  subscription_ = node->create_subscription<controller_manager_msgs::msg::ControllerManagerActivity>(
+      topic_, rclcpp::QoS(1).reliable().transient_local(),
+      std::bind(&Ros2ControlStatus::activityCb, this, std::placeholders::_1));
+}
+
+void Ros2ControlStatus::onCleanup()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& [name, detector] : controller_detectors_)
+  {
+    if (detector.state().has_value() && *detector.state() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    {
+      RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with controller '" << name
+                                                    << "' still active; no closing Record will be published");
+    }
+  }
+  for (const auto& [name, detector] : hardware_component_detectors_)
+  {
+    if (detector.state().has_value() && *detector.state() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE)
+    {
+      RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with hardware component '" << name
+                                                    << "' still active; no closing Record will be published");
+    }
+  }
+}
+
+void Ros2ControlStatus::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "ros2_control_status.json");
+  }
+}
+
+void Ros2ControlStatus::processEntries(const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& entries,
+                                       const std::string& component_type, const rclcpp::Time& stamp,
+                                       std::map<std::string, dc_common::StateTransitionDetector<uint8_t>>& detectors)
+{
+  const std::chrono::system_clock::time_point now{ std::chrono::nanoseconds(stamp.nanoseconds()) };
+
+  for (const auto& entry : entries)
+  {
+    const auto transition = detectors[entry.name].update(entry.state.id, now);
+    if (!transition.has_value())
+    {
+      continue;
+    }
+
+    const bool starts = transition->to == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+    const bool ends = transition->from == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE;
+    if (!starts && !ends)
+    {
+      // Neither entering nor leaving `active` (e.g. unconfigured to inactive during startup): a
+      // real transition, but not the boundary this Measurement reports.
+      continue;
+    }
+
+    json data;
+    data["seq"] = ++record_seq_;
+    data["component_type"] = component_type;
+    data["component"] = entry.name;
+    data["event"] = starts ? "start" : "end";
+    data["from_state"] = stateLabel(transition->from);
+    data["to_state"] = stateLabel(transition->to);
+    // The dwell of `from_state`: on a start Record, how long the component had been out of
+    // `active` before this; on an end Record, how long it had been `active` -- the same field
+    // means both, matching Intervention's `previous_duration` (#369's reasoning applies here too).
+    data["previous_state_duration_s"] = secondsOf(transition->dwell);
+    data["open"] = starts;
+
+    pending_records_.emplace_back(std::move(data), stamp);
+  }
+}
+
+void Ros2ControlStatus::activityCb(const controller_manager_msgs::msg::ControllerManagerActivity& msg)
+{
+  const rclcpp::Time stamp = getNode()->get_clock()->now();
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  processEntries(msg.controllers, kControllerType, stamp, controller_detectors_);
+  processEntries(msg.hardware_components, kHardwareComponentType, stamp, hardware_component_detectors_);
+
+  // One Record leaves per poll, so a controller manager flapping far faster than the polling
+  // interval would otherwise queue without bound. The oldest goes first: the recent transitions
+  // are the ones still worth reporting.
+  while (pending_records_.size() > kMaxPendingRecords)
+  {
+    pending_records_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement "
+                                    << measurement_name_
+                                    << ": ros2_control_status Records are arriving faster than the polling interval "
+                                       "can report them; dropping the oldest.");
+  }
+}
+
+dc_interfaces::msg::StringStamped Ros2ControlStatus::collect()
+{
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_records_.empty())
+  {
+    return msg;
+  }
+
+  auto record = std::move(pending_records_.front());
+  pending_records_.pop_front();
+  msg.header.stamp = record.second;
+  msg.data = record.first.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::Ros2ControlStatus, dc_core::Measurement)

--- a/dc_measurements/test/test_measurement_ros2_control_status.cpp
+++ b/dc_measurements/test/test_measurement_ros2_control_status.cpp
@@ -1,0 +1,301 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "controller_manager_msgs/msg/controller_manager_activity.hpp"
+#include "controller_manager_msgs/msg/named_lifecycle_state.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "lifecycle_msgs/msg/state.hpp"
+
+class MeasurementRos2ControlStatusTest : public ::testing::Test
+{
+protected:
+  MeasurementRos2ControlStatusTest()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(
+        rclcpp::NodeOptions(), std::vector<std::string>{ "ros2_control_status" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/ros2_control_status", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementRos2ControlStatusTest::dataCallback, this, std::placeholders::_1));
+    activity_pub_ = ms_node_->create_publisher<controller_manager_msgs::msg::ControllerManagerActivity>(
+        "/test/controller_manager/activity", rclcpp::QoS(1).reliable().transient_local());
+  }
+
+  void TearDown() override
+  {
+    stopCollection();
+  }
+
+  // Idempotent: one test stops collection mid-activation on purpose, and TearDown must not then
+  // drive the lifecycle node through a transition it is no longer in a state for.
+  void stopCollection()
+  {
+    if (stopped_)
+    {
+      return;
+    }
+    stopped_ = true;
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("ros2_control_status.plugin", std::string("dc_measurements/Ros2ControlStatus"));
+    ms_node_->declare_parameter("ros2_control_status.group_key", std::string("ros2_control_status"));
+    ms_node_->declare_parameter("ros2_control_status.topic_output", std::string("/dc/measurement/ros2_control_status"));
+    ms_node_->declare_parameter("ros2_control_status.topic", std::string("/test/controller_manager/activity"));
+    ms_node_->declare_parameter("ros2_control_status.polling_interval", 50);
+    ms_node_->declare_parameter("ros2_control_status.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+    callback_active_ = true;
+  }
+
+  static controller_manager_msgs::msg::NamedLifecycleState makeEntry(const std::string& name, uint8_t state_id,
+                                                                     const std::string& label)
+  {
+    controller_manager_msgs::msg::NamedLifecycleState entry;
+    entry.name = name;
+    entry.state.id = state_id;
+    entry.state.label = label;
+    return entry;
+  }
+
+  void publishActivity(const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& controllers,
+                       const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& hardware_components)
+  {
+    controller_manager_msgs::msg::ControllerManagerActivity msg;
+    msg.header.stamp = ms_node_->get_clock()->now();
+    msg.controllers = controllers;
+    msg.hardware_components = hardware_components;
+    activity_pub_->publish(msg);
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  void waitForSubscriber(const std::string& topic)
+  {
+    while (ms_node_->count_subscribers(topic) == 0)
+    {
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+    }
+  }
+
+  // The detector treats a component's very first observed sample as a baseline, not a
+  // transition: no Record comes out of it, and the state it carries never fires again since
+  // nothing is left to compare against. Every test that wants to observe an actual "start"
+  // therefore has to establish a non-active baseline first.
+  void establishInactiveBaseline(const std::string& name)
+  {
+    publishActivity({ makeEntry(name, lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, "inactive") }, {});
+    spinFor(std::chrono::milliseconds(100));
+  }
+
+  // Republishes `controllers`/`hardware_components` until a *new* Record matching `predicate`
+  // shows up, so a best-effort sample lost before the plugin subscribed doesn't make the test
+  // flaky.
+  nlohmann::json
+  publishUntilRecord(const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& controllers,
+                     const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& hardware_components,
+                     const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = records_.size();
+    for (int i = 0; i < 400; ++i)
+    {
+      publishActivity(controllers, hardware_components);
+      rclcpp::spin_some(ms_node_->get_node_base_interface());
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  // The schema the plugin itself validates against, applied here directly so a Record that only
+  // half fills it fails the test rather than only logging.
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path = ament_index_cpp::get_package_share_directory("dc_measurements") +
+                             "/plugins/measurements/json/ros2_control_status.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  rclcpp::Publisher<controller_manager_msgs::msg::ControllerManagerActivity>::SharedPtr activity_pub_;
+  std::vector<nlohmann::json> records_;
+
+  bool stopped_{ false };
+
+public:
+  bool callback_active_{ false };
+};
+
+TEST_F(MeasurementRos2ControlStatusTest, EnteringActiveRaisesAStartRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/controller_manager/activity");
+
+  // Staying in the same non-active state must not produce a Record.
+  publishActivity(
+      { makeEntry("diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured") },
+      {});
+  spinFor(std::chrono::milliseconds(200));
+  ASSERT_TRUE(records_.empty()) << "A first-seen sample is a baseline, not a transition";
+
+  const std::vector<controller_manager_msgs::msg::NamedLifecycleState> active = { makeEntry(
+      "diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active") };
+  const auto start = publishUntilRecord(active, {}, isEvent("start"));
+
+  EXPECT_EQ(start["seq"], 1);
+  EXPECT_EQ(start["component_type"], "controller");
+  EXPECT_EQ(start["component"], "diff_drive_controller");
+  EXPECT_EQ(start["from_state"], "unconfigured");
+  EXPECT_EQ(start["to_state"], "active");
+  EXPECT_TRUE(start["open"].get<bool>());
+  EXPECT_GE(start["previous_state_duration_s"].get<double>(), 0.0);
+  expectValidatesAgainstSchema(start);
+}
+
+TEST_F(MeasurementRos2ControlStatusTest, LeavingActiveRaisesAnEndRecordWithTheActiveDuration)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/controller_manager/activity");
+  establishInactiveBaseline("diff_drive_controller");
+
+  const std::vector<controller_manager_msgs::msg::NamedLifecycleState> active = { makeEntry(
+      "diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active") };
+  publishUntilRecord(active, {}, isEvent("start"));
+
+  const std::vector<controller_manager_msgs::msg::NamedLifecycleState> inactive = { makeEntry(
+      "diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE, "inactive") };
+  const auto end = publishUntilRecord(inactive, {}, isEvent("end"));
+
+  EXPECT_EQ(end["seq"], 2);
+  EXPECT_EQ(end["from_state"], "active");
+  EXPECT_EQ(end["to_state"], "inactive");
+  EXPECT_FALSE(end["open"].get<bool>());
+  EXPECT_GT(end["previous_state_duration_s"].get<double>(), 0.0);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementRos2ControlStatusTest, TransitionBetweenTwoNonActiveStatesProducesNoRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/controller_manager/activity");
+  establishInactiveBaseline("diff_drive_controller");
+
+  publishActivity(
+      { makeEntry("diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured") },
+      {});
+  spinFor(std::chrono::milliseconds(200));
+
+  EXPECT_TRUE(records_.empty()) << "inactive -> unconfigured crosses no `active` boundary";
+}
+
+TEST_F(MeasurementRos2ControlStatusTest, HardwareComponentsAreTrackedIndependentlyOfControllers)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/controller_manager/activity");
+
+  publishActivity({}, { makeEntry("arm", lifecycle_msgs::msg::State::PRIMARY_STATE_UNCONFIGURED, "unconfigured") });
+  spinFor(std::chrono::milliseconds(200));
+  ASSERT_TRUE(records_.empty());
+
+  const auto start = publishUntilRecord(
+      {}, { makeEntry("arm", lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active") }, isEvent("start"));
+
+  EXPECT_EQ(start["component_type"], "hardware_component");
+  EXPECT_EQ(start["component"], "arm");
+  expectValidatesAgainstSchema(start);
+}
+
+TEST_F(MeasurementRos2ControlStatusTest, ComponentActiveAtShutdownStaysOpenWithNoSyntheticEndRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  waitForSubscriber("/test/controller_manager/activity");
+  establishInactiveBaseline("diff_drive_controller");
+
+  const std::vector<controller_manager_msgs::msg::NamedLifecycleState> active = { makeEntry(
+      "diff_drive_controller", lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE, "active") };
+  publishUntilRecord(active, {}, isEvent("start"));
+
+  // Collection stops with the controller still active.
+  stopCollection();
+  spinFor(std::chrono::milliseconds(200));
+
+  ASSERT_EQ(records_.size(), 1u) << "Shutdown must not invent a closing Record";
+  EXPECT_EQ(records_.back()["event"], "start");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  // initialize ROS
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  // shutdown ROS
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -40,6 +40,7 @@
   - [Permissions](./dc/measurements/permissions.md)
   - [Position](./dc/measurements/position.md)
   - [Random](./dc/measurements/random.md)
+  - [ROS2 control status](./dc/measurements/ros2_control_status.md)
   - [Serial interface](./dc/measurements/serial_interface.md)
   - [Speed](./dc/measurements/speed.md)
   - [Storage](./dc/measurements/storage.md)

--- a/doc/src/dc/measurements/ros2_control_status.md
+++ b/doc/src/dc/measurements/ros2_control_status.md
@@ -1,0 +1,96 @@
+# ROS2 control status
+
+## Description
+
+Reports when a `ros2_control` controller or hardware component crosses into or out of the
+`active` lifecycle state -- the state in which it is actually commanding or reading hardware.
+Rather than polling `list_controllers`/`list_hardware_components`, Ros2ControlStatus subscribes to
+the controller manager's own `~/activity` topic
+(`controller_manager_msgs/ControllerManagerActivity`), republished with transient-local QoS on
+every controller/hardware-component lifecycle change, and feeds each component's stream of
+`(state, timestamp)` samples to its own `dc_common::StateTransitionDetector` -- one detector per
+component, mirroring Fault's per-component detector map, so components activate and deactivate
+independently.
+
+A Record is produced only for the boundary Intervention already reports in the same shape: a
+transition into `active` starts one (`"event": "start"`), and a transition out of `active` ends
+one (`"event": "end"`). A transition between two non-`active` states (e.g. `unconfigured` to
+`inactive` during startup) crosses no boundary and produces nothing.
+
+Every Record carries the component type (`controller` or `hardware_component`), its name, the
+state it left (`from_state`) and entered (`to_state`), and how long the previous state had been
+held (`previous_state_duration_s`) -- on a start Record, how long the component was out of
+`active` before this; on an end Record, how long it had just been `active`. `open` is `true` on a
+start Record and `false` on an end Record, so a component still active when collection stops
+simply never gets a matching end Record and cannot be averaged as a zero. Every Record carries a
+`seq` that increments by one across every controller and hardware component, so a dropped Record
+is a detectable gap.
+
+## Parameters
+
+| Parameter | Description                                       | Type | Default                          |
+| --------- | -------------------------------------------------- | ---- | --------------------------------- |
+| **topic** | Topic to subscribe to for controller manager activity | str  | "/controller_manager/activity" (Optional) |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Ros2ControlStatus",
+  "properties": {
+    "seq": { "type": "integer", "minimum": 1 },
+    "component_type": { "type": "string", "enum": ["controller", "hardware_component"] },
+    "component": { "type": "string" },
+    "event": { "type": "string", "enum": ["start", "end"] },
+    "from_state": { "type": "string", "enum": ["unconfigured", "inactive", "active", "finalized", "configuring", "cleaningup", "shuttingdown", "activating", "deactivating", "errorprocessing", "unknown"] },
+    "to_state": { "type": "string", "enum": ["unconfigured", "inactive", "active", "finalized", "configuring", "cleaningup", "shuttingdown", "activating", "deactivating", "errorprocessing", "unknown"] },
+    "previous_state_duration_s": { "type": "number", "minimum": 0 },
+    "open": { "type": "boolean" }
+  },
+  "required": ["seq", "component_type", "component", "event", "from_state", "to_state", "previous_state_duration_s", "open"],
+  "type": "object"
+}
+```
+
+## Measurement configuration
+
+```yaml
+...
+ros2_control_status:
+  plugin: "dc_measurements/Ros2ControlStatus"
+  topic_output: "/dc/measurement/ros2_control_status"
+  group_key: "ros2_control_status"
+  tags: ["console"]
+  topic: "/controller_manager/activity"
+```
+
+Example Record data, a start:
+
+```json
+{
+  "seq": 1,
+  "component_type": "controller",
+  "component": "diff_drive_controller",
+  "event": "start",
+  "from_state": "inactive",
+  "to_state": "active",
+  "previous_state_duration_s": 4.2,
+  "open": true
+}
+```
+
+and its end:
+
+```json
+{
+  "seq": 2,
+  "component_type": "controller",
+  "component": "diff_drive_controller",
+  "event": "end",
+  "from_state": "active",
+  "to_state": "inactive",
+  "previous_state_duration_s": 612.9,
+  "open": false
+}
+```

--- a/progress.txt
+++ b/progress.txt
@@ -8827,3 +8827,67 @@ reading the code (the repo's established verification standard):
   same instance after a `disconnect()`. Verified stable across 5 shuffled repeat runs.
 - Not wired into any Measurement plugin: interpreting a JSON schema over this transport (starting
   with Open-RMF's `TaskState`) is #391's job, per this ticket's explicit scope boundary.
+## #395 - ros2_control status Measurement: start/end Records from the controller manager's activity topic
+
+`ros2_control_status` (class `Ros2ControlStatus`) subscribes to the controller manager's own
+`~/activity` topic (`controller_manager_msgs/ControllerManagerActivity`, transient-local QoS,
+republished on every controller/hardware-component lifecycle change -- verified against
+`controller_manager.cpp`'s actual publisher: `rclcpp::QoS(1).reliable().transient_local()` on
+`~/activity`, not a guessed name/QoS) rather than polling `list_controllers`/
+`list_hardware_components`. Each controller and hardware component gets its own
+`dc_common::StateTransitionDetector<uint8_t>`, keyed by name in two maps (`controller_detectors_`,
+`hardware_component_detectors_`), mirroring Fault's per-component detector map exactly -- the
+message arrives as a callback carrying the *entire* current snapshot (like `DiagnosticArray`), not
+one change at a time, so `processEntries()` runs every entry through its own detector the same way
+`Fault::diagnosticsCb` does.
+
+**Record shape borrows Intervention's vocabulary, not Fault's.** A Record fires only on the
+boundary the issue calls out -- entering `active` (`"event": "start"`) or leaving it
+(`"event": "end"`) -- not on every lifecycle transition; a transition between two non-`active`
+states (e.g. `unconfigured` to `inactive` during startup) is absorbed silently, the same way
+Intervention drops a mode change that isn't a takeover boundary. `previous_state_duration_s` is the
+transition's own `dwell`, meaning both things at once exactly like Intervention's
+`previous_duration`: on a start Record, how long the component was out of `active` before this; on
+an end Record, how long it had just been `active`. `open` is `true`/`false` for start/end. A
+component still active when collection stops simply never gets a synthetic end Record (`onCleanup`
+only logs a warning per component, via each detector's `state()`), so it can't be averaged as a
+zero -- same contract as Intervention and Fault.
+
+State labels (`from_state`/`to_state`) are produced from the lifecycle state *id* through a local
+`stateLabel()` switch over `lifecycle_msgs::msg::State`'s primary/transition constants, not read
+from the message's own `label` field -- the detector only remembers the id it last held, not the
+label string that came with it, so the `from` side of a transition is reconstructed the same way
+`Fault::levelName()` turns a `DiagnosticStatus` level back into a name.
+
+**What shipped.** `dc_measurements/{plugins/measurements,include/dc_measurements/plugins/
+measurements}/ros2_control_status.{cpp,hpp}`, registered in `measurement_plugin.xml` and
+`CMakeLists.txt` like every other plugin; `controller_manager_msgs` added to `package.xml` and
+CMake's shared `dependencies` list (confirmed resolvable: a from-scratch `rosdep install` inside
+the workspace container resolved it with no missing-key errors). `plugins/measurements/json/
+ros2_control_status.json` validated through the existing `validateSchema()` path. `test/
+test_measurement_ros2_control_status.cpp`, 5 gtests over the real lifecycle node and a real
+`ControllerManagerActivity` publisher: entering `active` from a non-active baseline (start Record,
+`open: true`); leaving `active` (end Record, `open: false`, positive `previous_state_duration_s`);
+a transition between two non-active states producing no Record; hardware components tracked
+independently of controllers (own `component_type`); and a component still active at shutdown
+(one Record, no synthetic close). Docs: `doc/src/dc/measurements/ros2_control_status.md`, linked
+from `SUMMARY.md` (alphabetically between Random and Serial interface).
+
+**Verification gap, disclosed rather than papered over.** A from-scratch `colcon build` +
+`colcon test` inside `localhost/dc-workspace:latest` (rebuilt from the worktree, the same process
+#362/#365 used) was started to confirm this compiles and its gtests pass, but the host's shared
+podman storage was at 97% full (`/home` -- 13G free, 60GB "reclaimable" spread across ~200 images
+belonging to other issues'/sessions' verification runs); the build got past a from-scratch
+`aws_sdk_vendor` rebuild (the daily `APT_CACHEBUST` had invalidated that layer's cache -- 35 min)
+and then failed committing the next layer with "no space left on device". A dangling-image-only
+`podman image prune` was run (safe -- no tagged/in-use image touched) but freed negligible space,
+since the reclaimable size podman reports is mostly layers still shared with tagged images. Given
+the shared-host risk of a more aggressive prune (deleting another session's tagged verification
+image) and the time already spent, this was not retried locally; `prek run --all-files --skip
+build-doc` was run instead (clang-format reformatted the new files once, then green) and the code
+was reviewed by hand against Fault/Intervention's already-merged, already-tested patterns plus the
+real upstream `controller_manager_msgs`/`lifecycle_msgs` message definitions fetched from
+`ros-controls/ros2_control` and `ros2/rcl_interfaces` on GitHub. CI's `build-workspace` job (a
+GitHub-hosted runner, not this disk-constrained sandbox) is the actual `colcon build`/`colcon test`
+gate for this PR -- flagging here so a reviewer knows local verification stopped short of running
+the new tests, not that they were run and passed.


### PR DESCRIPTION
## Summary

- Adds `ros2_control_status` (class `Ros2ControlStatus`), a `dc_measurements` plugin that
  subscribes to the controller manager's transient-local `~/activity` topic
  (`controller_manager_msgs/ControllerManagerActivity`) and emits `start`/`end` Records when a
  controller or hardware component crosses into/out of the `active` lifecycle state.
- Built on `dc_common::StateTransitionDetector`, one instance per controller/hardware component
  (mirroring Fault's per-component detector map); the Record shape (`event`, `from_state`/
  `to_state`, `previous_state_duration_s`, `open`) follows Intervention's start/end convention.
- Ships the JSON Schema, gtest suite, doc page (`doc/src/dc/measurements/ros2_control_status.md`),
  and all the usual plugin registration (`CMakeLists.txt`, `package.xml`,
  `measurement_plugin.xml`, `SUMMARY.md`).

Closes #395

## Verification

- `prek run --all-files --skip build-doc`: green (clang-format reformatted the new files once).
- A from-scratch `colcon build`/`colcon test` inside the workspace container was started to
  confirm compilation and the new gtests, but the sandbox's shared podman storage ran out of disk
  space mid-build (unrelated pre-existing host condition, not this change) after a costly
  `aws_sdk_vendor` cache-miss rebuild. It was not safe to retry via a more aggressive image prune
  on a host shared with other sessions' work, so this was not completed locally — see
  `progress.txt`'s `#395` entry for the full detail. CI's `build-workspace` job is the actual
  `colcon build`/`colcon test` gate for this PR.
- Message/topic/QoS shape (`ControllerManagerActivity`, `NamedLifecycleState`,
  `lifecycle_msgs/State`, `~/activity` at `rclcpp::QoS(1).reliable().transient_local()`) was
  verified against the real `ros-controls/ros2_control` source on GitHub, not memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011eGokTRjYgFDQtjSNdt9QY