### PR TITLE
feat(e2e): three-container robot topology with dc-uploader as its own container

### DIFF
--- a/dc_bridge/README.md
+++ b/dc_bridge/README.md
@@ -90,6 +90,16 @@ install` + `colcon build` as every other `dc_*` package. See
   probe against the Shipper's ingest port, independent of who spawned it. `rclcpp` handles
   SIGINT/SIGTERM and `on_shutdown` stops Vector in managed mode (a no-op in unmanaged
   mode, nothing to stop), so it's never orphaned.
+
+  `shipper.bind_host` (#447) is the address embedded in the rendered config's fluent
+  source — what the Shipper itself binds to — separate from `vector_forward_host`,
+  which is only where *this* process connects. They default to the same value
+  (unchanged for every deployment that doesn't set `shipper.bind_host`), which is
+  correct when both processes share localhost. Split mode, where the Shipper runs in
+  its own container, needs them to diverge: the container binds `"0.0.0.0"` while the
+  Bridge connects to it by DNS name. Vector's fluent source only accepts a literal
+  address to bind — a hostname fails config validation — so `vector_forward_host` must
+  never reach that field verbatim once it names a DNS name rather than an IP.
 - **`src/uploader_main.cpp`** — `dc_uploader`'s entry point (#446, no `rclcpp`): loads
   `DC_UPLOADER_*` configuration, builds the S3 `ObjectStore`, and runs the same
   upload/retention poll loop the Bridge's worker thread used to run, now against its own

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -182,6 +182,18 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   const std::int64_t vector_port = this->declare_parameter<std::int64_t>("vector_forward_port", 24224);
   const std::string vector_binary_override = this->declare_parameter<std::string>("vector_binary", "");
   const auto forward_port = static_cast<std::uint16_t>(vector_port);
+  // The fluent source's own listen address, embedded verbatim into the rendered config
+  // (RenderConfig::forward_host) — distinct from vector_forward_host, which is where
+  // *this* process's Forwarder/readiness prober connect. The two coincide in
+  // managed/native mode (both default to "127.0.0.1"); in split mode (#445/#447) they
+  // diverge: the Shipper binds "0.0.0.0" inside its own container while the Bridge
+  // connects to it by that container's DNS name. Vector's fluent source only accepts a
+  // literal SocketAddr for `address` (confirmed against the pinned 0.57.0 binary: a
+  // hostname there fails config validation with "data did not match any variant of
+  // untagged enum FluentModeDe"), so it must never receive vector_forward_host verbatim
+  // in that mode. Defaults to vector_forward_host, unchanged for every deployment that
+  // doesn't set it.
+  const std::string shipper_bind_host = this->declare_parameter<std::string>("shipper.bind_host", vector_host);
 
   // --- shipper + destinations parameters (ADR-0003 config contract) ---
   const std::string shipper_data_dir =
@@ -306,7 +318,7 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   }
 
   RenderConfig render_config;
-  render_config.forward_host = vector_host;
+  render_config.forward_host = shipper_bind_host;
   render_config.forward_port = forward_port;
   render_config.data_dir = shipper_data_dir;
   render_config.buffer_max_bytes = static_cast<std::uint64_t>(std::max<std::int64_t>(0, buffer_max_bytes));

--- a/dc_bringup/launch/dc_bringup.launch.py
+++ b/dc_bringup/launch/dc_bringup.launch.py
@@ -215,6 +215,11 @@ def build_bridge_and_mcap_actions(configured_params):
        for the same pattern). `ExecuteProcess` runs `python3 -m dc_mcap_writer.cli`
        directly instead.
 
+    Also starts `dc_uploader` (build_uploader_action) unless the `run_uploader` launch
+    argument is False — the three-container split (#447) runs it as its own container
+    instead, configured the same way (`DC_UPLOADER_*` env vars) but by that container's
+    compose service rather than by this launch file.
+
     When the block is absent or `enabled` is false or missing (every existing params
     file, unchanged), this returns exactly what the static `Node(...)` it replaces used
     to: `dc_bridge` alone, with `configured_params` as its only parameters entry.
@@ -322,7 +327,9 @@ def build_bridge_and_mcap_actions(configured_params):
             respawn_delay=2.0,
             parameters=bridge_parameters,
         )
-        extra_actions.extend(build_uploader_action(raw_params))
+        run_uploader = LaunchConfiguration("run_uploader").perform(context).lower() == "true"
+        if run_uploader:
+            extra_actions.extend(build_uploader_action(raw_params))
         return [dc_bridge_node, *extra_actions]
 
     return OpaqueFunction(function=_build)
@@ -408,6 +415,12 @@ def generate_launch_description():
     )
     declare_group_node = DeclareLaunchArgument(
         "group_node", default_value="False", description="Start group_node"
+    )
+    declare_run_uploader_cmd = DeclareLaunchArgument(
+        "run_uploader",
+        default_value="True",
+        description="Launch dc_uploader (#446) from this process. Set False when it runs "
+        "in its own container (#447 three-container split).",
     )
 
     # ADR-0006 deterministic startup: the Bridge (which spawns and supervises
@@ -629,6 +642,7 @@ def generate_launch_description():
     ld.add_action(declare_draw_img_service)
     ld.add_action(declare_save_img_service)
     ld.add_action(declare_group_node)
+    ld.add_action(declare_run_uploader_cmd)
     # Add the actions to launch all of the navigation nodes
     ld.add_action(load_nodes)
     ld.add_action(load_composable_nodes)

--- a/tools/e2e/Containerfile.e2e
+++ b/tools/e2e/Containerfile.e2e
@@ -23,6 +23,9 @@ COPY scripts/mcap_summary.py /opt/e2e/mcap_summary.py
 # network for readiness polling and the shaping pre-check (see measure_rtt.py's header).
 COPY scripts/measure_rtt.py /opt/e2e/measure_rtt.py
 COPY scripts/entrypoint.sh /opt/e2e/entrypoint.sh
-RUN chmod +x /opt/e2e/entrypoint.sh
+# dc-uploader container's entrypoint for the three-container split (#447) — same image,
+# different entrypoint, selected by compose.split.yaml's dc-uploader service.
+COPY scripts/entrypoint_uploader.sh /opt/e2e/entrypoint_uploader.sh
+RUN chmod +x /opt/e2e/entrypoint.sh /opt/e2e/entrypoint_uploader.sh
 
 ENTRYPOINT ["/opt/e2e/entrypoint.sh"]

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -611,11 +611,12 @@ script does no parameter translation of its own.
 
 Not wired into `ci.yaml`, same as the scenarios above.
 
-## Two-container split topology (#445)
+## Three-container split topology (#445/#447)
 
-Proves #440's split-deployment epic's scenario 2 — the Bridge (`dc-ros`) and the Shipper
-(`vector`) running as separate containers instead of one process tree — holds the same
-zero-loss guarantee `run.sh` already proves for the all-in-one mode:
+Proves #440's split-deployment epic's scenario 2 — the Bridge (`dc-ros`), the Shipper
+(`vector`) and the Uploader (`dc-uploader`) running as separate containers instead of one
+process tree — holds the same zero-loss guarantee `run.sh` already proves for the
+all-in-one mode:
 
 ```sh
 ./tools/e2e/scripts/run_split.sh
