### PR TITLE
feat(dc_bridge): bless vector as a Destination type

### DIFF
--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -76,7 +76,7 @@ dc_bridge:
       data_dir: "$HOME/.dc/buffer"
     destinations: ["pgsql"]
     pgsql:
-      type: postgres            # blessed types: postgres | s3 | file | console
+      type: postgres            # blessed types: postgres | s3 | file | console | vector
       receives: records          # records (default) | files
       inputs: ["/dc/group/robot"]
       host: "127.0.0.1"

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -10,7 +10,7 @@
 // than an opaque payload key), one `route` transform exposing the public per-Tag
 // `dc.<tag>` routes (the
 // passthrough contract — see route_output_for_tag), disk-buffer settings, and the
-// blessed sinks (postgres, s3, file, console).
+// blessed sinks (postgres, s3, file, console, vector).
 //
 // Two layers, both pure: destination_from_raw (+ the per-type from_raw builders) turns
 // the flat, stringly-typed values ROS parameters give into validated typed config (this
@@ -109,7 +109,17 @@ struct ConsoleParams
 {
 };
 
-using DestinationKind = std::variant<PostgresParams, S3Params, FileParams, ConsoleParams>;
+/// Forwards to another Shipper (typically an edge aggregator) over Vector's own native
+/// inter-instance protocol — the `vector` sink/source pair. `host`/`port` name that
+/// Shipper's `vector` source; there is no sensible default for either, unlike postgres's
+/// dev-friendly `127.0.0.1`/`5432` (#443).
+struct VectorParams
+{
+  std::string host;
+  std::uint16_t port;
+};
+
+using DestinationKind = std::variant<PostgresParams, S3Params, FileParams, ConsoleParams, VectorParams>;
 
 struct Destination
 {
@@ -210,7 +220,7 @@ struct RawDestinationParams
 {
   std::optional<std::string> time_key;
   std::optional<std::string> time_format;
-  // postgres
+  // postgres, vector
   std::optional<std::string> host;
   std::optional<std::int64_t> port;
   std::optional<std::string> user;
@@ -233,6 +243,7 @@ struct RawDestinationParams
 PostgresParams postgres_from_raw(const std::string& name, const RawDestinationParams& raw);
 S3Params s3_from_raw(const std::string& name, const RawDestinationParams& raw);
 FileParams file_from_raw(const std::string& name, const RawDestinationParams& raw);
+VectorParams vector_from_raw(const std::string& name, const RawDestinationParams& raw);
 
 /// Validates and builds one Destination from the flat parameters ROS declares for it.
 Destination destination_from_raw(const std::string& name, const std::string& type_str, const std::string& receives_str,

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -349,6 +349,12 @@ toml::table render_sink(const RenderConfig& config, const Destination& dest)
     sink.insert("encoding", json_encoding());
     sink.insert("buffer", disk_buffer(config));
   }
+  else if (const auto* vec = std::get_if<VectorParams>(&dest.kind))
+  {
+    sink.insert("type", "vector");
+    sink.insert("address", vec->host + ":" + std::to_string(vec->port));
+    sink.insert("buffer", disk_buffer(config));
+  }
   else
   {  // Console
     sink.insert("type", "console");
@@ -531,6 +537,28 @@ FileParams file_from_raw(const std::string& name, const RawDestinationParams& ra
   return FileParams{ required_field(name, raw.path, "path") };
 }
 
+VectorParams vector_from_raw(const std::string& name, const RawDestinationParams& raw)
+{
+  VectorParams vec;
+  vec.host = required_field(name, raw.host, "host");
+
+  if (!raw.port)
+  {
+    throw RenderError(RenderErrorKind::MissingField, "destination '" + name + "': missing required field `port`", name,
+                      "port");
+  }
+  std::int64_t port_raw = *raw.port;
+  if (port_raw <= 0 || port_raw > 65535)
+  {
+    throw RenderError(RenderErrorKind::InvalidPort,
+                      "destination '" + name + "': port " + std::to_string(port_raw) +
+                          " is out of range (expected 1-65535)",
+                      name, "", port_raw);
+  }
+  vec.port = static_cast<std::uint16_t>(port_raw);
+  return vec;
+}
+
 Destination destination_from_raw(const std::string& name, const std::string& type_str, const std::string& receives_str,
                                  std::vector<std::string> inputs, const RawDestinationParams& raw)
 {
@@ -599,11 +627,15 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   {
     kind = ConsoleParams{};
   }
+  else if (type_str == "vector")
+  {
+    kind = vector_from_raw(name, raw);
+  }
   else
   {
     throw RenderError(RenderErrorKind::UnsupportedType,
                       "destination '" + name + "': type '" + type_str +
-                          "' is not a blessed destination type (supported: postgres, s3, file, console)",
+                          "' is not a blessed destination type (supported: postgres, s3, file, console, vector)",
                       name, type_str);
   }
 

--- a/dc_bridge/test/fixtures/render/vector_destination.toml
+++ b/dc_bridge/test/fixtures/render/vector_destination.toml
@@ -1,0 +1,35 @@
+data_dir = "/home/dc/.dc/buffer"
+
+[acknowledgements]
+enabled = true
+
+[sinks.to_aggregator]
+address = "dc-e2e-limits-agg:6000"
+inputs = ["dc.dc.group.robot"]
+type = "vector"
+
+[sinks.to_aggregator.buffer]
+max_size = 268435488
+type = "disk"
+
+[sources.dc_bridge_in]
+address = "127.0.0.1:24224"
+type = "fluent"
+
+[transforms.dc]
+inputs = ["dc_bridge_normalize"]
+reroute_unmatched = false
+type = "route"
+
+[transforms.dc.route."dc.group.robot"]
+source = '.tag == "dc.group.robot"'
+type = "vrl"
+
+[transforms.dc_bridge_normalize]
+inputs = ["dc_bridge_in"]
+source = """
+if includes(["dc.group.robot"], .tag) {
+  .date = to_float(to_unix_timestamp!(.timestamp, unit: "nanoseconds")) / 1000000000.0
+}
+"""
+type = "remap"

--- a/dc_bridge/test/fixtures/render/vector_destination.toml
+++ b/dc_bridge/test/fixtures/render/vector_destination.toml
@@ -1,30 +1,58 @@
+# This is the Vector config `dc_bridge` generates for a single `type: vector` Destination
+# named `to_aggregator` with `host: "dc-e2e-limits-agg"`, `port: 6000` and
+# `inputs: ["/dc/group/robot"]`. It's the gold file VectorDestinationForwardsToAggregator
+# in render_test.cpp compares against — kept commented as a worked example of what one
+# blessed Destination expands into; every DC-rendered config also has this same source,
+# transforms.dc and transforms.dc_bridge_normalize shape, whatever sinks are configured.
+
+# The Shipper's disk-buffer directory (`shipper.data_dir`), shared by every sink below.
 data_dir = "/home/dc/.dc/buffer"
 
+# Global delivery acknowledgements, always on: the Bridge's Forwarder expects every frame
+# it sends to be acked, so Records aren't dropped between the Bridge and this Shipper.
 [acknowledgements]
 enabled = true
 
+# The sink for the `to_aggregator` Destination. `type = "vector"` is Vector's own
+# inter-instance protocol — this Shipper connects OUT to another Shipper (the edge
+# aggregator) rather than to a database or object store directly.
 [sinks.to_aggregator]
+# host:port of the downstream Shipper's own `vector`-type *source*, from the
+# Destination's `host`/`port` parameters. Unlike `postgres`, there's no default here.
 address = "dc-e2e-limits-agg:6000"
+# The internal `dc.<tag>` routes this sink consumes — one per Tag in the Destination's
+# `inputs`, produced by the `transforms.dc` route below.
 inputs = ["dc.dc.group.robot"]
 type = "vector"
 
+# Every blessed sink gets the same on-disk buffer, so a downstream outage (the aggregator
+# unreachable) doesn't drop Records — they queue here until delivery succeeds.
 [sinks.to_aggregator.buffer]
 max_size = 268435488
 type = "disk"
 
+# Where Records enter this Shipper: the local shipper ingest protocol socket the Bridge
+# (dc_bridge) forwards to, fixed regardless of which Destinations are configured.
 [sources.dc_bridge_in]
 address = "127.0.0.1:24224"
 type = "fluent"
 
+# The `route` transform: fans normalized Records out to each Destination's sink by Tag.
 [transforms.dc]
 inputs = ["dc_bridge_normalize"]
 reroute_unmatched = false
 type = "route"
 
+# One branch per Tag reaching a Destination. `/dc/group/robot`'s Tag is `dc.group.robot`;
+# a Record matching this VRL predicate flows out on the `dc.dc.group.robot` route that
+# `sinks.to_aggregator.inputs` above consumes.
 [transforms.dc.route."dc.group.robot"]
 source = '.tag == "dc.group.robot"'
 type = "vrl"
 
+# The `remap` transform: writes each Destination's normalized timestamp field before
+# routing. `vector` gets no special normalization beyond this — no column mapping to do,
+# since the downstream Shipper's own sink (whatever it is) sees the same JSON payload.
 [transforms.dc_bridge_normalize]
 inputs = ["dc_bridge_in"]
 source = """

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -49,6 +49,11 @@ PostgresParams postgres_kind()
   return PostgresParams{ "127.0.0.1", 5432, "dc", "hunter2", "dc", "dc" };
 }
 
+VectorParams vector_kind()
+{
+  return VectorParams{ "dc-e2e-limits-agg", 6000 };
+}
+
 RenderConfig config_with(std::vector<Destination> dests)
 {
   RenderConfig c;
@@ -127,6 +132,16 @@ TEST(Render, FileAndConsoleDestinations)
       make_destination("debug_console", { "/dc/group/robot" }, TimeFormat::Double, ConsoleParams{}),
   });
   assert_matches_fixture(render(config), "file_and_console.toml");
+}
+
+// #443: `vector` forwards to another Shipper (typically an edge aggregator) over
+// Vector's own native inter-instance protocol — `address` is `host:port`, and it gets
+// the same disk buffer as every other blessed sink.
+TEST(Render, VectorDestinationForwardsToAggregator)
+{
+  auto config =
+      config_with({ make_destination("to_aggregator", { "/dc/group/robot" }, TimeFormat::Double, vector_kind()) });
+  assert_matches_fixture(render(config), "vector_destination.toml");
 }
 
 // #291: `incident_id` is a first-class column, not a key buried in the payload. Vector's
@@ -371,6 +386,12 @@ TEST(Render, DestinationFromRawBuildsS3FileConsole)
 
   auto console = destination_from_raw("debug_console", "console", "records", { "/dc/group/robot" }, {});
   EXPECT_TRUE(std::holds_alternative<ConsoleParams>(console.kind));
+
+  RawDestinationParams vecraw;
+  vecraw.host = "dc-e2e-limits-agg";
+  vecraw.port = 6000;
+  auto vec = destination_from_raw("to_aggregator", "vector", "records", { "/dc/group/robot" }, vecraw);
+  EXPECT_TRUE(std::holds_alternative<VectorParams>(vec.kind));
 }
 
 TEST(Render, DestinationFromRawRejectsFilesOnNonObjectStorage)
@@ -612,6 +633,65 @@ TEST(Render, PostgresFromRawAppliesDefaults)
   auto pg = postgres_from_raw("pgsql", raw);
   EXPECT_EQ(pg.host, "127.0.0.1");
   EXPECT_EQ(pg.port, 5432);
+}
+
+TEST(Render, VectorFromRawRejectsMissingHost)
+{
+  RawDestinationParams raw;
+  raw.port = 6000;
+  try
+  {
+    vector_from_raw("to_aggregator", raw);
+    FAIL();
+  }
+  catch (const RenderError& e)
+  {
+    EXPECT_EQ(e.kind(), RenderErrorKind::MissingField);
+    EXPECT_EQ(e.arg1(), "host");
+  }
+}
+
+TEST(Render, VectorFromRawRejectsMissingPort)
+{
+  RawDestinationParams raw;
+  raw.host = "dc-e2e-limits-agg";
+  try
+  {
+    vector_from_raw("to_aggregator", raw);
+    FAIL();
+  }
+  catch (const RenderError& e)
+  {
+    EXPECT_EQ(e.kind(), RenderErrorKind::MissingField);
+    EXPECT_EQ(e.arg1(), "port");
+  }
+}
+
+TEST(Render, VectorFromRawRejectsOutOfRangePort)
+{
+  RawDestinationParams raw;
+  raw.host = "dc-e2e-limits-agg";
+  raw.port = 70000;
+  try
+  {
+    vector_from_raw("to_aggregator", raw);
+    FAIL();
+  }
+  catch (const RenderError& e)
+  {
+    EXPECT_EQ(e.kind(), RenderErrorKind::InvalidPort);
+    EXPECT_EQ(e.number(), 70000);
+  }
+}
+
+TEST(Render, VectorFromRawBuildsAddress)
+{
+  RawDestinationParams raw;
+  raw.host = "dc-e2e-limits-agg";
+  raw.port = 6000;
+  auto vec = vector_from_raw("to_aggregator", raw);
+  EXPECT_EQ(vec.host, "dc-e2e-limits-agg");
+  EXPECT_EQ(vec.port, 6000);
 }
 
 // #308: the default is the exact integer format, not the lossy float one. A Destination

--- a/dc_demos/params/mcap_recording.yaml
+++ b/dc_demos/params/mcap_recording.yaml
@@ -26,7 +26,7 @@ dc_bridge:
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 
-# MCAP is not a blessed Destination type (only postgres, s3, file and console are —
+# MCAP is not a blessed Destination type (only postgres, s3, file, console and vector are —
 # see doc/src/dc/destinations.md) and Vector has no MCAP sink at all, so recording goes
 # through the ADR-0003/ADR-0009 passthrough — but configured here like any other
 # Destination: dc_bringup.launch.py reads this block, starts the standalone

--- a/doc/src/dc/cli.md
+++ b/doc/src/dc/cli.md
@@ -23,6 +23,6 @@ ros2 run dc_cli list_plugins --help
 
 ```admonish info
 There is no `destinations` command. Destinations are not pluginlib plugins in DC 2.0
-(ADR-0003): the four blessed types are listed in [Destinations](./destinations.md), and
+(ADR-0003): the blessed types are listed in [Destinations](./destinations.md), and
 everything else is reached through the passthrough.
 ```

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -16,7 +16,7 @@ DC has a small, fixed vocabulary. Using it precisely makes the rest of the docum
 | **Group**                 | A merge of Records from several Measurements into one Record, based on time proximity.                        |
 | **File**                  | A binary artifact produced by a Measurement (image, video, map), uploaded to object storage as-is; only its metadata travels as a Record. |
 | **Destination**           | An external system that receives Records or Files (PostgreSQL, S3-compatible storage, console…).              |
-| **Blessed Destination**   | A Destination DC configures natively from ROS parameters: `postgres`, `s3`, `file`, `console`.                |
+| **Blessed Destination**   | A Destination DC configures natively from ROS parameters: `postgres`, `s3`, `file`, `console`, `vector`.       |
 | **Passthrough Destination** | A Destination configured by handing raw Shipper configuration through DC, unlocking the Shipper's full catalog without DC code. |
 | **Bridge**                | The DC component (`dc_bridge`) that receives Records from ROS topics and hands them to the Shipper.           |
 | **Shipper**               | The external process (Vector by default) that buffers, transforms, and reliably delivers Records to Destinations. |

--- a/doc/src/dc/demos/elasticsearch.md
+++ b/doc/src/dc/demos/elasticsearch.md
@@ -1,7 +1,7 @@
 # Elasticsearch (passthrough)
 
-`dc_bridge` blesses exactly four Destination types — `postgres`, `s3`, `file`, `console`
-(see [Destinations](../destinations.md)) — and Elasticsearch is not one of them. This
+`dc_bridge` blesses exactly five Destination types — `postgres`, `s3`, `file`, `console`,
+`vector` (see [Destinations](../destinations.md)) — and Elasticsearch is not one of them. This
 tutorial is the worked example for reaching everything else: the ADR-0003 **passthrough**,
 a raw [Vector](https://vector.dev) config snippet loaded through `custom_config_files`
 that consumes the same public `dc.<tag>` routes a blessed Destination consumes. Nothing in

--- a/doc/src/dc/demos/mcap_recording.md
+++ b/doc/src/dc/demos/mcap_recording.md
@@ -1,7 +1,7 @@
 # MCAP recording (passthrough)
 
-`dc_bridge` blesses exactly four Destination types — `postgres`, `s3`, `file`, `console`
-(see [Destinations](../destinations.md)) — and MCAP is not one of them; Vector, the
+`dc_bridge` blesses exactly five Destination types — `postgres`, `s3`, `file`, `console`,
+`vector` (see [Destinations](../destinations.md)) — and MCAP is not one of them; Vector, the
 Shipper, has no MCAP sink at all. This tutorial is the worked example for #210: the
 ADR-0003 **passthrough** plus a small standalone process, `dc_mcap_writer`
 (ADR-0009, [`docs/adr/`](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr)),
@@ -115,9 +115,9 @@ what's specific to how MCAP recording is wired up.
 
 `dc_demos/params/mcap_recording.yaml`'s `dc_mcap_writer:` block is **not** nested
 inside `dc_bridge`'s `destinations` list, and can't be made to look exactly like
-`postgres`/`s3`/`file`/`console` there: `destinations` is parsed and validated by
+`postgres`/`s3`/`file`/`console`/`vector` there: `destinations` is parsed and validated by
 `dc_bridge` itself, in C++, and an unrecognized `type` is a hard startup error by
-design (see [Destinations](../destinations.md)) — teaching it a fifth type would mean
+design (see [Destinations](../destinations.md)) — teaching it a sixth type would mean
 changing `dc_bridge`, which ADR-0009 explicitly decided against (Vector's own
 at-least-once/disk-buffered guarantees already cover what would have justified that).
 So it's a sibling top-level block instead, structurally shaped like a Destination

--- a/doc/src/dc/demos/tb3_aws_influxdb.md
+++ b/doc/src/dc/demos/tb3_aws_influxdb.md
@@ -1,7 +1,7 @@
 # Turtlebot3 AWS Warehouse InfluxDB
 
-`dc_bridge` blesses exactly four Destination types — `postgres`, `s3`, `file`, `console`
-(see [Destinations](../destinations.md)) — and InfluxDB is not one of them. This demo is
+`dc_bridge` blesses exactly five Destination types — `postgres`, `s3`, `file`, `console`,
+`vector` (see [Destinations](../destinations.md)) — and InfluxDB is not one of them. This demo is
 not a peer of the [PostgreSQL/RustFS demos](./tb3_aws_minio_pgsql.md): it exists to show
 how to reach a destination `dc_bridge` doesn't bless directly, via the ADR-0003
 **passthrough** escape hatch — a raw [Vector](https://vector.dev) sink config loaded

--- a/doc/src/dc/demos/uptime_stdout.md
+++ b/doc/src/dc/demos/uptime_stdout.md
@@ -118,7 +118,7 @@ Let's analyze piece by piece. `dc_bridge` is the single C++ node that owns every
 
 **destinations (Mandatory)**: List all the Destinations to enable. Each name must have a matching section at the same level.
 
-**console.type (Mandatory)**: One of the four blessed Destination types (`postgres`, `s3`, `file`, `console`). `console` prints JSON to `dc_bridge`'s own stdout — handy for demos and debugging.
+**console.type (Mandatory)**: One of the blessed Destination types (`postgres`, `s3`, `file`, `console`, `vector`). `console` prints JSON to `dc_bridge`'s own stdout — handy for demos and debugging.
 
 **console.receives (Optional)**: `records` (default) or `files`.
 

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -5,9 +5,10 @@ architecture (ADR-0003,
 [`docs/adr/`](https://github.com/minipada/ros2_data_collection/tree/jazzy/docs/adr)), the
 pluginlib destination-plugin layer is retired. The Bridge (`dc_bridge`) renders the
 external Vector **Shipper's** configuration from plain ROS parameters for a **blessed
-set** of Destination types — `postgres`, `s3`, `file`, `console` — and every other
-destination in Vector's sink catalog is available through the **passthrough**: raw Vector
-config snippets listed in the `custom_config_files` parameter, merged natively by Vector.
+set** of Destination types — `postgres`, `s3`, `file`, `console`, `vector` — and every
+other destination in Vector's sink catalog is available through the **passthrough**: raw
+Vector config snippets listed in the `custom_config_files` parameter, merged natively by
+Vector.
 
 Coming from DC 1.x and its `flb_*` destination plugins? See the
 [migration guide](./migration.md).
@@ -82,6 +83,21 @@ upstream in 2026 and no longer receives maintenance — but existing MinIO or Ce
 deployments work identically: set `endpoint`, explicit credentials, and (typically)
 `force_path_style: true`.
 
+The `vector` type forwards to another Shipper over Vector's own native inter-instance
+protocol (`type = "vector"` sink → `type = "vector"` source) — the standard way to chain
+a robot's local Shipper to an edge aggregator's Shipper in a fleet deployment. `host` and
+`port` name the downstream Shipper; unlike `postgres`, there is no default for either,
+since there's no sensible address to assume for another Shipper.
+
+```yaml
+    to_aggregator:
+      type: vector
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      host: "edge-aggregator.local"
+      port: 6000
+```
+
 Common parameters for every blessed type: `type`, `receives` (`records` | `files`, see
 the File uploads section below), `inputs` (ROS topic names), `time_key` (default
 `date`) and `time_format` (default `epoch_nanos`) controlling the normalized timestamp
@@ -140,6 +156,7 @@ Type-specific parameters:
 | `s3`       | `bucket`                                    | `region`, `endpoint`, `key_prefix`, `access_key_id` + `secret_access_key` (together), `force_path_style`, `batch_timeout_secs` |
 | `file`     | `path` (Vector template syntax allowed)     |                                                                                                                    |
 | `console`  |                                             |                                                                                                                    |
+| `vector`   | `host`, `port`                              |                                                                                                                    |
 
 Invalid parameters (unknown `type`, missing required field, half a credential pair, an
 out-of-range port…) are rejected with a clear error at Bridge startup — before Vector

--- a/doc/src/dc/faq.md
+++ b/doc/src/dc/faq.md
@@ -9,7 +9,7 @@ Create a feature request in [Github Discussions](https://github.com/Minipada/ros
 
 ## I can't find the Destination I need
 
-You do not need one to exist. The four **blessed** Destination types are the ones DC
+You do not need one to exist. The **blessed** Destination types are the ones DC
 configures natively from ROS parameters; everything else in Vector's catalog works today
 through the [passthrough](./destinations.md#passthrough-custom_config_files) — see the
 question below.
@@ -23,7 +23,8 @@ DC 1.x Destination to its DC 2.0 equivalent with before/after configuration.
 
 The Bridge (`dc_bridge`) renders its Shipper's (Vector) config from plain ROS
 parameters for a **blessed set** of Destination types only (PostgreSQL,
-S3-compatible storage, file, console — see [Destinations](./destinations.md)). Every
+S3-compatible storage, file, console, another Vector Shipper — see
+[Destinations](./destinations.md)). Every
 other sink in [Vector's catalog](https://vector.dev/docs/reference/configuration/sinks/)
 (Kafka, Kinesis, InfluxDB, webhooks, …) is reachable through the **passthrough**: list a
 raw Vector config snippet (TOML) in the `custom_config_files` parameter, and consume the

--- a/doc/src/dc/migration.md
+++ b/doc/src/dc/migration.md
@@ -25,7 +25,7 @@ same. Everything below is about the **delivery** half.
 | `destination_server` node                             | `dc_bridge` node                                                               |
 | `destination_plugins: [...]`                          | `destinations: [...]`                                                          |
 | `plugin: "dc_destinations/FlbPgSQL"`                  | `type: postgres`                                                               |
-| 13 pluginlib destination plugins                      | 4 **blessed** types (`postgres`, `s3`, `file`, `console`) + **passthrough**    |
+| 13 pluginlib destination plugins                      | 5 **blessed** types (`postgres`, `s3`, `file`, `console`, `vector`) + **passthrough** |
 | Embedded Fluent Bit (forked, built from source)       | External Vector binary, vendored by `vector_vendor`, supervised by the Bridge  |
 | `flb.*` service parameters                            | `shipper.data_dir` / `shipper.buffer_max_bytes` (Vector's own defaults for the rest) |
 | `tags: [...]` on Measurements/Groups selects outputs  | A Destination's `inputs: [...]` topic list selects what it receives            |

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -16,7 +16,7 @@ dc_bridge:
       data_dir: "$HOME/.dc/buffer"
     destinations: ["raw_console"]
     raw_console:
-      type: console          # any blessed type works: postgres | s3 | file | console
+      type: console          # any blessed type works: postgres | s3 | file | console | vector
       receives: records
       time_key: "date"
     raw:

--- a/tools/infrastructure/docker/docker-compose.elasticsearch.yaml
+++ b/tools/infrastructure/docker/docker-compose.elasticsearch.yaml
@@ -3,7 +3,7 @@
 
 # Elasticsearch + Kibana, the store behind the passthrough Destination tutorial
 # (doc/src/dc/demos/elasticsearch.md). Elasticsearch is NOT a blessed Destination type —
-# dc_bridge blesses postgres/s3/file/console only (ADR-0003) — so nothing in dc_bridge
+# dc_bridge blesses postgres/s3/file/console/vector only (ADR-0003) — so nothing in dc_bridge
 # talks to this stack directly; a raw Vector `elasticsearch` sink loaded through
 # `custom_config_files` consumes the public `dc.<tag>` routes instead.
 #


### PR DESCRIPTION
## Summary

- Blesses `vector` as a Destination `type` alongside `postgres`, `s3`, `file` and `console` (ADR-0003), so a robot's edge-aggregator hop is validated ROS-param config instead of hand-written passthrough TOML that DC never parses.
- `vector_from_raw` requires `host` and `port` (no defaults — unlike `postgres`'s dev-friendly `127.0.0.1`/`5432`, there's no sensible address to assume for another Shipper) and validates the port range 1-65535, reusing the same `RawDestinationParams::host`/`port` fields `postgres` already declares — no new ROS param plumbing needed in `bridge_node.cpp`.
- `render_sink` emits `type = "vector"`, `address = "<host>:<port>"`, and the same disk buffer every other blessed sink gets — the identical shape already proven end-to-end by `tools/e2e/params/e2e_limits_forward_sink.toml`'s hand-written passthrough sink (verified against the pinned Vector build; see that file's header), now generated and validated by `dc_bridge` itself instead of hand-written TOML.
- Passthrough (`custom_config_files`) is untouched for every other sink type.
- Updates `doc/src/dc/destinations.md` (type table + example) and every other doc page that enumerated the blessed set as exactly four types.

## Test plan

- [x] `prek run --all-files --skip build-doc` passes (clang-format, REUSE, yaml/toml lint, etc.)
- [x] New `dc_bridge` render-test coverage (`render_test.cpp`), matching the existing pattern for `postgres`/`s3`/`file`:
  - `VectorDestinationForwardsToAggregator` — gold-file render test (`test/fixtures/render/vector_destination.toml`)
  - `VectorFromRawRejectsMissingHost` / `RejectsMissingPort` / `RejectsOutOfRangePort` / `BuildsAddress`
  - `DestinationFromRawBuildsS3FileConsole` extended to cover `vector`
- [ ] `colcon test --packages-select dc_bridge` — not run locally (this sandbox has no ROS 2 install and no network access to fetch `vector_vendor`/`aws_sdk_vendor` for a from-scratch workspace build); CI's `build-workspace` job covers this.

Closes #443