### PR TITLE
fix(doc): remove dead GitHub Pages links and stale jazzy references

### DIFF
--- a/doc/src/dc/future_work.md
+++ b/doc/src/dc/future_work.md
@@ -2,9 +2,8 @@
 
 DC still being in early development, it requires:
 1. High test coverage
-2. Automation: docker image build, PR and commit builds
-3. More Measurement plugins
-4. More blessed Destination types, promoted from the passthrough as usage justifies it
-5. Guide for the Backend developer: I would like DC to be simple enough so a web developer can run it, get the data and work on its backend application
-6. Guide for the ROS developer: I would like DC to be simple enough so a ROS developer can collect data without the expertise of knowing how to manage databases
-7. More use cases showcased in demos
+2. More Measurement plugins
+3. More blessed Destination types, promoted from the passthrough as usage justifies it
+4. Guide for the Backend developer: I would like DC to be simple enough so a web developer can run it, get the data and work on its backend application
+5. Guide for the ROS developer: I would like DC to be simple enough so a ROS developer can collect data without the expertise of knowing how to manage databases
+6. More use cases showcased in demos

--- a/doc/src/dc/introduction.md
+++ b/doc/src/dc/introduction.md
@@ -4,13 +4,11 @@
   <img height="300" src="./doc/src/images/dc.png" />
 </p>
 
-**Documentation**: [https://minipada.github.io/ros2_data_collection](https://minipada.github.io/ros2_data_collection)
-
 **Source code**: [https://github.com/minipada/ros2_data_collection](https://github.com/minipada/ros2_data_collection)
 
 [![ROS 2](https://img.shields.io/badge/ROS%202-jazzy-informational?style=for-the-badge)](https://docs.ros.org/en/jazzy/index.html) ![python](https://img.shields.io/badge/python-3.12-informational?style=for-the-badge) ![C++](https://img.shields.io/badge/C++-17-informational?style=for-the-badge)
 
-[![codecov](https://codecov.io/gh/Minipada/ros2_data_collection/branch/humble/graph/badge.svg?token=Y2UA5OE0KR)](https://codecov.io/gh/Minipada/ros2_data_collection) [![tests](https://minipada.testspace.com/spaces/219054/badge?token=8214fc76eff8c09b47136742d644d2a1ac0e38e3)](https://minipada.testspace.com/spaces/219054?utm_campaign=badge&utm_medium=referral&utm_source=test)
+[![codecov](https://codecov.io/gh/Minipada/ros2_data_collection/branch/jazzy/graph/badge.svg?token=Y2UA5OE0KR)](https://codecov.io/gh/Minipada/ros2_data_collection) [![tests](https://minipada.testspace.com/spaces/219054/badge?token=8214fc76eff8c09b47136742d644d2a1ac0e38e3)](https://minipada.testspace.com/spaces/219054?utm_campaign=badge&utm_medium=referral&utm_source=test)
 
 | Jazzy                                                                                                                                                                                                                        |
 | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -20,27 +18,9 @@
 | [![CI](https://github.com/Minipada/ros2_data_collection/actions/workflows/ci.yaml/badge.svg)](https://github.com/Minipada/ros2_data_collection/actions/workflows/ci.yaml)                                                     |
 
 
-For detailed instructions:
-
-- [Setup](https://minipada.github.io/ros2_data_collection/dc/setup.html)
-- [Migrating from DC 1.x to DC 2.0](https://minipada.github.io/ros2_data_collection/dc/migration.html)
-- [Demos](https://minipada.github.io/ros2_data_collection/dc/demos.html)
-- [Concepts](https://minipada.github.io/ros2_data_collection/dc/concepts.html)
-- [Data Pipeline](https://minipada.github.io/ros2_data_collection/dc/data_pipeline.html)
-- [Measurements](https://minipada.github.io/ros2_data_collection/dc/measurements.html)
-- [Conditions](https://minipada.github.io/ros2_data_collection/dc/conditions.html)
-- [Data validation](https://minipada.github.io/ros2_data_collection/dc/data_validation.html)
-- [Groups](https://minipada.github.io/ros2_data_collection/dc/groups.html)
-- [Destinations](https://minipada.github.io/ros2_data_collection/dc/destinations.html)
-- [Configuration examples](https://minipada.github.io/ros2_data_collection/dc/configuration_examples.html)
-- [Infrastructure setup](https://minipada.github.io/ros2_data_collection/dc/infrastructure_setup.html)
-- [CLI tools](https://minipada.github.io/ros2_data_collection/dc/cli.html)
-- [Requirements](https://minipada.github.io/ros2_data_collection/dc/requirements.html)
-- [Future work and Roadmap](https://minipada.github.io/ros2_data_collection/dc/future_work.html)
-- [Contributing](https://minipada.github.io/ros2_data_collection/dc/contributing.html)
-- [Security policy](https://github.com/Minipada/ros2_data_collection/blob/jazzy/SECURITY.md)
-- [FAQ](https://minipada.github.io/ros2_data_collection/dc/faq.html)
-- [About and contact](https://minipada.github.io/ros2_data_collection/dc/about_contact.html)
+For detailed instructions, see the navigation sidebar, or browse
+[doc/src/dc](https://github.com/Minipada/ros2_data_collection/tree/jazzy/doc/src/dc) on
+GitHub. [Security policy](https://github.com/Minipada/ros2_data_collection/blob/jazzy/SECURITY.md).
 
 ## Introduction
 


### PR DESCRIPTION
## Summary
- GitHub Pages for this repo has been taken down (gh-pages branch deleted, per `doc.yaml`), so every absolute `minipada.github.io` link in `introduction.md` (= `README.md` via symlink) 404s — including the whole "For detailed instructions" list. Replaced it with a pointer to the book's sidebar and a GitHub repo-browse link. No relative link syntax fixes this instead: mdbook copies the first chapter's rendered HTML to the site's root `index.html` without rewriting its relative links, so no single relative path resolves correctly at both that root copy and the chapter's real nested path.
- Pointed the codecov badge at `jazzy` instead of `humble` — CI already uploads coverage there under the `cpp-jazzy` flag.
- Dropped the `future_work.md` roadmap item for container-image build automation on PRs/commits: `ci.yaml` already does this with Podman.

## Test plan
- [x] Rebuilt the docs with the official toolchain (`tools/ci/pre-commit/build_doc.sh`, Podman + pinned mdbook/strictdoc) — clean build, only the 3 pre-existing harmless linkcheck warnings (unrelated `[str]`/`[int]` table cells).
- [x] Served the built site locally and curl-verified every previously-dead link now resolves (200), and confirmed no link on the root `index.html` copy points at a path that 404s.

https://claude.ai/code/session_01QFLuMgHLraGekrUyP9gbZL