### PR TITLE
feat(dc_measurements): add the Mission Measurement nav2 NavigateToPose adapter

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -192,6 +192,9 @@ list(APPEND dc_measurement_plugin_libs dc_manipulation_measurement)
 add_library(dc_map_measurement SHARED plugins/measurements/map.cpp)
 list(APPEND dc_measurement_plugin_libs dc_map_measurement)
 
+add_library(dc_mission_nav2_measurement SHARED plugins/measurements/mission_nav2.cpp)
+list(APPEND dc_measurement_plugin_libs dc_mission_nav2_measurement)
+
 add_library(dc_mission_nav2_follow_waypoints_measurement SHARED plugins/measurements/mission_nav2_follow_waypoints.cpp)
 list(APPEND dc_measurement_plugin_libs dc_mission_nav2_follow_waypoints_measurement)
 
@@ -382,6 +385,7 @@ set(tests
   test_measurement_manipulation
   test_measurement_map
   test_measurement_memory
+  test_measurement_mission_nav2
   test_measurement_mission_nav2_follow_waypoints
   test_measurement_mission_nav2_through_poses
   test_measurement_moving
@@ -403,6 +407,7 @@ set(tests
   test_measurement_thermal
   test_measurement_uptime
   mission_follow_waypoints_tracker_test
+  mission_nav2_tracker_test
   test_mission_nav2_through_poses_core
 )
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_HPP_
+
+#include <deque>
+#include <mutex>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "action_msgs/msg/goal_status.hpp"
+#include "action_msgs/msg/goal_status_array.hpp"
+#include "dc_core/measurement.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_measurements/plugins/measurements/mission_nav2_tracker.hpp"
+#include "dc_util/node_utils.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "unique_identifier_msgs/msg/uuid.hpp"
+
+namespace dc_measurements
+{
+
+/**
+ * @class dc_measurements::MissionNav2
+ * @brief The nav2 adapter of the Mission Measurement (#396) for `NavigateToPose`: the base case
+ * the mission lifecycle contract (#305, recorded in ADR-0010) was agreed against, with
+ * `NavigateThroughPoses`/`FollowWaypoints` as its siblings (#388/#389).
+ *
+ * A passive watcher, not a commander, matching #388/#389's design: nav2's `NavigateToPose` action
+ * is driven by whatever already dispatches missions on the robot (the BT navigator, a fleet
+ * orchestrator, an operator command) -- DC never sends a goal of its own. This subscribes directly
+ * to the action's `_action/status`/`_action/feedback` topics and calls its `_action/get_result`
+ * service for the terminal Result once a goal it is following reaches a terminal state -- the same
+ * standard, public per-action topics/services every `rclcpp_action::Server` exposes, rather than
+ * `rclcpp_action::Client`'s typed API, which only reports on goals the client itself sent.
+ */
+class MissionNav2 : public dc_measurements::Measurement
+{
+public:
+  using ActionT = nav2_msgs::action::NavigateToPose;
+  using GetResultService = ActionT::Impl::GetResultService;
+  using FeedbackMsg = ActionT::Impl::FeedbackMessage;
+
+  MissionNav2();
+  ~MissionNav2() override;
+  dc_interfaces::msg::StringStamped collect() override;
+
+private:
+  void statusCb(const action_msgs::msg::GoalStatusArray& msg);
+  void feedbackCb(const FeedbackMsg& msg);
+  void requestResult(const unique_identifier_msgs::msg::UUID& uuid, const std::string& goal_id,
+                     const rclcpp::Time& terminal_at);
+  void handleResultResponse(const std::string& goal_id, const rclcpp::Time& terminal_at,
+                            const GetResultService::Response::SharedPtr& response);
+  // Caller holds mutex_.
+  void enqueue(json data, const rclcpp::Time& stamp);
+  static json missionStartJson(const MissionStartFact& fact);
+  static json missionEndJson(const MissionEndFact& fact);
+
+  std::string action_name_;
+  rclcpp::Subscription<action_msgs::msg::GoalStatusArray>::SharedPtr status_sub_;
+  rclcpp::Subscription<FeedbackMsg>::SharedPtr feedback_sub_;
+  rclcpp::Client<GetResultService>::SharedPtr result_client_;
+
+  // The status/feedback callbacks and the get_result response callback run on different callback
+  // groups than the polling timer under a multi-threaded executor, so everything they share is
+  // guarded.
+  mutable std::mutex mutex_;
+  std::optional<MissionNav2Tracker> tracker_;
+  // Which goal_ids a get_result request is already in flight for, so a terminal status repeated
+  // across several status-array publishes doesn't fire the service call more than once.
+  std::set<std::string> result_requested_;
+  // Last-seen number_of_recoveries for the mission currently tracked, from the feedback topic --
+  // there is no recovery count on the terminal Result, only on Feedback.
+  std::optional<int> last_recoveries_;
+  // Records wait here for a poll to carry them out, one per poll, so they travel the same publish
+  // path (Conditions, buffering, Group) as every other Record.
+  std::deque<std::pair<json, rclcpp::Time>> pending_records_;
+
+protected:
+  void onConfigure() override;
+  void onCleanup() override;
+  void setValidationSchema() override;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_HPP_

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_tracker.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_tracker.hpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_TRACKER_HPP_
+#define DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_TRACKER_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "dc_common/state_transition_detector.hpp"
+
+namespace dc_measurements
+{
+
+/// Terminal nav2 GoalStatus values relevant to a mission, expressed with no ROS dependency --
+/// ACCEPTED/EXECUTING/CANCELING never reach the tracker, only what a goal can end on.
+enum class MissionTerminalStatus
+{
+  Succeeded,
+  Canceled,
+  Aborted,
+};
+
+/// The outcome a Record actually reports, per the mission lifecycle contract (#305, recorded in
+/// ADR-0010). Distinct from MissionTerminalStatus: a goal that reaches Succeeded with a non-zero
+/// error_code is reported as Failed rather than Succeeded -- an application-level failure nav2
+/// reported without aborting the goal status itself.
+enum class MissionOutcome
+{
+  Succeeded,
+  Failed,
+  Cancelled,
+  Aborted,
+};
+
+struct MissionStartFact
+{
+  std::string mission_id;
+  std::uint64_t sequence{ 0 };
+};
+
+struct MissionEndFact
+{
+  std::string mission_id;
+  std::uint64_t sequence{ 0 };
+  MissionOutcome outcome{ MissionOutcome::Succeeded };
+  double duration_sec{ 0.0 };
+  /// Set exactly when outcome is Failed or Aborted.
+  std::optional<std::string> reason;
+  std::optional<std::uint16_t> error_code;
+  /// NavigateToPose::Feedback.number_of_recoveries at completion, when feedback was seen.
+  std::optional<int> recoveries;
+};
+
+/**
+ * @class dc_measurements::MissionNav2Tracker
+ * @brief Turns a passively observed NavigateToPose goal lifecycle (accepted -> terminal) into
+ * mission_start/mission_end facts, with no ROS dependency. Built on
+ * dc_common::StateTransitionDetector<std::string> (#360), the same block `intervention`/`fault`
+ * use, with the tracked "state" being the active goal_id (empty = idle) -- the pattern #389's
+ * MissionFollowWaypointsTracker converged on, since a single-goal-at-a-time action server (nav2's
+ * bt_navigator included) never needs more than one idle<->active transition pair in flight.
+ *
+ * nav2's NavigateToPose action server processes one goal at a time, so this tracker only ever
+ * follows one mission at once; a second goal accepted before the first's result arrives is
+ * reported by startMission() returning nullopt, for the caller to log and ignore.
+ */
+class MissionNav2Tracker
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+
+  /// `at` seeds the tracker as idle since that moment -- without it, the very first mission this
+  /// instance ever observes would be silently absorbed as StateTransitionDetector's baseline
+  /// sample rather than reported as a transition.
+  explicit MissionNav2Tracker(TimePoint at) : detector_(std::string(), at)
+  {
+  }
+
+  /// A new goal_id was accepted. nullopt when a mission is already tracked, or `goal_id` is
+  /// already the one tracked (a duplicate status-array sighting).
+  std::optional<MissionStartFact> startMission(const std::string& goal_id, TimePoint at)
+  {
+    if (detector_.state().value_or(std::string()) != std::string())
+    {
+      return std::nullopt;
+    }
+    const auto transition = detector_.update(goal_id, at);
+    if (!transition.has_value())
+    {
+      return std::nullopt;
+    }
+    return MissionStartFact{ goal_id, transition->sequence };
+  }
+
+  /// The tracked goal's Result has arrived. nullopt when `goal_id` is not the one currently
+  /// tracked (a stale or foreign result).
+  std::optional<MissionEndFact> endMission(const std::string& goal_id, MissionTerminalStatus status,
+                                           std::uint16_t error_code, std::string error_msg,
+                                           std::optional<int> recoveries, TimePoint at)
+  {
+    if (detector_.state().value_or(std::string()) != goal_id || goal_id.empty())
+    {
+      return std::nullopt;
+    }
+    const auto transition = detector_.update(std::string(), at);
+    if (!transition.has_value())
+    {
+      return std::nullopt;
+    }
+
+    MissionEndFact fact;
+    fact.mission_id = goal_id;
+    fact.sequence = transition->sequence;
+    fact.duration_sec = std::chrono::duration<double>(transition->dwell).count();
+    fact.recoveries = recoveries;
+
+    if (status == MissionTerminalStatus::Aborted)
+    {
+      fact.outcome = MissionOutcome::Aborted;
+    }
+    else if (status == MissionTerminalStatus::Canceled)
+    {
+      fact.outcome = MissionOutcome::Cancelled;
+    }
+    else
+    {
+      // Succeeded at the action level, but nav2 still reports a non-zero error_code for an
+      // application-level failure that did not abort the goal status itself.
+      fact.outcome = (error_code != 0) ? MissionOutcome::Failed : MissionOutcome::Succeeded;
+    }
+
+    if (fact.outcome == MissionOutcome::Failed || fact.outcome == MissionOutcome::Aborted)
+    {
+      fact.reason = std::move(error_msg);
+      fact.error_code = error_code;
+    }
+    return fact;
+  }
+
+  /// The goal_id currently tracked, or nullopt while idle -- what onCleanup() checks for a mission
+  /// still open at shutdown.
+  std::optional<std::string> activeMissionId() const
+  {
+    const auto& state = detector_.state();
+    if (!state.has_value() || state->empty())
+    {
+      return std::nullopt;
+    }
+    return state;
+  }
+
+private:
+  dc_common::StateTransitionDetector<std::string> detector_;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__PLUGINS__MEASUREMENTS__MISSION_NAV2_TRACKER_HPP_

--- a/dc_measurements/measurement_plugin.xml
+++ b/dc_measurements/measurement_plugin.xml
@@ -120,6 +120,14 @@ SPDX-License-Identifier: MPL-2.0
         </class>
     </library>
 
+    <library path="dc_mission_nav2_measurement">
+        <class name="dc_measurements/MissionNav2" type="dc_measurements::MissionNav2" base_class_type="dc_core::Measurement">
+            <description>
+                dc_measurement_mission_nav2
+            </description>
+        </class>
+    </library>
+
     <library path="dc_mission_nav2_through_poses_measurement">
         <class name="dc_measurements/MissionNav2ThroughPoses" type="dc_measurements::MissionNav2ThroughPoses" base_class_type="dc_core::Measurement">
             <description>

--- a/dc_measurements/plugins/measurements/json/mission_nav2.json
+++ b/dc_measurements/plugins/measurements/json/mission_nav2.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2",
+  "description":
+      "One nav2 NavigateToPose goal's lifecycle, watched passively: a mission_start Record when it is accepted, a mission_end Record when it reaches a terminal state. The base Record contract every Mission Measurement nav2 adapter shares (NavigateThroughPoses, FollowWaypoints)",
+  "properties": {
+    "event": {
+      "description": "What this Record is: a mission being accepted, or one reaching a terminal state",
+      "type": "string",
+      "enum": [
+        "mission_start",
+        "mission_end"
+      ]
+    },
+    "mission_id": {
+      "description": "The NavigateToPose goal UUID, stringified",
+      "type": "string"
+    },
+    "mission_type": {
+      "description":
+          "Always 'navigate_to_pose' for this adapter -- other Mission Measurement adapters set their own value",
+      "type": "string",
+      "const": "navigate_to_pose"
+    },
+    "sequence": {
+      "description":
+          "Monotonically increasing transition number for this Measurement instance, so a dropped Record is detectable rather than silently corrupting a duration",
+      "type": "integer",
+      "minimum": 1
+    },
+    "outcome": {
+      "description":
+          "How the mission ended. 'failed' is a goal that reached GoalStatus SUCCEEDED but still carried a non-zero error_code, distinct from 'aborted' (the goal status itself)",
+      "type": "string",
+      "enum": [
+        "succeeded",
+        "failed",
+        "cancelled",
+        "aborted"
+      ]
+    },
+    "reason": {
+      "description": "Human-readable failure reason, verbatim from NavigateToPose::Result.error_msg",
+      "type": "string"
+    },
+    "error_code": {
+      "description": "nav2's own numeric NavigateToPose::Result.error_code, carried through verbatim",
+      "type": "integer",
+      "minimum": 0
+    },
+    "duration_sec": {
+      "description": "How long the mission ran, from acceptance to its terminal state",
+      "type": "number",
+      "minimum": 0
+    },
+    "recoveries": {
+      "description":
+          "NavigateToPose::Feedback.number_of_recoveries at mission completion, when feedback was seen before the terminal state",
+      "type": "integer",
+      "minimum": 0
+    }
+  },
+  "required": [
+    "event",
+    "mission_id",
+    "mission_type",
+    "sequence"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "event": {
+            "const": "mission_end"
+          }
+        },
+        "required": [
+          "event"
+        ]
+      },
+      "then": {
+        "required": [
+          "outcome",
+          "duration_sec"
+        ]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "outcome": {
+            "enum": [
+              "failed",
+              "aborted"
+            ]
+          }
+        },
+        "required": [
+          "outcome"
+        ]
+      },
+      "then": {
+        "required": [
+          "reason",
+          "error_code"
+        ]
+      }
+    }
+  ],
+  "type": "object"
+}

