### PR TITLE
docs(adr): ADRs and CONTEXT.md for the split deployment

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -71,12 +71,24 @@ The DC component that receives Records from ROS topics and hands them to the Shi
 The external process (Vector by default) that buffers, transforms, and reliably delivers Records to Destinations.
 _Avoid_: forwarder, agent, data plane, backend
 
+**Shipper buffer**:
+The Shipper's own on-disk buffer, where it holds Records it has already accepted but not yet delivered to a Destination, so a Shipper restart or an unreachable Destination doesn't lose Records the Bridge already handed off.
+_Avoid_: queue (reserved for the upload intent queue, below — a separate store with a different owner)
+
 **Shipper ingest protocol**:
-The wire format on the local socket between the Bridge and the Shipper (default port 24224). It is Fluentd's open "Forward" specification — chosen as the cheapest Shipper-native listener with built-in receipt acknowledgement (ADR-0002) — but **no Fluentd or Fluent Bit software runs anywhere in DC 2.0**: the Bridge implements the sender side itself (~170 lines of msgpack). Say "shipper ingest protocol"; the word "fluent" should only appear in the generated Shipper config (`type = "fluent"`) and interop docs.
-_Avoid_: "Fluent Forward" as a component name — it is a message format, not software in the pipeline
+The wire format between the Bridge and the Shipper (default port 24224) — a socket that is local to one machine in native and single-machine container deployments, and crosses a container or host boundary in a split deployment. It is Fluentd's open "Forward" specification — chosen as the cheapest Shipper-native listener with built-in receipt acknowledgement (ADR-0002) — but **no Fluentd or Fluent Bit software runs anywhere in DC 2.0**: the Bridge implements the sender side itself (~170 lines of msgpack). Say "shipper ingest protocol"; the word "fluent" should only appear in the generated Shipper config (`type = "fluent"`) and interop docs.
+_Avoid_: "Fluent Forward" as a component name — it is a message format, not software in the pipeline; "local socket" — true only of some deployments, not the protocol itself
 
 **File**:
 A binary artifact produced by a Measurement (image, video, map) that is uploaded to object storage as-is; only its metadata travels as a Record.
+
+**Uploader**:
+The process that reads the upload intent queue, uploads Files to object storage, verifies they landed, and emits the resulting metadata Record. Runs independently of the Bridge, so a failed or crashed upload never stops Record collection.
+_Avoid_: Bridge (the Bridge only receives Files and writes upload intents; it does not upload them)
+
+**Upload intent queue**:
+The durable on-disk record of Files the Uploader still owes a Destination, written by the Bridge when it receives a File and consumed by the Uploader. It is what lets an interrupted or restarted Uploader resume every upload it owes, without the Bridge and the Uploader needing to run in the same process — or agree on anything beyond this queue.
+_Avoid_: buffer (reserved for the Shipper buffer, above — a separate store with a different owner)
 
 **Tag**:
 A label carried by a Record naming a Destination that must receive it.
@@ -86,9 +98,12 @@ _Avoid_: route (a "route" is the Shipper-side path a Tag selects)
 
 - A **Measurement** emits **Records**, optionally gated by one or more **Conditions**
 - A **Group** merges Records from several **Measurements** into one **Record**
-- The **Bridge** forwards every **Record** to the **Shipper**
-- The **Shipper** delivers Records to one or more **Destinations**
-- A **File** is uploaded to an object-storage **Destination**; its metadata becomes a **Record**
+- The **Bridge** forwards every **Record** to the **Shipper** over the **shipper ingest
+  protocol**
+- The **Shipper** holds undelivered Records in its **Shipper buffer** and delivers them to
+  one or more **Destinations**
+- A **File** is uploaded to an object-storage **Destination** by the **Uploader**, via the
+  **upload intent queue**; its metadata becomes a **Record**
 - A **Record** carries **Tags**; each Tag names a **Destination**
 - A **Trigger** fires a **FlushEvent**; every Measurement listening for it releases its
   buffered **Records** and **Files** as one **Incident**

--- a/docs/adr/0001-external-shipper-replaces-embedded-fluent-bit.md
+++ b/docs/adr/0001-external-shipper-replaces-embedded-fluent-bit.md
@@ -1,6 +1,6 @@
 # External shipper process replaces embedded Fluent Bit
 
-The Humble-era design embedded a forked Fluent Bit 2.1.3 as an in-process library, which forced us to maintain `fluent_bit_vendor` (source build of a patched fork), a custom C input plugin (`in_ros2`), and cgo-built Go output plugins — the dominant cause of install pain. For the Jazzy rewrite, the shipper runs as an **external process on localhost**, supervised by DC's bringup, fed by a thin Bridge over the shipper ingest protocol. Install becomes "drop one prebuilt binary"; the fork, the vendor package, and the Go toolchain are deleted.
+The Humble-era design embedded a forked Fluent Bit 2.1.3 as an in-process library, which forced us to maintain `fluent_bit_vendor` (source build of a patched fork), a custom C input plugin (`in_ros2`), and cgo-built Go output plugins — the dominant cause of install pain. For the Jazzy rewrite, the shipper runs as an **external process**, fed by a thin Bridge over the shipper ingest protocol. Install becomes "drop one prebuilt binary"; the fork, the vendor package, and the Go toolchain are deleted.
 
 ## Considered Options
 
@@ -9,5 +9,19 @@ The Humble-era design embedded a forked Fluent Bit 2.1.3 as an in-process librar
 
 ## Consequences
 
