### PR TITLE
fix(dc_simulation): correct license metadata for third-party sim models

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -116,13 +116,38 @@ SPDX-FileCopyrightText = "Open Robotics"
 SPDX-License-Identifier = "CC-BY-4.0"
 
 # From the Gazebo Classic model database (osrf/gazebo_models), which is CC-BY-3.0 as a
-# whole; cutout_wall's model.config still credits its OSRF author.
+# whole; cutout_wall's model.config still credits its OSRF author. drc_practice_*,
+# table, pickup and construction_cone are #268 placeholders (simplified to primitive
+# geometry, no gz-sim port upstream) but still stand in for and are named after their
+# osrf/gazebo_models originals. charging_dock is deliberately NOT in this group: it's
+# original DC content built for #364, with no upstream sourcing at all.
 [[annotations]]
 path = [
   "dc_simulation/models/bag/**",
+  "dc_simulation/models/construction_cone/**",
   "dc_simulation/models/cutout_wall/**",
+  "dc_simulation/models/drc_practice_angled_barrier_135/**",
+  "dc_simulation/models/drc_practice_orange_jersey_barrier/**",
+  "dc_simulation/models/drc_practice_white_jersey_barrier/**",
+  "dc_simulation/models/drc_practice_yellow_parking_block/**",
   "dc_simulation/models/europallet/**",
   "dc_simulation/models/europallet_10/**",
+  "dc_simulation/models/pickup/**",
+  "dc_simulation/models/table/**",
 ]
 SPDX-FileCopyrightText = "2012 Nathan Koenig"
 SPDX-License-Identifier = "CC-BY-3.0"
+
+# #268 placeholders (simplified to primitive geometry, no gz-sim port upstream) that
+# stand in for and are named after their aws-robotics/aws-robomaker-small-warehouse-world
+# originals.
+[[annotations]]
+path = [
+  "dc_simulation/models/aws_robomaker_warehouse_ClutteringC_01/**",
+  "dc_simulation/models/aws_robomaker_warehouse_ClutteringD_01/**",
+  "dc_simulation/models/aws_robomaker_warehouse_ShelfD_01/**",
+  "dc_simulation/models/aws_robomaker_warehouse_ShelfF_01/**",
+  "dc_simulation/models/aws_robomaker_warehouse_TrashCanC_01/**",
+]
+SPDX-FileCopyrightText = "Amazon.com, Inc. or its affiliates"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## Summary

Splits `REUSE.toml`'s blanket `dc_simulation/models/**` → MPL-2.0 annotation into
accurate per-subtree entries:

- `aws_robomaker_warehouse_*` → MIT / `Amazon.com, Inc. or its affiliates`. These #268
  placeholders (simplified to primitive box/cylinder geometry, since neither
  `aws_robomaker_small_warehouse_world` nor the Gazebo Classic model database has a
  gz-sim port) still stand in for and are named after their
  `aws-robotics/aws-robomaker-small-warehouse-world` originals, confirmed MIT /
  Amazon-copyrighted upstream.
- `drc_practice_*`, `table`, `pickup`, `construction_cone` → CC-BY-3.0 / `2012 Nathan
  Koenig`, joining the existing `bag`/`cutout_wall`/`europallet`/`europallet_10` group.
  Same #268 placeholder situation; verified each name is present in
  `osrf/gazebo_models`, whose `LICENSE` is CC-BY-3.0 copyright Nathan Koenig.
- DC's own models (`qrcode_*`, `warehouse`, `charging_dock`, etc.) keep the MPL-2.0
  blanket — unchanged.

`dc_simulation/package.xml`'s `<license>` tags were already correct and are untouched.
`reuse lint` passes (910/910 files with copyright and license information).

### Deviation from the issue text

The issue's acceptance criteria also listed `charging_dock`, `Chair` and
`MonitorAndKeyboard` under the CC-BY-3.0/Nathan Koenig group. I verified and excluded
them instead, confirmed with the user before implementing:

- `charging_dock` is original DC content built for #364 (a battery-recharge contact
  pad), with no upstream sourcing at all — unlike the other #268 placeholders, its
  `model.config` makes no claim of standing in for any external asset.
- `Chair` and `MonitorAndKeyboard` aren't in `osrf/gazebo_models` at all — they're
  Gazebo Fuel entries by Open Robotics. I confirmed CC-BY-4.0 for `Chair` via the Fuel
  API, and `REUSE.toml` already annotated both correctly (with a comment noting the
  Fuel/Kenney.nl provenance) before this PR touched anything.

## Test plan

- [x] `reuse lint` passes
- [x] `prek run --all-files --skip build-doc` passes
- [x] `dc_simulation/package.xml` license tags left unchanged

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PB3kK2E2s4jTSuSbLCri1