--- a/dc_measurements/plugins/measurements/mission_nav2.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2.cpp
@@ -1,0 +1,281 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/plugins/measurements/mission_nav2.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+namespace dc_measurements
+{
+
+namespace
+{
+
+constexpr size_t kMaxPendingRecords = 64;
+
+std::string uuidToString(const unique_identifier_msgs::msg::UUID& uuid)
+{
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < uuid.uuid.size(); ++i)
+  {
+    oss << std::setw(2) << static_cast<int>(uuid.uuid[i]);
+    if (i == 3 || i == 5 || i == 7 || i == 9)
+    {
+      oss << '-';
+    }
+  }
+  return oss.str();
+}
+
+std::string outcomeName(MissionOutcome outcome)
+{
+  switch (outcome)
+  {
+    case MissionOutcome::Succeeded:
+      return "succeeded";
+    case MissionOutcome::Failed:
+      return "failed";
+    case MissionOutcome::Cancelled:
+      return "cancelled";
+    case MissionOutcome::Aborted:
+      return "aborted";
+  }
+  return "unknown";
+}
+
+MissionTerminalStatus terminalStatusOf(int8_t action_status)
+{
+  switch (action_status)
+  {
+    case action_msgs::msg::GoalStatus::STATUS_CANCELED:
+      return MissionTerminalStatus::Canceled;
+    case action_msgs::msg::GoalStatus::STATUS_ABORTED:
+      return MissionTerminalStatus::Aborted;
+    default:
+      return MissionTerminalStatus::Succeeded;
+  }
+}
+
+}  // namespace
+
+MissionNav2::MissionNav2() : dc_measurements::Measurement()
+{
+}
+
+MissionNav2::~MissionNav2() = default;
+
+void MissionNav2::onConfigure()
+{
+  auto node = getNode();
+  action_name_ = dc_util::get_str_type_param(node, measurement_name_, "action_name", "navigate_to_pose");
+
+  const rclcpp::Time now = node->get_clock()->now();
+  tracker_.emplace(std::chrono::system_clock::time_point(std::chrono::nanoseconds(now.nanoseconds())));
+
+  // Matches the QoS an action server publishes its status topic with (reliable, transient_local):
+  // a late-joining watcher still gets the current goal's last-known status rather than waiting for
+  // the next change.
+  status_sub_ = node->create_subscription<action_msgs::msg::GoalStatusArray>(
+      action_name_ + "/_action/status", rclcpp::QoS(rclcpp::KeepLast(1)).reliable().transient_local(),
+      std::bind(&MissionNav2::statusCb, this, std::placeholders::_1));
+  feedback_sub_ =
+      node->create_subscription<FeedbackMsg>(action_name_ + "/_action/feedback", rclcpp::QoS(10),
+                                             std::bind(&MissionNav2::feedbackCb, this, std::placeholders::_1));
+  result_client_ = node->create_client<GetResultService>(action_name_ + "/_action/get_result");
+}
+
+void MissionNav2::onCleanup()
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (tracker_.has_value())
+  {
+    if (const auto active = tracker_->activeMissionId())
+    {
+      RCLCPP_WARN_STREAM(logger_, measurement_name_ << ": collection stopped with mission '" << *active
+                                                    << "' still active; no closing Record will be published");
+    }
+  }
+  status_sub_.reset();
+  feedback_sub_.reset();
+  result_client_.reset();
+}
+
+void MissionNav2::setValidationSchema()
+{
+  if (enable_validator_)
+  {
+    validateSchema("dc_measurements", "mission_nav2.json");
+  }
+}
+
+json MissionNav2::missionStartJson(const MissionStartFact& fact)
+{
+  json data;
+  data["event"] = "mission_start";
+  data["mission_id"] = fact.mission_id;
+  data["mission_type"] = "navigate_to_pose";
+  data["sequence"] = fact.sequence;
+  return data;
+}
+
+json MissionNav2::missionEndJson(const MissionEndFact& fact)
+{
+  json data;
+  data["event"] = "mission_end";
+  data["mission_id"] = fact.mission_id;
+  data["mission_type"] = "navigate_to_pose";
+  data["sequence"] = fact.sequence;
+  data["outcome"] = outcomeName(fact.outcome);
+  data["duration_sec"] = fact.duration_sec;
+  if (fact.reason.has_value())
+  {
+    data["reason"] = *fact.reason;
+  }
+  if (fact.error_code.has_value())
+  {
+    data["error_code"] = *fact.error_code;
+  }
+  if (fact.recoveries.has_value())
+  {
+    data["recoveries"] = *fact.recoveries;
+  }
+  return data;
+}
+
+void MissionNav2::enqueue(json data, const rclcpp::Time& stamp)
+{
+  pending_records_.emplace_back(std::move(data), stamp);
+  // One Record leaves per poll, so missions starting/ending far faster than the polling interval
+  // would otherwise queue without bound. The oldest goes first: the recent boundaries are the ones
+  // still worth reporting.
+  while (pending_records_.size() > kMaxPendingRecords)
+  {
+    pending_records_.pop_front();
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_
+                                               << ": mission Records are arriving faster than the polling interval "
+                                                  "can report them; dropping the oldest.");
+  }
+}
+
+void MissionNav2::statusCb(const action_msgs::msg::GoalStatusArray& msg)
+{
+  const rclcpp::Time now = getNode()->get_clock()->now();
+  const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(now.nanoseconds()) };
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& entry : msg.status_list)
+  {
+    const std::string goal_id = uuidToString(entry.goal_info.goal_id);
+
+    if (entry.status == action_msgs::msg::GoalStatus::STATUS_ACCEPTED ||
+        entry.status == action_msgs::msg::GoalStatus::STATUS_EXECUTING ||
+        entry.status == action_msgs::msg::GoalStatus::STATUS_CANCELING)
+    {
+      const auto start = tracker_->startMission(goal_id, at);
+      if (start.has_value())
+      {
+        enqueue(missionStartJson(*start), now);
+      }
+      else if (!tracker_->activeMissionId().has_value() || *tracker_->activeMissionId() != goal_id)
+      {
+        RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                    "Measurement " << measurement_name_ << ": goal '" << goal_id << "' accepted on '"
+                                                   << action_name_
+                                                   << "' while another mission is already being tracked; ignoring it.");
+      }
+      continue;
+    }
+
+    const bool is_terminal = entry.status == action_msgs::msg::GoalStatus::STATUS_SUCCEEDED ||
+                             entry.status == action_msgs::msg::GoalStatus::STATUS_CANCELED ||
+                             entry.status == action_msgs::msg::GoalStatus::STATUS_ABORTED;
+    if (!is_terminal)
+    {
+      continue;
+    }
+    if (!tracker_->activeMissionId().has_value() || *tracker_->activeMissionId() != goal_id)
+    {
+      // Not the mission this instance is following (or already closed) -- most likely this same
+      // terminal status republished after its get_result response already ended it.
+      continue;
+    }
+    if (!result_requested_.insert(goal_id).second)
+    {
+      continue;
+    }
+    requestResult(entry.goal_info.goal_id, goal_id, now);
+  }
+}
+
+void MissionNav2::feedbackCb(const FeedbackMsg& msg)
+{
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (tracker_.has_value() && tracker_->activeMissionId().has_value())
+  {
+    last_recoveries_ = msg.feedback.number_of_recoveries;
+  }
+}
+
+void MissionNav2::requestResult(const unique_identifier_msgs::msg::UUID& uuid, const std::string& goal_id,
+                                const rclcpp::Time& terminal_at)
+{
+  if (!result_client_->service_is_ready())
+  {
+    RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
+                                "Measurement " << measurement_name_ << ": '" << action_name_
+                                               << "/_action/get_result' is not ready; will retry on the next terminal "
+                                                  "status for '"
+                                               << goal_id << "'.");
+    result_requested_.erase(goal_id);
+    return;
+  }
+
+  auto request = std::make_shared<GetResultService::Request>();
+  request->goal_id = uuid;
+  result_client_->async_send_request(request, [this, goal_id,
+                                               terminal_at](rclcpp::Client<GetResultService>::SharedFuture future) {
+    handleResultResponse(goal_id, terminal_at, future.get());
+  });
+}
+
+void MissionNav2::handleResultResponse(const std::string& goal_id, const rclcpp::Time& terminal_at,
+                                       const GetResultService::Response::SharedPtr& response)
+{
+  const std::chrono::system_clock::time_point at{ std::chrono::nanoseconds(terminal_at.nanoseconds()) };
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  result_requested_.erase(goal_id);
+  const std::optional<int> recoveries = last_recoveries_;
+  last_recoveries_.reset();
+  const auto end = tracker_->endMission(goal_id, terminalStatusOf(response->status), response->result.error_code,
+                                        response->result.error_msg, recoveries, at);
+  if (end.has_value())
+  {
+    enqueue(missionEndJson(*end), terminal_at);
+  }
+}
+
+dc_interfaces::msg::StringStamped MissionNav2::collect()
+{
+  dc_interfaces::msg::StringStamped msg;
+  msg.group_key = group_key_;
+
+  const std::lock_guard<std::mutex> lock(mutex_);
+  if (pending_records_.empty())
+  {
+    return msg;
+  }
+  auto record = std::move(pending_records_.front());
+  pending_records_.pop_front();
+  msg.header.stamp = record.second;
+  msg.data = record.first.dump(-1, ' ', true);
+  return msg;
+}
+
+}  // namespace dc_measurements
+
+#include "pluginlib/class_list_macros.hpp"
+PLUGINLIB_EXPORT_CLASS(dc_measurements::MissionNav2, dc_core::Measurement)

