### PR TITLE
feat(dc_common): add a reusable websocket JSON client

### DIFF
--- a/dc_common/CMakeLists.txt
+++ b/dc_common/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.5)
 project(dc_common)
 
 find_package(ament_cmake REQUIRED)
+find_package(Boost REQUIRED)
+find_package(nlohmann_json REQUIRED)
+find_package(Threads REQUIRED)
 
 # dc_common defines dc_package(); it can't find_package() itself the way every other dc_*
 # package does, so it pulls the macro in directly here to apply the same standard project
@@ -18,13 +21,14 @@ install(
 )
 
 # RecordRingBuffer / FileScratchRing (#285), StateTransitionDetector / BatteryCycleAccumulator
-# (#360): header-only, ROS-free utilities, same shape as dc_core's condition_set.hpp -- no
-# compiled library needed, just the headers on the include path.
+# (#360), WebSocketJsonClient (#390): header-only, ROS-free utilities, same shape as dc_core's
+# condition_set.hpp -- no compiled library needed, just the headers on the include path.
 install(
   DIRECTORY include/
   DESTINATION include/
 )
 ament_export_include_directories(include)
+ament_export_dependencies(Boost nlohmann_json)
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
@@ -37,6 +41,21 @@ if(BUILD_TESTING)
       $<INSTALL_INTERFACE:include>
     )
   endforeach()
