### PR TITLE
chore(release): bump all packages to 0.2.0, bootstrap CHANGELOG.rst

### DIFF
--- a/dc_bridge/CHANGELOG.rst
+++ b/dc_bridge/CHANGELOG.rst
@@ -1,0 +1,46 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_bridge
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* feat(e2e): three-container robot topology with dc-uploader as its own container (`#447 <https://github.com/Minipada/ros2_data_collection/issues/447>`_)
+* feat(dc_bridge): extract the Uploader into its own dc_uploader process (`#446 <https://github.com/Minipada/ros2_data_collection/issues/446>`_)
+* style: trim overly long comments in the split-topology changes
+* fix(dc_bridge): resolve vector_forward_host via DNS, not literal IP only
+* feat(dc_bridge): add unmanaged-shipper mode and atomic config write (`#444 <https://github.com/Minipada/ros2_data_collection/issues/444>`_)
+* docs(dc_bridge): annotate the vector render test fixture
+* feat(dc_bridge): bless vector as a Destination type (`#443 <https://github.com/Minipada/ros2_data_collection/issues/443>`_)
+* feat(dc_bridge): split shipper.data_dir into separate Shipper and Uploader directories (`#441 <https://github.com/Minipada/ros2_data_collection/issues/441>`_)
+* fix(dc_bridge): carry Measurement custom keys onto File metadata Records (`#419 <https://github.com/Minipada/ros2_data_collection/issues/419>`_)
+* test(dc_bridge,e2e): prove the pipeline under degraded network conditions (`#366 <https://github.com/Minipada/ros2_data_collection/issues/366>`_)
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(dc_bridge): map incident_id onto a Postgres column in the rendered Vector config
+* feat(dc_measurements): stage Files into a FileScratchRing while incident capture is armed (`#290 <https://github.com/Minipada/ros2_data_collection/issues/290>`_)
+* feat(uploader): optional thumbnail/preview generation for image and video Files
+* docs(raw): correct the size-cap advice and the rate-limiter description
+* feat(dc_bridge): collect any ROS topic with a generic-subscription mode (`#227 <https://github.com/Minipada/ros2_data_collection/issues/227>`_)
+* fix(bridge): send Record timestamps at nanosecond resolution (`#308 <https://github.com/Minipada/ros2_data_collection/issues/308>`_)
+* test(dc_bridge): make forwarder reconnect/ack tests robust to CI scheduling jitter
+* feat(dc_bridge): files retention policy — bounded local storage for un-uploaded Files (`#267 <https://github.com/Minipada/ros2_data_collection/issues/267>`_)
+* feat(dc_bridge): confirmed delivery from Bridge to Vector via shipper ingest acks (`#266 <https://github.com/Minipada/ros2_data_collection/issues/266>`_)
+* feat(dc_bridge): durable Uploader intent queue — File uploads survive Bridge restarts (`#265 <https://github.com/Minipada/ros2_data_collection/issues/265>`_)
+* fix(dc_bridge): stop supervisor_test flaking on loaded CI runners
+* docs: remove stale Rust-pilot references from current source and docs
+* fix(e2e): make the reference workload actually flow end-to-end
+* feat: DC 2.0 Bridge C++ Phase 2 — aws_sdk_vendor + File Uploader (ADR-0005)
+* feat: DC 2.0 S8 harness + CI, and revert the Rust Bridge to C++ (Phase 1)
+* refactor: extract status-row builders into an uploader::status submodule
+* feat: Uploader — verified File uploads with metadata Records (ADR-0005) (`#248 <https://github.com/Minipada/ros2_data_collection/issues/248>`_)
+* feat: deterministic launch ordering — Vector/Bridge first, ready gate, then activation (`#247 <https://github.com/Minipada/ros2_data_collection/issues/247>`_)
+* test: store-backed e2e tests hard-fail with instructions instead of skipping
+* docs: recommend RustFS over discontinued MinIO for self-hosted s3 destinations
+* feat: complete blessed Destinations (s3/file/console) + dc.<tag> passthrough contract (`#246 <https://github.com/Minipada/ros2_data_collection/issues/246>`_)
+* feat: add dc_bridge config renderer + PostgreSQL blessed destination (`#245 <https://github.com/Minipada/ros2_data_collection/issues/245>`_)
+* feat: add colcon-test-integrated integration tests for dc_bridge; fix Vector orphaning on shutdown
+* fix: add ros2_data_collection_jazzy.repos for dc_bridge's reproducible Rust builds
+* feat: add dc_bridge tracer bullet — Records flow to Vector console (`#244 <https://github.com/Minipada/ros2_data_collection/issues/244>`_)
+* Contributors: David Bensoussan

--- a/dc_bridge/package.xml
+++ b/dc_bridge/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_bridge</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>
     Bridge node (C++): subscribes to StringStamped Record topics and forwards them to the
     Vector shipper over the Fluent Forward protocol, rendering Vector's config from ROS