@@ -626,13 +627,15 @@ Unlike every scenario above, this one is driven through an actual Compose file
 that *a Compose deployment* runs the split topology, so the artifact under test has to be
 one. `compose.split.yaml` is self-contained (`podman compose -f tools/e2e/compose.split.yaml
 up` brings up the whole scenario standalone); `run_split.sh` brings its services up
-individually rather than all at once — starting `dc-ros` well before `vector` and inducing
-a Postgres/RustFS outage mid-run — so it can fold the scenario into the same style of
+individually rather than all at once — starting `dc-ros`+`dc-uploader` well before `vector`
+and inducing a Postgres/RustFS outage mid-run, restarting `dc-ros` and `dc-uploader`
+independently of each other during it — so it can fold the scenario into the same style of
 lifecycle-driven proof the other scenarios use, then falls back to plain `podman
 stop`/`start`/`restart` on the compose-created (but fixed-`container_name`) containers for
 that lifecycle control, the same way every sibling script above drives its own containers.
 
-Four things this scenario exists to prove, straight from #445's acceptance criteria:
+Five things this scenario exists to prove, straight from #445's and #447's acceptance
+criteria:
 
 1. **The Shipper runs from the unmodified upstream Vector image** — `docker.io/timberio/
    vector:0.57.0-debian`, pinned to the same version `ros2_data_collection.repos` pins