+
+  # WebSocketJsonClient (#390) needs nlohmann_json and pthread beyond the other header-only
+  # utilities above, and its fixture (a synchronous websocket echo server) needs Boost.Asio/Beast
+  # too -- linked explicitly rather than relying on Boost's headers being found on the system
+  # include path.
+  ament_add_gtest(${PROJECT_NAME}_websocket_json_client_test test/websocket_json_client_test.cpp)
+  target_include_directories(${PROJECT_NAME}_websocket_json_client_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(${PROJECT_NAME}_websocket_json_client_test
+    Boost::boost
+    nlohmann_json::nlohmann_json
+    Threads::Threads
+  )
 endif()
 
 ament_package(

--- a/dc_common/include/dc_common/websocket_json_client.hpp
+++ b/dc_common/include/dc_common/websocket_json_client.hpp
@@ -1,0 +1,399 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_COMMON_WEBSOCKET_JSON_CLIENT_HPP_
+#define DC_COMMON_WEBSOCKET_JSON_CLIENT_HPP_
+
+#include <algorithm>
+#include <atomic>
+#include <boost/asio/connect.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/websocket.hpp>
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+
+namespace dc_common
+{
+
+/// Connection state reported to a WebSocketJsonClient's state handler.
+enum class WebSocketState
+{
+  Disconnected,
+  Connecting,
+  Connected,
+};
+
+/// Tuning for WebSocketJsonClient's reconnect backoff. A free struct (not nested in
+/// WebSocketJsonClient, though it's used as `WebSocketJsonClient::Options` there via a type
+/// alias): a nested struct's own default member initializers aren't usable in a default argument
+/// of the enclosing class's member function -- GCC/Clang both reject that ordering.
+struct WebSocketJsonClientOptions
+{
+  /// Delay before the first reconnect attempt after a drop.
+  std::chrono::milliseconds initial_backoff{ 500 };
+  /// Reconnect delay never grows past this, however many attempts fail in a row.
+  std::chrono::milliseconds max_backoff{ 30000 };
+  /// Multiplier applied to the backoff after each failed connect/handshake/read.
+  double backoff_multiplier{ 2.0 };
+};
+
+/**
+ * @class dc_common::WebSocketJsonClient
+ * @brief Connects to a `ws://` URL, sends/receives newline-free JSON text frames, and reconnects
+ * with exponential backoff on a dropped connection -- no ROS dependency, transport only (#390).
+ *
+ * Every existing Measurement subscribes to something inside the robot's own ROS graph, where DDS
+ * handles reconnection for free; this is what a Measurement reaching outside that graph (e.g. the
+ * Open-RMF task-state API, #391) uses instead. A Measurement plugin owns one instance, calling
+ * connect() from onConfigure() and disconnect() from onCleanup() -- the same shape every other
+ * Measurement's create_subscription()/reset() pair already follows (see dc_measurements::Measurement).
+ *
+ * Runs its own io_context on a background thread so connect()/send()/disconnect() never block the
+ * caller. onMessage/onStateChange/onError handlers fire on that background thread -- not the
+ * caller's -- so a handler touching ROS state must marshal itself onto the node's executor. Message,
+ * state and error handlers should be set once, before the first connect().
+ */
+class WebSocketJsonClient
+{
+public:
+  using MessageHandler = std::function<void(const nlohmann::json&)>;
+  using StateHandler = std::function<void(WebSocketState)>;
+  using ErrorHandler = std::function<void(const std::string&)>;
+  using Options = WebSocketJsonClientOptions;
+
+  explicit WebSocketJsonClient(Options options = Options{}) : options_(options)
+  {
+  }
+
+  ~WebSocketJsonClient()
+  {
+    disconnect();
+  }
+
+  WebSocketJsonClient(const WebSocketJsonClient&) = delete;
+  WebSocketJsonClient& operator=(const WebSocketJsonClient&) = delete;
+
+  void onMessage(MessageHandler handler)
+  {
+    message_handler_ = std::move(handler);
+  }
+
+  void onStateChange(StateHandler handler)
+  {
+    state_handler_ = std::move(handler);
+  }
+
+  void onError(ErrorHandler handler)
+  {
+    error_handler_ = std::move(handler);
+  }
+
+  /**
+   * @brief Start connecting to `url` (`ws://host[:port][/path]`) and keep reconnecting with
+   * exponential backoff on any drop until disconnect() is called. One connection at a time: call
+   * disconnect() first before connecting to a different URL on the same instance.
+   */
+  void connect(const std::string& url)
+  {
+    parsed_url_ = parseUrl(url);
+    stopping_ = false;
+    current_backoff_ = options_.initial_backoff;
+    // Bumped here (not just in doConnect()) so a completion from a *previous* connect()/
+    // disconnect() cycle -- e.g. a resolver lookup still in flight when disconnect() was called,
+    // whose handler asio only gets around to delivering after this new run() starts -- reads a
+    // stale value and is ignored below, instead of racing this session's own connection attempt.
+    ++generation_;
+    io_thread_ = std::thread([this] { runIoThread(); });
+  }
+
+  /// Stops reconnection and closes any open connection. Idempotent; safe to call from any thread.
+  void disconnect()
+  {
+    if (!io_thread_.joinable())
+    {
+      return;
+    }
+    stopping_ = true;
+    ++generation_;
+    // Posted rather than done inline: ws_/reconnect_timer_ are touched only from io_thread_, so
+    // tearing them down has to happen there too, then stop() the io_context from that same handler
+    // so run() cannot return before the close has actually been issued.
+    boost::asio::post(ioc_, [this] {
+      closeStream();
+      ioc_.stop();
+    });
+    io_thread_.join();
+    ioc_.restart();
+    setState(WebSocketState::Disconnected);
+  }
+
+  /// Serializes `message` and sends it as a text frame on the current connection; silently dropped
+  /// if not connected.
+  void send(const nlohmann::json& message)
+  {
+    if (state() != WebSocketState::Connected)
+    {
+      return;
+    }
+    auto text = std::make_shared<std::string>(message.dump());
+    boost::asio::post(ioc_, [this, text] {
+      if (!ws_ || !ws_->is_open())
+      {
+        return;
+      }
+      ws_->async_write(boost::asio::buffer(*text), [this](boost::beast::error_code ec, std::size_t) {
+        if (ec)
+        {
+          reportError("write failed: " + ec.message());
+        }
+      });
+    });
+  }
+
+  WebSocketState state() const
+  {
+    return state_.load();
+  }
+
+private:
+  struct ParsedUrl
+  {
+    std::string host;
+    std::string port;
+    std::string target;
+  };
+
+  /// Minimal `ws://host[:port][/path]` parser. `wss://` (TLS) is out of scope here, matching this
+  /// ticket's transport-only remit -- adding it later only changes doConnect()'s stream type.
+  static ParsedUrl parseUrl(const std::string& url)
+  {
+    static const std::string scheme_prefix = "ws://";
+    if (url.rfind(scheme_prefix, 0) != 0)
+    {
+      throw std::invalid_argument{ "WebSocketJsonClient only supports ws:// URLs, got: " + url };
+    }
+    const std::string rest = url.substr(scheme_prefix.size());
+    const auto slash = rest.find('/');
+    const std::string authority = slash == std::string::npos ? rest : rest.substr(0, slash);
+    const std::string target = slash == std::string::npos ? "/" : rest.substr(slash);
+    const auto colon = authority.find(':');
+
+    ParsedUrl parsed;
+    if (colon == std::string::npos)
+    {
+      parsed.host = authority;
+      parsed.port = "80";
+    }
+    else
+    {
+      parsed.host = authority.substr(0, colon);
+      parsed.port = authority.substr(colon + 1);
+    }
+    parsed.target = target;
+
+    if (parsed.host.empty())
+    {
+      throw std::invalid_argument{ "WebSocketJsonClient: empty host in URL: " + url };
+    }
+    return parsed;
+  }
+
+  void runIoThread()
+  {
+    doConnect();
+    ioc_.run();
+  }
+
+  void doConnect()
+  {
+    // Captured by every completion handler below and compared against generation_ when it fires:
+    // a handler whose generation has fallen behind belongs to a connect()/disconnect() cycle that
+    // is no longer current (e.g. a resolve still in flight when disconnect() ran) and must be a
+    // no-op rather than act on -- or replace -- the current attempt's ws_.
+    const auto gen = generation_.load();
+    setState(WebSocketState::Connecting);
+    ws_ = std::make_unique<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>>(ioc_);
+    resolver_.async_resolve(
+        parsed_url_.host, parsed_url_.port,
+        [this, gen](boost::beast::error_code ec, const boost::asio::ip::tcp::resolver::results_type& results) {
+          if (gen != generation_.load())
+          {
+            return;
+          }
+          if (ec)
+          {
+            reportError("resolve failed: " + ec.message());
+            scheduleReconnect(gen);
+            return;
+          }
+          boost::asio::async_connect(ws_->next_layer(), results,
+                                     [this, gen](boost::beast::error_code connect_ec,
+                                                 const boost::asio::ip::tcp::endpoint&) { onConnect(gen, connect_ec); });
+        });
+  }
+
+  void onConnect(std::uint64_t gen, boost::beast::error_code ec)
+  {
+    if (gen != generation_.load())
+    {
+      return;
+    }
+    if (ec)
+    {
+      reportError("connect failed: " + ec.message());
+      scheduleReconnect(gen);
+      return;
+    }
+    ws_->async_handshake(parsed_url_.host + ":" + parsed_url_.port, parsed_url_.target,
+                         [this, gen](boost::beast::error_code handshake_ec) { onHandshake(gen, handshake_ec); });
+  }
+
+  void onHandshake(std::uint64_t gen, boost::beast::error_code ec)
+  {
+    if (gen != generation_.load())
+    {
+      return;
+    }
+    if (ec)
+    {
+      reportError("handshake failed: " + ec.message());
+      scheduleReconnect(gen);
+      return;
+    }
+    ws_->text(true);
+    current_backoff_ = options_.initial_backoff;
+    setState(WebSocketState::Connected);
+    doRead(gen);
+  }
+
+  void doRead(std::uint64_t gen)
+  {
+    ws_->async_read(buffer_, [this, gen](boost::beast::error_code ec, std::size_t) {
+      if (gen != generation_.load())
+      {
+        return;
+      }
+      if (ec)
+      {
+        // stopping_ means this read failed because disconnect() closed the stream out from under
+        // it -- expected, not a drop, and reconnection must not be scheduled behind disconnect()'s
+        // back.
+        if (!stopping_)
+        {
+          reportError("read failed: " + ec.message());
+          setState(WebSocketState::Disconnected);
+          scheduleReconnect(gen);
+        }
+        return;
+      }
+      const auto text = boost::beast::buffers_to_string(buffer_.data());
+      buffer_.consume(buffer_.size());
+      try
+      {
+        const auto json_message = nlohmann::json::parse(text);
+        if (message_handler_)
+        {
+          message_handler_(json_message);
+        }
+      }
+      catch (const nlohmann::json::parse_error& e)
+      {
+        reportError(std::string("received non-JSON message: ") + e.what());
+      }
+      doRead(gen);
+    });
+  }
+
+  void scheduleReconnect(std::uint64_t gen)
+  {
+    if (stopping_)
+    {
+      return;
+    }
+    setState(WebSocketState::Disconnected);
+    reconnect_timer_.expires_after(current_backoff_);
+    reconnect_timer_.async_wait([this, gen](boost::beast::error_code ec) {
+      if (ec || stopping_ || gen != generation_.load())
+      {
+        return;
+      }
+      current_backoff_ = std::min(
+          std::chrono::milliseconds(static_cast<std::int64_t>(current_backoff_.count() * options_.backoff_multiplier)),
+          options_.max_backoff);
+      doConnect();
+    });
+  }
+
+  /// Only ever called from io_thread_ (directly, or via post() from disconnect()).
+  ///
+  /// Closes the underlying TCP layer directly rather than attempting a graceful websocket close
+  /// handshake (`ws_->close()`): doRead() keeps exactly one async_read perpetually outstanding on
+  /// ws_ while connected, and Beast does not support a second read-family operation (which a
+  /// synchronous close()'s wait-for-the-peer's-close-frame amounts to) starting while one is
+  /// already pending on the same stream -- verified empirically, it silently never completes a
+  /// real handshake. Closing the transport instead completes the outstanding async_read (with an
+  /// error, which doRead() already treats as a no-op once stopping_ is set) immediately, safely,
+  /// same-thread.
+  void closeStream()
+  {
+    reconnect_timer_.cancel();
+    resolver_.cancel();
+    if (!ws_)
+    {
+      return;
+    }
+    boost::beast::error_code ec;
+    ws_->next_layer().close(ec);
+  }
+
+  void setState(WebSocketState new_state)
+  {
+    state_.store(new_state);
+    if (state_handler_)
+    {
+      state_handler_(new_state);
+    }
+  }
+
+  void reportError(const std::string& message)
+  {
+    if (error_handler_)
+    {
+      error_handler_(message);
+    }
+  }
+
+  Options options_;
+  ParsedUrl parsed_url_;
+  std::atomic<bool> stopping_{ true };
+  std::atomic<WebSocketState> state_{ WebSocketState::Disconnected };
+  std::chrono::milliseconds current_backoff_{ 500 };
+  /// Incremented on every connect()/disconnect(); see doConnect()'s comment on `gen`.
+  std::atomic<std::uint64_t> generation_{ 0 };
+
+  boost::asio::io_context ioc_;
+  boost::asio::ip::tcp::resolver resolver_{ ioc_ };
+  boost::asio::steady_timer reconnect_timer_{ ioc_ };
+  std::unique_ptr<boost::beast::websocket::stream<boost::asio::ip::tcp::socket>> ws_;
+  boost::beast::flat_buffer buffer_;
+  std::thread io_thread_;
+
+  MessageHandler message_handler_;
+  StateHandler state_handler_;
+  ErrorHandler error_handler_;
+};
+
+}  // namespace dc_common
+
+#endif  // DC_COMMON_WEBSOCKET_JSON_CLIENT_HPP_

--- a/dc_common/package.xml
+++ b/dc_common/package.xml
@@ -20,6 +20,9 @@ SPDX-License-Identifier: MPL-2.0
 
     <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
 
+    <depend>boost</depend>
+    <depend>nlohmann-json-dev</depend>
+
     <test_depend>ament_cmake_gtest</test_depend>
 
     <export>

--- a/dc_common/test/websocket_json_client_test.cpp
+++ b/dc_common/test/websocket_json_client_test.cpp
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_common::WebSocketJsonClient (#390). No ROS node, no rclcpp::init(): the
+// fixture is a trivial synchronous websocket echo server bound to an ephemeral loopback port, per
+// #360's ROS-free-unit precedent.
+
+#include "dc_common/websocket_json_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/beast/websocket.hpp>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+using dc_common::WebSocketJsonClient;
+using dc_common::WebSocketState;
+
+namespace
+{
+
+namespace beast = boost::beast;
+namespace websocket = beast::websocket;
+namespace asio = boost::asio;
+using tcp = asio::ip::tcp;
+
+// Same idiom as dc_bridge/test/forwarder_test.cpp's poll_until(): a wall-clock deadline rather
+// than a fixed iteration count, so scheduler contention or a slow build shrinks nothing but the
+// margin.
+bool poll_until(std::chrono::milliseconds budget, const std::function<bool()>& condition)
+{
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  do
+  {
+    if (condition())
+    {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  } while (std::chrono::steady_clock::now() < deadline);
+  return condition();
+}
+
+// A trivial websocket echo server: binds :0 on loopback, accepts connections one at a time on a
+// background thread, and echoes every text frame it reads back verbatim. dropConnection() force-
+// closes whichever connection is current, standing in for a network drop; the accept loop then
+// takes the next incoming connection, so a reconnecting client succeeds.
+//
+// Entirely async, driven by ioc_.run() on thread_ -- not a synchronous accept()/read() loop.
+// Boost.Asio only guarantees that closing a socket/acceptor safely and promptly cancels an
+// operation *pending on that same io_context*, regardless of which thread calls close(); a raw
+// blocking syscall in another thread has no such guarantee (closing an fd out from under a thread
+// already blocked in accept()/read() on it does not reliably unblock that call on Linux) --
+// verified empirically here, it hangs. So dropConnection()/stop() below post their close() calls
+// onto ioc_ instead of calling it inline from the test thread, exactly like
+// WebSocketJsonClient::disconnect() already does for the same reason.
+class EchoServer
+{
+public:
+  EchoServer() : acceptor_(ioc_, tcp::endpoint(tcp::v4(), 0))
+  {
+    doAccept();
+    thread_ = std::thread([this] { ioc_.run(); });
+  }
+
+  ~EchoServer()
+  {
+    stop();
+  }
+
+  unsigned short port() const
+  {
+    return acceptor_.local_endpoint().port();
+  }
+
+  void dropConnection()
+  {
+    asio::post(ioc_, [this] {
+      if (current_ws_ && current_ws_->is_open())
+      {
+        beast::error_code ec;
+        current_ws_->next_layer().close(ec);
+      }
+    });
+  }
+
+  void stop()
+  {
+    if (stopped_.exchange(true))
+    {
+      return;
+    }
+    asio::post(ioc_, [this] {
+      boost::system::error_code ec;
+      acceptor_.close(ec);
+      if (current_ws_ && current_ws_->is_open())
+      {
+        beast::error_code wec;
+        current_ws_->next_layer().close(wec);
+      }
+      ioc_.stop();
+    });
+    if (thread_.joinable())
+    {
+      thread_.join();
+    }
+  }
+
+private:
+  // current_ws_ is only ever touched from thread_ (directly, or via asio::post() from
+  // dropConnection()/stop() above), so it needs no lock.
+  void doAccept()
+  {
+    acceptor_.async_accept([this](boost::system::error_code ec, tcp::socket socket) {
+      if (ec)
+      {
+        // acceptor_ closed (stop()) or a real error either way there's nothing more to accept.
+        return;
+      }
+      auto ws = std::make_shared<websocket::stream<tcp::socket>>(std::move(socket));
+      current_ws_ = ws;
+      ws->async_accept([this, ws](beast::error_code handshake_ec) {
+        if (handshake_ec)
+        {
+          if (!stopped_)
+          {
+            doAccept();
+          }
+          return;
+        }
+        ws->text(true);
+        doRead(ws);
+      });
+    });
+  }
+
+  void doRead(const std::shared_ptr<websocket::stream<tcp::socket>>& ws)
+  {
+    auto buffer = std::make_shared<beast::flat_buffer>();
+    ws->async_read(*buffer, [this, ws, buffer](beast::error_code ec, std::size_t) {
+      if (ec)
+      {
+        // This connection is done (closed by the client, or dropConnection()); the next one --
+        // possibly a reconnecting client -- gets its own accept.
+        if (!stopped_)
+        {
+          doAccept();
+        }
+        return;
+      }
+      ws->async_write(buffer->data(), [this, ws, buffer](beast::error_code write_ec, std::size_t) {
+        if (write_ec)
+        {
+          if (!stopped_)
+          {
+            doAccept();
+          }
+          return;
+        }
+        doRead(ws);
+      });
+    });
+  }
+
+  asio::io_context ioc_;
+  tcp::acceptor acceptor_;
+  std::thread thread_;
+  std::atomic<bool> stopped_{ false };
+  std::shared_ptr<websocket::stream<tcp::socket>> current_ws_;
+};
+
+// Records every state transition and message a client reports, guarded by one mutex so a test can
+// poll it from the gtest thread while the client's handlers fire on its own IO thread.
+struct ClientObserver
+{
+  std::mutex mutex;
+  std::vector<WebSocketState> states;
+  std::vector<nlohmann::json> messages;
+  std::vector<std::string> errors;
+
+  void wire(WebSocketJsonClient& client)
+  {
+    client.onStateChange([this](WebSocketState s) {
+      std::lock_guard<std::mutex> lock(mutex);
+      states.push_back(s);
+    });
+    client.onMessage([this](const nlohmann::json& msg) {
+      std::lock_guard<std::mutex> lock(mutex);
+      messages.push_back(msg);
+    });
+    client.onError([this](const std::string& msg) {
+      std::lock_guard<std::mutex> lock(mutex);
+      errors.push_back(msg);
+    });
+  }
+
+  bool sawState(WebSocketState s)
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    return std::find(states.begin(), states.end(), s) != states.end();
+  }
+
+  std::size_t stateCount(WebSocketState s)
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    return static_cast<std::size_t>(std::count(states.begin(), states.end(), s));
+  }
+
+  std::size_t messageCount()
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    return messages.size();
+  }
+
+  nlohmann::json lastMessage()
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    return messages.back();
+  }
+};
+
+std::string wsUrl(const EchoServer& server)
+{
+  return "ws://127.0.0.1:" + std::to_string(server.port()) + "/";
+}
+
+}  // namespace
+
+TEST(WebSocketJsonClient, RejectsNonWebSocketUrl)
+{
+  WebSocketJsonClient client;
+  EXPECT_THROW(client.connect("http://127.0.0.1:9"), std::invalid_argument);
+}
+
+TEST(WebSocketJsonClient, RejectsUrlWithEmptyHost)
+{
+  WebSocketJsonClient client;
+  EXPECT_THROW(client.connect("ws:///path"), std::invalid_argument);
+}
+
+TEST(WebSocketJsonClient, ConnectsSendsAndReceivesJson)
+{
+  EchoServer server;
+  ClientObserver observer;
+  WebSocketJsonClient client;
+  observer.wire(client);
+
+  client.connect(wsUrl(server));
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return client.state() == WebSocketState::Connected; }));
+
+  const nlohmann::json request{ { "op", "subscribe" }, { "task_id", "abc-123" } };
+  client.send(request);
+
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return observer.messageCount() >= 1; }));
+  EXPECT_EQ(observer.lastMessage(), request);
+
+  client.disconnect();
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+}
+
+TEST(WebSocketJsonClient, ReconnectsAfterDroppedConnectionAndKeepsWorking)
+{
+  EchoServer server;
+  ClientObserver observer;
+  WebSocketJsonClient::Options options;
+  options.initial_backoff = std::chrono::milliseconds(50);
+  options.max_backoff = std::chrono::milliseconds(200);
+  WebSocketJsonClient client(options);
+  observer.wire(client);
+
+  client.connect(wsUrl(server));
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return client.state() == WebSocketState::Connected; }));
+
+  server.dropConnection();
+
+  // Reconnection: the client must observe the drop, then re-establish a *working* connection --
+  // not just flip back to Connected, which a stale/half-open socket could also do. Proven by
+  // sending after the second Connected and getting a real echo back, not just the state value.
+  ASSERT_TRUE(
+      poll_until(std::chrono::milliseconds(3000), [&] { return observer.stateCount(WebSocketState::Connected) >= 2; }));
+
+  const nlohmann::json request{ { "after", "reconnect" } };
+  client.send(request);
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return observer.messageCount() >= 1; }));
+  EXPECT_EQ(observer.lastMessage(), request);
+
+  EXPECT_TRUE(observer.sawState(WebSocketState::Disconnected));
+
+  client.disconnect();
+}
+
+TEST(WebSocketJsonClient, DisconnectStopsReconnectionAndIsIdempotent)
+{
+  EchoServer server;
+  WebSocketJsonClient::Options options;
+  options.initial_backoff = std::chrono::milliseconds(50);
+  options.max_backoff = std::chrono::milliseconds(100);
+  WebSocketJsonClient client(options);
+
+  client.connect(wsUrl(server));
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return client.state() == WebSocketState::Connected; }));
+
+  client.disconnect();
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+
+  // No crash/hang, and the state stays put: a reconnect loop still running behind disconnect()'s
+  // back would eventually flip this back to Connected/Connecting on its own.
+  std::this_thread::sleep_for(std::chrono::milliseconds(300));
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+
+  client.disconnect();
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+}
+
+TEST(WebSocketJsonClient, DisconnectBeforeAnyConnectIsSafe)
+{
+  WebSocketJsonClient client;
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+  client.disconnect();
+  EXPECT_EQ(client.state(), WebSocketState::Disconnected);
+}
+
+TEST(WebSocketJsonClient, CanReconnectToANewUrlAfterDisconnect)
+{
+  EchoServer server_a;
+  WebSocketJsonClient client;
+
+  client.connect(wsUrl(server_a));
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return client.state() == WebSocketState::Connected; }));
+  client.disconnect();
+  ASSERT_EQ(client.state(), WebSocketState::Disconnected);
+
+  EchoServer server_b;
+  ClientObserver observer;
+  observer.wire(client);
+  client.connect(wsUrl(server_b));
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return client.state() == WebSocketState::Connected; }));
+
+  const nlohmann::json request{ { "server", "b" } };
+  client.send(request);
+  ASSERT_TRUE(poll_until(std::chrono::milliseconds(2000), [&] { return observer.messageCount() >= 1; }));
+  EXPECT_EQ(observer.lastMessage(), request);
+
+  client.disconnect();
+}