--- a/dc_bringup/CHANGELOG.rst
+++ b/dc_bringup/CHANGELOG.rst
@@ -1,0 +1,48 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_bringup
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* feat(e2e): three-container robot topology with dc-uploader as its own container (`#447 <https://github.com/Minipada/ros2_data_collection/issues/447>`_)
+* feat(dc_bridge): extract the Uploader into its own dc_uploader process (`#446 <https://github.com/Minipada/ros2_data_collection/issues/446>`_)
+* docs(dc_bridge): explain shipper.managed's deployment modes
+* feat(dc_bridge): add unmanaged-shipper mode and atomic config write (`#444 <https://github.com/Minipada/ros2_data_collection/issues/444>`_)
+* chore: remove progress.txt session log, rely on git history
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(uploader): optional thumbnail/preview generation for image and video Files
+* docs(raw): correct the size-cap advice and the rate-limiter description
+* feat(dc_bridge): collect any ROS topic with a generic-subscription mode (`#227 <https://github.com/Minipada/ros2_data_collection/issues/227>`_)
+* feat(dc_bringup): auto-launch dc_mcap_writer so it configures like a Destination
+* fix(bridge): send Record timestamps at nanosecond resolution (`#308 <https://github.com/Minipada/ros2_data_collection/issues/308>`_)
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* feat(dc_bridge): files retention policy — bounded local storage for un-uploaded Files (`#267 <https://github.com/Minipada/ros2_data_collection/issues/267>`_)
+* docs: use RustFS instead of MinIO in DC 2.0 example Destinations
+* style: drop issue/ADR provenance from dc_bridge launch comments
+* chore: demolish embedded Fluent Bit — remove fluent_bit\_*, dc_destinations, flb\_* layer (`#250 <https://github.com/Minipada/ros2_data_collection/issues/250>`_)
+* docs: remove stale Rust-pilot references from current source and docs
+* feat: Uploader — verified File uploads with metadata Records (ADR-0005) (`#248 <https://github.com/Minipada/ros2_data_collection/issues/248>`_)
+* feat: deterministic launch ordering — Vector/Bridge first, ready gate, then activation (`#247 <https://github.com/Minipada/ros2_data_collection/issues/247>`_)
+* docs: recommend RustFS over discontinued MinIO for self-hosted s3 destinations
+* feat: complete blessed Destinations (s3/file/console) + dc.<tag> passthrough contract (`#246 <https://github.com/Minipada/ros2_data_collection/issues/246>`_)
+* feat: add dc_bridge config renderer + PostgreSQL blessed destination (`#245 <https://github.com/Minipada/ros2_data_collection/issues/245>`_)
+* feat: add dc_bridge tracer bullet — Records flow to Vector console (`#244 <https://github.com/Minipada/ros2_data_collection/issues/244>`_)
+* feat: port C++ core to ROS 2 Jazzy, ignore Fluent Bit packages (`#242 <https://github.com/Minipada/ros2_data_collection/issues/242>`_)
+* feat: add dc_lifecycle package, to start nodes in requested order (`#220 <https://github.com/Minipada/ros2_data_collection/issues/220>`_)
+* fix: typo in dc_bringup parameter
+* fix+doc: list string equal url
+* feat: can set to start group node in launchfile
+* feat: can set to start dc services from bringup
+* cleanup
+* cleanup: remove unused dep and cmake tests
+* feat: add group node in bringup
+* fix: dependencies dc_bringup
+* feat: add pre-commit and fix all errors
+* feat: start draw, save image and barcode detection service in dc_bringup
+* feat: add tb3_simulation in dc_demos
+* feat: add Destination node and include in uptime configuration and bringup
+* feat: add bringup package to start measurement as lifecycle node
+* Contributors: David Bensoussan

--- a/dc_bringup/package.xml
+++ b/dc_bringup/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
     <name>dc_bringup</name>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <description>Bringup scripts and configurations for the DC stack</description>
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>

--- a/dc_cli/CHANGELOG.rst
+++ b/dc_cli/CHANGELOG.rst
@@ -1,0 +1,15 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_cli
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* docs: DC 2.0 migration guide and docs overhaul, with a live docs CI build (`#252 <https://github.com/Minipada/ros2_data_collection/issues/252>`_)
+* feat: DC 2.0 S8 harness + CI, and revert the Rust Bridge to C++ (Phase 1)
+* feat: add dc_cli package with list_plugin cli tool
+* Contributors: David Bensoussan