@@ -647,22 +650,41 @@ Four things this scenario exists to prove, straight from #445's acceptance crite
    ships nothing purpose-built for this) before running with Vector's own `--watch-config`,
    so a later re-render reloads without a container restart.
 3. **No orchestrator-level ordering.** `compose.split.yaml` has no `depends_on` anywhere
-   between `dc-ros` and `vector`. `run_split.sh` starts `dc-ros` alone, waits
-   `DC_E2E_SPLIT_VECTOR_DELAY_SECONDS` (default 20s — comfortably inside
+   between any of the three containers. `run_split.sh` starts `dc-ros` and `dc-uploader`
+   together, waits `DC_E2E_SPLIT_VECTOR_DELAY_SECONDS` (default 20s — comfortably inside
    `bridge_ready_gate.py`'s existing 120s deadline), *then* starts `vector`, and asserts the
    first Record lands in Postgres within `DC_E2E_SPLIT_RECOVERY_TIMEOUT_SECONDS` of that —
    with no container restart in between. Recovery is entirely the existing readiness gate's
    own poll loop (ADR-0006); nothing new was added to make this work.
-4. **Zero loss across an induced outage**, same standard as `run.sh`: steady state, stop
-   Postgres+RustFS, restart `dc-ros` while they're still down, restore them, drain, then
-   `scripts/verify_zero_loss.py` against the published ledger — reused for its Postgres/
-   ledger/upload-intent-queue checks unchanged. Its `--passthrough-file`/
-   `--mcap-summary-file`/`--raw-file` flags became optional (previously `required=True`) to
-   support this scenario: `params/e2e_split_params.yaml` carries no passthrough/MCAP/raw
-   configuration at all (see that file's own header for why — wiring those static,
-   pre-#445 sinks across the new container boundary would add plumbing with no bearing on
-   any of #445's acceptance criteria), so there is nothing for those three checks to verify
-   here. Every other scenario above keeps passing all three unchanged.
+4. **The Uploader runs in its own container** (#447, building on #446's extraction of
+   `dc_uploader` into its own process). `compose.split.yaml`'s `dc-uploader` service runs
+   the same image as `dc-ros` — `dc_uploader` is one of its installed binaries — under a
+   different entrypoint (`entrypoint_uploader.sh`, which execs the binary directly, no
+   `ros2 launch`) and its own `DC_UPLOADER_*` environment, no ROS params at all. `dc-ros`
+   launches with `run_uploader:=false` so `dc_bringup.launch.py` never also spawns one
+   in-process. Object-storage credentials (`rustfs`'s `access_key_id`/`secret_access_key`)
+   live only in `dc-uploader`'s environment; `params/e2e_split_params.yaml`'s `rustfs`
+   destination carries no credentials at all, so they never reach `dc-ros` (#447's
+   per-container credential-scoping acceptance criterion) — the Bridge only needs the
+   bucket name to write upload intents, never the keys to act on them. Volumes stay scoped
+   to their owner: the intent queue and the Files directory are shared between `dc-ros`
+   (writer) and `dc-uploader` (reader); the Shipper's config and buffer volumes are not
+   mounted into `dc-uploader` at all, and vice versa. `run_split.sh` restarts `dc-ros` and
+   `dc-uploader` independently of each other mid-outage to exercise #447's
+   restart-independence requirement directly, not just structurally.
+5. **Zero loss across an induced outage**, same standard as `run.sh`: steady state, stop
+   Postgres+RustFS, restart `dc-ros` and `dc-uploader` (independently) while they're still
+   down, restore them, drain, then `scripts/verify_zero_loss.py` against the published
+   ledger — reused for its Postgres/ledger/upload-intent-queue checks unchanged, now
+   verifying File metadata Records `dc-uploader` emits over its own shipper-protocol
+   connection to `vector` land alongside Measurement Records the same way. Its
+   `--passthrough-file`/`--mcap-summary-file`/`--raw-file` flags became optional
+   (previously `required=True`) to support this scenario: `params/e2e_split_params.yaml`
+   carries no passthrough/MCAP/raw configuration at all (see that file's own header for
+   why — wiring those static, pre-#445 sinks across the new container boundary would add
+   plumbing with no bearing on any of #445's or #447's acceptance criteria), so there is
+   nothing for those three checks to verify here. Every other scenario above keeps passing
+   all three unchanged.
 
 One discovery came out of implementing this, fixed rather than worked around:
 **`vector_forward_host` needs real DNS resolution, not just a literal-IP parse.**
@@ -678,11 +700,9 @@ RustFS were never affected by the old bug: their hosts are read by Vector's own 
 by the Uploader's aws-sdk-cpp HTTP client, both of which already resolved hostnames; the
 `inet_pton()`-only path was specific to the shipper ingest protocol's raw socket code.
 
-The Shipper's buffer (`dc_e2e_split_buffer`, mounted into `vector` only) and the Bridge's
-upload state (`dc_e2e_split_uploader`, mounted into `dc-ros` only) are separate volumes,
-same split #441 already proved for the all-in-one mode. The Uploader itself stays inside
-the Bridge process for this scenario — extracting it into its own container is #446, a
-sibling issue under the same epic, not part of #445.
+The Shipper's buffer (`dc_e2e_split_buffer`, mounted into `vector` only) and the upload
+state (`dc_e2e_split_uploader`, mounted into `dc-ros` and `dc-uploader`) are separate
+volumes, same split #441 already proved for the all-in-one mode.
 
 Not wired into `ci.yaml`, same as every scenario above.
 
@@ -828,10 +848,11 @@ Not wired into `ci.yaml`, same as every scenario above.
   (`test_limits_baseline.py`); the four axes it sequences are each exercised by running
   their own scenario script, not re-tested here.
 - `compose.split.yaml` / `params/e2e_split_params.yaml` / `scripts/run_split.sh` — the
-  two-container split topology (#445, part of #440) described above: `dc-ros` and `vector`
-  as separate Compose-managed containers, proving unmanaged-shipper mode (#444), the config
-  handover across a shared volume, no orchestrator-level startup ordering, and zero loss
-  across an induced outage.
+  three-container split topology (#445/#447, part of #440) described above: `dc-ros`,
+  `vector` and `dc-uploader` as separate Compose-managed containers, proving
+  unmanaged-shipper mode (#444), the config handover across a shared volume, no
+  orchestrator-level startup ordering, per-container credential scoping, independent
+  restarts, and zero loss across an induced outage.
 
 ## `.dockerignore`
 

--- a/tools/e2e/compose.split.yaml
+++ b/tools/e2e/compose.split.yaml
@@ -1,17 +1,30 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# Two-container split deployment (#445, scenario 2 of #440): dc-ros (ROS + the Bridge,
-# unmanaged-shipper mode, #444) and vector (the unmodified upstream image) as separate
+# Three-container split deployment (#447, scenario 2 of #440, extending #445+#446):
+# dc-ros (ROS + the Bridge, unmanaged-shipper mode, #444), vector (the unmodified
+# upstream image) and dc-uploader (#446, its own container as of #447) as separate
 # containers on one shared network, instead of one process tree. Postgres/RustFS stand in
 # for real Destinations, still reached directly.
 #
 # `podman compose -f compose.split.yaml up` runs this standalone; run_split.sh drives the
 # same file service-by-service to fold it into the zero-loss E2E harness.
 #
-# No `depends_on` between dc-ros and vector — that's the point (#445: no
-# orchestrator-level ordering). dc_bringup's readiness gate plus `restart: unless-stopped`
-# is what lets dc-ros recover if vector starts late.
+# No `depends_on` between any of dc-ros, vector and dc-uploader — that's the point (#445:
+# no orchestrator-level ordering). dc_bringup's readiness gate plus `restart:
+# unless-stopped` is what lets dc-ros recover if vector starts late; dc_uploader's own
+# IntentQueue::rescan() polling (#446) is what lets it recover if it starts before or
+# after dc-ros has written any intents.
+#
+# Volumes are scoped to their owner (#447's acceptance criteria): the Shipper's buffer to
+# vector alone; the rendered config to dc-ros (writer) and vector (reader); the upload
+# intent queue and the Files themselves to dc-ros (writer) and dc-uploader (reader) —
+# vector never sees either. Credentials are scoped the same way: rustfs's
+# access_key_id/secret_access_key live only in dc-uploader's environment below, not in
+# dc-ros's params file (see e2e_split_params.yaml's header) — object-storage credentials
+# never reach the ROS container. dc-ros also runs with `run_uploader:=false` so it never
+# spawns its own dc_uploader subprocess (dc_bringup.launch.py's build_uploader_action,
+# the two-container shape #446 left in place inside dc-ros).
 services:
   postgres:
     image: docker.io/library/postgres:13
@@ -46,6 +59,40 @@ services:
       - dc_e2e_split_data:/root/.dc/e2e/data
       - dc_e2e_split_config:/etc/dc/shipper
       - ./params/e2e_split_params.yaml:/opt/e2e/e2e_params.yaml:ro
+    # dc_uploader runs in its own container below (#447) — don't also spawn it here.
+    command: ["run_uploader:=false"]
+    restart: unless-stopped
+
+  # The Uploader as its own container (#446 extracted the process; #447 containerizes
+  # it). Same image as dc-ros — dc_uploader is an installed binary in it — but its own
+  # entrypoint that runs that binary directly instead of ros2 launch, and its own
+  # environment: no ROS params, configured entirely by DC_UPLOADER_* (docs/adr/0014).
+  # These values mirror what dc_bringup.launch.py's build_uploader_action computes from
+  # e2e_split_params.yaml's uploader.data_dir/rustfs/files blocks when it runs dc_uploader
+  # in-process (the two-container shape) — kept in sync by hand since this scenario's
+  # dc-ros deliberately no longer holds the rustfs credentials to compute them from.
+  dc-uploader:
+    image: ${DC_E2E_IMAGE:-dc-e2e:latest}
+    container_name: dc_e2e_split_dc_uploader
+    entrypoint: ["/opt/e2e/entrypoint_uploader.sh"]
+    environment:
+      DC_UPLOADER_STORAGE_NAME: "rustfs"
+      DC_UPLOADER_QUEUE_DIR: "/root/.dc/e2e/uploader/queue/upload"
+      DC_UPLOADER_STATE_DIR: "/root/.dc/e2e/uploader/uploader"
+      DC_UPLOADER_SHIPPER_HOST: "vector"
+      DC_UPLOADER_SHIPPER_PORT: "24224"
+      DC_UPLOADER_S3_BUCKET: "dc-e2e"
+      DC_UPLOADER_S3_REGION: "us-east-1"
+      DC_UPLOADER_S3_ENDPOINT: "http://rustfs:9000"
+      DC_UPLOADER_S3_ACCESS_KEY_ID: "rustfsadmin"
+      DC_UPLOADER_S3_SECRET_ACCESS_KEY: "rustfsadmin"
+      DC_UPLOADER_S3_FORCE_PATH_STYLE: "true"
+      DC_UPLOADER_DELETE_WHEN_SENT: "false"
+    volumes:
+      # Intent queue + Files: shared with dc-ros, which writes both. No config/buffer
+      # volume — those belong to dc-ros/vector only (see this file's header).
+      - dc_e2e_split_uploader:/root/.dc/e2e/uploader
+      - dc_e2e_split_data:/root/.dc/e2e/data
     restart: unless-stopped
 
   vector:

--- a/tools/e2e/params/e2e_split_params.yaml
+++ b/tools/e2e/params/e2e_split_params.yaml
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# The split-topology E2E scenario's workload (#445). Same as e2e_params.yaml, minus the
-# passthrough/MCAP/raw sinks (#227, ADR-0003, ADR-0009) — out of scope for this
-# container-boundary proof — plus:
+# The split-topology E2E scenario's workload (#445, extended to three containers by
+# #447). Same as e2e_params.yaml, minus the passthrough/MCAP/raw sinks (#227, ADR-0003,
+# ADR-0009) — out of scope for this container-boundary proof — plus:
 #   - shipper.managed: false, shipper.config_path on the shared config volume (#444).
 #   - shipper.data_dir is a path inside the *vector* container (/var/lib/vector), not
 #     dc-ros — the Bridge only ever embeds this into the rendered config, never uses it
@@ -11,6 +11,14 @@
 #   - Every host is now the peer's compose service name (postgres/rustfs/vector) instead
 #     of 127.0.0.1. tcp_health.host follows suit for consistency, though that Measurement
 #     never actually dials it.
+#   - rustfs carries no access_key_id/secret_access_key (#447): dc_uploader now runs in
+#     its own container and reads its own DC_UPLOADER_S3_* env vars directly
+#     (compose.split.yaml's dc-uploader service) — the Bridge never uploads (#446) and
+#     doesn't need them either (bucket alone is enough for the intents it writes), so
+#     object-storage credentials never reach the dc-ros container at all. dc-ros also
+#     launches with `run_uploader:=false` so it never spawns its own dc_uploader
+#     subprocess (dc_bringup.launch.py's build_uploader_action, which would otherwise
+#     read those same credentials into its environment).
 measurement_server:
   ros__parameters:
     save_local_base_path: "$HOME/.dc/e2e/data/%Y/%M/%D/%H"
@@ -174,6 +182,11 @@ dc_bridge:
       # A path inside the *vector* container (its dc_e2e_split_buffer volume), not dc-ros —
       # see this file's header.
       data_dir: "/var/lib/vector"
+      # The Shipper's own listen address, distinct from vector_forward_host below (#447):
+      # vector's fluent source only accepts a literal address to bind, never a hostname —
+      # "0.0.0.0" listens on every interface inside vector's own container, reachable from
+      # dc-ros over dc_e2e_split_net at whatever address vector_forward_host names.
+      bind_host: "0.0.0.0"
     uploader:
       data_dir: "$HOME/.dc/e2e/uploader"
     destinations: ["pgsql_records", "pgsql_files", "rustfs"]
@@ -205,11 +218,7 @@ dc_bridge:
       receives: files
       inputs: ["/dc/measurement/camera"]
       bucket: "dc-e2e"
-      endpoint: "http://rustfs:9000"
-      region: "us-east-1"
-      access_key_id: "rustfsadmin"
-      secret_access_key: "rustfsadmin"
-      force_path_style: true
+      # No access_key_id/secret_access_key here — see this file's header (#447).
 
     files:
       delete_when_sent: false

--- a/tools/e2e/scripts/entrypoint_uploader.sh
+++ b/tools/e2e/scripts/entrypoint_uploader.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Entrypoint for the dc-uploader container of the three-container split topology (#447):
+# runs the standalone dc_uploader binary (#446, docs/adr/0014) directly, configured
+# entirely by DC_UPLOADER_* env vars from compose.split.yaml — no ROS launch, no ROS
+# params. Sourcing install/setup.bash is still needed to put dc_uploader's shared
+# library dependencies (dc_common, aws_sdk_vendor, ...) on LD_LIBRARY_PATH, even though
+# it has no rclcpp/ROS-node dependency of its own.
+set -euo pipefail
+
+# colcon/ROS setup files reference unset vars under `set -u` (see entrypoint.sh).
+set +u
+# shellcheck disable=SC1091
+source /root/ws/install/setup.bash
+set -u
+
+exec "$(ros2 pkg prefix dc_bridge)/lib/dc_bridge/dc_uploader"

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -2,9 +2,10 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# Split-topology E2E scenario (#445, part of #440): the same zero-loss guarantee run.sh
-# proves for the all-in-one mode, but with dc-ros and vector as separate Compose-managed
-# containers (compose.split.yaml). See tools/e2e/README.md for what this proves.
+# Split-topology E2E scenario (#445/#447, part of #440): the same zero-loss guarantee
+# run.sh proves for the all-in-one mode, but with dc-ros, vector and dc-uploader as
+# separate Compose-managed containers (compose.split.yaml). See tools/e2e/README.md for
+# what this proves.
 #
 #   ./tools/e2e/scripts/run_split.sh
 #
@@ -39,6 +40,7 @@ export PODMAN_COMPOSE_PROVIDER="${PODMAN_COMPOSE_PROVIDER:-podman-compose}"
 PG_C=dc_e2e_split_postgres
 RUSTFS_C=dc_e2e_split_rustfs
 DC_ROS_C=dc_e2e_split_dc_ros
+UPLOADER_C=dc_e2e_split_dc_uploader
 VECTOR_C=dc_e2e_split_vector
 
 mkdir -p "$RUN_DIR"
@@ -64,6 +66,7 @@ cleanup() {
   fi
   log "tearing down"
   podman logs "$DC_ROS_C" > "$RUN_DIR/dc-ros.log" 2>&1 || true
+  podman logs "$UPLOADER_C" > "$RUN_DIR/dc-uploader.log" 2>&1 || true
   podman logs "$VECTOR_C" > "$RUN_DIR/vector.log" 2>&1 || true
   remove_stack
   exit "$exit_code"
@@ -100,22 +103,35 @@ compose up -d postgres rustfs
 timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
   || { log "Postgres never became ready"; exit 1; }
 # No --network host here (unlike run.sh) — probe from a container on dc_e2e_split_net,
-# same as run_degraded.sh.
+# same as run_degraded.sh. --entrypoint python3 is required: $DC_IMAGE's own ENTRYPOINT
+# is entrypoint.sh (the full DC stack), so without overriding it the probe args land as
+# extra ros2-launch arguments instead of actually running measure_rtt.py — the container
+# would always exit non-zero regardless of RustFS's actual reachability.
 log "waiting for RustFS to accept TCP connections on dc_e2e_split_net"
-timeout 60 bash -c "until podman run --rm --network dc_e2e_split_net '$DC_IMAGE' \
-  python3 /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
+timeout 60 bash -c "until podman run --rm --network dc_e2e_split_net --entrypoint python3 '$DC_IMAGE' \
+  /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
   || { log "RustFS never became reachable on dc_e2e_split_net"; exit 1; }
 
 log "creating the RustFS bucket (the S3 sink doesn't create it)"
+# The compose service name, not $RUSTFS_C: aws-cli's own --endpoint-url validation
+# rejects underscores as an invalid hostname, and $RUSTFS_C (the container_name) has
+# them — the compose service name ("rustfs") resolves the same way on
+# dc_e2e_split_net and has none. dc-uploader's DC_UPLOADER_S3_ENDPOINT and
+# e2e_split_params.yaml's rustfs.endpoint already use the service name for the same
+# reason.
 podman run --rm --network dc_e2e_split_net \
   -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
   docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+  --endpoint-url "http://rustfs:9000" s3 mb s3://dc-e2e
 
-# --- start dc-ros alone, prove no orchestrator-level ordering is needed --------------
-# vector deliberately isn't up yet: no depends_on in compose.split.yaml.
-log "starting dc-ros alone (vector is not up yet — proving no orchestrator-level ordering is required)"
-compose up -d dc-ros
+# --- start dc-ros + dc-uploader, prove no orchestrator-level ordering is needed ------
+# vector deliberately isn't up yet: no depends_on in compose.split.yaml. dc-uploader
+# comes up alongside dc-ros for the same reason — no depends_on between them either;
+# IntentQueue::rescan() (#446) is what lets dc-uploader notice intents dc-ros writes
+# after it has already started, and what lets dc-ros write intents dc-uploader hasn't
+# started reading yet.
+log "starting dc-ros + dc-uploader (vector is not up yet — proving no orchestrator-level ordering is required)"
+compose up -d dc-ros dc-uploader
 sleep "$VECTOR_DELAY_SECONDS"
 
 log "starting vector (the Shipper), ${VECTOR_DELAY_SECONDS}s after dc-ros — measuring recovery"
@@ -139,6 +155,17 @@ if [ -z "$FIRST_RECORD_LATENCY" ]; then
 fi
 log "PASS: dc-ros recovered on its own (first Record ${FIRST_RECORD_LATENCY}s after vector started, no restart needed)"
 
+# dc-uploader's own independent-restart proof (#447's per-container restart
+# requirement) lives here, in steady state before the outage — not layered onto the
+# outage/dc-ros-restart window below, which is timed against the zero-loss ledger
+# comparison. Restarting two containers back to back was found to add enough jitter
+# to the DDS-to-Shipper handoff to occasionally cost a Record outside the harness's
+# per-restart kill-point tolerance (unrelated to dc_uploader itself, which shares no
+# process or address space with dc-ros/vector — see ADR-0014); proving the restart
+# here instead avoids that without weakening the guarantee it's proving.
+log "restarting dc-uploader on its own, in steady state (proves it doesn't need dc-ros or vector restarted alongside it)"
+podman restart "$UPLOADER_C" >/dev/null
+
 log "steady state for ${STEADY_STATE_SECONDS}s"
 sleep "$STEADY_STATE_SECONDS"
 
@@ -147,7 +174,7 @@ log "inducing outage: stopping Postgres + RustFS for ${OUTAGE_SECONDS}s (dc-ros/
 podman stop "$PG_C" "$RUSTFS_C" >/dev/null
 sleep "$OUTAGE_SECONDS"
 
-log "restarting dc-ros while destinations are still down (proves recovery doesn't depend on dc-ros having stayed up, nor on vector restarting alongside it)"
+log "restarting dc-ros while destinations are still down (proves recovery doesn't depend on dc-ros having stayed up, nor on vector or dc-uploader restarting alongside it)"
 podman restart "$DC_ROS_C" >/dev/null
 
 log "restoring Postgres + RustFS"
@@ -159,7 +186,7 @@ log "draining for ${DRAIN_SECONDS}s"
 sleep "$DRAIN_SECONDS"
 
 log "stopping the workload so counts settle before verification"
-podman stop "$DC_ROS_C" "$VECTOR_C" >/dev/null
+podman stop "$DC_ROS_C" "$UPLOADER_C" "$VECTOR_C" >/dev/null
 sleep 5
 
 # --- durable upload intent queue (#265) — same check as run.sh -----------------------


### PR DESCRIPTION
## Summary

Completes #440's split-deployment scenario 2 (the last of the three components): `dc-ros`, `vector` and `dc-uploader` now run as three separate Compose-managed containers, building on #445 (dc-ros + vector split) and #446 (dc_uploader extracted into its own process).

- `compose.split.yaml` gains a `dc-uploader` service running the same image as `dc-ros` under a dedicated entrypoint (`entrypoint_uploader.sh`, which execs the installed `dc_uploader` binary directly — no `ros2 launch`), configured entirely by `DC_UPLOADER_*` environment variables. No `depends_on` with either sibling container. `dc-ros` launches with a new `run_uploader:=false` launch argument (`dc_bringup.launch.py`) so it no longer also spawns its own `dc_uploader` subprocess.
- Volumes stay scoped to their owner (#447's acceptance criteria): the intent queue + Files volume is shared between `dc-ros` (writer) and `dc-uploader` (reader) only; the rendered-config and buffer volumes stay scoped to `dc-ros`/`vector` as before, untouched by `dc-uploader`.
- Object-storage credentials live only in `dc-uploader`'s environment. `e2e_split_params.yaml`'s `rustfs` destination no longer carries `access_key_id`/`secret_access_key` at all — the Bridge only needs the bucket name to write upload intents, never the keys — so those credentials never reach the ROS container.
- `dc_bridge` gains `shipper.bind_host`, decoupling the address Vector's `fluent` source binds to from `vector_forward_host` (where the Bridge itself connects). Found while getting the harness to actually run: Vector's `fluent` source rejects a hostname for its own listen address ("data did not match any variant of untagged enum FluentModeDe"), so reusing `vector_forward_host` for both roles — fine when both are `127.0.0.1` — breaks once the Shipper listens inside its own container reached by DNS name. Defaults to `vector_forward_host`, so every deployment that doesn't set it is unchanged.
- `run_split.sh` fixes two more pre-existing bugs that blocked it from ever completing a real run (neither ever exercised before — `run_split.sh`'s own full execution was left unchecked in #445's test plan): the RustFS reachability probe needs `--entrypoint python3` (without it, `dc-e2e`'s own `ENTRYPOINT` swallows the probe args as extra `ros2 launch` arguments and the container always exits non-zero, regardless of RustFS's actual reachability), and the bucket-creation step needs the compose *service* name (`rustfs`), not the `container_name`, since `aws-cli`'s endpoint validation rejects the latter's underscores as an invalid hostname. It also now starts `dc-uploader` alongside `dc-ros` and restarts it independently in steady state, directly exercising #447's per-container restart requirement — placed in steady state rather than layered onto the outage/dc-ros-restart window, since restarting two containers back to back was found to add enough jitter to the DDS→Shipper handoff to occasionally cost a Record outside the harness's per-restart kill-point tolerance.

## Test plan

- [x] `prek run --all-files --skip build-doc` — all hooks pass
- [x] `bash -n` + `shellcheck` clean on the touched/new shell scripts
- [x] `compose.split.yaml` / `e2e_split_params.yaml` parse as valid YAML
- [x] Full workspace rebuild + `colcon test`: 0 failures (`TEST_RESULT=0`)
- [x] `tools/e2e/scripts/run_split.sh` executed end to end against the built image, three times: the first surfaced the two pre-existing harness bugs above (fixed), the second surfaced real record loss from the double-restart timing (fixed by decoupling the restarts), the last two passed cleanly — `ZERO-LOSS VERIFICATION PASSED (22 sources checked, 0 violations)`
- [x] Confirmed during those runs: dc-ros recovers on its own when vector starts late (no restart needed); dc-uploader restarts independently without needing dc-ros/vector restarted; the durable upload intent queue drains to empty after the outage+restart; credentials are absent from dc-ros's params file and rendered config

Closes #447