### PR TITLE
feat(deploy): Helm chart + Kustomize overlays for the robot tier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,8 +43,10 @@ repos:
         # kubeconform (this file's `kubeconform` hook, scoped to the same `kubernetes/`
         # dirs) already parses and schema-validates every document in these files, so
         # excluding them here doesn't drop coverage, just the redundant single-document
-        # check.
-        exclude: "(^|/)tools/kind/kubernetes/.*\\.ya?ml$"
+        # check. deploy/robot/helm/dc-robot/templates/*.yaml are Helm templates (#466)
+        # — Go template syntax (`{{ }}`), not standalone YAML; `helm lint`/`helm
+        # template` (see deploy/robot/README.md) is that directory's own syntax check.
+        exclude: "(^|/)tools/kind/kubernetes/.*\\.ya?ml$|(^|/)deploy/robot/helm/dc-robot/templates/.*\\.ya?ml$"
       - id: check-toml
         name: Verify toml syntax
       - id: check-xml

--- a/deploy/robot/README.md
+++ b/deploy/robot/README.md
@@ -20,6 +20,47 @@ All three point at the same published images
 `build-dc-ros-image`/`build-dc-uploader-image` jobs — this ticket adds no new build or
 publish path (building and shipping still goes through Podman, unchanged).
 