--- a/dc_measurements/test/mission_nav2_tracker_test.cpp
+++ b/dc_measurements/test/mission_nav2_tracker_test.cpp
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_measurements::MissionNav2Tracker (#387). No action server, no node: goal_id/
+// status/result all arrive as arguments, mirroring
+// dc_common/test/battery_cycle_accumulator_test.cpp's standalone coverage of
+// BatteryCycleAccumulator. rclcpp::init()/shutdown() in main() below is only for link
+// compatibility with this package's CMakeLists.txt test registration, which does not pass
+// SKIP_LINKING_MAIN_LIBRARIES to ament_add_gtest.
+
+#include "dc_measurements/plugins/measurements/mission_nav2_tracker.hpp"
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <string>
+
+#include "rclcpp/rclcpp.hpp"
+
+using dc_measurements::MissionNav2Tracker;
+using dc_measurements::MissionOutcome;
+using dc_measurements::MissionTerminalStatus;
+
+namespace
+{
+
+std::chrono::system_clock::time_point at(int seconds)
+{
+  return std::chrono::system_clock::time_point(std::chrono::seconds(seconds));
+}
+
+}  // namespace
+
+TEST(MissionNav2Tracker, StartsIdle)
+{
+  MissionNav2Tracker tracker(at(0));
+  EXPECT_FALSE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionNav2Tracker, AcceptedGoalProducesAMissionStart)
+{
+  MissionNav2Tracker tracker(at(0));
+
+  const auto start = tracker.startMission("goal-1", at(5));
+  ASSERT_TRUE(start.has_value());
+  EXPECT_EQ(start->mission_id, "goal-1");
+  EXPECT_EQ(start->sequence, 1u);
+  ASSERT_TRUE(tracker.activeMissionId().has_value());
+  EXPECT_EQ(*tracker.activeMissionId(), "goal-1");
+}
+
+TEST(MissionNav2Tracker, SecondGoalWhileOneIsActiveIsIgnored)
+{
+  MissionNav2Tracker tracker(at(0));
+  ASSERT_TRUE(tracker.startMission("goal-1", at(5)).has_value());
+
+  EXPECT_FALSE(tracker.startMission("goal-2", at(6)).has_value());
+  EXPECT_EQ(*tracker.activeMissionId(), "goal-1");
+}
+
+TEST(MissionNav2Tracker, SucceededResultProducesAMissionEndWithNoReason)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(5));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 0, "", std::nullopt, at(35));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->mission_id, "goal-1");
+  EXPECT_EQ(end->sequence, 2u);
+  EXPECT_EQ(end->outcome, MissionOutcome::Succeeded);
+  EXPECT_DOUBLE_EQ(end->duration_sec, 30.0);
+  EXPECT_FALSE(end->reason.has_value());
+  EXPECT_FALSE(end->error_code.has_value());
+  EXPECT_FALSE(end->recoveries.has_value());
+  EXPECT_FALSE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionNav2Tracker, SucceededStatusWithNonZeroErrorCodeIsReportedAsFailed)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(5));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 9101, "failed to load behavior tree",
+                                      std::nullopt, at(20));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Failed);
+  ASSERT_TRUE(end->reason.has_value());
+  EXPECT_EQ(*end->reason, "failed to load behavior tree");
+  ASSERT_TRUE(end->error_code.has_value());
+  EXPECT_EQ(*end->error_code, 9101u);
+}
+
+TEST(MissionNav2Tracker, CanceledStatusIsReportedAsCancelled)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Canceled, 0, "", std::nullopt, at(10));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Cancelled);
+  EXPECT_FALSE(end->reason.has_value());
+  EXPECT_FALSE(end->error_code.has_value());
+}
+
+TEST(MissionNav2Tracker, AbortedStatusCarriesReasonAndErrorCode)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  const auto end =
+      tracker.endMission("goal-1", MissionTerminalStatus::Aborted, 9102, "tf timeout", std::nullopt, at(2));
+  ASSERT_TRUE(end.has_value());
+  EXPECT_EQ(end->outcome, MissionOutcome::Aborted);
+  ASSERT_TRUE(end->reason.has_value());
+  EXPECT_EQ(*end->reason, "tf timeout");
+  ASSERT_TRUE(end->error_code.has_value());
+  EXPECT_EQ(*end->error_code, 9102u);
+}
+
+TEST(MissionNav2Tracker, ResultForAForeignGoalIdIsIgnored)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  EXPECT_FALSE(
+      tracker.endMission("goal-stale", MissionTerminalStatus::Succeeded, 0, "", std::nullopt, at(10)).has_value());
+  EXPECT_TRUE(tracker.activeMissionId().has_value());
+}
+
+TEST(MissionNav2Tracker, RecoveriesAreCarriedThrough)
+{
+  MissionNav2Tracker tracker(at(0));
+  tracker.startMission("goal-1", at(0));
+
+  const auto end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 0, "", 2, at(1));
+  ASSERT_TRUE(end.has_value());
+  ASSERT_TRUE(end->recoveries.has_value());
+  EXPECT_EQ(*end->recoveries, 2);
+}
+
+TEST(MissionNav2Tracker, SequenceIncrementsAcrossMultipleMissions)
+{
+  MissionNav2Tracker tracker(at(0));
+
+  const auto first_start = tracker.startMission("goal-1", at(0));
+  const auto first_end = tracker.endMission("goal-1", MissionTerminalStatus::Succeeded, 0, "", std::nullopt, at(10));
+  const auto second_start = tracker.startMission("goal-2", at(20));
+  const auto second_end =
+      tracker.endMission("goal-2", MissionTerminalStatus::Aborted, 9102, "tf timeout", std::nullopt, at(30));
+
+  ASSERT_TRUE(first_start.has_value());
+  ASSERT_TRUE(first_end.has_value());
+  ASSERT_TRUE(second_start.has_value());
+  ASSERT_TRUE(second_end.has_value());
+  EXPECT_EQ(first_start->sequence, 1u);
+  EXPECT_EQ(first_end->sequence, 2u);
+  EXPECT_EQ(second_start->sequence, 3u);
+  EXPECT_EQ(second_end->sequence, 4u);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  const bool all_successful = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return all_successful;
+}