--- a/dc_cli/package.xml
+++ b/dc_cli/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_cli</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>DC CLI tools</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_cli/setup.py
+++ b/dc_cli/setup.py
@@ -7,7 +7,7 @@ package_name = "dc_cli"
 
 setup(
     name=package_name,
-    version="0.1.0",
+    version="0.2.0",
     packages=[package_name],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/dc_common/CHANGELOG.rst
+++ b/dc_common/CHANGELOG.rst
@@ -1,0 +1,18 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_common
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* feat(dc_common): add a reusable websocket JSON client (`#390 <https://github.com/Minipada/ros2_data_collection/issues/390>`_)
+* feat(dc_common): StateTransitionDetector and BatteryCycleAccumulator (`#367 <https://github.com/Minipada/ros2_data_collection/issues/367>`_)
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(dc_measurements): stage Files into a FileScratchRing while incident capture is armed (`#290 <https://github.com/Minipada/ros2_data_collection/issues/290>`_)
+* feat(dc_measurements): add IncidentReleaser state machine with post-roll, cooldown and auto re-arm
+* feat(dc_common): add RecordRingBuffer and FileScratchRing utilities (`#285 <https://github.com/Minipada/ros2_data_collection/issues/285>`_)
+* fix+doc: list string equal url
+* feat: add dc_common package which has common class for all future dc packages
+* Contributors: David Bensoussan

--- a/dc_common/package.xml
+++ b/dc_common/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
     <name>dc_common</name>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <description>Common support functionality used throughout the DC stack</description>
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>

--- a/dc_core/CHANGELOG.rst
+++ b/dc_core/CHANGELOG.rst
@@ -1,0 +1,49 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_core
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(dc_measurements): rate-limit the IncidentReleaser buffered-window release (`#289 <https://github.com/Minipada/ros2_data_collection/issues/289>`_)
+* feat(dc_measurements): add IncidentReleaser state machine with post-roll, cooldown and auto re-arm
+* feat(dc_measurements): wire RecordRingBuffer into Measurement with flush-triggered release
+* feat(dc_triggers): add Trigger plugin base, EdgeTrigger, and broadcast node
+* refactor(core): extract the shared ConditionSet evaluator out of Measurement (`#284 <https://github.com/Minipada/ros2_data_collection/issues/284>`_)
+* refactor(dc_measurements,dc_core): rename custom_params to custom_keys (`#186 <https://github.com/Minipada/ros2_data_collection/issues/186>`_)
+* feat(dc_measurements): add gate_condition arming latch for Measurements (`#124 <https://github.com/Minipada/ros2_data_collection/issues/124>`_)
+* chore: demolish embedded Fluent Bit — remove fluent_bit\_*, dc_destinations, flb\_* layer (`#250 <https://github.com/Minipada/ros2_data_collection/issues/250>`_)
+* feat: can nest and flatten sample  (`#206 <https://github.com/Minipada/ros2_data_collection/issues/206>`_)
+* feat: can override custom key or not (`#189 <https://github.com/Minipada/ros2_data_collection/issues/189>`_)
+* fix: move custom parameters to measurement node (`#185 <https://github.com/Minipada/ros2_data_collection/issues/185>`_)
+* fix: run id set in measurement and not in destination (`#181 <https://github.com/Minipada/ros2_data_collection/issues/181>`_)
+* fix: plugins could not be loaded (`#9 <https://github.com/Minipada/ros2_data_collection/issues/9>`_)
+* ci: add ci job (`#1 <https://github.com/Minipada/ros2_data_collection/issues/1>`_)
+* fix: remove callback groups, not used
+* fix: publishActive declared
+* fix: typo
+* doc: add uptime demo
+* fix+doc: list string equal url
+* fix: same_as_previous does not subscribe, data passed directly
+* feat: add pre-commit and fix all errors
+* conf+feat: configure navigation for qrcodes demo
+* feat: add Map measurement plugin
+* feat: add  custom_params in destinations
+* feat: add run id and filter in destination
+* refactor: filter initialization and flb debug moved
+* feat: add base structure for Fluent Bit destinations and flb stdout plugin
+* feat: can set max measurements when condition is enabled
+* feat: add Destination node and include in uptime configuration and bringup
+* feat: add Conditions, plugins to enable collect on condition. Add moving condition
+* feat: add parameter to include parameter name in JSON measurement
+* feat: add init_max_measurements to limit measurements to a certain number when starting the node
+* feat add parameter init_collect for measurements to collect without waiting first tick
+* feat: add tags in the JSON for each measurement plugin. It will be used to match to destinations
+* feat: Add group key, used to group data in the future group node
+* feat: add possibility to validate JSON schema and not send if not validated
+* feat: add basics for the measurement class in new dc_core package
+* feat: add dc_common package which has common class for all future dc packages
+* Contributors: David Bensoussan

--- a/dc_core/package.xml
+++ b/dc_core/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_core</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>A set of headers for plugins core to the DC stack</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_demos/CHANGELOG.rst
+++ b/dc_demos/CHANGELOG.rst
@@ -1,0 +1,88 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_demos
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* feat(dc_bridge): bless vector as a Destination type (`#443 <https://github.com/Minipada/ros2_data_collection/issues/443>`_)
+* chore: remove progress.txt session log, rely on git history
+* feat(dc_measurements): add the Fast DDS statistics Measurement (`#392 <https://github.com/Minipada/ros2_data_collection/issues/392>`_)
+* feat(dc_simulation): publish battery state in the simulation (`#364 <https://github.com/Minipada/ros2_data_collection/issues/364>`_)
+* feat(tools/infrastructure): utilisation, intervention rate and MTBF/MTTR KPI views (`#369 <https://github.com/Minipada/ros2_data_collection/issues/369>`_)
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* fix(tools/sim): read the QR ground truth the way the world file allows
+* feat(dc_measurements): estimate the pose of detected codes (`#48 <https://github.com/Minipada/ros2_data_collection/issues/48>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* refactor(demos): build the demo launch files from one shared description
+* fix(simulation): declare the cameras' field of view instead of inheriting it
+* fix(demos): aim the QR-code demo's cameras at the codes it stops in front of (`#51 <https://github.com/Minipada/ros2_data_collection/issues/51>`_)
+* fix(demos): repoint the AWS warehouse demos at dc_simulation's world
+* fix(demos): drop dead Jazzy paths from the tb3_simulation demos and docs
+* fix(demos): port the Nav2 QR-codes waypoint demo onto `#268 <https://github.com/Minipada/ros2_data_collection/issues/268>`_'s gz-sim simulation
+* fix(demos): rewrite Streamlit dashboard onto the flat postgres schema (`#272 <https://github.com/Minipada/ros2_data_collection/issues/272>`_)
+* feat(uploader): optional thumbnail/preview generation for image and video Files
+* feat(dc_bringup): auto-launch dc_mcap_writer so it configures like a Destination
+* feat(dc_mcap_writer,docs): add MCAP as a passthrough Destination (`#210 <https://github.com/Minipada/ros2_data_collection/issues/210>`_)
+* refactor(dc_measurements,dc_core): rename custom_params to custom_keys (`#186 <https://github.com/Minipada/ros2_data_collection/issues/186>`_)
+* fix(demos): repair the InfluxDB passthrough demo, and cover passthrough in E2E
+* docs(demos): add the Elasticsearch passthrough tutorial
+* fix(bridge): send Record timestamps at nanosecond resolution (`#308 <https://github.com/Minipada/ros2_data_collection/issues/308>`_)
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* fix(dc_demos): resolve build failures surfaced by the full-workspace build
+* feat(dc_simulation): migrate warehouse sim off Gazebo Classic to Gazebo Harmonic (`#268 <https://github.com/Minipada/ros2_data_collection/issues/268>`_)
+* feat(dc_demos): rework demos onto the DC 2.0 Bridge/Vector pipeline (`#251 <https://github.com/Minipada/ros2_data_collection/issues/251>`_)
+* conf: no email for streamlit (headless) (`#233 <https://github.com/Minipada/ros2_data_collection/issues/233>`_)
+* fix: out plugins work (`#230 <https://github.com/Minipada/ros2_data_collection/issues/230>`_)
+* [ImgBot] Optimize images (`#226 <https://github.com/Minipada/ros2_data_collection/issues/226>`_)
+* feat: add grafana dashboard (`#209 <https://github.com/Minipada/ros2_data_collection/issues/209>`_)
+* conf: update to reflect custom_params changes (`#191 <https://github.com/Minipada/ros2_data_collection/issues/191>`_)
+* fix: run id set in measurement and not in destination (`#181 <https://github.com/Minipada/ros2_data_collection/issues/181>`_)
+* conf: group_key is optional, empty by default (`#136 <https://github.com/Minipada/ros2_data_collection/issues/136>`_)
+* doc: add turtlebot aws minio pgsql demos (`#45 <https://github.com/Minipada/ros2_data_collection/issues/45>`_)
+* feat: set minio key and secret from environment in Streamlit (`#43 <https://github.com/Minipada/ros2_data_collection/issues/43>`_)
+* feat: set step for streamlit slider dynamically (`#44 <https://github.com/Minipada/ros2_data_collection/issues/44>`_)
+* refactor: rename qrcodes_dashboard to streamlit_dashboard (`#42 <https://github.com/Minipada/ros2_data_collection/issues/42>`_)
+* feat: can select by time too (`#41 <https://github.com/Minipada/ros2_data_collection/issues/41>`_)
+* feat: streamlit dashboard handles when there is no data or backend/storage not available (`#40 <https://github.com/Minipada/ros2_data_collection/issues/40>`_)
+* feat: add simulation for tb3 pgsql and minio in aws warehouse (`#39 <https://github.com/Minipada/ros2_data_collection/issues/39>`_)
+* feat: add streamlit dashboard (`#37 <https://github.com/Minipada/ros2_data_collection/issues/37>`_)
+* fix: add missing includes (`#7 <https://github.com/Minipada/ros2_data_collection/issues/7>`_)
+* doc+conf: qrcodes demo configuration works and doc updated
+* fix: sim_time used in launch
+* fix+conf: update hooks and fix package.xml
+* fix: add aws warehouse package as dependency to dc_demos
+* doc: add demo for custom uptime
+* fix: add changes to tb3 stdout simulation launch and conf
+* feat: measurement callback with failed validation has access to json data
+* doc: add group memory_uptime demo
+* doc: add uptime demo
+* fix+doc: list string equal url
+* feat: can set to start group node in launchfile
+* fix: set composition to false tb3_qrcodes since it calls a service from a callback
+* feat: can set to start dc services from bringup
+* cleanup: fix syntax update_custom.json
+* feat: add group demo
+* feat: add demo on external measurement plugin and validation failed callback
+* feat: add pre-commit and fix all errors
+* feat+cleanup: add param to start dc and remove unused code
+* refactor: move some simulation packages to a description one
+* conf+feat: configure navigation for qrcodes demo
+* feat: add Node that goes to all points in qr codes demo
+* conf: collect from 2 cameras in demo, if not moving and only 1 measurement
+* feat: add Camera measurement plugin
+* feat: add dc_demo with qrcode environment
+* conf: add map in tb3 demo
+* conf: add cmd_vel in tb3 demo
+* feat: add tb3_simulation in dc_demos
+* feat: add Map measurement plugin
+* doc: machine-id requires systemd package
+* fix: need to cast to int to print bool
+* feat: add newly created parameters in the uptime_stdout.yaml demo
+* feat: add base structure for Fluent Bit destinations and flb stdout plugin
+* feat: add Destination node and include in uptime configuration and bringup
+* feat: add tags in the JSON for each measurement plugin. It will be used to match to destinations
+* feat: add dc_demos repos with examples
+* Contributors: David Bensoussan, imgbot[bot]

--- a/dc_demos/package.xml
+++ b/dc_demos/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_demos</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>DC demo packages</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_description/CHANGELOG.rst
+++ b/dc_description/CHANGELOG.rst
@@ -1,0 +1,16 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_description
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* fix(demos): aim the QR-code demo's cameras at the codes it stops in front of (`#51 <https://github.com/Minipada/ros2_data_collection/issues/51>`_)
+* fix(simulation): spawn the robot, bridge joint_states, and retract a bad diagnosis (`#324 <https://github.com/Minipada/ros2_data_collection/issues/324>`_)
+* fix+conf: update hooks and fix package.xml
+* fix+doc: list string equal url
+* refactor: move some simulation packages to a description one
+* Contributors: David Bensoussan

--- a/dc_description/package.xml
+++ b/dc_description/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
     <name>dc_description</name>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <description>Description files for DC</description>
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>

--- a/dc_group/CHANGELOG.rst
+++ b/dc_group/CHANGELOG.rst
@@ -1,0 +1,24 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_group
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* feat(dc_group): lift a member's incident_id onto the merged Record
+* feat(group): throttle the sync-timeout warnings per group
+* feat(group): drop or emit a partial Record on sync timeout (`#126 <https://github.com/Minipada/ros2_data_collection/issues/126>`_)
+* fix: remove unnecessary list of comprehension
+* feat+fix: add pre-commit for same version for all packages + fix
+* feat+doc: add include_group_name parameter in group node
+* fix: remove tags in measurements when grouping them
+* fix+doc: list string equal url
+* feat: catch when groups is not initialized and exits the groups node
+* cleanup: fix docstrings and run pre-commit
+* refactor: dc_group upgraded to python3.10
+* feat: add dc_group node
+* Contributors: David Bensoussan

--- a/dc_group/package.xml
+++ b/dc_group/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_group</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>DC Group node</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_group/setup.py
+++ b/dc_group/setup.py
@@ -12,7 +12,7 @@ package_name = "dc_group"
 
 setup(
     name=package_name,
-    version="0.1.0",
+    version="0.2.0",
     packages=find_packages(),
     data_files=[
         (

--- a/dc_interfaces/CHANGELOG.rst
+++ b/dc_interfaces/CHANGELOG.rst
@@ -1,0 +1,17 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_interfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(dc_triggers): add Trigger plugin base, EdgeTrigger, and broadcast node
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* fix: condition_pub\_ is a normal publisher, could not publish when lifecycle
+* fix+doc: list string equal url
+* feat: add Camera measurement plugin
+* feat: add StringStamped message which will be used to transmit data as JSON
+* Contributors: David Bensoussan

--- a/dc_interfaces/package.xml
+++ b/dc_interfaces/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_interfaces</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Package containing data collection interfaces.</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_lifecycle_manager/CHANGELOG.rst
+++ b/dc_lifecycle_manager/CHANGELOG.rst
@@ -1,0 +1,15 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_lifecycle_manager
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* test(dc_lifecycle_manager): add gtest coverage for startup ordering, bonds and respawn
+* feat: deterministic launch ordering — Vector/Bridge first, ready gate, then activation (`#247 <https://github.com/Minipada/ros2_data_collection/issues/247>`_)
+* feat: port C++ core to ROS 2 Jazzy, ignore Fluent Bit packages (`#242 <https://github.com/Minipada/ros2_data_collection/issues/242>`_)
+* feat: add dc_lifecycle package, to start nodes in requested order (`#220 <https://github.com/Minipada/ros2_data_collection/issues/220>`_)
+* Contributors: David Bensoussan

--- a/dc_lifecycle_manager/package.xml
+++ b/dc_lifecycle_manager/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
     <name>dc_lifecycle_manager</name>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
     <description>A controller/manager for the lifecycle nodes of the DC system</description>
     <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
     <license>MPL-2.0</license>

--- a/dc_mcap_writer/CHANGELOG.rst
+++ b/dc_mcap_writer/CHANGELOG.rst
@@ -1,0 +1,14 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_mcap_writer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* test(dc_mcap_writer,e2e): add smoke + zero-loss e2e coverage for the MCAP passthrough
+* feat(dc_mcap_writer,docs): add MCAP as a passthrough Destination (`#210 <https://github.com/Minipada/ros2_data_collection/issues/210>`_)
+* Contributors: David Bensoussan

--- a/dc_mcap_writer/package.xml
+++ b/dc_mcap_writer/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_mcap_writer</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>
     Passthrough MCAP writer (ADR-0003, ADR-0009): consumes Records over the public
     dc.&lt;tag&gt; routes and writes rotated .mcap files for ROS 2 bag replay (#210).

--- a/dc_mcap_writer/setup.py
+++ b/dc_mcap_writer/setup.py
@@ -7,7 +7,7 @@ package_name = "dc_mcap_writer"
 
 setup(
     name=package_name,
-    version="0.1.0",
+    version="0.2.0",
     packages=[package_name],
     data_files=[
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),

--- a/dc_measurements/CHANGELOG.rst
+++ b/dc_measurements/CHANGELOG.rst
@@ -1,0 +1,185 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_measurements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* fix(dc_measurements): assert on lifecycle state, not a thrown exception
+* style: fix clang-format violations in test_measurement_dummy.cpp
+* feat(dc_measurements): resolve robot_name from literal, hostname, or file (`#442 <https://github.com/Minipada/ros2_data_collection/issues/442>`_)
+* style(dc_measurements): apply clang-format to Mission adapter changes
+* refactor(dc_measurements): share the Mission Record JSON Schema via a loader-backed $ref
+* refactor(dc_measurements): deepen the Mission adapter lifecycle and pending-record queue
+* fix(dc_bridge): carry Measurement custom keys onto File metadata Records (`#419 <https://github.com/Minipada/ros2_data_collection/issues/419>`_)
+* fix(dc_measurements): keep PushServer's io_context alive between sends
+* fix(dc_measurements): init rclcpp in the mission_open_rmf integration test
+* feat(dc_measurements): add the Mission Measurement Open-RMF adapter (`#391 <https://github.com/Minipada/ros2_data_collection/issues/391>`_)
+* feat(dc_measurements): add the Mission Measurement nav2 NavigateToPose adapter (`#387 <https://github.com/Minipada/ros2_data_collection/issues/387>`_)
+* feat(dc_measurements): add the slam_toolbox quality Measurement (`#407 <https://github.com/Minipada/ros2_data_collection/issues/407>`_)
+* fix(dc_measurements): rename fastdds_stats' processes field to process_names
+* feat(dc_measurements): add the Fast DDS statistics Measurement (`#392 <https://github.com/Minipada/ros2_data_collection/issues/392>`_)
+* fix(dc_measurements): use abort(), not canceled(), for the PREEMPTED test case
+* feat(dc_measurements): add the Manipulation Measurement, a MoveIt MoveGroup adapter (`#393 <https://github.com/Minipada/ros2_data_collection/issues/393>`_)
+* feat(dc_measurements): add the ros2_control status Measurement
+* fix(dc_measurements): use GoalStatusArray.status_list, not .status (`#389 <https://github.com/Minipada/ros2_data_collection/issues/389>`_)
+* fix(dc_measurements): use MissedWaypoint, not WaypointStatus, for FollowWaypoints (`#389 <https://github.com/Minipada/ros2_data_collection/issues/389>`_)
+* feat(measurements): add mission_nav2_follow_waypoints Measurement (`#389 <https://github.com/Minipada/ros2_data_collection/issues/389>`_)
+* fix(dc_measurements): remove redundant goal_handle->execute() in test fixture
+* fix(dc_measurements): drop waypoint_statuses, absent from Jazzy's nav2_msgs
+* feat(dc_measurements): add Mission Measurement NavigateThroughPoses adapter (`#388 <https://github.com/Minipada/ros2_data_collection/issues/388>`_)
+* fix(dc_measurements): establish an OK baseline before a fault's first transition in tests
+* style(dc_measurements): apply clang-format to the fault Measurement
+* feat(dc_measurements): add the fault Measurement, raise/change/clear from diagnostics (`#365 <https://github.com/Minipada/ros2_data_collection/issues/365>`_)
+* feat(dc_measurements): intervention Measurement for human takeovers (`#373 <https://github.com/Minipada/ros2_data_collection/issues/373>`_)
+* feat(dc_measurements): add the battery Measurement, with charge sessions and cycles
+* test(dc_measurements): cover one FlushEvent releasing several Measurements (`#345 <https://github.com/Minipada/ros2_data_collection/issues/345>`_)
+* fix(dc_measurements): retract the QR in-plane rotation limitation (`#297 <https://github.com/Minipada/ros2_data_collection/issues/297>`_)
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* feat(dc_measurements): estimate the pose of detected codes (`#48 <https://github.com/Minipada/ros2_data_collection/issues/48>`_)
+* fix(dc_measurements): constrain the Thermal Record's JSON schema
+* test(dc_measurements): pace the released window in the File staging test
+* feat(dc_measurements): stage Files into a FileScratchRing while incident capture is armed (`#290 <https://github.com/Minipada/ros2_data_collection/issues/290>`_)
+* feat(dc_measurements): rate-limit the IncidentReleaser buffered-window release (`#289 <https://github.com/Minipada/ros2_data_collection/issues/289>`_)
+* feat(dc_measurements): add IncidentReleaser state machine with post-roll, cooldown and auto re-arm
+* feat(dc_measurements): wire RecordRingBuffer into Measurement with flush-triggered release
+* refactor(core): extract the shared ConditionSet evaluator out of Measurement (`#284 <https://github.com/Minipada/ros2_data_collection/issues/284>`_)
+* fix(simulation): spawn the robot, bridge joint_states, and retract a bad diagnosis (`#324 <https://github.com/Minipada/ros2_data_collection/issues/324>`_)
+* fix(measurements): assert no-data measurements never publish, not that they publish empty
+* fix(measurements): link yaml-cpp/ffmpeg into plugins that dlopen-failed in CI
+* test(measurements): add gtest coverage for the remaining 11 measurement plugins
+* test(conditions): add gtest coverage for the remaining condition plugins
+* fix(conditions): fix 8 bugs found while adding condition-plugin test coverage
+* test(conditions): add gtest coverage for the double_equal condition plugin
+* test(measurements): add gtest coverage for the camera plugin
+* refactor(dc_measurements,dc_core): rename custom_params to custom_keys (`#186 <https://github.com/Minipada/ros2_data_collection/issues/186>`_)
+* refactor(dc_measurements,dc_util): unify parameter declaration on dc_util helpers (`#178 <https://github.com/Minipada/ros2_data_collection/issues/178>`_)
+* feat(dc_measurements): add gate_condition arming latch for Measurements (`#124 <https://github.com/Minipada/ros2_data_collection/issues/124>`_)
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* feat(dc_measurements): add DrivingType measurement plugin
+* feat(dc_measurements): add Thermal measurement plugin (`#100 <https://github.com/Minipada/ros2_data_collection/issues/100>`_)
+* fix(dc_measurements): use a second, independently-named node for the Random seed test
+* feat(dc_measurements): add Random measurement plugin (`#88 <https://github.com/Minipada/ros2_data_collection/issues/88>`_)
+* fix(dc_measurements): detect serial hangup via poll(POLLHUP), not read()==0
+* fix(dc_measurements): allocate the reconnect test's pty directly, not via a second socat
+* fix(dc_measurements): use posix_spawn for the serial test's socat subprocess
+* fix(dc_measurements): don't treat VMIN=0 termios read()=0 as serial disconnect
+* feat(dc_measurements): add Serial Interface measurement plugin (`#60 <https://github.com/Minipada/ros2_data_collection/issues/60>`_)
+* feat(dc_measurements): add Diagnostics measurement plugin (`#49 <https://github.com/Minipada/ros2_data_collection/issues/49>`_)
+* chore: demolish embedded Fluent Bit — remove fluent_bit\_*, dc_destinations, flb\_* layer (`#250 <https://github.com/Minipada/ros2_data_collection/issues/250>`_)
+* feat: deterministic launch ordering — Vector/Bridge first, ready gate, then activation (`#247 <https://github.com/Minipada/ros2_data_collection/issues/247>`_)
+* feat: port C++ core to ROS 2 Jazzy, ignore Fluent Bit packages (`#242 <https://github.com/Minipada/ros2_data_collection/issues/242>`_)
+* feat: stop measurement if it reached limit (`#231 <https://github.com/Minipada/ros2_data_collection/issues/231>`_)
+* feat: add dc_lifecycle package, to start nodes in requested order (`#220 <https://github.com/Minipada/ros2_data_collection/issues/220>`_)
+* fix: position plugin uses right timeout parameter (`#218 <https://github.com/Minipada/ros2_data_collection/issues/218>`_)
+* feat: add grafana dashboard (`#209 <https://github.com/Minipada/ros2_data_collection/issues/209>`_)
+* feat: can nest and flatten sample  (`#206 <https://github.com/Minipada/ros2_data_collection/issues/206>`_)
+* feat: can save map as base64 img (`#207 <https://github.com/Minipada/ros2_data_collection/issues/207>`_)
+* feat: save camera image as base64 (`#205 <https://github.com/Minipada/ros2_data_collection/issues/205>`_)
+* fix: distance_traveled measurement checks tf is available (`#204 <https://github.com/Minipada/ros2_data_collection/issues/204>`_)
+* fix: load base path in right place (`#202 <https://github.com/Minipada/ros2_data_collection/issues/202>`_)
+* conf: better messages from condition when failed (`#199 <https://github.com/Minipada/ros2_data_collection/issues/199>`_)
+* conf: better information message for activation of nodes (`#198 <https://github.com/Minipada/ros2_data_collection/issues/198>`_)
+* feat: can override custom key or not (`#189 <https://github.com/Minipada/ros2_data_collection/issues/189>`_)
+* fix: move custom parameters to measurement node (`#185 <https://github.com/Minipada/ros2_data_collection/issues/185>`_)
+* fix: run id set in measurement and not in destination (`#181 <https://github.com/Minipada/ros2_data_collection/issues/181>`_)
+* feat: add dummy measurement (`#145 <https://github.com/Minipada/ros2_data_collection/issues/145>`_)
+* conf: group_key is optional, empty by default (`#136 <https://github.com/Minipada/ros2_data_collection/issues/136>`_)
+* fix+test: fix test polling interval (`#109 <https://github.com/Minipada/ros2_data_collection/issues/109>`_)
+* test: split test_os node and add test_m_parameters (`#107 <https://github.com/Minipada/ros2_data_collection/issues/107>`_)
+* cleanup: Camera measurement (`#36 <https://github.com/Minipada/ros2_data_collection/issues/36>`_)
+* fix: non blocking measurement subscriber (`#35 <https://github.com/Minipada/ros2_data_collection/issues/35>`_)
+* conf: set include_measurement_name to true by default (`#32 <https://github.com/Minipada/ros2_data_collection/issues/32>`_)
+* fix: same_as_previous condition does not crash with empty json (`#30 <https://github.com/Minipada/ros2_data_collection/issues/30>`_)
+* feat: add camera name in camera (`#29 <https://github.com/Minipada/ros2_data_collection/issues/29>`_)
+* fix: non inspected camera images are collected (`#28 <https://github.com/Minipada/ros2_data_collection/issues/28>`_)
+* feat: add total memory in OS measurement (`#27 <https://github.com/Minipada/ros2_data_collection/issues/27>`_)
+* feat: add tcp health measurement (`#26 <https://github.com/Minipada/ros2_data_collection/issues/26>`_)
+* cleanup+doc: remove not used variables and fix comment on ram data (`#19 <https://github.com/Minipada/ros2_data_collection/issues/19>`_)
+* fix: max_process handled properly in cpu measurement (`#22 <https://github.com/Minipada/ros2_data_collection/issues/22>`_)
+* feat: also save map as png (`#20 <https://github.com/Minipada/ros2_data_collection/issues/20>`_)
+* feat+doc: add computed field in cmd_vel (`#17 <https://github.com/Minipada/ros2_data_collection/issues/17>`_)
+* fix: moving use and as in python and not && (`#16 <https://github.com/Minipada/ros2_data_collection/issues/16>`_)
+* fix: when getting command, strip 0 unicode (`#13 <https://github.com/Minipada/ros2_data_collection/issues/13>`_)
+* fix: plugins could not be loaded (`#9 <https://github.com/Minipada/ros2_data_collection/issues/9>`_)
+* fix: add missing includes (`#7 <https://github.com/Minipada/ros2_data_collection/issues/7>`_)
+* test: add test for uptime (`#5 <https://github.com/Minipada/ros2_data_collection/issues/5>`_)
+* test: add test for os value (`#2 <https://github.com/Minipada/ros2_data_collection/issues/2>`_)
+* ci: add ci job (`#1 <https://github.com/Minipada/ros2_data_collection/issues/1>`_)
+* fix+ci: uuid included as lib
+* test: add first test
+* feat: throw an error if ffmpeg not installed in ip_camera measurement
+* fix: double_equal condition returns data correctly
+* fix: ignore init publish if init_max_measurements = -1
+* fix: camera measurement only send measurement if field non empty
+* fix+conf: update hooks and fix package.xml
+* feat: catch JSON parsing error in conditions
+* fix: include condition msg header
+* fix: functions needed to be virtual or overridden
+* cleanup: condition are UniqueInstance plugin
+* fix: only save inspected image if there are result to inspection
+* fix: rename remote_keys to remote_paths in camera measurement
+* fix: condition_pub\_ is a normal publisher, could not publish when lifecycle
+* fix: remove callback groups, not used
+* feat: add parameter validation to ip camera measurement
+* feat: change permission format from integer to string(rwx/int)
+* fix: if measurement crash, does not collect measurement with init_collect
+* feat: add parameter validation to network measurement
+* feat: if error during measurement initialization, stop it from publishing
+* fix: if topic_output is empty, use the measurement name properly
+* fix: enabled is a bool, not a double
+* fix: speed measurement typos
+* feat: measurement callback with failed validation has access to json data
+* fix: apply clang-format
+* featL add ip_camera measurement
+* fix+doc: list string equal url
+* fix: same as previous cpp
+* refactor: add naming convention for plugins
+* refactor: edit start service message in camera.cpp
+* fix string stamped measurement and can get all messages
+* feat: add conditions (list bool, double, integer, string and string match)
+* feat: add warning on problems in conditions
+* feat: add condition for int, double and bool equal
+* cleanup
+* feat: add exist condition
+* fix: same_as_previous does not subscribe, data passed directly
+* feat: add same_as_previous condition
+* refactor: move moving condition include to include directory
+* doc: add basis for documentation
+* cleanup: include and dependencies
+* feat: add pre-commit and fix all errors
+* fix: rename variable active to active\_
+* conf+feat: configure navigation for qrcodes demo
+* fix: conditions plugin parameter loaded in measurement node
+* feat: start draw, save image and barcode detection service in dc_bringup
+* feat: add Camera measurement plugin
+* fix: load custom parameters in measurement server
+* conf: add map in tb3 demo
+* conf: add cmd_vel in tb3 demo
+* feat: add Command Velocity measurement plugin
+* feat: add Map measurement plugin
+* feat: can set max measurements when condition is enabled
+* feat: add Destination node and include in uptime configuration and bringup
+* feat: add Distance Travaled plugin
+* feat: add Speed plugin
+* feat: add Position plugin
+* cleanup: remove non needed class variable
+* feat: add Conditions, plugins to enable collect on condition. Add moving condition
+* feat: add parameter to include parameter name in JSON measurement
+* feat: add init_max_measurements to limit measurements to a certain number when starting the node
+* feat add parameter init_collect for measurements to collect without waiting first tick
+* feat: add tags in the JSON for each measurement plugin. It will be used to match to destinations
+* feat: add Permissions measurement plugin
+* feat: add Storage measurement plugin
+* feat: add Memory measurement plugin
+* feat: add Network measurement plugin
+* feat: add CPU measurement plugin
+* feat: add OS measurement plugin
+* feat: add StringStamped measurement plugin
+* feat: Add group key, used to group data in the future group node
+* feat: add bringup package to start measurement as lifecycle node
+* feat: add possibility to validate JSON schema and not send if not validated
+* feat: initialize measurement node with polling interval and uptime plugin
+* Contributors: David Bensoussan

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_measurements</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Collect data with measurement plugins</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_services/CHANGELOG.rst
+++ b/dc_services/CHANGELOG.rst
@@ -1,0 +1,23 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_services
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* fix(demos): drop dead Jazzy paths from the tb3_simulation demos and docs
+* fix(demos): port the Nav2 QR-codes waypoint demo onto `#268 <https://github.com/Minipada/ros2_data_collection/issues/268>`_'s gz-sim simulation
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* feat+fix: add pre-commit for same version for all packages + fix
+* fix+doc: list string equal url
+* feat: add pre-commit and fix all errors
+* fix: add zbar as dep to dc_services
+* conf+feat: configure navigation for qrcodes demo
+* feat: add service to detect barcodes on image
+* feat: add service to save image
+* feat: add service to draw on image
+* Contributors: David Bensoussan

--- a/dc_services/package.xml
+++ b/dc_services/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_services</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Collect uptime data</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_services/setup.py
+++ b/dc_services/setup.py
@@ -12,7 +12,7 @@ package_name = "dc_services"
 
 setup(
     name=package_name,
-    version="0.1.0",
+    version="0.2.0",
     packages=find_packages(),
     data_files=[
         (

--- a/dc_simulation/CHANGELOG.rst
+++ b/dc_simulation/CHANGELOG.rst
@@ -1,0 +1,39 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_simulation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* fix(dc_simulation): correct license metadata for third-party sim models (`#426 <https://github.com/Minipada/ros2_data_collection/issues/426>`_)
+* chore: remove progress.txt session log, rely on git history
+* feat(dc_simulation): publish battery state in the simulation (`#364 <https://github.com/Minipada/ros2_data_collection/issues/364>`_)
+* fix(dc_simulation): replace the MOV.AI warehouse mesh with primitive geometry (`#357 <https://github.com/Minipada/ros2_data_collection/issues/357>`_)
+* fix(dc_simulation): restore the MOV.AI warehouse model to its verbatim upstream
+* feat(tools/sim): measure raw-mode collection volume against the simulated robot (`#326 <https://github.com/Minipada/ros2_data_collection/issues/326>`_)
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* fix(simulation): declare qrcodes.world's ambient light, verify `#61 <https://github.com/Minipada/ros2_data_collection/issues/61>`_ doesn't reproduce
+* fix(simulation): measure, attribute and partially trim `#52 <https://github.com/Minipada/ros2_data_collection/issues/52>`_'s slow QR-codes demo startup
+* fix(simulation): declare the cameras' field of view instead of inheriting it
+* fix(demos): aim the QR-code demo's cameras at the codes it stops in front of (`#51 <https://github.com/Minipada/ros2_data_collection/issues/51>`_)
+* fix(demos): drop dead Jazzy paths from the tb3_simulation demos and docs
+* fix(simulation): spawn the robot, bridge joint_states, and retract a bad diagnosis (`#324 <https://github.com/Minipada/ros2_data_collection/issues/324>`_)
+* fix(demos): port the Nav2 QR-codes waypoint demo onto `#268 <https://github.com/Minipada/ros2_data_collection/issues/268>`_'s gz-sim simulation
+* fix(dc_simulation): resolve qrcode texture-loading errors from a real run
+* fix(dc_demos): resolve build failures surfaced by the full-workspace build
+* feat(dc_simulation): migrate warehouse sim off Gazebo Classic to Gazebo Harmonic (`#268 <https://github.com/Minipada/ros2_data_collection/issues/268>`_)
+* [ImgBot] Optimize images (`#226 <https://github.com/Minipada/ros2_data_collection/issues/226>`_)
+* fix: remove fireextanguisher
+* cleanup: remove fireextanguisher item for simulation
+* feat: add MonitorAndKeyboard item for simulation
+* fix+doc: list string equal url
+* feat: add pre-commit and fix all errors
+* feat: add tool to generate qrcodes
+* cleanup: remove unused MonitorAndKeyboard model
+* refactor: move some simulation packages to a description one
+* conf+feat: configure navigation for qrcodes demo
+* fix: camera left points left and right right
+* feat: add dc_demo with qrcode environment
+* Contributors: David Bensoussan, imgbot[bot]

--- a/dc_simulation/package.xml
+++ b/dc_simulation/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_simulation</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Warehouse simulation.</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_triggers/CHANGELOG.rst
+++ b/dc_triggers/CHANGELOG.rst
@@ -1,0 +1,14 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_triggers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* build(tooling): run the hooks with prek and manage Python deps with uv
+* fix(dc_triggers): re-arm Moving with two above-threshold messages in test
+* feat(dc_triggers): add Trigger plugin base, EdgeTrigger, and broadcast node
+* Contributors: David Bensoussan

--- a/dc_triggers/package.xml
+++ b/dc_triggers/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_triggers</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>Trigger plugins and the broadcast node that publishes FlushEvents when one fires</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>

--- a/dc_util/CHANGELOG.rst
+++ b/dc_util/CHANGELOG.rst
@@ -1,0 +1,36 @@
+.. SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+.. SPDX-License-Identifier: MPL-2.0
+
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package dc_util
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.2.0 (2026-09-02)
+------------------
+* chore(license): declare copyright and license on every file (REUSE) (`#301 <https://github.com/Minipada/ros2_data_collection/issues/301>`_)
+* refactor(dc_measurements,dc_util): unify parameter declaration on dc_util helpers (`#178 <https://github.com/Minipada/ros2_data_collection/issues/178>`_)
+* feat(dc_measurements): move barcode/QR detection in-process via ZXing-C++ (`#123 <https://github.com/Minipada/ros2_data_collection/issues/123>`_)
+* feat: deterministic launch ordering — Vector/Bridge first, ready gate, then activation (`#247 <https://github.com/Minipada/ros2_data_collection/issues/247>`_)
+* feat: port C++ core to ROS 2 Jazzy, ignore Fluent Bit packages (`#242 <https://github.com/Minipada/ros2_data_collection/issues/242>`_)
+* feat: add grafana dashboard (`#209 <https://github.com/Minipada/ros2_data_collection/issues/209>`_)
+* feat: save camera image as base64 (`#205 <https://github.com/Minipada/ros2_data_collection/issues/205>`_)
+* test: add test for os value (`#2 <https://github.com/Minipada/ros2_data_collection/issues/2>`_)
+* ci: add ci job (`#1 <https://github.com/Minipada/ros2_data_collection/issues/1>`_)
+* fix: camera measurement only send measurement if field non empty
+* fix+conf: update hooks and fix package.xml
+* feat: change permission format from integer to string(rwx/int)
+* fix+doc: list string equal url
+* feat: add same_as_previous condition
+* feat: add pre-commit and fix all errors
+* feat: add Camera measurement plugin
+* feat: add Fluent Bit PostgreSQL destination plugin
+* conf: add cmd_vel in tb3 demo
+* feat: add Command Velocity measurement plugin
+* feat: add Map measurement plugin
+* feat: add run id and filter in destination
+* feat: add base structure for Fluent Bit destinations and flb stdout plugin
+* feat: add Conditions, plugins to enable collect on condition. Add moving condition
+* feat: add Storage measurement plugin
+* fix: add boost as dep for dc_util
+* feat: add wrappers to load parameters easily in new dc_util package
+* Contributors: David Bensoussan

--- a/dc_util/package.xml
+++ b/dc_util/package.xml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MPL-2.0
 
 <package format="3">
   <name>dc_util</name>
-  <version>0.1.0</version>
+  <version>0.2.0</version>
   <description>General headers used in DC</description>
   <maintainer email="d.bensoussan@proton.me">David Bensoussan</maintainer>
   <license>MPL-2.0</license>


### PR DESCRIPTION
## Summary

- Bumps all 16 in-repo packages' `package.xml` `<version>` from `0.1.0` to `0.2.0` in one lockstep commit, plus the 4 Python packages' `setup.py` `version` (kept in sync by the `ros2-package-versions` pre-commit hook).
- Bootstraps a `CHANGELOG.rst` per package via `catkin_generate_changelog -a -y` (no release tag exists yet, so `-a` was needed to seed history), hand-edited down from full commit bodies to one-line REP-0132 entries — dropping prose, `Co-Authored-By`/`Claude-Session` footers, keeping each entry's subject line plus a `Closes #N` link where the source commit had one.
- `dc_simulation/CHANGELOG.rst` gets a hand-added entry for #426, since that commit only touched root-level `REUSE.toml` — outside `catkin_generate_changelog`'s per-package path scoping, so the tool couldn't pick it up automatically.
- `codespell` auto-fixed a handful of pre-existing typos surfaced while formatting the generated changelogs (`configuraiton`, `subsribe`, `overriden`, `unecessary`, `measurment`).

## Note on #424 / #425 (18 vs 16 packages)

Issue #427's acceptance criteria (written when #421 was filed) refer to "18 packages." Since then, #424 and #425 concluded with `vector_vendor` and `aws_sdk_vendor` split out into their own repos (`github.com/Minipada/vector_vendor`, `github.com/Minipada/aws_sdk_vendor`, pulled in via `ros2_data_collection.repos`), each with its own independent release/changelog lifecycle. Neither package's `package.xml` lives in this repo any more, so neither is bumped or changelogged here — this repo now has 16 packages, all bumped to `0.2.0`.

## Verification (acceptance criteria)

- [x] All 16 in-repo `package.xml` `<version>` tags (the current package count — see note above) read `0.2.0`
- [x] Every package has a `CHANGELOG.rst` generated via `catkin_generate_changelog` and hand-edited for clarity
- [x] Changelog entries reflect #426 (dc_simulation license, added by hand); #424/#425 have no entry since their packages no longer live in this repo (see note above)
- [x] `reuse lint` passes
- [x] `prek run --all-files --skip build-doc` passes clean, including the `ros2-package-versions` and `reuse` hooks

Closes #427

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XiyaKw8R3tg1fCHBvaXUF