+## Helm chart + Kustomize overlays per site/robot (#466)
+
+`kubernetes/robot-pod.yaml` above is one fixed topology — correct for the runtime-free
+check, k3d (#451) and kind (#452) loops, but a real fleet's robots genuinely differ:
+edge aggregator address, robot identity, resource limits, image tags, credentials.
+`helm/dc-robot/` is a chart that parameterizes exactly that (`docs/adr/0016`); its
+defaults reproduce `kubernetes/robot-pod.yaml` + `params/robot_params.yaml` field for
+field, so `helm template` with no overrides passes the same `kubeconform` check that
+file does — this is a parameterized rendering path alongside the other three, not a
+replacement of any of them. `helm/overlays/site-a/` is a reference Kustomize overlay
+showing per-site variation composed on top: a site's own `values-<site>.yaml` (robot
+identity, edge address — the chart's values surface) plus a patch for whatever a chart
+value shouldn't cover (here, a `nodeSelector` pinning the Pod to that site's labeled
+edge-adjacent node).
+
+```sh
+# Render the chart alone, with defaults (same shape as kubernetes/robot-pod.yaml):
+helm template dc-robot deploy/robot/helm/dc-robot
+
+# Render a site's overlay — chart values + Kustomize patches, in one command
+# (--enable-helm is required: kustomize's Helm inflator is opt-in; --load-restrictor
+# LoadRestrictionsNone is required because the overlay's base, the chart, lives outside
+# its own directory tree, same reason k3d/kustomization.yaml needs it):
+kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone \
+  --helm-command="$(which helm)" deploy/robot/helm/overlays/site-a
+
+# Schema-validate either rendering the same way as kubernetes/robot-pod.yaml
+# (kubeconform.sh resolves its argument against the repo root, so render to a path
+# inside it, not /tmp):
+kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone \
+  --helm-command="$(which helm)" deploy/robot/helm/overlays/site-a > deploy/robot/helm/.rendered-site-a.yaml
+./tools/ci/pre-commit/kubeconform.sh deploy/robot/helm/.rendered-site-a.yaml
+rm deploy/robot/helm/.rendered-site-a.yaml
+```
+
+A site with N robots installs N releases (one per robot, each its own
+`values-<robot>.yaml`/overlay), never one release templating N robots internally — see
+`docs/adr/0016` for the full design and rejected alternatives, including why this is a
+different call from `tools/kind/README.md`'s "Why not Helm" (a fixed one-topology CI
+harness, not a real fleet).
+
 ## What differs from `tools/e2e/compose.split.yaml`
 
 `compose.split.yaml` is the *test* rendering of the three-container topology (#447): it adds

--- a/deploy/robot/helm/dc-robot/.helmignore
+++ b/deploy/robot/helm/dc-robot/.helmignore
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+.git/
+.gitignore
+*.tgz

--- a/deploy/robot/helm/dc-robot/Chart.yaml
+++ b/deploy/robot/helm/dc-robot/Chart.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Helm chart for the robot tier's Kubernetes rendering (#466, docs/adr/0016). Templates
+# the same three-container shape as ../../kubernetes/robot-pod.yaml (#450) — this chart
+# does not replace that file, which stays the runtime-free/k3d/kind reference; it is the
+# parameterized version for a real fleet, where edge address, robot identity, image tags
+# and resource limits genuinely vary per deployment.
+apiVersion: v2
+name: dc-robot
+description: DC robot tier (dc-ros + vector + dc-uploader) for a fleet's per-site/per-robot Kubernetes deployment
+type: application
+version: 0.1.0
+appVersion: "0.2.0"
+home: https://github.com/Minipada/ros2_data_collection
+sources:
+  - https://github.com/Minipada/ros2_data_collection

--- a/deploy/robot/helm/dc-robot/templates/_helpers.tpl
+++ b/deploy/robot/helm/dc-robot/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Shared labels for the chart's two objects (Pod, ConfigMap) — a leading underscore
+# keeps Helm from rendering this file as a manifest of its own.
+{{- define "dc-robot.labels" -}}
+app.kubernetes.io/part-of: dc-robot-tier
+app.kubernetes.io/name: dc-robot
+app.kubernetes.io/instance: {{ .Values.robot.name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deploy/robot/helm/dc-robot/templates/configmap-robot-params.yaml
+++ b/deploy/robot/helm/dc-robot/templates/configmap-robot-params.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Renders ../../params/robot_params.yaml as a ConfigMap (docs/adr/0016): the real-
+# cluster mechanism ../../kubernetes/robot-pod.yaml's own header already calls for
+# ("a Pod-scoped Secret/ConfigMap object is the real-cluster mechanism"), in place of
+# that file's hostPath (a podman-kube-play/k3d/kind convenience only, not something a
+# real cluster offers). templates/pod.yaml mounts this ConfigMap at the same
+# /opt/dc/robot_params.yaml path.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.robot.name }}-params
+  labels:
+    {{- include "dc-robot.labels" . | nindent 4 }}
+data:
+  # Two branches, not a partial template: robotParams.override is a full literal
+  # replacement (see values.yaml), never merged field-by-field with the templated
+  # default below — a site either takes the templated `uptime`-only shape or supplies
+  # its own file whole, same as hand-editing params/robot_params.yaml today.
+  robot_params.yaml: |
+{{- if .Values.robotParams.override }}
+{{ .Values.robotParams.override | indent 4 }}
+{{- else }}
+    measurement_server:
+      ros__parameters:
+        save_local_base_path: "$HOME/.dc/robot/data/%Y/%M/%D/%H"
+        all_base_path: "robot"
+        measurement_plugins: ["uptime"]
+
+        uptime:
+          plugin: "dc_measurements/Uptime"
+          polling_interval: 1000
+          group_key: "uptime"
+
+    dc_bridge:
+      ros__parameters:
+        shipper:
+          managed: false
+          config_path: "/etc/dc/shipper/vector.toml"
+          data_dir: "/var/lib/vector"
+          bind_host: "0.0.0.0"
+        uploader:
+          data_dir: "$HOME/.dc/robot/uploader"
+        destinations: ["edge_vector"]
+        edge_vector:
+          type: vector
+          receives: records
+          inputs: ["/dc/measurement/uptime"]
+          host: {{ .Values.edge.vectorHost | quote }}
+          port: {{ .Values.edge.vectorPort }}
+
+        vector_forward_host: "vector"
+        vector_forward_port: 24224
+
+    lifecycle_manager_dc:
+      ros__parameters:
+        node_names: ["measurement_server"]
+        transitions: [configure, activate]
+{{- end }}

--- a/deploy/robot/helm/dc-robot/templates/pod.yaml
+++ b/deploy/robot/helm/dc-robot/templates/pod.yaml
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Templated version of ../../kubernetes/robot-pod.yaml (#450, docs/adr/0016): same
+# three-container/shared-volume/hostAlias shape — only image refs, resources, robot
+# identity and dc-uploader's per-site env become chart values (see ../values.yaml's own
+# header for what does and doesn't vary here). The one structural difference from that
+# file: robot-params mounts from the ConfigMap this chart renders
+# (../templates/configmap-robot-params.yaml) instead of a hostPath.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ .Values.robot.name }}
+  labels:
+    {{- include "dc-robot.labels" . | nindent 4 }}
+spec:
+  restartPolicy: Always
+  # All three containers share the Pod's network namespace, so dc-uploader's
+  # DC_UPLOADER_SHIPPER_HOST and the rendered robot_params.yaml's vector_forward_host
+  # both name "vector" rather than 127.0.0.1 — this alias is what makes that resolve.
+  hostAliases:
+    - ip: "127.0.0.1"
+      hostnames: ["vector"]
+  containers:
+    - name: dc-ros
+      image: "{{ .Values.images.dcRos.repository }}:{{ .Values.images.dcRos.tag }}"
+      imagePullPolicy: {{ .Values.images.pullPolicy }}
+      args: ["dc_params_file:=/opt/dc/robot_params.yaml", "run_uploader:=false"]
+      resources:
+        {{- toYaml .Values.resources.dcRos | nindent 8 }}
+      volumeMounts:
+        - name: uploader
+          mountPath: /root/.dc/robot/uploader
+        - name: config
+          mountPath: /etc/dc/shipper
+        - name: robot-params
+          mountPath: /opt/dc/robot_params.yaml
+          subPath: robot_params.yaml
+          readOnly: true
+
+    # The Uploader as its own container (docs/adr/0014), configured entirely by
+    # DC_UPLOADER_* env — no ROS params.
+    - name: dc-uploader
+      image: "{{ .Values.images.dcUploader.repository }}:{{ .Values.images.dcUploader.tag }}"
+      imagePullPolicy: {{ .Values.images.pullPolicy }}
+      resources:
+        {{- toYaml .Values.resources.dcUploader | nindent 8 }}
+      env:
+        - name: DC_UPLOADER_STORAGE_NAME
+          value: {{ .Values.uploader.storageName | quote }}
+        - name: DC_UPLOADER_QUEUE_DIR
+          value: /root/.dc/robot/uploader/queue/upload
+        - name: DC_UPLOADER_STATE_DIR
+          value: /root/.dc/robot/uploader/uploader
+        - name: DC_UPLOADER_SHIPPER_HOST
+          value: vector
+        - name: DC_UPLOADER_SHIPPER_PORT
+          value: "24224"
+        - name: DC_UPLOADER_S3_BUCKET
+          value: {{ .Values.uploader.s3.bucket | quote }}
+        - name: DC_UPLOADER_S3_ENDPOINT
+          value: {{ .Values.uploader.s3.endpoint | quote }}
+        - name: DC_UPLOADER_S3_ACCESS_KEY_ID
+          value: {{ .Values.uploader.s3.accessKeyId | quote }}
+        - name: DC_UPLOADER_S3_SECRET_ACCESS_KEY
+          value: {{ .Values.uploader.s3.secretAccessKey | quote }}
+        - name: DC_UPLOADER_DELETE_WHEN_SENT
+          value: {{ .Values.uploader.deleteWhenSent | quote }}
+      volumeMounts:
+        - name: uploader
+          mountPath: /root/.dc/robot/uploader
+
+    # The unmodified upstream Vector image, unmanaged by the Bridge (docs/adr/0001,
+    # docs/adr/0015). Waits for dc-ros's atomically-written config, then watches it for
+    # reload-without-restart.
+    - name: vector
+      image: "{{ .Values.images.vector.repository }}:{{ .Values.images.vector.tag }}"
+      imagePullPolicy: {{ .Values.images.pullPolicy }}
+      resources:
+        {{- toYaml .Values.resources.vector | nindent 8 }}
+      command: ["/bin/sh", "-c"]
+      args:
+        - >
+          trap exit TERM;
+          until [ -f /etc/dc/shipper/vector.toml ]; do sleep 0.2; done;
+          exec vector --config /etc/dc/shipper/vector.toml --watch-config
+      volumeMounts:
+        - name: buffer
+          mountPath: /var/lib/vector
+        - name: config
+          mountPath: /etc/dc/shipper
+          readOnly: true
+
+  volumes:
+    - name: uploader
+      emptyDir: {}
+    - name: config
+      emptyDir: {}
+    - name: buffer
+      emptyDir: {}
+    - name: robot-params
+      configMap:
+        name: {{ .Values.robot.name }}-params

--- a/deploy/robot/helm/dc-robot/values.yaml
+++ b/deploy/robot/helm/dc-robot/values.yaml
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Defaults reproduce ../../kubernetes/robot-pod.yaml + ../../params/robot_params.yaml as
+# closely as a templated chart can (docs/adr/0016) — `helm template` with no `--set`/
+# `-f` renders the same topology, so this baseline is provably identical to the
+# hand-written reference, not a new design. Only what genuinely varies between
+# deployments (issue #466: edge address, robot identity, resource limits, image tags,
+# credentials) is a value; everything else — the three-container/shared-volume shape
+# itself, the vector hostAlias, the ConfigMap-vs-Secret split — stays in templates/.
+
+robot:
+  # Pod name, and the identity dc-uploader's DC_UPLOADER_STORAGE_NAME et al. render
+  # under. One release == one robot: a site with N robots installs this chart N times
+  # with a different robot.name (and, in practice, --namespace) each time.
+  name: dc-robot
+
+images:
+  dcRos:
+    repository: ghcr.io/minipada/ros2_data_collection/dc-ros
+    tag: jazzy
+  dcUploader:
+    repository: ghcr.io/minipada/ros2_data_collection/dc-uploader
+    tag: jazzy
+  vector:
+    # Pinned to ros2_data_collection.repos' vector_vendor version, same constraint as
+    # ../../compose.yaml/quadlet/vector.container/kubernetes/robot-pod.yaml — bump by
+    # hand alongside vector_vendor (#448).
+    repository: docker.io/timberio/vector
+    tag: 0.57.0-debian
+  pullPolicy: IfNotPresent
+
+# Per-container resource requests/limits. Empty by default (no request/limit set),
+# matching ../../kubernetes/robot-pod.yaml today; a real deployment sets these per its
+# own edge hardware.
+resources:
+  dcRos: {}
+  dcUploader: {}
+  vector: {}
+
+# The blessed `vector` Destination's forwarding target — the edge tier's own address
+# (epic #440 scenario 3), outside this repository. `edge.site.example` is the same
+# placeholder ../../params/robot_params.yaml ships; override per site.
+edge:
+  vectorHost: edge.site.example
+  vectorPort: 24224
+
+# dc-uploader is configured entirely by env (docs/adr/0014), no ROS params.
+uploader:
+  storageName: edge
+  s3:
+    bucket: dc-robot
+    # Placeholder — the edge tier's object storage is outside this repository. Override
+    # per site; endpoint/accessKeyId/secretAccessKey are exactly the "credentials" the
+    # issue calls out as genuinely per-deployment. For anything beyond local iteration,
+    # pass these via `helm install -f <site-secrets.yaml>` (not committed), never a
+    # committed values file.
+    endpoint: http://edge.site.example:9000
+    accessKeyId: changeme
+    secretAccessKey: changeme
+  deleteWhenSent: true
+
+# Escape hatch for a site whose Measurement config genuinely differs from the single
+# `uptime` plugin templates/configmap-robot-params.yaml renders by default (not a
+# reference workload — see ../../params/robot_params.yaml's own header). Set to the
+# full literal contents of robot_params.yaml to replace the templated default outright,
+# same tradeoff as hand-editing that file today, just scoped to one values field
+# instead of a second manifest to maintain.
+robotParams:
+  override: ""

--- a/deploy/robot/helm/overlays/site-a/kustomization.yaml
+++ b/deploy/robot/helm/overlays/site-a/kustomization.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Site A overlay (#466, docs/adr/0016): inflates ../../dc-robot with this site's values
+# (edge address, robot identity — the chart's own values surface), then patches in a
+# namespace and a nodeSelector pinning the Pod to this site's labeled edge-adjacent
+# node. Neither is a chart value (see ../dc-robot/values.yaml's header): which
+# namespace/node a site's robot Pod lands on is a per-cluster placement decision the
+# chart has no business knowing about — exactly the kind of difference Kustomize
+# overlays exist for, per this issue's own framing ("patches on top of the chart's
+# rendered output ... for the environment-specific differences a chart's own values
+# don't cover").
+#
+# Render: kubectl kustomize --enable-helm --helm-command="$(which helm)" \
+#           deploy/robot/helm/overlays/site-a
+# (--enable-helm is required: kustomize's Helm chart inflator is opt-in, and `apply -k`
+# itself doesn't accept it — same `kubectl kustomize | kubectl apply -f -` pattern
+# ../../k3d/kustomization.yaml already uses for a different reason.)
+namespace: dc-robot-site-a
+
+# chartHome points at the chart's parent directory (deploy/robot/helm/), relative to
+# this file; kustomize looks for <chartHome>/<name> before trying to fetch anything
+# from a repo, so this resolves to ../../dc-robot with no repo/version needed for an
+# in-tree chart.
+helmGlobals:
+  chartHome: ../..
+
+helmCharts:
+  - name: dc-robot
+    releaseName: dc-robot-site-a
+    valuesFile: values-site-a.yaml
+
+patches:
+  - path: node-selector.yaml

--- a/deploy/robot/helm/overlays/site-a/node-selector.yaml
+++ b/deploy/robot/helm/overlays/site-a/node-selector.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Pins site A's robot Pod to its labeled edge-adjacent node — a per-cluster placement
+# fact the chart's values surface deliberately does not expose (see kustomization.yaml).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dc-robot-site-a
+spec:
+  nodeSelector:
+    dc.site: site-a

--- a/deploy/robot/helm/overlays/site-a/values-site-a.yaml
+++ b/deploy/robot/helm/overlays/site-a/values-site-a.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Site A's chart values (#466): robot identity and the edge aggregator address — the
+# per-site variation the chart itself parameterizes (../dc-robot/values.yaml). Image
+# tags/resources/credentials are left at chart defaults here for a focused
+# demonstration; a real site overrides those the same way, credentials from an
+# uncommitted file (see ../dc-robot/values.yaml's own note).
+robot:
+  name: dc-robot-site-a
+
+edge:
+  vectorHost: edge-a.site.example
+  vectorPort: 24224
+
+uploader:
+  s3:
+    endpoint: http://edge-a.site.example:9000

--- a/docs/adr/0016-helm-chart-plus-kustomize-overlays.md
+++ b/docs/adr/0016-helm-chart-plus-kustomize-overlays.md
@@ -1,0 +1,102 @@
+# Helm chart for the robot tier, Kustomize overlays per site/robot
+
+`deploy/robot/` (#450) renders the robot tier's fixed topology three ways (Compose,
+Quadlet, Kubernetes) — one shape, identical on every run. `tools/kind/` (#452) faced the
+same question for its CI harness and rejected Helm there: that harness deploys one fixed
+topology every run, nothing to parameterize, so a chart would template a variance that
+doesn't exist (`tools/kind/README.md`'s "Why not Helm"). That reasoning does not carry
+over to `deploy/robot/`'s actual deployable manifests: a fleet's robots genuinely differ
+— edge aggregator address, robot identity, resource limits, image tags, credentials — and
+`kubernetes/robot-pod.yaml` has no way to express that difference except hand-editing a
+copy per site, the same problem `tools/kind/kubernetes/robot-a.yaml` already shows in
+miniature (a second, hand-forked copy of the base Pod for one test site).
+
+## Decision
+
+Two tools, two different jobs, composed in one command:
+
+- **Helm** owns the values surface: whatever genuinely varies per deployment and is
+  worth typing, defaulting, and validating as a named field — robot identity
+  (`robot.name`), image repository/tag per container, per-container resource
+  requests/limits, the edge aggregator's address (`edge.vectorHost`/`vectorPort`), and
+  the Uploader's S3 credentials/endpoint. `deploy/robot/helm/dc-robot/` is this chart.
+  Its defaults reproduce `kubernetes/robot-pod.yaml` + `params/robot_params.yaml` field
+  for field (verified: `helm template` with no overrides passes the same `kubeconform`
+  check that file does) — the chart is a parameterized version of the existing
+  reference, not a new design, and that file remains the runtime-free/k3d/kind reference
+  it already was.
+- **Kustomize** owns what a chart's values don't, and shouldn't, cover: per-site
+  placement and cluster-specific concerns that have nothing to do with the
+  application's own configuration — which namespace a site's release lands in, which
+  node it's scheduled to, any raw patch a site needs that doesn't rise to the level of
+  a chart value. `deploy/robot/helm/overlays/site-a/` is the reference overlay: it sets
+  `namespace: dc-robot-site-a`, supplies `values-site-a.yaml` (robot identity + edge
+  address — the chart's own surface), and patches in a `nodeSelector` pinning the Pod
+  to that site's labeled edge-adjacent node — deliberately not a chart value, because
+  which node a robot lands on is a per-cluster scheduling fact the chart has no business
+  knowing about.
+
+The two compose through kustomize's native Helm chart inflator (`helmGlobals.chartHome` +
+`helmCharts:`, `--enable-helm`), not a two-step `helm template | kubectl apply -k -`
+pipeline: one command (`kubectl kustomize --enable-helm --load-restrictor
+LoadRestrictionsNone deploy/robot/helm/overlays/site-a`) renders the chart and applies
+the overlay's namespace/patches to the result, matching the single-command shape
+`deploy/robot/k3d/kustomization.yaml` already established for piping `kubectl kustomize`
+into `kubectl apply -f -`. `--load-restrictor LoadRestrictionsNone` is required for the
+same reason it already is there: the overlay's base (the chart, via `chartHome: ../..`)
+lives outside the overlay's own directory tree.
+
+A site with N robots installs N releases — one per robot, each with its own
+`values-<robot>.yaml` and, where needed, its own overlay directory — never one release
+templating N robots internally; `robot.name` (and, by convention, the release's
+namespace) is the per-robot identity, matching how `tools/kind/kubernetes/robot-a.yaml`
+already names one Pod per test site rather than templating a list.
+
+## Rejected alternatives
+
+**Kustomize alone, patching `kubernetes/robot-pod.yaml` per site (no Helm).** This is
+what `tools/kind/` already does, correctly, for its own one-fixed-topology problem.
+`deploy/robot/`'s real fleet has a values surface shared and validated the same way
+across every site — image tags bumped in one place per release, resource limits typed
+as actual Kubernetes `resources` stanzas, credentials with a documented shape — that
+raw per-site strategic-merge patches would reduplicate at every overlay instead of
+declaring once. Kustomize's own patches are the right tool for one-off, structural
+differences (a `nodeSelector`, an extra label); they are the wrong tool for a values
+contract every site fills in.
+
+**Helm alone, one `values-<site>.yaml` per site, no Kustomize.** Considered, since Helm
+values could technically carry a `nodeSelector` or namespace override too. Rejected
+because it pushes every future site-specific concern into the chart's own values schema
+regardless of whether it belongs there, growing `values.yaml` into a dumping ground and
+coupling unrelated cluster-placement changes to chart version bumps. Kustomize overlays
+keep that class of change scoped to the site's own directory, reviewable independently
+of the chart.
+
+**Per-site values vendored as Helm subcharts or an umbrella chart.** Rejected: it
+couples a site's own inventory (and, worse, tempts committing its credentials) into the
+chart's own repository structure. Overlay directories under `helm/overlays/` keep
+site inventory as plain files a site's own GitOps tooling can manage independently of
+chart releases, with credentials passed via an uncommitted `-f`/`--set` file rather than
+living in the chart.
+
+## Consequences
+
+- Additive only: `compose.yaml` and `quadlet/*.container` are untouched, and
+  `kubernetes/robot-pod.yaml` remains the runtime-free/k3d/kind reference — this ADR
+  adds a parameterized *rendering path* for real Kubernetes deployments, not a
+  replacement of any of the three.
+- `deploy/robot/helm/dc-robot/templates/configmap-robot-params.yaml` replaces
+  `robot-pod.yaml`'s `hostPath` mount for `robot_params.yaml` with a ConfigMap — the
+  real-cluster mechanism that file's own header already called for
+  ("a Pod-scoped Secret/ConfigMap object is the real-cluster mechanism ... kustomize or
+  a site's own GitOps tool"). `robot-pod.yaml` itself keeps the `hostPath`, since that
+  is what makes `podman kube play`/k3d/kind runnable with no cluster-side object to
+  create first.
+- Values that hold real credentials (`uploader.s3.accessKeyId`/`secretAccessKey`) ship
+  with the same literal placeholders `params/robot_params.yaml`/`robot-pod.yaml` already
+  use ("changeme"), for the same reason: runnable as shipped, not a design invitation to
+  commit real ones — a real deployment overrides them from an uncommitted values file,
+  never a committed one.
+- `tools/kind/README.md`'s "Why not Helm" stays correct for that harness: it is a
+  different problem (one fixed topology, nothing to parameterize) from the one this ADR
+  answers.


### PR DESCRIPTION
## Summary

- Add `deploy/robot/helm/dc-robot`, a Helm chart parameterizing the robot tier's Kubernetes rendering (`kubernetes/robot-pod.yaml`) for what genuinely varies per fleet deployment: robot identity, image tags, resource limits, edge aggregator address, and Uploader credentials. Chart defaults reproduce the existing hand-written manifest field for field — verified with `helm template` + `kubeconform` — so this is a parameterized rendering path alongside Compose, Quadlet and the existing Kubernetes Pod, not a replacement of any of them.
- Add `deploy/robot/helm/overlays/site-a`, a reference Kustomize overlay composed on top of the chart via kustomize's native Helm inflator, demonstrating a real per-site difference: edge address + robot identity via chart values, namespace + node placement via Kustomize patches (the class of concern the chart's values surface deliberately doesn't cover).
- Record the design decision and rejected alternatives (Kustomize-only, Helm-only, subchart-per-site) in `docs/adr/0016-helm-chart-plus-kustomize-overlays.md`.
- Exclude Helm chart templates from the `check-yaml` pre-commit hook (Go template syntax isn't standalone YAML); `helm lint`/`helm template` is that directory's own syntax check.

## Test plan

- [x] `helm lint deploy/robot/helm/dc-robot` passes
- [x] `helm template dc-robot deploy/robot/helm/dc-robot` renders and passes `kubeconform -strict` (schema-valid Pod + ConfigMap)
- [x] `kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone deploy/robot/helm/overlays/site-a` renders the chart with site-a's overrides (edge address, robot identity, namespace, nodeSelector patch) and passes `kubeconform -strict`
- [x] `prek run --all-files --skip build-doc` passes (REUSE, shellcheck, codespell, yaml/toml/json checks, etc.)
- [x] `compose.yaml`, `quadlet/*.container`, and `kubernetes/robot-pod.yaml` are unmodified — additive only

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJxB1E942euLSKrcTTkcfH