### PR TITLE
feat(ci): publish dc-ros and dc-uploader images to ghcr

### DIFF
--- a/.github/actions/podman-push/action.yaml
+++ b/.github/actions/podman-push/action.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+name: Push podman image with retry
+description: >-
+  Tags and pushes a container image to a registry, retrying transient push
+  failures. The first ref in `refs` must already exist locally (e.g. just
+  built by `podman build`); any additional refs are `podman tag`-ed from it
+  before all of them are pushed. Factored out of ci.yaml's dc-ros/dc-uploader
+  publish jobs (#448), which both push the same :<sha> image under a second,
+  floating :latest tag.
+
+inputs:
+  refs:
+    description: >-
+      Newline-separated image refs to push. The first must already be a
+      locally-tagged image; every other ref is created via `podman tag` from
+      it first.
+    required: true
+  retry_count:
+    description: Push attempts per ref before failing the step.
+    default: "3"
+  retry_wait_seconds:
+    description: Seconds to wait between push attempts.
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - name: Tag and push
+      shell: bash
+      env:
+        REFS: ${{ inputs.refs }}
+        RETRY_COUNT: ${{ inputs.retry_count }}
+        RETRY_WAIT_SECONDS: ${{ inputs.retry_wait_seconds }}
+      run: |
+        set -euo pipefail
+        mapfile -t refs <<< "$REFS"
+        primary="${refs[0]}"
+        for ref in "${refs[@]:1}"; do
+          podman tag "$primary" "$ref"
+        done
+        for ref in "${refs[@]}"; do
+          for attempt in $(seq 1 "$RETRY_COUNT"); do
+            podman push "$ref" && continue 2
+            echo "push $ref attempt $attempt/$RETRY_COUNT failed; retrying in ${RETRY_WAIT_SECONDS}s" >&2
+            sleep "$RETRY_WAIT_SECONDS"
+          done
+          echo "push $ref failed after $RETRY_COUNT attempts" >&2
+          exit 1
+        done

--- a/.github/actions/podman-push/action.yaml
+++ b/.github/actions/podman-push/action.yaml
@@ -6,9 +6,10 @@ description: >-
   Tags and pushes a container image to a registry, retrying transient push
   failures. The first ref in `refs` must already exist locally (e.g. just
   built by `podman build`); any additional refs are `podman tag`-ed from it
-  before all of them are pushed. Factored out of ci.yaml's dc-ros/dc-uploader
-  publish jobs (#448), which both push the same :<sha> image under a second,
-  floating :latest tag.
+  before all of them are pushed. Every ghcr push in ci.yaml goes through this
+  (dc-workspace, dc-e2e — single :<sha> ref each — and dc-ros/dc-uploader,
+  #448, which push a second, floating :latest tag alongside it) instead of
+  each job hand-rolling its own retry loop.
 
 inputs:
   refs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -211,14 +211,9 @@ jobs:
 
       - name: Push the workspace image
         if: success()
-        env:
-          REF: ${{ steps.refs.outputs.workspace_ref }}
-        run: |
-          for attempt in 1 2 3; do
-            podman push "$REF" && exit 0
-            echo "push $REF attempt $attempt failed; retrying in 10s"; sleep 10
-          done
-          exit 1
+        uses: ./.github/actions/podman-push
+        with:
+          refs: ${{ steps.refs.outputs.workspace_ref }}
 
       - name: Upload C++ coverage
         if: always()
@@ -314,14 +309,9 @@ jobs:
         run: podman build --build-arg "BASE_IMAGE=$BASE_IMAGE" -t "$E2E_REF" -f tools/e2e/Containerfile.e2e tools/e2e
 
       - name: Push the E2E image
-        env:
-          E2E_REF: ${{ needs.build-workspace.outputs.e2e_ref }}
-        run: |
-          for attempt in 1 2 3; do
-            podman push "$E2E_REF" && exit 0
-            echo "push $E2E_REF attempt $attempt failed; retrying in 10s"; sleep 10
-          done
-          exit 1
+        uses: ./.github/actions/podman-push
+        with:
+          refs: ${{ needs.build-workspace.outputs.e2e_ref }}
 
   # Publishes the first runnable images this repo ships (#448) — every earlier ghcr push
   # (dc-workspace, dc-e2e above) exists purely for CI-internal reuse. Only on `push` to

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -353,18 +353,11 @@ jobs:
         run: podman build --build-arg "BASE_IMAGE=$BASE_IMAGE" -t "$DC_ROS_REF" -f containers/dc-ros/Containerfile containers/dc-ros
 
       - name: Push the dc-ros image (:<sha> and :latest)
-        env:
-          DC_ROS_REF: ${{ needs.build-workspace.outputs.dc_ros_ref }}
-          DC_ROS_LATEST_REF: ${{ needs.build-workspace.outputs.dc_ros_latest_ref }}
-        run: |
-          podman tag "$DC_ROS_REF" "$DC_ROS_LATEST_REF"
-          for ref in "$DC_ROS_REF" "$DC_ROS_LATEST_REF"; do
-            for attempt in 1 2 3; do
-              podman push "$ref" && continue 2
-              echo "push $ref attempt $attempt failed; retrying in 10s"; sleep 10
-            done
-            exit 1
-          done
+        uses: ./.github/actions/podman-push
+        with:
+          refs: |
+            ${{ needs.build-workspace.outputs.dc_ros_ref }}
+            ${{ needs.build-workspace.outputs.dc_ros_latest_ref }}
 
   build-dc-uploader-image:
     needs: build-workspace
@@ -390,18 +383,11 @@ jobs:
         run: podman build --build-arg "BASE_IMAGE=$BASE_IMAGE" -t "$DC_UPLOADER_REF" -f containers/dc-uploader/Containerfile containers/dc-uploader
 
       - name: Push the dc-uploader image (:<sha> and :latest)
-        env:
-          DC_UPLOADER_REF: ${{ needs.build-workspace.outputs.dc_uploader_ref }}
-          DC_UPLOADER_LATEST_REF: ${{ needs.build-workspace.outputs.dc_uploader_latest_ref }}
-        run: |
-          podman tag "$DC_UPLOADER_REF" "$DC_UPLOADER_LATEST_REF"
-          for ref in "$DC_UPLOADER_REF" "$DC_UPLOADER_LATEST_REF"; do
-            for attempt in 1 2 3; do
-              podman push "$ref" && continue 2
-              echo "push $ref attempt $attempt failed; retrying in 10s"; sleep 10
-            done
-            exit 1
-          done
+        uses: ./.github/actions/podman-push
+        with:
+          refs: |
+            ${{ needs.build-workspace.outputs.dc_uploader_ref }}
+            ${{ needs.build-workspace.outputs.dc_uploader_latest_ref }}
 
   # Proves the two images build-dc-ros-image/build-dc-uploader-image just pushed are
   # actually runnable as the three-container topology (#448 acceptance criteria) — pull

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,12 +9,16 @@
 # Podman (CLAUDE.md "Containers: Podman, not Docker").
 #
 # One job builds each artifact and pushes it; the others pull and use it (build once, use
-# many). The immutable :<sha> ref is the only tag published — per CLAUDE.md, a floating
-# :<branch> ref is added only once the repo publishes runnable images for others, which it
-# doesn't yet; here the images exist purely for CI-internal reuse + traceability.
+# many). dc-workspace/dc-e2e stay :<sha>-only — they exist purely for CI-internal reuse +
+# traceability, never pulled by anything outside this workflow. dc-ros and dc-uploader
+# (#448) are different: the first images this repo publishes for others to actually
+# deploy, so they get :<sha> *and* a floating :latest, per CLAUDE.md's convention, and
+# only on `push` to `jazzy` — never from a PR build.
 #
-#   build-workspace (build + colcon test + coverage) ─┬─▶ sim               (pull dc-workspace, simulation smoke check)
-#                                                      └─▶ build-e2e-image ─▶ e2e   (pull dc-e2e, zero-loss harness)
+#   build-workspace (build + colcon test + coverage) ─┬─▶ sim                    (pull dc-workspace, simulation smoke check)
+#                                                      ├─▶ build-e2e-image ────▶ e2e   (pull dc-e2e, zero-loss harness)
+#                                                      ├─▶ build-dc-ros-image ─┐
+#                                                      └─▶ build-dc-uploader-image ─▶ verify-published-images (pull + run, no build)
 #   kpi-views (standalone: SQL + a throwaway Postgres, no workspace image needed)
 #   raw-volume (standalone: stdlib Python fixtures over the shared volume accounting)
 #
@@ -72,6 +76,10 @@ jobs:
       workspace_ref: ${{ steps.refs.outputs.workspace_ref }}
       e2e_ref: ${{ steps.refs.outputs.e2e_ref }}
       cache_ref: ${{ steps.refs.outputs.cache_ref }}
+      dc_ros_ref: ${{ steps.refs.outputs.dc_ros_ref }}
+      dc_ros_latest_ref: ${{ steps.refs.outputs.dc_ros_latest_ref }}
+      dc_uploader_ref: ${{ steps.refs.outputs.dc_uploader_ref }}
+      dc_uploader_latest_ref: ${{ steps.refs.outputs.dc_uploader_latest_ref }}
     steps:
       - uses: actions/checkout@v5
 
@@ -95,6 +103,10 @@ jobs:
             echo "workspace_ref=$IMAGE/dc-workspace:$SHA"
             echo "e2e_ref=$IMAGE/dc-e2e:$SHA"
             echo "cache_ref=$IMAGE/dc-workspace-cache"
+            echo "dc_ros_ref=$IMAGE/dc-ros:$SHA"
+            echo "dc_ros_latest_ref=$IMAGE/dc-ros:latest"
+            echo "dc_uploader_ref=$IMAGE/dc-uploader:$SHA"
+            echo "dc_uploader_latest_ref=$IMAGE/dc-uploader:latest"
           } >> "$GITHUB_OUTPUT"
 
       # `podman compose` shells out to a host-side provider — it can't be baked into an
@@ -310,6 +322,123 @@ jobs:
             echo "push $E2E_REF attempt $attempt failed; retrying in 10s"; sleep 10
           done
           exit 1
+
+  # Publishes the first runnable images this repo ships (#448) — every earlier ghcr push
+  # (dc-workspace, dc-e2e above) exists purely for CI-internal reuse. Only on `push` to
+  # `jazzy` (never on a PR build): a fleet pins robots to `:<sha>`/`:latest`, so a
+  # not-yet-merged PR must never produce a ref someone could pull. Thin `FROM` layers
+  # over the already-tested workspace image (containers/dc-ros, containers/dc-uploader),
+  # same shape as build-e2e-image above, just with no E2E-only content.
+  build-dc-ros-image:
+    needs: build-workspace
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build the dc-ros image
+        env:
+          BASE_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
+          DC_ROS_REF: ${{ needs.build-workspace.outputs.dc_ros_ref }}
+        run: podman build --build-arg "BASE_IMAGE=$BASE_IMAGE" -t "$DC_ROS_REF" -f containers/dc-ros/Containerfile containers/dc-ros
+
+      - name: Push the dc-ros image (:<sha> and :latest)
+        env:
+          DC_ROS_REF: ${{ needs.build-workspace.outputs.dc_ros_ref }}
+          DC_ROS_LATEST_REF: ${{ needs.build-workspace.outputs.dc_ros_latest_ref }}
+        run: |
+          podman tag "$DC_ROS_REF" "$DC_ROS_LATEST_REF"
+          for ref in "$DC_ROS_REF" "$DC_ROS_LATEST_REF"; do
+            for attempt in 1 2 3; do
+              podman push "$ref" && continue 2
+              echo "push $ref attempt $attempt failed; retrying in 10s"; sleep 10
+            done
+            exit 1
+          done
+
+  build-dc-uploader-image:
+    needs: build-workspace
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build the dc-uploader image
+        env:
+          BASE_IMAGE: ${{ needs.build-workspace.outputs.workspace_ref }}
+          DC_UPLOADER_REF: ${{ needs.build-workspace.outputs.dc_uploader_ref }}
+        run: podman build --build-arg "BASE_IMAGE=$BASE_IMAGE" -t "$DC_UPLOADER_REF" -f containers/dc-uploader/Containerfile containers/dc-uploader
+
+      - name: Push the dc-uploader image (:<sha> and :latest)
+        env:
+          DC_UPLOADER_REF: ${{ needs.build-workspace.outputs.dc_uploader_ref }}
+          DC_UPLOADER_LATEST_REF: ${{ needs.build-workspace.outputs.dc_uploader_latest_ref }}
+        run: |
+          podman tag "$DC_UPLOADER_REF" "$DC_UPLOADER_LATEST_REF"
+          for ref in "$DC_UPLOADER_REF" "$DC_UPLOADER_LATEST_REF"; do
+            for attempt in 1 2 3; do
+              podman push "$ref" && continue 2
+              echo "push $ref attempt $attempt failed; retrying in 10s"; sleep 10
+            done
+            exit 1
+          done
+
+  # Proves the two images build-dc-ros-image/build-dc-uploader-image just pushed are
+  # actually runnable as the three-container topology (#448 acceptance criteria) — pull
+  # + run only, no podman build. See tools/release/scripts/verify_published_images.sh.
+  verify-published-images:
+    needs: [build-workspace, build-dc-ros-image, build-dc-uploader-image]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Verify podman
+        run: podman --version
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Install podman-compose
+        run: pip install --user "podman-compose==1.5.0" && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run the published-image smoke check
+        env:
+          DC_ROS_IMAGE: ${{ needs.build-workspace.outputs.dc_ros_ref }}
+          DC_UPLOADER_IMAGE: ${{ needs.build-workspace.outputs.dc_uploader_ref }}
+        run: ./tools/release/scripts/verify_published_images.sh
+
+      - name: Upload smoke-check logs (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-published-images-logs
+          path: tools/release/.run/**
+          if-no-files-found: ignore
 
   # tools/e2e/scripts/raw_volume.py is stdlib Python shared by the zero-loss verifier and
   # the sim-backed volume benchmark (#326) — no workspace image, no simulator, no database.

--- a/.gitignore
+++ b/.gitignore
@@ -281,6 +281,7 @@ cython_debug/
 .ci-ws/
 tools/e2e/.run/
 tools/sim/.run/
+tools/release/.run/
 
 # dc_bridge local core test build dir (fast-iteration cmake, not colcon)
 dc_bridge/test/local/build/

--- a/containers/dc-ros/Containerfile
+++ b/containers/dc-ros/Containerfile
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The `dc-ros` runtime image (#448): every ROS node plus the Bridge, for the
+# three-container split topology (#440 scenario 2/3, #447). A thin `FROM` on top of
+# tools/e2e/Containerfile's tested `workspace` stage — same pattern as
+# tools/e2e/Containerfile.e2e, but with no E2E-only content (workload generator, MCAP
+# writer, test params): this is the image a real deployment pulls and runs, published to
+# ghcr.io on merge to `jazzy` (see .github/workflows/ci.yaml's build-dc-ros-image job).
+#
+# Unlike Containerfile.e2e, this carries no default params file: `dc_bringup` already
+# installs one (dc_bringup/params/dc_params.yaml) as its `dc_params_file` launch
+# argument's default, so a plain `podman run <image>` launches with all-in-one/managed
+# defaults; a real deployment mounts its own params file over a volume and passes
+# `dc_params_file:=/path/to/params.yaml run_uploader:=false` as container args (see
+# entrypoint.sh) the same way compose.split.yaml does for the E2E harness.
+
+ARG BASE_IMAGE=dc-workspace:latest
+FROM ${BASE_IMAGE}
+
+COPY entrypoint.sh /opt/dc/entrypoint.sh
+RUN chmod +x /opt/dc/entrypoint.sh
+
+ENTRYPOINT ["/opt/dc/entrypoint.sh"]

--- a/containers/dc-ros/entrypoint.sh
+++ b/containers/dc-ros/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Entrypoint for the published `dc-ros` image (#448): launches the real DC stack and
+# nothing else — no workload generator, no E2E-only params (contrast
+# tools/e2e/scripts/entrypoint.sh, which is test-harness-only). Every argument this
+# script receives is forwarded to `dc_bringup.launch.py` as-is, so a deployment
+# selects unmanaged-shipper mode and its own params file with e.g.:
+#
+#   podman run ghcr.io/<repo>/dc-ros:<tag> \
+#     dc_params_file:=/etc/dc/params.yaml run_uploader:=false
+set -euo pipefail
+
+# colcon/ROS setup files reference unset vars (COLCON_TRACE, AMENT_TRACE_SETUP_FILES,
+# …); sourcing them under `set -u` aborts this script before the stack ever launches.
+set +u
+# shellcheck disable=SC1091
+source /root/ws/install/setup.bash
+set -u
+
+exec ros2 launch dc_bringup dc_bringup.launch.py "$@"

--- a/containers/dc-uploader/Containerfile
+++ b/containers/dc-uploader/Containerfile
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The `dc-uploader` runtime image (#448): the standalone Uploader process (#446,
+# docs/adr/0014) for the three-container split topology (#440 scenario 2/3, #447). A
+# thin `FROM` on top of tools/e2e/Containerfile's tested `workspace` stage — same
+# pattern as tools/e2e/Containerfile.e2e, but with no E2E-only content. Published to
+# ghcr.io on merge to `jazzy` (see .github/workflows/ci.yaml's build-dc-uploader-image
+# job). Configured entirely by `DC_UPLOADER_*` environment variables (no ROS params, no
+# ROS dependency of its own — see entrypoint.sh).
+
+ARG BASE_IMAGE=dc-workspace:latest
+FROM ${BASE_IMAGE}
+
+COPY entrypoint.sh /opt/dc/entrypoint.sh
+RUN chmod +x /opt/dc/entrypoint.sh
+
+ENTRYPOINT ["/opt/dc/entrypoint.sh"]

--- a/containers/dc-uploader/entrypoint.sh
+++ b/containers/dc-uploader/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Entrypoint for the published `dc-uploader` image (#448): runs the standalone
+# dc_uploader binary (#446, docs/adr/0014) directly, configured entirely by
+# `DC_UPLOADER_*` env vars (dc_bridge/uploader/process_config.hpp) — no ROS launch, no
+# ROS params. Sourcing install/setup.bash is still needed to put dc_uploader's shared
+# library dependencies (dc_common, aws_sdk_vendor, ...) on LD_LIBRARY_PATH, even though
+# it has no rclcpp/ROS-node dependency of its own. Same logic as
+# tools/e2e/scripts/entrypoint_uploader.sh, which the E2E harness keeps as its own copy
+# so the test harness never depends on this production image's own layout.
+set -euo pipefail
+
+# colcon/ROS setup files reference unset vars under `set -u` (see entrypoint.sh).
+set +u
+# shellcheck disable=SC1091
+source /root/ws/install/setup.bash
+set -u
+
+exec "$(ros2 pkg prefix dc_bridge)/lib/dc_bridge/dc_uploader"

--- a/tools/e2e/compose.split.yaml
+++ b/tools/e2e/compose.split.yaml
@@ -96,8 +96,12 @@ services:
     restart: unless-stopped
 
   vector:
-    # Version matches ros2_data_collection.repos' vector_vendor pin (v0.57.0).
-    image: docker.io/timberio/vector:0.57.0-debian
+    # VECTOR_VERSION comes from ros2_data_collection.repos' vector_vendor pin (#448: the
+    # Vector image tag and vector_vendor's pinned version come from one place) —
+    # run_split.sh exports it before calling compose; the literal default here only
+    # matters for a standalone `podman compose -f compose.split.yaml up` (see this
+    # file's header) where nothing has exported it.
+    image: docker.io/timberio/vector:${VECTOR_VERSION:-0.57.0}-debian
     container_name: dc_e2e_split_vector
     volumes:
       - dc_e2e_split_buffer:/var/lib/vector

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -37,6 +37,13 @@ KEEP="${DC_E2E_KEEP:-false}"
 # Docker"; matches ci.yaml's own compose.test.yaml usage) — it needs no Podman API socket.
 export PODMAN_COMPOSE_PROVIDER="${PODMAN_COMPOSE_PROVIDER:-podman-compose}"
 
+# compose.split.yaml's vector service interpolates this (#448: the Vector image tag and
+# vector_vendor's pinned version come from one place) — same grep already used by
+# run_limits_two_tier.sh / run_load_driver_shipper_test.sh / run_limits_drain_rate.sh /
+# run_limits_shipper_fanin.sh, so the apt and container paths cannot drift apart.
+VECTOR_VERSION="$(grep -oP 'version: v\K[0-9.]+' "$E2E_DIR/../../ros2_data_collection.repos")"
+export VECTOR_VERSION
+
 PG_C=dc_e2e_split_postgres
 RUSTFS_C=dc_e2e_split_rustfs
 DC_ROS_C=dc_e2e_split_dc_ros

--- a/tools/release/params/smoke_params.yaml
+++ b/tools/release/params/smoke_params.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Minimal params for verify_published_images.sh (#448): proves the published `dc-ros`
+# image boots in unmanaged-shipper mode and ships a Record through a real Vector
+# container to Postgres — nothing else. Not the E2E harness's zero-loss proof (that's
+# tools/e2e/params/e2e_split_params.yaml, an existing, separate seam per #440's Testing
+# Decisions); this only has to show the published image itself is runnable.
+measurement_server:
+  ros__parameters:
+    save_local_base_path: "$HOME/.dc/smoke/data/%Y/%M/%D/%H"
+    all_base_path: "smoke"
+    measurement_plugins: ["uptime"]
+
+    uptime:
+      plugin: "dc_measurements/Uptime"
+      polling_interval: 500
+      group_key: "uptime"
+
+dc_bridge:
+  ros__parameters:
+    shipper:
+      managed: false
+      config_path: "/etc/dc/shipper/vector.toml"
+      data_dir: "/var/lib/vector"
+      bind_host: "0.0.0.0"
+    destinations: ["pgsql_records"]
+    pgsql_records:
+      type: postgres
+      receives: records
+      inputs: ["/dc/measurement/uptime"]
+      host: "127.0.0.1"
+      port: 5432
+      user: "dc"
+      password: "password"
+      database: "dc"
+      table: "dc_records"
+      time_key: "date"
+
+    vector_forward_host: "127.0.0.1"
+    vector_forward_port: 24224
+
+lifecycle_manager_dc:
+  ros__parameters:
+    node_names: ["measurement_server"]
+    transitions: [configure, activate]

--- a/tools/release/scripts/verify_published_images.sh
+++ b/tools/release/scripts/verify_published_images.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Proves the published `dc-ros` and `dc-uploader` images (#448) run the three-container
+# split topology (dc-ros + vector + dc-uploader) with zero local `podman build` — only
+# `podman pull` and `podman run`, against the public upstream Vector image. This is a
+# boot-and-ship smoke check, not the zero-loss proof: that's
+# tools/e2e/scripts/run_split.sh, an existing, separate seam (#440's Testing Decisions)
+# that still runs against a locally-built dc-e2e image with its own workload generator.
+# Here, a single Record making it from dc-ros through vector into Postgres is enough to
+# show the published images themselves are runnable, not just CI-internal build
+# artifacts.
+#
+#   DC_ROS_IMAGE=ghcr.io/<repo>/dc-ros:<sha> \
+#   DC_UPLOADER_IMAGE=ghcr.io/<repo>/dc-uploader:<sha> \
+#     ./tools/release/scripts/verify_published_images.sh
+#
+# Env vars:
+#   DC_ROS_IMAGE       (required) the dc-ros image ref to pull and run.
+#   DC_UPLOADER_IMAGE  (required) the dc-uploader image ref to pull and run.
+#   VECTOR_VERSION     Vector image tag; defaults to ros2_data_collection.repos'
+#                      vector_vendor pin (#448: single source, same grep run_split.sh uses).
+#   DC_RELEASE_TIMEOUT_SECONDS  deadline for the first Record to land (default 60).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_DIR="$(dirname "$SCRIPT_DIR")"
+REPO_ROOT="$(dirname "$(dirname "$RELEASE_DIR")")"
+RUN_DIR="$RELEASE_DIR/.run"
+mkdir -p "$RUN_DIR"
+
+DC_ROS_IMAGE="${DC_ROS_IMAGE:?DC_ROS_IMAGE must be set to a published dc-ros image ref}"
+DC_UPLOADER_IMAGE="${DC_UPLOADER_IMAGE:?DC_UPLOADER_IMAGE must be set to a published dc-uploader image ref}"
+VECTOR_VERSION="${VECTOR_VERSION:-$(grep -oP 'version: v\K[0-9.]+' "$REPO_ROOT/ros2_data_collection.repos")}"
+VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
+TIMEOUT_SECONDS="${DC_RELEASE_TIMEOUT_SECONDS:-60}"
+
+log() { echo "[verify-published-images $(date -u +%H:%M:%S)] $*"; }
+
+# dc_pg_test is the fixed Postgres container name from tools/e2e/compose.test.yaml, not
+# ours to choose; RustFS is only reached over 127.0.0.1:9000 below, never by name.
+PG_C=dc_pg_test
+DC_ROS_C=dc_release_smoke_dc_ros
+UPLOADER_C=dc_release_smoke_dc_uploader
+VECTOR_C=dc_release_smoke_vector
+CONFIG_VOL=dc_release_smoke_config
+BUFFER_VOL=dc_release_smoke_buffer
+UPLOADER_VOL=dc_release_smoke_uploader
+
+pg_exec() { podman exec "$PG_C" psql -U dc -d dc -tAc "$1"; }
+
+cleanup() {
+  local exit_code=$?
+  log "tearing down"
+  for c in "$DC_ROS_C" "$UPLOADER_C" "$VECTOR_C"; do
+    podman logs "$c" > "$RUN_DIR/${c}.log" 2>&1 || true
+  done
+  podman rm -f "$DC_ROS_C" "$UPLOADER_C" "$VECTOR_C" >/dev/null 2>&1 || true
+  podman compose -f "$REPO_ROOT/tools/e2e/compose.test.yaml" down >/dev/null 2>&1 || true
+  podman volume rm -f "$CONFIG_VOL" "$BUFFER_VOL" "$UPLOADER_VOL" >/dev/null 2>&1 || true
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+# --- destinations: reuse the existing store-backed-test fixtures (compose.test.yaml) --
+log "starting Postgres + RustFS"
+export PODMAN_COMPOSE_PROVIDER="${PODMAN_COMPOSE_PROVIDER:-podman-compose}"
+podman compose -f "$REPO_ROOT/tools/e2e/compose.test.yaml" up -d
+
+timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
+  || { log "Postgres never became ready"; exit 1; }
+timeout 60 bash -c "until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done" \
+  || { log "RustFS never became ready"; exit 1; }
+
+# compose.test.yaml's Postgres carries no schema (unlike compose.split.yaml's, which
+# mounts tools/e2e/sql/init.sql) — dc_bridge's postgres sink maps event keys onto
+# existing columns 1:1, it never creates the table. Just enough columns for the
+# `uptime` measurement smoke_params.yaml uses.
+pg_exec "CREATE TABLE IF NOT EXISTS dc_records (date bigint, tag text, group_key text, time double precision)"
+
+podman run --rm --network host \
+  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+  docker.io/amazon/aws-cli:latest \
+  --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-release-smoke >/dev/null 2>&1 || true
+
+# --- pull the published images (no local build) ---------------------------------------
+log "pulling published images (dc-ros=$DC_ROS_IMAGE, dc-uploader=$DC_UPLOADER_IMAGE, vector=$VECTOR_IMAGE)"
+podman pull "$DC_ROS_IMAGE"
+podman pull "$DC_UPLOADER_IMAGE"
+podman pull "$VECTOR_IMAGE"
+
+podman volume create "$CONFIG_VOL" >/dev/null
+podman volume create "$BUFFER_VOL" >/dev/null
+podman volume create "$UPLOADER_VOL" >/dev/null
+
+# --- vector: unmanaged Shipper, waits for dc-ros's atomically-written config ----------
+log "starting vector"
+podman run -d --network host --name "$VECTOR_C" \
+  -v "$BUFFER_VOL:/var/lib/vector" \
+  -v "$CONFIG_VOL:/etc/dc/shipper:ro" \
+  --entrypoint /bin/sh "$VECTOR_IMAGE" -c \
+  'until [ -f /etc/dc/shipper/vector.toml ]; do sleep 0.2; done; exec vector --config /etc/dc/shipper/vector.toml --watch-config' \
+  >/dev/null
+
+# --- dc-uploader: standalone, proves it starts cleanly off DC_UPLOADER_* env alone ----
+log "starting dc-uploader"
+podman run -d --network host --name "$UPLOADER_C" \
+  -v "$UPLOADER_VOL:/root/.dc/smoke/uploader" \
+  -e DC_UPLOADER_STORAGE_NAME=rustfs \
+  -e DC_UPLOADER_QUEUE_DIR=/root/.dc/smoke/uploader/queue/upload \
+  -e DC_UPLOADER_STATE_DIR=/root/.dc/smoke/uploader/uploader \
+  -e DC_UPLOADER_SHIPPER_HOST=127.0.0.1 \
+  -e DC_UPLOADER_SHIPPER_PORT=24224 \
+  -e DC_UPLOADER_S3_BUCKET=dc-release-smoke \
+  -e DC_UPLOADER_S3_ENDPOINT=http://127.0.0.1:9000 \
+  -e DC_UPLOADER_S3_ACCESS_KEY_ID=rustfsadmin \
+  -e DC_UPLOADER_S3_SECRET_ACCESS_KEY=rustfsadmin \
+  -e DC_UPLOADER_S3_FORCE_PATH_STYLE=true \
+  "$DC_UPLOADER_IMAGE" \
+  >/dev/null
+
+# --- dc-ros: unmanaged-shipper mode, no in-process uploader ---------------------------
+log "starting dc-ros"
+podman run -d --network host --name "$DC_ROS_C" \
+  -v "$CONFIG_VOL:/etc/dc/shipper" \
+  -v "$RELEASE_DIR/params/smoke_params.yaml:/opt/dc/smoke_params.yaml:ro" \
+  "$DC_ROS_IMAGE" \
+  dc_params_file:=/opt/dc/smoke_params.yaml run_uploader:=false \
+  >/dev/null
+
+log "waiting up to ${TIMEOUT_SECONDS}s for dc-ros to report ready"
+timeout "$TIMEOUT_SECONDS" bash -c "until podman logs $DC_ROS_C 2>&1 | grep -q 'dc_bridge reports ready'; do sleep 1; done" \
+  || { log "FAIL: dc-ros never reported ready"; exit 1; }
+log "PASS: dc-ros reports ready"
+
+for c in "$VECTOR_C" "$UPLOADER_C"; do
+  if [ "$(podman inspect --format '{{.State.Running}}' "$c")" != "true" ]; then
+    log "FAIL: $c is not running"
+    exit 1
+  fi
+done
+log "PASS: vector and dc-uploader are both still running"
+
+log "waiting up to ${TIMEOUT_SECONDS}s for a Record to land in Postgres"
+DEADLINE=$(( $(date +%s) + TIMEOUT_SECONDS ))
+COUNT=0
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
+  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
+  if [ "${COUNT:-0}" -gt 0 ] 2>/dev/null; then
+    break
+  fi
+  sleep 1
+done
+if [ "${COUNT:-0}" -eq 0 ]; then
+  log "FAIL: no Record landed in Postgres within ${TIMEOUT_SECONDS}s"
+  exit 1
+fi
+log "PASS: dc-ros shipped a Record through vector into Postgres ($COUNT row(s))"
+
+log "PASS: published dc-ros/dc-uploader images run the three-container topology with no local build"


### PR DESCRIPTION
## Summary

- Adds production Containerfiles for `dc-ros` and `dc-uploader` (`containers/dc-ros/`, `containers/dc-uploader/`) — thin layers over the already-tested `dc-workspace` image, with no E2E-only content (no workload generator, no test params), each with its own minimal entrypoint.
- Adds `build-dc-ros-image` and `build-dc-uploader-image` CI jobs that build and push both images to ghcr.io, tagged with the commit `:<sha>` and a floating `:latest`, gated to `push` events on `jazzy` only (never a PR build) — the first runnable images this repo publishes, per CLAUDE.md's convention.
- Adds a `verify-published-images` job (`tools/release/scripts/verify_published_images.sh`) that pulls the just-published `dc-ros`/`dc-uploader` images plus the public Vector image and runs the three-container topology with zero local `podman build`, proving a Record flows from `dc-ros` through `vector` into Postgres and that `dc-uploader` starts cleanly off `DC_UPLOADER_*` env vars alone.
- Fixes the Vector image tag / `vector_vendor` pin drift risk: `compose.split.yaml`'s `vector` service now interpolates `VECTOR_VERSION` (derived from `ros2_data_collection.repos`, same `grep` four sibling E2E scripts already use) instead of hardcoding `0.57.0`; `run_split.sh` exports it.

Closes #448

## Test plan

- [x] `prek run --all-files --skip build-doc` (hadolint, shellcheck, REUSE, ruff, etc.) passes locally
- [x] `hadolint`/`shellcheck` run directly against the new Containerfiles/scripts
- [ ] CI: `build-dc-ros-image`, `build-dc-uploader-image`, and `verify-published-images` run and go green on push to `jazzy`