--- a/progress.txt
+++ b/progress.txt
@@ -8692,3 +8692,63 @@ reading the code (the repo's established verification standard):
   ticket, the specific line that failed is now confirmed compiling-clean against the
   actual error message -- though a full `colcon build`/`colcon test` pass is still owed
   to CI, since this sandbox still has no ROS 2 toolchain to run one.
+
+### #390 - Reusable websocket JSON client for dc_measurements
+
+- Added `dc_common::WebSocketJsonClient` (`dc_common/include/dc_common/websocket_json_client.hpp`):
+  a header-only, ROS-free client that connects to a `ws://host[:port][/path]` URL, sends/receives
+  JSON text frames, and reconnects with exponential backoff on a dropped connection -- the
+  transport Open-RMF's task-state API (#391, blocked by this ticket) needs, generic enough for any
+  future out-of-ROS-graph Measurement to reuse rather than rolling its own. Built on Boost.Beast +
+  Boost.Asio (already a transitive dependency via `dc_util`/`dc_bridge`, added here directly to
+  `dc_common`'s `package.xml`/`CMakeLists.txt` alongside `nlohmann-json-dev`) running its own
+  `io_context` on a background thread, so `connect()`/`send()`/`disconnect()` never block the
+  caller. Lifecycle shape matches every other Measurement's `create_subscription()`/teardown pair:
+  a plugin calls `connect()` from `onConfigure()` and `disconnect()` from `onCleanup()`/`cleanup()`
+  (`dc_measurements::Measurement`, `dc_core::Measurement`) -- no new lifecycle plumbing needed, and
+  no RMF-specific parsing lives here, matching the ticket's transport-only scope; `wss://` (TLS) is
+  explicitly out of scope too (would only change `doConnect()`'s stream type).
+- `WebSocketJsonClient::Options` is a free struct (`WebSocketJsonClientOptions`), not nested in the
+  class despite being used as `WebSocketJsonClient::Options` via a type alias -- GCC/Clang both
+  reject a nested struct's own default member initializers being used in a default argument of the
+  *enclosing* class's constructor (a real compile error caught by manually compiling against the
+  cached `dc-workspace` image's installed Boost/nlohmann/gtest, not by reading the code).
+- Every async completion handler (resolve/connect/handshake/read/reconnect-timer) carries a
+  generation counter, bumped on every `connect()`/`disconnect()`, and bails out if it no longer
+  matches: without it, a resolver lookup still in flight when `disconnect()` runs could have its
+  completion delivered *after* a later `connect()` starts (asio doesn't cancel an in-flight resolve
+  just because the io_context stopped and restarted), racing that new session's own `ws_`.
+- **Two real hangs found and fixed by actually running the tests**, not just reading the code --
+  full `colcon build`+`colcon test` in this sandbox's podman got stuck in a 36-minute from-source
+  `aws_sdk_vendor` rebuild (the cached `dc-workspace` image's apt layer got invalidated by
+  `build.sh`'s date-stamped `APT_CACHEBUST`), so verification instead compiled/linked/ran the new
+  gtest directly against that same cached image's already-installed Boost 1.83/nlohmann/gtest with
+  the identical `-Wall -Wextra -Wpedantic -Werror -Wdeprecated` flags `dc_package()` uses -- close
+  enough to the real CMake build to trust, and fast enough to actually run repeatedly:
+  1. `disconnect()`'s `closeStream()` called a *synchronous* `ws_->close()` (graceful WS close
+     handshake) while `doRead()` always keeps exactly one `async_read` outstanding on the same
+     stream (it re-arms itself at the end of every read). Beast doesn't support a concurrent
+     read-family operation and a close on one stream; the sync close silently never completed a
+     real handshake, so the peer never saw a close frame and stayed blocked forever waiting for
+     one. Fixed by having `closeStream()` just close the transport directly instead of attempting
+     a graceful handshake -- safe and immediate since it always runs on `io_thread_` itself, which
+     is what actually owns the pending `async_read`.
+  2. The test fixture's `EchoServer` used a synchronous `accept()`/`read()` loop on a background
+     thread, with `dropConnection()`/`stop()` calling `.close()` on that same socket/acceptor from
+     the *test* thread. Closing a fd out from under a thread already blocked in a raw syscall on it
+     does not reliably unblock that call on Linux -- confirmed empirically (hung consistently,
+     reproduced with a minimal standalone repro outside gtest to isolate it from gtest itself).
+     Rewritten to be fully async (`async_accept`/`async_read`/`async_write` driven by `ioc_.run()`
+     on its own thread), with `dropConnection()`/`stop()` posting their `close()` calls onto that
+     `io_context` instead -- Boost.Asio *does* guarantee closing a socket safely cancels a pending
+     operation on the same io_context regardless of which thread calls close(), the same pattern
+     `WebSocketJsonClient::disconnect()` already relies on.
+- `dc_common/test/websocket_json_client_test.cpp`: 7 gtests against a local fixture echo server
+  (no ROS node, no rclcpp::init(), per #360's ROS-free-unit precedent) -- connect/send/receive a
+  real JSON round trip; reconnection after a dropped connection, proven by a second successful
+  send/receive after the reconnect rather than just the state flipping back to Connected (a
+  stale/half-open socket could do that too); `disconnect()` stopping reconnection and being
+  idempotent; safe to call before any `connect()`; and reconnecting to a *different* URL on the
+  same instance after a `disconnect()`. Verified stable across 5 shuffled repeat runs.
+- Not wired into any Measurement plugin: interpreting a JSON schema over this transport (starting
+  with Open-RMF's `TaskState`) is #391's job, per this ticket's explicit scope boundary.


### PR DESCRIPTION
## Summary

- Adds `dc_common::WebSocketJsonClient`: a header-only, ROS-free client that connects to a `ws://` URL, sends/receives JSON text frames, and reconnects with exponential backoff on a dropped connection.
- Transport only — no RMF-specific parsing lives here; interpreting Open-RMF's `TaskState` JSON is #391's job.
- Lifecycle shape matches every other Measurement's ROS subscription: a plugin calls `connect()` from `onConfigure()` and `disconnect()` from `onCleanup()`/`cleanup()`.
- Reconnection is proven end-to-end by the tests, not just by a state flag: after a dropped connection, the client re-establishes a *working* connection and a real send/receive round trip succeeds again.

## Notable fixes found while actually running the tests (not just reading the code)

1. `disconnect()` used to attempt a synchronous graceful websocket close while a read was always outstanding on the same stream — Beast doesn't support that combination, so the peer never got a real close frame and hung. Fixed by closing the transport directly instead.
2. The test fixture's echo server used a synchronous accept/read loop with cross-thread `close()` calls to force a drop — closing an fd out from under a thread blocked reading it doesn't reliably unblock that read on Linux. Rewritten to be fully async, closing via the same io_context the pending operation belongs to (the same pattern `WebSocketJsonClient::disconnect()` uses).

## Test plan

- [x] 7 new gtests in `dc_common/test/websocket_json_client_test.cpp` against a local fixture echo server — no ROS node, no `rclcpp::init()`, per #360's ROS-free-unit precedent.
- [x] Compiled and linked against the cached `dc-workspace` image's Boost 1.83/nlohmann/gtest with the same `-Wall -Wextra -Wpedantic -Werror -Wdeprecated` flags `dc_package()` uses (a full `colcon build`+`colcon test` run got stuck in a 36-minute from-source `aws_sdk_vendor` rebuild unrelated to this change, in this sandbox).
- [x] All 7 tests pass, stable across 5 shuffled repeat runs.
- [x] Pre-existing `dc_common` gtests (`record_ring_buffer_test`, `file_scratch_ring_test`, `state_transition_detector_test`, `battery_cycle_accumulator_test`) still build and pass.
- [x] `prek run --all-files --skip build-doc` passes.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jhvQQy3f4nPPtpQHhjkfk