--- a/dc_measurements/test/test_measurement_mission_nav2.cpp
+++ b/dc_measurements/test/test_measurement_mission_nav2.cpp
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <nlohmann/json-schema.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement_server.hpp"
+#include "dc_util/json_utils.hpp"
+#include "nav2_msgs/action/navigate_to_pose.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+
+using NavigateToPose = nav2_msgs::action::NavigateToPose;
+using NavigateToPoseGoalHandle = rclcpp_action::ServerGoalHandle<NavigateToPose>;
+
+// Stands in for whatever nav2's bt_navigator and its commander (a fleet orchestrator, an operator
+// command, ...) really are: a real rclcpp_action::Server the plugin under test watches, and a real
+// rclcpp_action::Client that drives it, completely independent of dc_measurements::MissionNav2 --
+// exactly the passive-watcher relationship the plugin has to the real thing.
+class MeasurementMissionNav2Test : public ::testing::Test
+{
+protected:
+  MeasurementMissionNav2Test()
+  {
+    SetUp();
+  }
+
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "mission" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/mission", rclcpp::SystemDefaultsQoS(),
+        std::bind(&MeasurementMissionNav2Test::dataCallback, this, std::placeholders::_1));
+
+    server_node_ = std::make_shared<rclcpp::Node>("fake_nav2_" + std::to_string(instance_++));
+    action_server_ = rclcpp_action::create_server<NavigateToPose>(
+        server_node_, kActionName,
+        [](const rclcpp_action::GoalUUID&, std::shared_ptr<const NavigateToPose::Goal>) {
+          return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+        },
+        [](const std::shared_ptr<NavigateToPoseGoalHandle>&) { return rclcpp_action::CancelResponse::ACCEPT; },
+        [this](const std::shared_ptr<NavigateToPoseGoalHandle>& goal_handle) { goal_handle_ = goal_handle; });
+
+    commander_node_ = std::make_shared<rclcpp::Node>("fake_commander_" + std::to_string(instance_++));
+    commander_client_ = rclcpp_action::create_client<NavigateToPose>(commander_node_, kActionName);
+  }
+
+  void TearDown() override
+  {
+    stopCollection();
+  }
+
+  // Idempotent: one test stops collection mid-mission on purpose.
+  void stopCollection()
+  {
+    if (stopped_)
+    {
+      return;
+    }
+    stopped_ = true;
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  void declareCommonParameters()
+  {
+    ms_node_->declare_parameter("mission.plugin", std::string("dc_measurements/MissionNav2"));
+    ms_node_->declare_parameter("mission.group_key", std::string("mission"));
+    ms_node_->declare_parameter("mission.topic_output", std::string("/dc/measurement/mission"));
+    ms_node_->declare_parameter("mission.action_name", std::string(kActionName));
+    ms_node_->declare_parameter("mission.polling_interval", 50);
+    ms_node_->declare_parameter("mission.init_collect", false);
+  }
+
+  void startLifecycleNode()
+  {
+    ms_node_->configure();
+    ms_node_->activate();
+  }
+
+  void dataCallback(const dc_interfaces::msg::StringStamped& msg)
+  {
+    std::string data_str = msg.data.c_str();
+    boost::replace_all(data_str, "'", "\"");
+    records_.push_back(nlohmann::json::parse(data_str));
+  }
+
+  void spinAll()
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+    rclcpp::spin_some(server_node_);
+    rclcpp::spin_some(commander_node_);
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  // Sends a goal through the fake commander and spins until the fake server's handle_accepted has
+  // fired, so the test controls exactly when (and how) the goal completes.
+  void sendGoalAndWaitForAcceptance()
+  {
+    ASSERT_TRUE(commander_client_->wait_for_action_server(std::chrono::seconds(5)));
+    NavigateToPose::Goal goal;
+    client_goal_handle_future_ = commander_client_->async_send_goal(goal);
+    for (int i = 0; i < 400 && !goal_handle_; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(goal_handle_) << "Fake nav2 action server never reported the goal as accepted";
+  }
+
+  // Drives a real cancel request through the commander so the server-side goal handle legally
+  // reaches CANCELING before the test completes it -- succeed()/abort() are reachable directly
+  // from EXECUTING, but canceled() is only a legal transition out of CANCELING.
+  void requestCancelAndWaitForCanceling()
+  {
+    for (int i = 0;
+         i < 400 && client_goal_handle_future_.wait_for(std::chrono::seconds(0)) != std::future_status::ready; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_EQ(client_goal_handle_future_.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    commander_client_->async_cancel_goal(client_goal_handle_future_.get());
+    for (int i = 0; i < 400 && !goal_handle_->is_canceling(); ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    ASSERT_TRUE(goal_handle_->is_canceling());
+  }
+
+  void publishFeedback(int16_t recoveries)
+  {
+    auto feedback = std::make_shared<NavigateToPose::Feedback>();
+    feedback->number_of_recoveries = recoveries;
+    goal_handle_->publish_feedback(feedback);
+  }
+
+  nlohmann::json waitForRecord(const std::function<bool(const nlohmann::json&)>& predicate)
+  {
+    const size_t first_new = records_.size();
+    for (int i = 0; i < 600; ++i)
+    {
+      spinAll();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+      for (size_t r = first_new; r < records_.size(); ++r)
+      {
+        if (predicate(records_[r]))
+        {
+          return records_[r];
+        }
+      }
+    }
+    ADD_FAILURE() << "No matching Record within the timeout";
+    return nlohmann::json{};
+  }
+
+  static std::function<bool(const nlohmann::json&)> isEvent(const std::string& event)
+  {
+    return [event](const nlohmann::json& record) { return record.value("event", "") == event; };
+  }
+
+  static void expectValidatesAgainstSchema(const nlohmann::json& record)
+  {
+    const std::string path = ament_index_cpp::get_package_share_directory("dc_measurements") +
+                             "/plugins/measurements/json/mission_nav2.json";
+    std::ifstream schema_file(path);
+    ASSERT_TRUE(schema_file.good()) << "Schema not installed at " << path;
+    nlohmann::json_schema::json_validator validator;
+    validator.set_root_schema(nlohmann::json::parse(schema_file));
+    EXPECT_NO_THROW(validator.validate(record)) << record.dump();
+  }
+
+  static constexpr const char* kActionName = "/test/navigate_to_pose";
+  static int instance_;
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+
+  rclcpp::Node::SharedPtr server_node_;
+  rclcpp_action::Server<NavigateToPose>::SharedPtr action_server_;
+  std::shared_ptr<NavigateToPoseGoalHandle> goal_handle_;
+
+  rclcpp::Node::SharedPtr commander_node_;
+  rclcpp_action::Client<NavigateToPose>::SharedPtr commander_client_;
+  std::shared_future<rclcpp_action::ClientGoalHandle<NavigateToPose>::SharedPtr> client_goal_handle_future_;
+
+  std::vector<nlohmann::json> records_;
+  bool stopped_{ false };
+};
+
+int MeasurementMissionNav2Test::instance_ = 0;
+
+TEST_F(MeasurementMissionNav2Test, AcceptedGoalProducesAMissionStartRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+
+  const auto start = waitForRecord(isEvent("mission_start"));
+  EXPECT_EQ(start["mission_type"], "navigate_to_pose");
+  EXPECT_GT(start["sequence"].get<uint64_t>(), 0u);
+  EXPECT_FALSE(start["mission_id"].get<std::string>().empty());
+  expectValidatesAgainstSchema(start);
+}
+
+TEST_F(MeasurementMissionNav2Test, SucceededGoalProducesAMissionEndWithNoReason)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  const auto start = waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<NavigateToPose::Result>();
+  result->error_code = 0;
+  goal_handle_->succeed(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["mission_id"], start["mission_id"]);
+  EXPECT_EQ(end["mission_type"], "navigate_to_pose");
+  EXPECT_EQ(end["sequence"].get<uint64_t>(), start["sequence"].get<uint64_t>() + 1);
+  EXPECT_EQ(end["outcome"], "succeeded");
+  EXPECT_GE(end["duration_sec"].get<double>(), 0.0);
+  EXPECT_FALSE(end.contains("reason"));
+  EXPECT_FALSE(end.contains("error_code"));
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2Test, SucceededStatusWithNonZeroErrorCodeIsReportedAsFailed)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<NavigateToPose::Result>();
+  result->error_code = 9101;
+  result->error_msg = "failed to load behavior tree";
+  goal_handle_->succeed(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "failed");
+  EXPECT_EQ(end["reason"], "failed to load behavior tree");
+  EXPECT_EQ(end["error_code"].get<int>(), 9101);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2Test, CanceledGoalIsReportedAsCancelled)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+  requestCancelAndWaitForCanceling();
+
+  auto result = std::make_shared<NavigateToPose::Result>();
+  goal_handle_->canceled(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "cancelled");
+  EXPECT_FALSE(end.contains("reason"));
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2Test, AbortedGoalCarriesReasonAndErrorCode)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  auto result = std::make_shared<NavigateToPose::Result>();
+  result->error_code = 9102;
+  result->error_msg = "tf timeout";
+  goal_handle_->abort(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  EXPECT_EQ(end["outcome"], "aborted");
+  EXPECT_EQ(end["reason"], "tf timeout");
+  EXPECT_EQ(end["error_code"].get<int>(), 9102);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2Test, RecoveriesFromFeedbackAreCarriedOntoMissionEnd)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  publishFeedback(3);
+  spinFor(std::chrono::milliseconds(100));
+
+  auto result = std::make_shared<NavigateToPose::Result>();
+  goal_handle_->succeed(result);
+
+  const auto end = waitForRecord(isEvent("mission_end"));
+  ASSERT_TRUE(end.contains("recoveries"));
+  EXPECT_EQ(end["recoveries"], 3);
+  expectValidatesAgainstSchema(end);
+}
+
+TEST_F(MeasurementMissionNav2Test, MissionOpenAtShutdownGetsNoClosingRecord)
+{
+  declareCommonParameters();
+  startLifecycleNode();
+  sendGoalAndWaitForAcceptance();
+  waitForRecord(isEvent("mission_start"));
+
+  stopCollection();
+  spinFor(std::chrono::milliseconds(200));
+
+  ASSERT_EQ(records_.size(), 1u) << "Shutdown must not invent a closing Record";
+  EXPECT_EQ(records_.back()["event"], "mission_start");
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -38,6 +38,7 @@
   - [Memory](./dc/measurements/memory.md)
   - [Mission (nav2 FollowWaypoints)](./dc/measurements/mission_nav2_follow_waypoints.md)
   - [Mission Nav2 (NavigateThroughPoses)](./dc/measurements/mission_nav2_through_poses.md)
+  - [Mission Nav2 (NavigateToPose)](./dc/measurements/mission_nav2.md)
   - [Network](./dc/measurements/network.md)
   - [OS](./dc/measurements/os.md)
   - [Permissions](./dc/measurements/permissions.md)

--- a/doc/src/dc/measurements/mission_nav2.md
+++ b/doc/src/dc/measurements/mission_nav2.md
@@ -4,7 +4,8 @@
 
 The nav2 adapter of the Mission Measurement for nav2's `NavigateToPose` action -- a single-pose
 navigation goal, the base case the mission lifecycle contract (#305, recorded in
-[ADR-0010](../../adr/0010-mission-lifecycle-contract.md)) was agreed against. Emits a
+[ADR-0010](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr/0010-mission-lifecycle-contract.md))
+was agreed against. Emits a
 `mission_start` Record when a goal is accepted and a `mission_end` Record once it reaches a
 terminal state. `NavigateThroughPoses` and `FollowWaypoints` are its siblings (#388/#389): same
 Record schema, same `mission_id`/`sequence` conventions, each with its own `mission_type`.

--- a/doc/src/dc/measurements/mission_nav2.md
+++ b/doc/src/dc/measurements/mission_nav2.md
@@ -1,0 +1,125 @@
+# Mission Nav2 (NavigateToPose)
+
+## Description
+
+The nav2 adapter of the Mission Measurement for nav2's `NavigateToPose` action -- a single-pose
+navigation goal, the base case the mission lifecycle contract (#305, recorded in
+[ADR-0010](../../adr/0010-mission-lifecycle-contract.md)) was agreed against. Emits a
+`mission_start` Record when a goal is accepted and a `mission_end` Record once it reaches a
+terminal state. `NavigateThroughPoses` and `FollowWaypoints` are its siblings (#388/#389): same
+Record schema, same `mission_id`/`sequence` conventions, each with its own `mission_type`.
+
+This Measurement is a **passive watcher, not a commander**: it never sends a `NavigateToPose` goal
+itself. Whatever already dispatches navigation missions on the robot -- nav2's `bt_navigator`, a
+fleet orchestrator, an operator command -- keeps doing exactly that; this Measurement only
+observes. That is a deliberate match to every other Measurement's read-only relationship to the
+systems it reports on, and it is also why it does not use `rclcpp_action::Client`'s typed
+goal-tracking API: that API only reports on goals the client itself sent. Instead it subscribes
+directly to the action's `_action/status` (`action_msgs/msg/GoalStatusArray`, the same message
+type for every action) and `_action/feedback` topics to see a goal get accepted, pick up its
+recovery count, and reach a terminal state, and calls the action's `_action/get_result` service
+directly once it does, to fetch the Result -- all standard, public parts of the ROS 2 action wire
+protocol that any client may use, sender or not.
+
+nav2's `NavigateToPose` action server processes one goal at a time, so this Measurement only ever
+tracks one mission at once. A second goal accepted before the first reaches a terminal state is
+logged and otherwise ignored -- it produces no Record of its own, and the mission already being
+tracked is unaffected.
+
+`outcome` on the end Record is one of `succeeded`, `failed`, `cancelled`, `aborted`: `CANCELED`
+maps to `cancelled`, `ABORTED` to `aborted` (both carrying nav2's own `error_msg`/`error_code` as
+`reason`/`error_code`), and `SUCCEEDED` maps to `succeeded` unless
+`NavigateToPose::Result.error_code` is non-zero, in which case it is `failed` -- an
+application-level failure nav2 reported without aborting the goal status itself.
+
+`recoveries` (from `NavigateToPose::Feedback.number_of_recoveries`, when feedback was seen before
+completion) is carried on the end Record when available.
+
+A mission still running when collection stops simply never gets a matching `mission_end` Record:
+nothing downstream can average an interval that was never closed as a zero, because there is no
+`mission_end` Record to average. `sequence` is a monotonically increasing counter across every
+Record this Measurement instance emits (start and end alike, not per mission_id), so a dropped
+Record shows up as a gap rather than silently corrupting a duration or a mission-success-rate
+denominator.
+
+## Parameters
+
+| Parameter     | Type   | Default            | Description                        |
+| ------------- | ------ | ------------------- | ------------------------------------ |
+| `action_name` | string | `navigate_to_pose`  | The nav2 `NavigateToPose` action to watch |
+
+## Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "MissionNav2",
+  "properties": {
+    "event": { "type": "string", "enum": ["mission_start", "mission_end"] },
+    "mission_id": { "type": "string" },
+    "mission_type": { "type": "string", "const": "navigate_to_pose" },
+    "sequence": { "type": "integer", "minimum": 1 },
+    "outcome": { "type": "string", "enum": ["succeeded", "failed", "cancelled", "aborted"] },
+    "reason": { "type": "string" },
+    "error_code": { "type": "integer", "minimum": 0 },
+    "duration_sec": { "type": "number", "minimum": 0 },
+    "recoveries": { "type": "integer", "minimum": 0 }
+  },
+  "required": ["event", "mission_id", "mission_type", "sequence"],
+  "type": "object"
+}
+```
+
+`outcome` and `duration_sec` are required on `mission_end` only. `reason` and `error_code` are
+required on `mission_end` when `outcome` is `failed` or `aborted`.
+
+## Measurement configuration
+
+```yaml
+...
+mission:
+  plugin: "dc_measurements/MissionNav2"
+  topic_output: "/dc/measurement/mission"
+  group_key: "mission"
+  action_name: "navigate_to_pose"
+```
+
+Example Record data, start:
+
+```json
+{
+  "event": "mission_start",
+  "mission_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "mission_type": "navigate_to_pose",
+  "sequence": 7
+}
+```
+
+and end (succeeded):
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "mission_type": "navigate_to_pose",
+  "sequence": 8,
+  "outcome": "succeeded",
+  "duration_sec": 96.4,
+  "recoveries": 1
+}
+```
+
+and end (aborted):
+
+```json
+{
+  "event": "mission_end",
+  "mission_id": "6c9f6a3e-2d1a-4e3a-9f7a-1b2c3d4e5f60",
+  "mission_type": "navigate_to_pose",
+  "sequence": 10,
+  "outcome": "aborted",
+  "reason": "tf timeout",
+  "error_code": 9102,
+  "duration_sec": 12.1
+}
+```

