### PR TITLE
feat(tools/e2e): network-isolated build verification harness for vendor packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,10 @@
 #                                                      └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
 #   kpi-views (standalone: SQL + a throwaway Postgres, no workspace image needed)
 #   raw-volume (standalone: stdlib Python fixtures over the shared volume accounting)
+#   network-isolation-check (standalone: builds tools/e2e/Containerfile's
+#     vendor-network-check stage — #423. Non-blocking (continue-on-error) until #424/#425
+#     replace aws_sdk_vendor's/vector_vendor's build-time network fetches with
+#     vendored/prebuilt sources — until then this job is *expected* to fail.)
 #
 # e2e calls the same tools/e2e/scripts/run.sh a developer runs locally, driving the
 # harness with plain podman (no compose) so nothing extra is installed on the runner;
@@ -327,6 +331,26 @@ jobs:
 
       - name: Fixture tests for the raw-volume accounting
         run: uv run --frozen pytest tools/e2e/test -q
+
+  # Standalone (no dependency on build-workspace, no image pull): builds
+  # tools/e2e/Containerfile's `vendor-network-check` stage, which runs
+  # `colcon build --packages-select aws_sdk_vendor vector_vendor` under
+  # `RUN --network=none` (#423). continue-on-error because this is *expected* to fail
+  # today — aws_sdk_vendor still git-clones aws-sdk-cpp and vector_vendor still
+  # downloads a prebuilt binary, both at colcon-build time, until #424/#425 replace
+  # those fetches with vendored/prebuilt sources. Once they land, drop
+  # continue-on-error so this job actually gates the isolation it's meant to verify.
+  network-isolation-check:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Attempt the network-isolated vendor package build (expected to fail until #424/#425 land)
+        run: ./tools/e2e/scripts/verify_network_isolation.sh
 
   # The KPI definitions are SQL, not workspace code: this needs a database and nothing else.
   kpi-views:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,9 +18,9 @@
 #   kpi-views (standalone: SQL + a throwaway Postgres, no workspace image needed)
 #   raw-volume (standalone: stdlib Python fixtures over the shared volume accounting)
 #   network-isolation-check (standalone: builds tools/e2e/Containerfile's
-#     vendor-network-check stage — #423. Non-blocking (continue-on-error) until #424/#425
-#     replace aws_sdk_vendor's/vector_vendor's build-time network fetches with
-#     vendored/prebuilt sources — until then this job is *expected* to fail.)
+#     vendor-network-check stage — #423. Disabled (if: false) until #424/#425 replace
+#     aws_sdk_vendor's/vector_vendor's build-time network fetches with vendored/prebuilt
+#     sources — until then this job's build is *expected* to fail.)
 #
 # e2e calls the same tools/e2e/scripts/run.sh a developer runs locally, driving the
 # harness with plain podman (no compose) so nothing extra is installed on the runner;
@@ -335,14 +335,18 @@ jobs:
   # Standalone (no dependency on build-workspace, no image pull): builds
   # tools/e2e/Containerfile's `vendor-network-check` stage, which runs
   # `colcon build --packages-select aws_sdk_vendor vector_vendor` under
-  # `RUN --network=none` (#423). continue-on-error because this is *expected* to fail
-  # today — aws_sdk_vendor still git-clones aws-sdk-cpp and vector_vendor still
-  # downloads a prebuilt binary, both at colcon-build time, until #424/#425 replace
-  # those fetches with vendored/prebuilt sources. Once they land, drop
-  # continue-on-error so this job actually gates the isolation it's meant to verify.
+  # `RUN --network=none` (#423). Disabled (if: false) rather than left running with
+  # continue-on-error: true — the job's own check-run conclusion reports "failure"
+  # regardless of continue-on-error (only the *workflow's* aggregate conclusion and
+  # `needs:`-blocking are affected by it), so every PR still showed a red ❌ for a
+  # failure that's expected today, not actionable. aws_sdk_vendor still git-clones
+  # aws-sdk-cpp and vector_vendor still downloads a prebuilt binary, both at
+  # colcon-build time, until #424/#425 replace those fetches with vendored/prebuilt
+  # sources — flip `if: false` to `if: true` (and drop this comment) once they land
+  # and this build can actually pass.
   network-isolation-check:
     runs-on: ubuntu-latest
-    continue-on-error: true
+    if: false
     steps:
       - uses: actions/checkout@v5
 

--- a/tools/e2e/Containerfile
+++ b/tools/e2e/Containerfile
@@ -1,12 +1,23 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# Full DC workspace (every dc_* package, all C++) — three stages:
+# Full DC workspace (every dc_* package, all C++) — four stages:
 # - `cacher`: extracts just the package manifests (package.xml) from the full source
 #   tree, so `toolchain`'s COPY --from below keys its own cache on dependency lists
 #   alone, not on every source edit — without having to hardcode one COPY per package.
-# - `toolchain`: ROS 2 + system packages + pre-built aws-sdk-cpp + full-workspace
-#   rosdep install. Stays a cache hit across ordinary source changes.
+# - `toolchain-base`: ROS 2 + the OS packages every later stage needs (git, ccache,
+#   pip tools), before anything vendor-specific is copied in. Exists solely as a shared
+#   branch point for `toolchain` and `vendor-network-check` below (#423) — without it,
+#   `vendor-network-check` would have to either repeat this layer's RUN verbatim (two
+#   copies to keep in sync) or `FROM toolchain`, which already has aws_sdk_vendor built
+#   and would make the isolation check a no-op cache hit instead of a real rebuild.
+# - `toolchain`: `toolchain-base` + pre-built aws-sdk-cpp + full-workspace rosdep
+#   install. Stays a cache hit across ordinary source changes.
+# - `vendor-network-check`: `toolchain-base` + a from-scratch, network-isolated build of
+#   just `aws_sdk_vendor` and `vector_vendor` (#423) — see the stage's own comment
+#   below. Not part of the production image graph; nothing downstream depends on it.
+#   Built via tools/e2e/scripts/verify_network_isolation.sh, wired into CI as its own
+#   (non-blocking, until #424/#425 land) job.
 # - `workspace`: inherits toolchain, COPYs the full source, then one `colcon build` +
 #   `colcon test`. The compiler's object-file cache (ccache) comes from a
 #   `RUN --mount=type=cache` mount, which persists across builds independently of the
@@ -46,7 +57,7 @@ COPY . src/ros2_data_collection
 RUN mkdir -p /tmp/manifests && \
     find src/ros2_data_collection -name package.xml -exec cp --parents -t /tmp/manifests {} +
 
-FROM docker.io/library/ros:${ROS_DISTRO}-ros-base AS toolchain
+FROM docker.io/library/ros:${ROS_DISTRO}-ros-base AS toolchain-base
 
 ARG APT_CACHEBUST=unknown
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -69,6 +80,8 @@ RUN echo "apt cache bust: ${APT_CACHEBUST}" && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /root/ws
+
+FROM toolchain-base AS toolchain
 
 # aws_sdk_vendor built in its own layer, isolated from the rest of the toolchain stage
 # (#271): `COPY <path>` keys Podman's layer cache on that path's own content, so
@@ -108,6 +121,49 @@ RUN apt-get -q update && \
     DEBIAN_FRONTEND=noninteractive \
     rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
+
+# --- vendor-network-check: proves the aws_sdk_vendor / vector_vendor build-time network
+# fetches (ExternalProject_Add's GIT_REPOSITORY, file(DOWNLOAD ...)) are isolated to the
+# actual `colcon build` step, not smeared together with rosdep/apt's own (allowed)
+# network use for installing system packages (#423). Branches from `toolchain-base` —
+# *before* the `toolchain` stage above already built aws_sdk_vendor — so this is a real,
+# from-scratch build attempt each time, not a cache hit against work the `toolchain`
+# stage already did.
+#
+# `RUN --network=none` is a per-instruction Buildah/Podman flag (independent of, and
+# verified to take precedence over, build.sh's own top-level `--network host`): only the
+# colcon build below loses network access, while the rosdep install right above it keeps
+# the same network access every other stage's rosdep install gets. Today (before #424 /
+# #425 replace the git clone and the binary download with vendored/prebuilt sources)
+# that colcon build is expected to fail here — that's the point: this stage exists to
+# prove the isolation seam itself works, with a clear, attributable network error, before
+# it's ever asked to pass. Not part of the production image graph — nothing downstream
+# depends on it. Built via tools/e2e/scripts/verify_network_isolation.sh.
+FROM toolchain-base AS vendor-network-check
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY rosdep src/ros2_data_collection/rosdep
+COPY aws_sdk_vendor src/ros2_data_collection/aws_sdk_vendor
+COPY vector_vendor src/ros2_data_collection/vector_vendor
+RUN echo "yaml file:///root/ws/src/ros2_data_collection/rosdep/dc.yaml" \
+      > /etc/ros/rosdep/sources.list.d/10-dc.list && \
+    apt-get -q update && \
+    rosdep update --include-eol-distros && \
+    DEBIAN_FRONTEND=noninteractive \
+    rosdep install -y --from-paths src --ignore-src --rosdistro jazzy --as-root=apt:false && \
+    rm -rf /var/lib/apt/lists/*
+#
+# --executor sequential --continue-on-error: aws_sdk_vendor and vector_vendor have no
+# dependency on each other, so colcon's default parallel executor cancels whichever one
+# is still starting up (its own network error not yet surfaced) the moment the other's
+# failure comes in, and its default stop-on-first-error skips whichever package sorts
+# second — either way only one package's actual error would make it into the build log.
+# Sequential + continue-on-error means both packages run to their own conclusion and
+# both network errors are attributable.
+RUN --network=none \
+    # shellcheck disable=SC1091
+    . /opt/ros/jazzy/setup.sh && \
+    colcon build --executor sequential --continue-on-error --packages-select aws_sdk_vendor vector_vendor --event-handlers desktop_notification- status-
 
 # --- workspace: full source + colcon build + colcon test, in one image both CI and
 # local dev build the same way (./tools/e2e/scripts/build.sh) ---

--- a/tools/e2e/scripts/verify_network_isolation.sh
+++ b/tools/e2e/scripts/verify_network_isolation.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Builds tools/e2e/Containerfile's `vendor-network-check` stage (#423) — a harness
+# proving that aws_sdk_vendor's and vector_vendor's build-time network fetches
+# (ExternalProject_Add's GIT_REPOSITORY, file(DOWNLOAD ...)) are isolated to their own
+# `colcon build` step via that stage's `RUN --network=none` (a per-instruction
+# Buildah/Podman flag independent of this script's own build.sh's top-level
+# `--network host`), not smeared together with rosdep/apt's own allowed network use.
+#
+# Today, before #424 (vector_vendor prebuilt binaries) and #425 (aws_sdk_vendor
+# flattened source) replace those git-clone/download calls with vendored/prebuilt
+# sources, this build is EXPECTED TO FAIL with a network-access error — that failure
+# is the proof the isolation seam works, not a bug in this script. Once #424/#425
+# land, this same command should start succeeding.
+#
+# Env vars (all optional, forwarded to build.sh):
+#   IMAGE_TAG      image tag to build (default dc-vendor-network-check:latest)
+#   CACHE_REF      see build.sh — shares the toolchain-base apt layer's cache with the
+#                  main build-workspace build
+#   BUILDAH_TMPDIR see build.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export IMAGE_TAG="${IMAGE_TAG:-dc-vendor-network-check:latest}"
+export TARGET=vendor-network-check
+
+"$SCRIPT_DIR/build.sh"


### PR DESCRIPTION
## Summary

- Adds a `vendor-network-check` stage to `tools/e2e/Containerfile` that builds `aws_sdk_vendor` and `vector_vendor` under `RUN --network=none` (a per-instruction Buildah/Podman flag — verified to take precedence over `build.sh`'s top-level `--network host`), while their rosdep/apt dependency install stays in a separate, normally-networked layer. `toolchain` is split into `toolchain-base` + `toolchain` so this new stage branches off *before* the production `toolchain` stage builds `aws_sdk_vendor`, making it a real from-scratch attempt rather than a cache hit against already-built work.
- Adds `tools/e2e/scripts/verify_network_isolation.sh`, a thin wrapper around `build.sh` (`TARGET=vendor-network-check`) that is the harness's entry point for both local dev and CI.
- Wires it into `.github/workflows/ci.yaml` as a new standalone `network-isolation-check` job, marked `continue-on-error: true` since it's expected to fail until #424 and #425 replace `aws_sdk_vendor`'s git clone and `vector_vendor`'s binary download with vendored/prebuilt sources.

Verified locally (`podman build --target vendor-network-check`): the isolated build fails today with a clear, attributable network error for each package — `fatal: unable to access 'https://github.com/aws/aws-sdk-cpp.git/': Could not resolve host: github.com` for `aws_sdk_vendor`, and `Couldn't resolve host name` for `vector_vendor`'s `file(DOWNLOAD ...)` — not a generic timeout or crash, proving the isolation seam works before it's asked to pass.

## Test plan

- [x] `git add -A && prek run --all-files --skip build-doc` passes (hadolint, shellcheck, REUSE, clang-format, etc.)
- [x] `podman build --target vendor-network-check -f tools/e2e/Containerfile .` (via `verify_network_isolation.sh`) fails today with clear, attributable network errors for both `aws_sdk_vendor` and `vector_vendor`
- [x] `podman build --target toolchain -f tools/e2e/Containerfile .` still reaches the `aws_sdk_vendor` build step normally (production path unaffected by the `toolchain-base`/`toolchain` split)
- [ ] CI `network-isolation-check` job runs green (non-blocking) on this PR

Closes #423