### PR TITLE
feat(dc_bridge): split shipper.data_dir into separate Shipper and Uploader directories

### DIFF
--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -16,7 +16,10 @@ Records referencing Files get their Files uploaded to S3-compatible object stora
 (multipart + resumable), verified, and reported as status/metadata Records under the
 `dc.files` Tag. Pending uploads are durable (#265): each is written to a disk-backed
 intent queue before being handed to the Uploader, so a Bridge restart replays whatever
-never got acked instead of forgetting it.
+never got acked instead of forgetting it. That queue and the Uploader's multipart-resume
+state live under `uploader.data_dir` (#441), a directory separate from the Shipper's own
+`shipper.data_dir` buffer — they default to the same path, so a deployment that only ever
+set `shipper.data_dir` keeps working unchanged, but each can be mounted as its own volume.
 
 `dc_bridge` is an ordinary `ament_cmake` C++ package. It builds with the same `rosdep
 install` + `colcon build` as every other `dc_*` package. See
@@ -57,7 +60,7 @@ install` + `colcon build` as every other `dc_*` package. See
   `ObjectStore` (the only Uploader piece that links the SDK, via `aws_sdk_vendor`).
   Verified against RustFS (PutObject + multipart) before adoption.
 - **`src/bridge_node.cpp` / `src/main.cpp`** — the `rclcpp` node: declares the
-  `shipper`/`destinations`/`files` parameters (ADR-0003 config contract + ADR-0005),
+  `shipper`/`uploader`/`destinations`/`files` parameters (ADR-0003 config contract + ADR-0005),
   renders and `vector validate`s the config, spawns/supervises Vector, subscribes to
   every Destination's `inputs` topics, forwards Records, runs the Uploader worker thread,
   and exposes a `~/ready` (`std_srvs/Trigger`) service. `rclcpp` handles SIGINT/SIGTERM

--- a/dc_bridge/include/dc_bridge/uploader/retention.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/retention.hpp
@@ -57,7 +57,7 @@ struct SweepResult
 };
 
 /// One retention sweep: stats the on-disk pool of Files referenced by `queue`'s pending
-/// intents (every intent still in `<data_dir>/queue/upload/` — the Uploader hasn't
+/// intents (every intent still in `<uploader.data_dir>/queue/upload/` — the Uploader hasn't
 /// finished with it, so this excludes Records whose Files already uploaded, verified, and
 /// left the queue via ack()) and, while either configured limit is exceeded, sheds the
 /// oldest eligible intent's Files — File and intent removed together, never one without

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -196,8 +196,14 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   const auto forward_port = static_cast<std::uint16_t>(vector_port);
 
   // --- shipper + destinations parameters (ADR-0003 config contract) ---
-  const std::string data_dir =
+  const std::string shipper_data_dir =
       expand_with_env(this->declare_parameter<std::string>("shipper.data_dir", "$HOME/.dc/buffer"));
+  // The Uploader's own directory (#441): the durable upload intent queue and multipart-resume
+  // state don't need to share a directory with the Shipper's disk buffer — only pulling from
+  // one parameter made them. Defaults to shipper.data_dir so a deployment that only ever set
+  // that keeps working unchanged; the two may still point at the same directory.
+  const std::string uploader_data_dir =
+      expand_with_env(this->declare_parameter<std::string>("uploader.data_dir", shipper_data_dir));
   const std::int64_t buffer_max_bytes = this->declare_parameter<std::int64_t>(
       "shipper.buffer_max_bytes", static_cast<std::int64_t>(MIN_DISK_BUFFER_BYTES));
   const std::vector<std::string> destination_names =
@@ -319,7 +325,7 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
     // worker thread's periodic sweep. Cheap: Storage is name/prefix strings plus a
     // shared_ptr<ObjectStore>.
     files_storages_ = storages;
-    uploader::UploaderConfig ucfg(data_dir + "/uploader", files_delete_when_sent);
+    uploader::UploaderConfig ucfg(uploader_data_dir + "/uploader", files_delete_when_sent);
     if (files_multipart_threshold)
     {
       ucfg.multipart_threshold_bytes =
@@ -339,15 +345,15 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
                                                      uploader::ffprobe_duration_prober(files_ffprobe),
                                                      uploader::ffmpeg_thumbnail_generator(thumbnail_binary_));
     // The durable intent queue (#265): sibling to the Uploader's own
-    // <data_dir>/uploader multipart-resume state, replayed on every startup so a Bridge
-    // restart never forgets a pending upload.
-    intent_queue_ = std::make_unique<uploader::IntentQueue>(data_dir + "/queue/upload");
+    // <uploader.data_dir>/uploader multipart-resume state, replayed on every startup so a
+    // Bridge restart never forgets a pending upload.
+    intent_queue_ = std::make_unique<uploader::IntentQueue>(uploader_data_dir + "/queue/upload");
   }
 
   RenderConfig render_config;
   render_config.forward_host = vector_host;
   render_config.forward_port = forward_port;
-  render_config.data_dir = data_dir;
+  render_config.data_dir = shipper_data_dir;
   render_config.buffer_max_bytes = static_cast<std::uint64_t>(std::max<std::int64_t>(0, buffer_max_bytes));
   render_config.destinations = records_destinations;
 

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -241,16 +241,18 @@ Files (images, maps, videos) never travel through the Shipper. A `receives: file
 Destination is served by the Bridge's Uploader, and the per-File status Records it
 produces go to whichever Destination `files.metadata_destination` names. The Uploader's
 durable upload intent queue and multipart-resume state live under `uploader.data_dir`,
-which defaults to `shipper.data_dir` — set it separately if the Shipper's buffer and the
-Uploader's state should be mounted as different volumes.
+separate from the Shipper's own disk buffer under `shipper.data_dir` — set both, as below,
+so it's obvious on disk (and later in volume mounts) which files belong to which owner.
+If `uploader.data_dir` is omitted it defaults to `shipper.data_dir`, so existing configs
+that only set the latter keep working unchanged.
 
 ```yaml
 dc_bridge:
   ros__parameters:
     shipper:
-      data_dir: "$HOME/.dc/buffer"
+      data_dir: "$HOME/.dc/shipper"
     uploader:
-      data_dir: "$HOME/.dc/buffer"            # optional; defaults to shipper.data_dir
+      data_dir: "$HOME/.dc/uploader"
     destinations: ["pgsql", "rustfs"]
     pgsql:                                    # the Records, and the File status log
       type: postgres

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -239,13 +239,18 @@ columns; it does not create tables or columns. Create the table before starting 
 
 Files (images, maps, videos) never travel through the Shipper. A `receives: files`
 Destination is served by the Bridge's Uploader, and the per-File status Records it
-produces go to whichever Destination `files.metadata_destination` names.
+produces go to whichever Destination `files.metadata_destination` names. The Uploader's
+durable upload intent queue and multipart-resume state live under `uploader.data_dir`,
+which defaults to `shipper.data_dir` — set it separately if the Shipper's buffer and the
+Uploader's state should be mounted as different volumes.
 
 ```yaml
 dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
+    uploader:
+      data_dir: "$HOME/.dc/buffer"            # optional; defaults to shipper.data_dir
     destinations: ["pgsql", "rustfs"]
     pgsql:                                    # the Records, and the File status log
       type: postgres

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -74,8 +74,9 @@ not just a local tool.
    published with the store down, the Bridge process restarted, the store then
    restored) — the camera Measurement's File goes through exactly that path every run.
 5. **Durable upload intent queue check** (#265): asserts the on-disk intent queue
-   (`dc_bridge`'s `<shipper.data_dir>/queue/upload/`, on the `dc_e2e_buffer` named
-   volume) is empty once the run stops — proof the queue actually drained rather than
+   (`dc_bridge`'s `<uploader.data_dir>/queue/upload/`, on its own `dc_e2e_uploader` named
+   volume — deliberately separate from the Shipper's `dc_e2e_buffer` volume, #441) is
+   empty once the run stops — proof the queue actually drained rather than
    silently orphaning a pending upload across the restart above (the pre-#265 in-memory
    queue would have forgotten it).
 6. **Passthrough coverage** (ADR-0003, `params/e2e_passthrough_sink.toml`): a raw Vector

--- a/tools/e2e/params/e2e_params.yaml
+++ b/tools/e2e/params/e2e_params.yaml
@@ -167,6 +167,11 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/e2e/buffer"
+    # Deliberately a different directory from shipper.data_dir (#441), on its own
+    # dc_e2e_uploader volume (see run.sh) — exercises the split rather than only ever
+    # proving the same-directory default still works.
+    uploader:
+      data_dir: "$HOME/.dc/e2e/uploader"
     destinations: ["pgsql_records", "pgsql_files", "rustfs", "raw_file"]
     pgsql_records:
       type: postgres

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -53,13 +53,19 @@ STARTUP_TIMEOUT_SECONDS="${DC_E2E_STARTUP_TIMEOUT_SECONDS:-10}"
 KEEP="${DC_E2E_KEEP:-false}"
 
 # Container + volume names. Volumes are named (not host bind-mounts) so a full stack
-# restart (podman restart / stop+start) preserves dc_bridge's on-disk buffer
-# (shipper.data_dir) and Postgres's data directory — that persistence is what makes the
-# zero-loss guarantee (ADR-0002) survive a restart, not just a live process.
+# restart (podman restart / stop+start) preserves dc_bridge's on-disk state
+# (shipper.data_dir, uploader.data_dir) and Postgres's data directory — that persistence
+# is what makes the zero-loss guarantee (ADR-0002) survive a restart, not just a live
+# process. dc_e2e_buffer and dc_e2e_uploader are deliberately separate volumes (#441):
+# params/e2e_params.yaml points shipper.data_dir and uploader.data_dir at different
+# directories, so this harness actually exercises the split — the Shipper's disk buffer
+# and the Uploader's intent queue / multipart-resume state living on genuinely different
+# mounts, the way a real deployment would split them across containers — rather than
+# only ever proving the same-directory default still works.
 PG_C=dc_e2e_postgres
 RUSTFS_C=dc_e2e_rustfs
 DC_C=dc_e2e_dc
-VOLUMES=(dc_e2e_pgdata dc_e2e_rustfs_data dc_e2e_buffer dc_e2e_data)
+VOLUMES=(dc_e2e_pgdata dc_e2e_rustfs_data dc_e2e_buffer dc_e2e_uploader dc_e2e_data)
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
@@ -160,6 +166,7 @@ log "starting the DC stack — measuring launch-to-first-Record latency"
 START_TS=$(date +%s.%N)
 podman run -d --network host --name "$DC_C" \
   -v dc_e2e_buffer:/root/.dc/e2e/buffer \
+  -v dc_e2e_uploader:/root/.dc/e2e/uploader \
   -v dc_e2e_data:/root/.dc/e2e/data \
   "$DC_IMAGE" >/dev/null
 
@@ -224,9 +231,11 @@ STATS_PID=""
 # in-memory queue would have silently forgotten anything pending across the
 # `podman restart` above) — so assert the on-disk queue is empty via the same named
 # volume dc_bridge writes it to, overriding the image's entrypoint for a one-off `find`.
+# The queue lives under uploader.data_dir (#441), not shipper.data_dir — on its own
+# dc_e2e_uploader volume here, separate from the Shipper's dc_e2e_buffer.
 log "verifying the durable upload intent queue drained (no orphaned intents after the outage+restart)"
 LEFTOVER_INTENTS=$(podman run --rm --entrypoint bash \
-  -v dc_e2e_buffer:/vol:ro "$DC_IMAGE" \
+  -v dc_e2e_uploader:/vol:ro "$DC_IMAGE" \
   -c 'find /vol/queue/upload -maxdepth 1 -name "*.json" 2>/dev/null | wc -l')
 if [ "${LEFTOVER_INTENTS:-0}" -ne 0 ]; then
   log "FAIL: ${LEFTOVER_INTENTS} orphaned upload intent(s) left in the queue after the run"


### PR DESCRIPTION
## Summary
- `shipper.data_dir` fed both the Shipper's disk buffer (rendered into Vector's config) and the Uploader's durable intent queue + multipart-resume state — one parameter tied two independent owners to the same directory for no architectural reason.
- Adds `uploader.data_dir`, used for `<uploader.data_dir>/uploader` (multipart-resume state) and `<uploader.data_dir>/queue/upload` (the durable intent queue, #265).
- Defaults to `shipper.data_dir`, so a deployment that only ever set `shipper.data_dir` keeps working unchanged; the two may still point at the same directory, or be split so each can be mounted as its own volume.

## Test plan
- [ ] `colcon test` (CI)
- [ ] Zero-loss E2E harness still reports zero loss (CI/e2e) — unaffected since `uploader.data_dir` defaults to the existing `shipper.data_dir` value in all e2e param files

Closes #441