--- a/docs/adr/0010-mission-lifecycle-contract.md
+++ b/docs/adr/0010-mission-lifecycle-contract.md
@@ -1,0 +1,106 @@
+# The Mission Measurement's lifecycle contract: nav2 adapter scope and Record shape
+
+ROS has no standard interface for mission or task lifecycle. Issue #305 asked two
+questions before any Mission Measurement could be written: how far a built-in nav2
+adapter should go inferring "mission" from action goal status, and what an escape-hatch
+message for stacks with their own mission executive should look like. This ADR records
+that decision so #387 (the nav2 adapter) and later adapters (Open-RMF, a mission
+executive) can implement against it without re-litigating scope.
+
+**Decision: the nav2 adapter reports exactly one `NavigateToPose` goal's lifecycle, and
+every adapter — nav2 or otherwise — emits the same `StringStamped`/JSON Record shape
+used by every other Measurement, not a new typed `dc_interfaces` message.**
+
+## Nav2 adapter scope
+
+The nav2 adapter derives `mission_start`/`mission_end` purely from one `NavigateToPose`
+goal: acceptance, terminal status, and result. It deliberately does not infer anything
+above that:
+
+- A "mission" that spans more than one nav2 goal (a multi-waypoint run coordinated by an
+  external mission executive) is out of scope — nav2 has no concept of it, so DC will
+  not guess at grouping goals into one mission.
+- A mission sourced from a stack other than nav2 (Open-RMF, VDA5050, a custom mission
+  executive) is out of scope for this adapter. `mission_id` and `mission_type` exist on
+  the Record specifically so a future adapter can supply its own values without a schema
+  change or reopening this decision.
+- `NavigateThroughPoses` and `FollowWaypoints` are separate nav2 action interfaces with
+  their own goal/feedback/result shapes; they get their own adapters, not a generalized
+  one, tracked as issues blocked by #387.
+
+## The escape-hatch: no new message, reuse the existing Record contract
+
+Every Measurement in this codebase (`battery`, `intervention`, `fault`) publishes
+`dc_interfaces::msg::StringStamped` carrying a JSON payload validated against a
+`dc_measurements` JSON Schema — there is no precedent for a typed `dc_interfaces`
+message per Measurement. The Mission Measurement does not introduce the first
+exception: a stack with its own mission executive is a new Measurement plugin (or a
+future generic "external mission" plugin) publishing the same Record shape below with
+its own `mission_id`/`mission_type`, not a new `dc_interfaces` message type.
+
+## Record shape
+
+- `event`: `"mission_start"` or `"mission_end"`, required — matching `battery`'s
+  `charge_session_start`/`_end` convention (a named episode kind), not
+  `intervention`/`fault`'s generic `start`/`end`.
+- `mission_id`: string, required on both events. The nav2 adapter synthesises it from
+  the goal UUID (`unique_identifier_msgs/UUID`, stringified). Typed as a string, not an
+  incrementing integer like `battery`'s `session_id`, so a future adapter can supply an
+  externally issued id (a WMS order number, an Open-RMF booking id) without a type
+  change.
+- `mission_type`: optional string. The nav2 adapter sets it to the nav2 action name
+  (`"navigate_to_pose"`, `"navigate_through_poses"`, `"follow_waypoints"` for sibling
+  adapters). The schema accepts any string so a non-nav2 source can supply a richer
+  value later without a schema change.
+- `sequence`: integer, monotonic, incremented per emitted Record from one Measurement
+  instance (not per `mission_id`) — gap detection, mirroring `fault`'s global counter.
+- `outcome`: required on `mission_end` only. Enum: `succeeded`, `failed`, `cancelled`,
+  `aborted`. For the nav2 adapter: `GoalStatus.ABORTED` → `aborted`,
+  `GoalStatus.CANCELED` → `cancelled`, and `failed` is driven by a documented
+  application-level condition (non-zero `NavigateToPose::Result.error_code` on an
+  otherwise-succeeded goal status) rather than being collapsed into `aborted`.
+- `reason`: string, required on `mission_end` when `outcome` is `failed` or `aborted`.
+  Free text — for the nav2 adapter, verbatim from `NavigateToPose::Result.error_msg`.
+  No DC-invented coded/structured reason table.
+- `error_code`: integer, required alongside `reason`. For the nav2 adapter, verbatim
+  from `NavigateToPose::Result.error_code`.
+- `duration_sec`: number, required on `mission_end` only.
+- `recoveries`: integer, optional on `mission_end` — for the nav2 adapter, from
+  `NavigateToPose::Feedback.number_of_recoveries` at goal completion.
+- No `update_id`/order-update field: a VDA5050-specific mid-mission-amendment concept
+  with no evidence DC needs it; adding it later is a non-breaking schema change.
+
+## A mission still running at shutdown
+
+There is no explicit "open" field on the Record. A mission still running when the
+process stops simply never gets a `mission_end` Record — nothing downstream can average
+an unclosed interval as zero-duration, because there is nothing to average. Deriving an
+"open"/still-running signal at query time (the way `dc_kpi_intervention_rate` derives
+`open_interventions`) is the concern of the mission-success-rate view deferred from
+#363, not this Record schema.
+
+## Consequences
+
+- #387 (the nav2 `NavigateToPose` adapter) and its siblings for `NavigateThroughPoses`
+  and `FollowWaypoints` implement against this Record shape and scope boundary without
+  needing further design discussion.
+- A future non-nav2 adapter (Open-RMF is the leading candidate; VDA5050 explicitly is
+  not, per #305) targets the same `mission_start`/`mission_end` contract, supplying its
+  own `mission_id`/`mission_type`, rather than requiring a new message type or a schema
+  redesign.
+- `dc_measurements/plugins/measurements/json/mission_nav2.json` (and any sibling
+  adapter's schema) validates against this shape; downstream views (#363's deferred
+  mission-success-rate panel) can rely on `outcome` and `sequence` having the same
+  meaning across every adapter that targets this contract.
+
+## Considered Options
+
+- A new typed `dc_interfaces` message for mission lifecycle events — rejected: no
+  existing Measurement publishes a typed message for structured data: introducing one
+  here would be the first exception to a load-bearing convention, for no benefit over
+  the JSON Record + schema every other Measurement already uses.
+- An adapter that groups nav2 goals into multi-goal missions itself (e.g. by proximity
+  in time) — rejected: nav2 has no concept of a multi-goal mission, so any grouping
+  heuristic DC invented would be a guess it could not honestly stand behind; the
+  `mission_id`/`mission_type` escape hatch defers that grouping to a system that
+  actually has the information.


### PR DESCRIPTION
## Summary

- Records the mission lifecycle contract #305 asked for as [ADR-0010](docs/adr/0010-mission-lifecycle-contract.md) — #305's decision content was already fully written out in #387's own issue text, but never recorded in the repository as #305's acceptance criteria require. Closes #305.
- Adds `mission_nav2` (class `MissionNav2`), the nav2 adapter of the Mission Measurement for `NavigateToPose` — the base case the sibling adapters `mission_nav2_through_poses` (#388) and `mission_nav2_follow_waypoints` (#389), both already merged, target the same Record contract against.
- A **passive watcher, not a commander**, matching #388/#389's already-established design: never sends a `NavigateToPose` goal itself. Subscribes directly to the action's `_action/status`/`_action/feedback` topics and calls `_action/get_result` for the terminal Result — the same standard, public per-action endpoints any client may use, sender or not.
- ROS-free core (`mission_nav2_tracker.hpp`, class `MissionNav2Tracker`) built on `dc_common::StateTransitionDetector<std::string>` (#360), following the pattern #389's `MissionFollowWaypointsTracker` converged on (a single active-mission-at-a-time tracker) rather than #388's earlier bespoke multi-goal map.
- New JSON Schema (`mission_nav2.json`), doc page, a ROS-free core unit test (`mission_nav2_tracker_test`), and a `MeasurementServer` integration test using a real `rclcpp_action::Server` fixture standing in for nav2 (`test_measurement_mission_nav2`).

## Dependency note

#387 was blocked by #305 per this repo's issue-tracker workflow. Since #305's substantive decision was already fully specified inline in #387's own issue text (nav2 adapter scope, Record field shape, outcome enum, shutdown handling — only "recorded in the repository" was missing), this PR includes the ADR that satisfies #305's last acceptance criterion as a same-PR prerequisite, then implements #387 against it.

Closes #387

## Test plan

- [x] `git add -A && prek run --all-files --skip build-doc` passes clean
- [ ] `colcon build --packages-select dc_common dc_measurements` — attempted locally against a cached `dc-workspace` container image; the image predates several recent dependency additions (`controller_manager_msgs`, `moveit_msgs`, `dc_core`), and a full up-to-date rebuild was infeasible in this sandbox due to sustained host memory pressure (13GB+ swapped). `dc_common` alone built and passed cleanly against the current source. New code closely mirrors the already-merged, CI-passing `mission_nav2_follow_waypoints`/`mission_nav2_through_poses` plugins field-for-field (verified against the real `NavigateToPose.action` definition from the installed Jazzy `nav2_msgs`), so I'm relying on CI for full build/test verification — same situation #388/#389's own PRs were in.
- [ ] `colcon test --packages-select dc_measurements` (new tests: `dc_measurements_mission_nav2_tracker_test`, `dc_measurements_test_measurement_mission_nav2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ9YSNzdp9HxP6j7SjEkCR