-- One extra supervised process at runtime; negligible localhost hop for JSON-sized Records.
+- One extra process at runtime alongside the Bridge; negligible hop for JSON-sized Records.
 - The Forward-protocol boundary makes the shipper swappable (Vector and Fluent Bit both consume it).
+
+## Amendment (#440/#444): supervision is no longer always "localhost, by DC's bringup"
+
+This ADR originally read "the shipper runs as an external process on localhost, supervised
+by DC's bringup" without qualification. That is still the default (**managed mode**), but
+it is no longer the only supported shape: in **unmanaged mode** (#444) the Bridge renders
+the Shipper's config and connects over the shipper ingest protocol exactly as before, but
+does not locate a binary, spawn it, or supervise it — an orchestrator does, and the Shipper
+may run in its own container, possibly on a different host from the Bridge. See
+[ADR-0015](./0015-split-deployment-topology.md) for why the decomposition stops at the
+Shipper (and the Uploader) rather than extending further, and
+[ADR-0014](./0014-uploader-runs-as-its-own-process.md) for the Uploader's own extraction
+out of the Bridge process. Nothing about the shipper ingest protocol itself changes between
+the two modes; only who starts and watches the Shipper does.

--- a/docs/adr/0015-split-deployment-topology.md
+++ b/docs/adr/0015-split-deployment-topology.md
@@ -1,0 +1,60 @@
+# Split deployment topology: the Shipper and the Uploader as separable processes
+
+ADR-0001 put the Shipper on localhost, supervised by DC's bringup, because that was
+correct for one robot and did not need to be anything else at the time. Epic #440 asks DC
+to run as a fleet: robots with no internet access, forwarding through an edge Vector
+aggregator, needing per-component restarts, resource limits, and credentials that a single
+process tree cannot give. This ADR records where the decomposition line goes and why it
+stops there.
+
+## Decision
+
+The robot decomposes into three processes — the ROS stack (with the Bridge), the Shipper,
+and the Uploader — and no further. Whether those three run as one process tree (ADR-0001's
+original native mode), three containers on one machine (#447), or spread across robot,
+edge, and hub tiers (#440's target architecture) is a deployment-time choice, not a code
+change: the Bridge's unmanaged-shipper mode (#444) and the Uploader's extraction into its
+own process (ADR-0014) are what let the same binaries run in every shape.
+
+**Why the decomposition stops at the Shipper and the Uploader, and does not extend to ROS
+nodes.** DDS is the wrong protocol to run over anything but a robot's own local network —
+it assumes multicast discovery and low-latency links that neither an edge tunnel nor a
+security-conscious deployment can offer (epic #440's user stories 21/22: DDS stays on the
+robot, no inbound connection reaches it). The Shipper and the Uploader are the two
+components that already speak something else — the shipper ingest protocol and a plain
+object-storage API, respectively — so they are the only components that can cross a
+process, container, or host boundary without inventing a new transport for the purpose.
+Every ROS node, including the Bridge, stays together in one container on one machine per
+robot.
+
+## Rejected alternative: routing File bytes through the Shipper or a database
+
+Considered and rejected: instead of the Uploader talking to object storage directly, put
+File bytes on the same path as Records — base64 them into a Record field, or write them
+into a database column. Rejected because:
+
+- Base64 inflates payload size by roughly a third, for images and videos that are already
+  the largest artifacts DC moves.
+- Multi-megabyte Records force the Shipper's buffer, and any relational Destination's row
+  storage (PostgreSQL TOAST), to handle a size class neither is designed for — at the cost
+  of every other Record sharing that same path.
+- On a fleet robot's constrained uplink, the bytes would cross the network twice: once to
+  the Destination, and once because neither the Shipper nor a database offers a way to
+  skip re-sending a field that already made it through.
+
+DC keeps the claim-check pattern instead (ADR-0005): the Record carries a reference, the
+Uploader moves the bytes out of band.
+
+## Consequences
+
+- Managed mode (one supervised process tree, ADR-0001's original design) and unmanaged
+  mode (#444, this ADR) are both first-class; native install and simulation do not need
+  containers to stay correct.
+- The Shipper's own buffer and the Bridge's upload intent queue are separate volumes with
+  separate owners — a container boundary makes visible, as two mount points, what was
+  already two independent pieces of on-disk state internally.
+- `compose.split.yaml` (#447) is the concrete rendering of this decision for one machine;
+  Podman Quadlet and Kubernetes manifests for the fleet tiers describe the same topology
+  differently, not a different decision.
+- ADR-0001 is amended alongside this ADR: "runs on localhost, supervised by DC's bringup"
+  is no longer true of every deployment.


### PR DESCRIPTION
## Summary
- Add ADR-0015 recording the split-deployment topology decision: why the decomposition stops at the Shipper and the Uploader and does not extend to ROS nodes, and the rejected alternative of routing File bytes through the Shipper or a database.
- Amend ADR-0001, whose "runs on localhost, supervised by DC's bringup" claim is only true of managed mode now that unmanaged-shipper mode (#444) exists.
- Fix CONTEXT.md's shipper ingest protocol definition, which asserted a local socket — no longer true once the protocol crosses a container boundary in split deployments.
- Add CONTEXT.md glossary entries for the Shipper buffer, the Uploader, and the upload intent queue — terms this work made load-bearing but were previously undocumented.

The ADR documenting the Uploader's extraction into its own process already exists (ADR-0014, merged with #446), so that acceptance criterion was already satisfied before this PR.

Closes #449

## Test plan
- [x] `prek run` on the changed files (CONTEXT.md, docs/adr/0001, docs/adr/0015) — passes, including the copyright/license and doc-build hooks
- Documentation-only change; no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MPiWs8DqRxWAxA4os9VZD3