### PR TITLE
feat(demos,deploy,docs): migrate off blessed postgres/s3/console

### DIFF
--- a/dc_bringup/launch/dc_bringup.launch.py
+++ b/dc_bringup/launch/dc_bringup.launch.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import os
+import shutil
 
 import yaml
 from ament_index_python.packages import get_package_prefix, get_package_share_directory
@@ -191,6 +192,36 @@ def build_uploader_action(raw_params):
     ]
 
 
+def _stage_custom_config_files(params_file_path, custom_config_files):
+    """Stage a demo's passthrough sink TOML(s) at the path `custom_config_files` names.
+
+    A `custom_config_files` entry (ADR-0003 passthrough, #471) is handed to `dc_bridge`
+    as a plain filesystem path -- nothing installs a file there on its own. A
+    containerized deploy solves this with a bind mount straight onto that path
+    (deploy/robot/compose.isolated-network.yaml); a demo launched from an installed
+    package has no such mount, so without this the referenced file is simply missing
+    and `dc_bridge` runs without the sink (see the sim CI job this fixed: qrcodes_stdout
+    reached every nav waypoint but read zero QR codes, because the passthrough console
+    sink was never in place, and no `dc.*` route makes it to the Measurement pipeline
+    without one). Recipes live in a `config/` directory `dc_demos/CMakeLists.txt`
+    installs as a sibling of `params/`, so that sibling is where this looks for a
+    same-named file to copy from. Never overwrites an existing destination file --
+    demos.md and elasticsearch.md both document hand-editing the staged copy to
+    experiment, which a blind refresh on every launch would clobber.
+    """
+    config_dir = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(params_file_path))), "config"
+    )
+    for raw_path in custom_config_files:
+        dest_path = os.path.expanduser(os.path.expandvars(raw_path))
+        if os.path.exists(dest_path):
+            continue
+        candidate = os.path.join(config_dir, os.path.basename(dest_path))
+        if os.path.isfile(candidate):
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            shutil.copyfile(candidate, dest_path)
+
+
 def build_bridge_and_mcap_actions(configured_params):
     """Build the `dc_bridge` Node, plus `dc_mcap_writer` if the params file enables it.
 
@@ -240,6 +271,11 @@ def build_bridge_and_mcap_actions(configured_params):
                 raw_params = yaml.safe_load(f) or {}
         except OSError:
             raw_params = {}
+
+        dc_bridge_params_early = (raw_params.get("dc_bridge") or {}).get("ros__parameters") or {}
+        _stage_custom_config_files(
+            params_file_path, dc_bridge_params_early.get("custom_config_files", [])
+        )
 
         mcap_params = (raw_params.get("dc_mcap_writer") or {}).get("ros__parameters") or {}
         bridge_parameters = [configured_params]

--- a/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml
+++ b/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `postgres` Destination, for the
+# fastdds_stats_pgsql_grafana demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml" ~/.dc/
+
+[sinks.pgsql]
+type = "postgres"
+inputs = ["dc.dc.measurement.fastdds_stats"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"  # user:password@host:port/database
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488   # Vector's disk-buffer minimum; a passthrough sink gets none by default

--- a/dc_demos/config/group_memory_uptime_stdout_sink.toml
+++ b/dc_demos/config/group_memory_uptime_stdout_sink.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `console` Destination, for the
+# group_memory_uptime_stdout demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/group_memory_uptime_stdout_sink.toml" ~/.dc/
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.group.memory_uptime"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"

--- a/dc_demos/config/qrcodes_minio_pgsql_sink.toml
+++ b/dc_demos/config/qrcodes_minio_pgsql_sink.toml
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `postgres` Destinations, for the
+# qrcodes_minio_pgsql demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_minio_pgsql_sink.toml" ~/.dc/
+
+[sinks.pgsql]
+type = "postgres"
+inputs = [
+  "dc.dc.measurement.map",
+  "dc.dc.measurement.right_camera",
+  "dc.dc.measurement.left_camera",
+  "dc.dc.group.robot",
+]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"  # user:password@host:port/database
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488   # Vector's disk-buffer minimum; a passthrough sink gets none by default
+
+# File status Records (ADR-0005): `records_log`'s params/qrcodes_minio_pgsql.yaml block
+# names it as `files.metadata_destination`, which appends the `dc.files` Tag to its
+# routed set -- consumed here exactly like any other `dc.<tag>` route.
+[sinks.pgsql_files]
+type = "postgres"
+inputs = ["dc.dc.files"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc_files"
+
+[sinks.pgsql_files.buffer]
+type = "disk"
+max_size = 268435488

--- a/dc_demos/config/qrcodes_stdout_sink.toml
+++ b/dc_demos/config/qrcodes_stdout_sink.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `console` Destination, for the
+# qrcodes_stdout demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_stdout_sink.toml" ~/.dc/
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.measurement.right_camera", "dc.dc.measurement.left_camera"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"

--- a/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml
+++ b/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `postgres` Destinations, for the
+# tb3_simulation_pgsql_minio demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml" ~/.dc/
+
+[sinks.pgsql]
+type = "postgres"
+inputs = [
+  "dc.dc.measurement.cpu",
+  "dc.dc.measurement.memory",
+  "dc.dc.measurement.os",
+  "dc.dc.measurement.uptime",
+  "dc.dc.measurement.camera",
+  "dc.dc.measurement.cmd_vel",
+  "dc.dc.measurement.distance_traveled",
+  "dc.dc.measurement.driving_type",
+  "dc.dc.measurement.position",
+  "dc.dc.measurement.speed",
+  "dc.dc.measurement.map",
+  "dc.dc.measurement.rustfs_health",
+  "dc.dc.measurement.pgsql_health",
+]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"  # user:password@host:port/database
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488   # Vector's disk-buffer minimum; a passthrough sink gets none by default
+
+# File status Records (ADR-0005): `records_log`'s params/tb3_simulation_pgsql_minio.yaml
+# block names it as `files.metadata_destination`, which appends the `dc.files` Tag to
+# its routed set -- consumed here exactly like any other `dc.<tag>` route.
+[sinks.pgsql_files]
+type = "postgres"
+inputs = ["dc.dc.files"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc_files"
+
+[sinks.pgsql_files.buffer]
+type = "disk"
+max_size = 268435488

--- a/dc_demos/config/tb3_simulation_stdout_sink.toml
+++ b/dc_demos/config/tb3_simulation_stdout_sink.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `console` Destination, for the
+# tb3_simulation_stdout demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_stdout_sink.toml" ~/.dc/
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.group.robot", "dc.dc.measurement.map"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"

--- a/dc_demos/config/uptime_custom_stdout_sink.toml
+++ b/dc_demos/config/uptime_custom_stdout_sink.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `console` Destination, for the
+# uptime_custom_stdout demo -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_custom_stdout_sink.toml" ~/.dc/
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.measurement.uptime_custom"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"

--- a/dc_demos/config/uptime_stdout_sink.toml
+++ b/dc_demos/config/uptime_stdout_sink.toml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `console` Destination, for the
+# uptime_stdout demo (doc/src/dc/demos/uptime_stdout.md) -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Copied into place before launching:
+#   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_stdout_sink.toml" ~/.dc/
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.measurement.uptime"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"

--- a/dc_demos/params/elasticsearch.yaml
+++ b/dc_demos/params/elasticsearch.yaml
@@ -14,11 +14,14 @@ dc_bridge:
     # `destinations` still has to name at least one blessed Destination, and the routes
     # the snippet consumes exist only for topics listed in *its* `inputs` — dc_bridge
     # derives both its ROS subscriptions and its route branches from `destinations`, and
-    # never reads the snippet's `inputs`. `console` is the cheapest thing to put there,
-    # and doubles as a local view of the same Records that land in Elasticsearch.
-    destinations: ["console"]
-    console:
-      type: console
+    # never reads the snippet's `inputs`. `console` used to be the cheapest thing to put
+    # here, doubling as a local view of the same Records that land in Elasticsearch;
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough), so
+    # `file` is the anchor now instead.
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs:
         [
@@ -27,6 +30,7 @@ dc_bridge:
           "/dc/measurement/os",
           "/dc/measurement/uptime",
         ]
+      path: "/tmp/dc/elasticsearch_records.ndjson"
       time_key: "date"
       time_format: "double"
     custom_config_files: ["$HOME/.dc/elasticsearch_sink.toml"]

--- a/dc_demos/params/elasticsearch.yaml
+++ b/dc_demos/params/elasticsearch.yaml
@@ -10,6 +10,9 @@ dc_bridge:
     # ADR-0003 passthrough: a raw Vector sink config listed in `custom_config_files`,
     # consuming the public `dc.<tag>` routes. Copy it into place before launching:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/elasticsearch_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     #
     # `destinations` still has to name at least one blessed Destination, and the routes
     # the snippet consumes exist only for topics listed in *its* `inputs` — dc_bridge

--- a/dc_demos/params/fastdds_stats_pgsql_grafana.yaml
+++ b/dc_demos/params/fastdds_stats_pgsql_grafana.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/dc_demos/params/fastdds_stats_pgsql_grafana.yaml
+++ b/dc_demos/params/fastdds_stats_pgsql_grafana.yaml
@@ -5,19 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql"]
-    pgsql:
-      type: postgres
+    # blessed `postgres` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/fastdds_stats"]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
+      path: "/tmp/dc/fastdds_stats_pgsql_grafana_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/fastdds_stats_pgsql_grafana_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/group_memory_uptime_stdout.yaml
+++ b/dc_demos/params/group_memory_uptime_stdout.yaml
@@ -5,13 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/group_memory_uptime_stdout_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/group/memory_uptime"]
+      path: "/tmp/dc/group_memory_uptime_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/group_memory_uptime_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/group_memory_uptime_stdout.yaml
+++ b/dc_demos/params/group_memory_uptime_stdout.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/group_memory_uptime_stdout_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/dc_demos/params/mcap_recording.yaml
+++ b/dc_demos/params/mcap_recording.yaml
@@ -8,11 +8,14 @@ dc_bridge:
     # `destinations` still has to name at least one blessed Destination — dc_bridge
     # derives both its ROS subscriptions and its `dc.<tag>` route branches from
     # `destinations` alone, and dc_mcap_writer's own `inputs` below never adds a route
-    # dc_bridge doesn't already have. `console` is the cheapest thing to put here, and
-    # doubles as a local view of the same Records dc_mcap_writer is recording.
-    destinations: ["console"]
-    console:
-      type: console
+    # dc_bridge doesn't already have. `console` used to be the cheapest thing to put
+    # here, doubling as a local view of the same Records dc_mcap_writer is recording;
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough), so
+    # `file` is the anchor now instead -- tail the ndjson path below for the same view.
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs:
         [
@@ -21,6 +24,7 @@ dc_bridge:
           "/dc/measurement/os",
           "/dc/measurement/uptime",
         ]
+      path: "/tmp/dc/mcap_recording_records.ndjson"
       time_key: "date"
       time_format: "epoch_nanos"
     vector_forward_host: "127.0.0.1"

--- a/dc_demos/params/qrcodes_minio_pgsql.yaml
+++ b/dc_demos/params/qrcodes_minio_pgsql.yaml
@@ -23,6 +23,9 @@ dc_bridge:
     #
     # Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_minio_pgsql_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log", "rustfs"]
     records_log:
       type: file

--- a/dc_demos/params/qrcodes_minio_pgsql.yaml
+++ b/dc_demos/params/qrcodes_minio_pgsql.yaml
@@ -5,9 +5,27 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql", "pgsql_files", "rustfs"]
-    pgsql:
-      type: postgres
+    # blessed `postgres` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. `records_log` also stands in for the old
+    # `pgsql_files` Destination as `files.metadata_destination` below: that parameter
+    # must name a configured `receives: records` Destination (dc_bridge rejects
+    # anything else at startup), so it cannot point at a passthrough-only sink id --
+    # the passthrough `pgsql_files` sink in the snippet instead consumes the
+    # `dc.dc.files` route this anchor gains from being named there.
+    #
+    # `rustfs` (`type: s3`, `receives: files`) is unchanged and stays blessed: it is
+    # served by the Uploader (`dc_uploader`, ADR-0005), a separate process configured
+    # entirely from these ROS params and never from Vector sink config, so there is no
+    # passthrough equivalent for `receives: files` to migrate to.
+    #
+    # Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_minio_pgsql_sink.toml" ~/.dc/
+    destinations: ["records_log", "rustfs"]
+    records_log:
+      type: file
       receives: records
       inputs:
         [
@@ -16,22 +34,7 @@ dc_bridge:
           "/dc/measurement/left_camera",
           "/dc/group/robot",
         ]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
-      time_key: "date"
-    pgsql_files:
-      type: postgres
-      receives: records
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc_files"
+      path: "/tmp/dc/qrcodes_minio_pgsql_records.ndjson"
       time_key: "date"
     rustfs:
       type: s3
@@ -50,13 +53,14 @@ dc_bridge:
       force_path_style: true
     files:
       delete_when_sent: true
-      metadata_destination: "pgsql_files"
+      metadata_destination: "records_log"
       # The demo dashboard's camera gallery loads these previews instead of the
       # full-size JPEGs (#256). Best-effort: with no ffmpeg installed the demo still
       # works, the gallery just falls back to the originals.
       thumbnails:
         enabled: true
         max_dimension: 320
+    custom_config_files: ["$HOME/.dc/qrcodes_minio_pgsql_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/qrcodes_stdout.yaml
+++ b/dc_demos/params/qrcodes_stdout.yaml
@@ -5,13 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_stdout_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/right_camera", "/dc/measurement/left_camera"]
+      path: "/tmp/dc/qrcodes_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/qrcodes_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/qrcodes_stdout.yaml
+++ b/dc_demos/params/qrcodes_stdout.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_stdout_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/dc_demos/params/tb3_simulation_influxdb.yaml
+++ b/dc_demos/params/tb3_simulation_influxdb.yaml
@@ -12,6 +12,9 @@ dc_bridge:
     # doc/src/dc/destinations.md. Copy the example sink shipped with this package into
     # place before launching this demo:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_influxdb_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     #
     # `destinations` must still name at least one *blessed* Destination, and its `inputs`
     # are what create the `dc.<tag>` routes the snippet consumes — dc_bridge derives both

--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -5,9 +5,27 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql", "pgsql_files", "rustfs"]
-    pgsql:
-      type: postgres
+    # blessed `postgres` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. `records_log` also stands in for the old
+    # `pgsql_files` Destination as `files.metadata_destination` below: that parameter
+    # must name a configured `receives: records` Destination (dc_bridge rejects
+    # anything else at startup), so it cannot point at a passthrough-only sink id --
+    # the passthrough `pgsql_files` sink in the snippet instead consumes the
+    # `dc.dc.files` route this anchor gains from being named there.
+    #
+    # `rustfs` (`type: s3`, `receives: files`) is unchanged and stays blessed: it is
+    # served by the Uploader (`dc_uploader`, ADR-0005), a separate process configured
+    # entirely from these ROS params and never from Vector sink config, so there is no
+    # passthrough equivalent for `receives: files` to migrate to.
+    #
+    # Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml" ~/.dc/
+    destinations: ["records_log", "rustfs"]
+    records_log:
+      type: file
       receives: records
       inputs: [
           # System
@@ -28,22 +46,7 @@ dc_bridge:
           "/dc/measurement/rustfs_health",
           "/dc/measurement/pgsql_health",
         ]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
-      time_key: "date"
-    pgsql_files:
-      type: postgres
-      receives: records
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc_files"
+      path: "/tmp/dc/tb3_simulation_pgsql_minio_records.ndjson"
       time_key: "date"
     rustfs:
       type: s3
@@ -57,12 +60,13 @@ dc_bridge:
       force_path_style: true
     files:
       delete_when_sent: true
-      metadata_destination: "pgsql_files"
+      metadata_destination: "records_log"
       # Previews for the dashboard's camera gallery and map view (#256); best-effort,
       # so the demo is unaffected if ffmpeg isn't installed.
       thumbnails:
         enabled: true
         max_dimension: 320
+    custom_config_files: ["$HOME/.dc/tb3_simulation_pgsql_minio_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/tb3_simulation_pgsql_minio.yaml
+++ b/dc_demos/params/tb3_simulation_pgsql_minio.yaml
@@ -23,6 +23,9 @@ dc_bridge:
     #
     # Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log", "rustfs"]
     records_log:
       type: file

--- a/dc_demos/params/tb3_simulation_stdout.yaml
+++ b/dc_demos/params/tb3_simulation_stdout.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_stdout_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/dc_demos/params/tb3_simulation_stdout.yaml
+++ b/dc_demos/params/tb3_simulation_stdout.yaml
@@ -5,13 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_stdout_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/group/robot", "/dc/measurement/map"]
+      path: "/tmp/dc/tb3_simulation_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/tb3_simulation_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/uptime_custom_stdout.yaml
+++ b/dc_demos/params/uptime_custom_stdout.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_custom_stdout_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/dc_demos/params/uptime_custom_stdout.yaml
+++ b/dc_demos/params/uptime_custom_stdout.yaml
@@ -5,13 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_custom_stdout_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime_custom"]
+      path: "/tmp/dc/uptime_custom_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/uptime_custom_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/uptime_stdout.yaml
+++ b/dc_demos/params/uptime_stdout.yaml
@@ -5,13 +5,21 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    # blessed `console` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
+    #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_stdout_sink.toml" ~/.dc/
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/uptime_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/uptime_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
 

--- a/dc_demos/params/uptime_stdout.yaml
+++ b/dc_demos/params/uptime_stdout.yaml
@@ -11,6 +11,9 @@ dc_bridge:
     # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
     # passthrough snippet's `inputs`. Copy the passthrough sink into place first:
     #   mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_stdout_sink.toml" ~/.dc/
+    # (dc_bringup.launch.py now stages this file automatically at launch time if
+    # it's not already there -- see _stage_custom_config_files -- so this manual
+    # step is only needed when running dc_bridge some other way.)
     destinations: ["records_log"]
     records_log:
       type: file

--- a/deploy/robot/compose.isolated-network.yaml
+++ b/deploy/robot/compose.isolated-network.yaml
@@ -15,4 +15,7 @@ services:
   dc-ros:
     volumes:
       - ${DC_ROBOT_AIO_PARAMS:-./params/aio_params_local.yaml}:/opt/dc/dc_params.yaml:ro
+      # aio_params_local.yaml's postgres Destination is passthrough (ADR-0003, #471) --
+      # this is the raw Vector sink config its `custom_config_files` parameter loads.
+      - ${DC_ROBOT_AIO_PGSQL_SINK:-./params/aio_pgsql_sink.toml}:/root/.dc/aio_pgsql_sink.toml:ro
     command: ["dc_params_file:=/opt/dc/dc_params.yaml"]

--- a/deploy/robot/params/aio_params_local.yaml
+++ b/deploy/robot/params/aio_params_local.yaml
@@ -1,13 +1,13 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# dc_bringup/params/dc_params.yaml (the dc-ros image's own baked-in default), with its
-# Postgres Destination's `host` pointed at compose.local-destinations.yaml's `postgres`
-# service instead of 127.0.0.1 — needed only for compose.isolated-network.yaml, which
+# dc_bringup/params/dc_params.yaml (the dc-ros image's own baked-in default), pointed at
+# compose.local-destinations.yaml's `postgres` service instead of 127.0.0.1 via the
+# passthrough sink's `endpoint` — needed only for compose.isolated-network.yaml, which
 # puts dc-ros on a named bridge network where "127.0.0.1" no longer reaches Postgres'
-# own container. The Bridge doesn't env-expand the `host` field (only credentials and
-# data-dir paths — see doc/src/dc/destinations.md), so this is a full file, not an
-# override var. compose.host-network.yaml needs none of this: 127.0.0.1 already works
+# own container. Vector's own `${VAR}` interpolation is off by default (see
+# doc/src/dc/destinations.md's passthrough-recipes warning), so this is a full file, not
+# an override var. compose.host-network.yaml needs none of this: 127.0.0.1 already works
 # there, so it runs the image with no params override at all.
 measurement_server:
   ros__parameters:
@@ -21,19 +21,22 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql"]
-    pgsql:
-      type: postgres
+    # blessed `postgres` is retired in favor of the ADR-0003 passthrough recipe (#471,
+    # see doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough); `file`
+    # is the anchor Destination `destinations` still needs -- dc_bridge derives its ROS
+    # subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
+    # passthrough snippet's `inputs`. The matching sink is baked into the compose image
+    # via compose.isolated-network.yaml's `/root/.dc/aio_pgsql_sink.toml` bind mount
+    # (params/aio_pgsql_sink.toml in this directory).
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
-      host: "postgres"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
+      path: "/root/.dc/buffer/aio_records.ndjson"
       time_key: "date"
       time_format: "epoch_nanos"
+    custom_config_files: ["$HOME/.dc/aio_pgsql_sink.toml"]
     # compose.local-destinations.yaml also brings up a `rustfs` service (S3-compatible),
     # reachable here at http://rustfs:9000 — add a files-producing Measurement (camera,
     # map, …) and a `receives: files` Destination block to exercise it; see

--- a/deploy/robot/params/aio_pgsql_sink.toml
+++ b/deploy/robot/params/aio_pgsql_sink.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# ADR-0003 passthrough equivalent of the blessed `postgres` Destination, for the
+# all-in-one isolated-network robot deployment (aio_params_local.yaml) -- see
+# doc/src/dc/destinations.md#recipes-postgres-s3-console-via-passthrough.
+#
+# Bind-mounted into the dc-ros container at /root/.dc/aio_pgsql_sink.toml by
+# compose.isolated-network.yaml.
+
+[sinks.pgsql]
+type = "postgres"
+inputs = ["dc.dc.measurement.uptime"]
+endpoint = "postgres://dc:password@postgres:5432/dc"  # user:password@host:port/database
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488   # Vector's disk-buffer minimum; a passthrough sink gets none by default

--- a/deploy/robot/params/robot_params_local.yaml
+++ b/deploy/robot/params/robot_params_local.yaml
@@ -28,6 +28,17 @@ dc_bridge:
       bind_host: "0.0.0.0"
     uploader:
       data_dir: "$HOME/.dc/robot/uploader"
+    # NOT migrated to the ADR-0003 passthrough recipe (#471) -- unlike aio_params_local.yaml,
+    # this scenario runs `shipper.managed: false` (the three-container split, ADR-0015):
+    # `custom_config_files` snippets are validated against the render but, in unmanaged
+    # mode, dc_bridge writes only the single rendered `shipper.config_path` file for the
+    # separate `vector` container to read -- the snippet's own path is never copied
+    # anywhere that container can see, so a passthrough sink here would silently never
+    # run. Confirmed empirically: rendering this scenario with `custom_config_files`
+    # pointed at a passthrough postgres sink produced a `vector.toml` with no `pgsql`
+    # sink in it at all. Filed as a gap in dc_bridge/the split-deployment topology
+    # (custom_config_files needs a way to reach the unmanaged Shipper too) rather than
+    # worked around here; `pgsql` stays blessed until that's fixed.
     destinations: ["pgsql"]
     pgsql:
       type: postgres

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -137,19 +137,22 @@ passthrough Destinations consume. A Destination selects what it receives through
 
 ## Destinations
 
-A Destination is where data ends up: PostgreSQL, S3-compatible storage, a file, or the
-console are **blessed** (rendered from plain ROS parameters); any other Vector sink is
-reachable through the **passthrough**. See [Destinations](./destinations.md) for the full
-contract.
+A Destination is where data ends up: a file is **blessed** (rendered from plain ROS
+parameters), and so are PostgreSQL, S3-compatible storage, another Shipper, and (through a
+[passthrough recipe](./destinations.md#recipes-postgres-s3-console-via-passthrough) rather
+than the ROS-param form, per [ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md))
+the console; any other Vector sink is reachable through the **passthrough** too. See
+[Destinations](./destinations.md) for the full contract.
 
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]                 # Destination names to enable
-    console:                                  # a name you choose
-      type: console                           # a blessed type
+    destinations: ["records_log"]             # Destination names to enable
+    records_log:                              # a name you choose
+      type: file                              # a blessed type
       receives: records
       inputs: ["/dc/measurement/uptime"]      # the topics this Destination receives
+      path: "/tmp/dc/records.ndjson"
 
 measurement_server:
   ros__parameters:

--- a/doc/src/dc/configuration_examples.md
+++ b/doc/src/dc/configuration_examples.md
@@ -27,17 +27,46 @@ and the topic each one publishes on. Routing is the overlap between the two list
 nothing on the Measurement side names a Destination.
 ```
 
+```admonish info title="Why `file` + a passthrough snippet, not a blessed `console` Destination"
+Every "to the console" example below prints through a passthrough `console` sink loaded
+via `custom_config_files`, not a blessed `console` Destination — per
+[ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md), `console` (along with
+`postgres` and `s3`) moved from the blessed ROS-param form to a passthrough recipe (#471),
+being a pure Vector-sink wrapper with no DC-specific logic. `destinations` still names a
+`file` Destination in each example: `dc_bridge` derives its ROS subscriptions and
+`dc.<tag>` routes from `destinations` alone, never from a passthrough snippet's `inputs`,
+so a cheap `file` anchor is what actually creates the route the snippet consumes. See
+[Destinations: Recipes](./destinations.md#recipes-postgres-s3-console-via-passthrough) for
+the recipe this reuses throughout, and [Passthrough](./destinations.md#passthrough-custom_config_files)
+for the underlying mechanism.
+
+Save this once as `~/.dc/console_sink.toml`, and update its `inputs` to match whichever
+example you're running (each example below says what to set it to):
+
+    [sinks.debug_console]
+    type = "console"
+    inputs = ["dc.dc.measurement.uptime"]   # <- change this to match the example
+    target = "stdout"
+
+    [sinks.debug_console.encoding]
+    codec = "json"
+```
+
 ## Running the examples
 ### Example 1: Uptime to the console every second
+
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.uptime"]` (the default above).
 
 ```yaml
 dc_bridge:                                    # Bridge (Shipper) node configuration
   ros__parameters:
-    destinations: ["console"]                 # List of Destination names to enable
-    console:                                  # Destination name, you choose
-      type: console                           # Blessed Destination type, fixed
+    destinations: ["records_log"]             # List of Destination names to enable
+    records_log:                              # Destination name, you choose
+      type: file                              # Blessed Destination type -- the passthrough's anchor
       receives: records
       inputs: ["/dc/measurement/uptime"]      # Same as topic_output in the uptime measurement in measurement_server
+      path: "/tmp/dc/example1_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:                           # Measurement node configuration
   ros__parameters:
@@ -49,16 +78,20 @@ measurement_server:                           # Measurement node configuration
 
 ### Example 2: Uptime to the console with ISO 8601 timestamps
 
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.uptime"]` (unchanged from Example 1).
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/example2_records.ndjson"
       time_key: "date"                       # Field the normalized timestamp is written to
       time_format: "iso8601"                 # "epoch_nanos" (default) | "iso8601" | "double"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -70,14 +103,18 @@ measurement_server:
 
 ### Example 3: Uptime to the console only at start and 3 times
 
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.uptime"]` (unchanged from Example 1).
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/example3_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -90,14 +127,18 @@ measurement_server:
 
 ### Example 4: CPU and Memory to the console every 5 seconds forever
 
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.cpu", "dc.dc.measurement.memory"]`.
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/cpu", "/dc/measurement/memory"]
+      path: "/tmp/dc/example4_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -114,14 +155,18 @@ measurement_server:
 
 ### Example 5: CPU and Memory as a group to the console every 5 seconds forever
 
+`console_sink.toml`'s `inputs`: `["dc.dc.group.cpu_memory"]`.
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/group/cpu_memory"]        # Group to create
+      path: "/tmp/dc/example5_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 group_server:                                 # Group server configuration
   ros__parameters:
@@ -147,14 +192,18 @@ measurement_server:
 
 ### Example 6: Custom ROS message to the console every 2 seconds forever
 
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.my_string_stamped"]`.
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/my_string_stamped"]
+      path: "/tmp/dc/example6_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -175,14 +224,18 @@ ros2 topic pub -r 1 /hello-world dc_interfaces/msg/StringStamped  "{data: '{\"he
 
 ### Example 7: Custom ROS message to the console every time it is published
 
+`console_sink.toml`'s `inputs`: `["dc.dc.measurement.my_string_stamped"]` (unchanged from Example 6).
+
 ```yaml
 dc_bridge:
   ros__parameters:
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/my_string_stamped"]
+      path: "/tmp/dc/example7_records.ndjson"
+    custom_config_files: ["$HOME/.dc/console_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -197,29 +250,25 @@ measurement_server:
 
 ### Example 8: Uptime to PostgreSQL, and to the console at the same time
 
-A Record is delivered to every Destination that lists its topic — listing the same topic
-twice is how you fan out.
+A Record is delivered to every Vector sink that consumes its route — listing the same
+`dc.<tag>` route in two sinks' `inputs` is how you fan out. Both PostgreSQL and console are
+reached through the passthrough here (per [ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md),
+neither is a blessed Destination any more — see
+[Destinations: Recipes](./destinations.md#recipes-postgres-s3-console-via-passthrough)); a
+single `file` anchor creates the one route both passthrough sinks consume.
 
 ```yaml
 dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"            # Where the Shipper keeps its disk buffer
-    destinations: ["pgsql", "console"]
-    pgsql:
-      type: postgres
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "$DC_PG_PASSWORD"             # $VAR / ${VAR} are read from the environment
-      database: "dc"
-      table: "dc"
-    console:
-      type: console
-      receives: records
-      inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/example8_records.ndjson"
+    custom_config_files: ["$HOME/.dc/example8_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -229,9 +278,33 @@ measurement_server:
       topic_output: "/dc/measurement/uptime"
 ```
 
+```toml
+# ~/.dc/example8_sink.toml
+[sinks.pgsql]
+type = "postgres"
+inputs = ["dc.dc.measurement.uptime"]
+endpoint = "postgres://dc:$DC_PG_PASSWORD@127.0.0.1:5432/dc"  # user:password@host:port/database
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488
+
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.measurement.uptime"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"
+```
+
 ```admonish warning
-The Shipper's `postgres` Destination maps a Record's top-level JSON keys onto **existing**
+Vector's `postgres` sink maps a Record's top-level JSON keys onto **existing**
 columns; it does not create tables or columns. Create the table before starting DC.
+Unlike the blessed form's `password`, the `$DC_PG_PASSWORD` above is Vector's *own*
+`${VAR}` interpolation, off by default in the vendored Vector binary `dc_bridge` spawns
+— see the warning in [Destinations: Recipes](./destinations.md#recipes-postgres-s3-console-via-passthrough).
 ```
 
 ### Example 9: Camera images to object storage, with their metadata in PostgreSQL
@@ -254,17 +327,12 @@ dc_bridge:
       data_dir: "$HOME/.dc/shipper"
     uploader:
       data_dir: "$HOME/.dc/uploader"
-    destinations: ["pgsql", "rustfs"]
-    pgsql:                                    # the Records, and the File status log
-      type: postgres
+    destinations: ["records_log", "rustfs"]
+    records_log:                              # anchor for the Records, and for the File status log
+      type: file
       receives: records
       inputs: ["/dc/measurement/camera"]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "$DC_PG_PASSWORD"
-      database: "dc"
-      table: "dc"
+      path: "/tmp/dc/example9_records.ndjson"
     rustfs:                                   # the File bytes
       type: s3
       receives: files
@@ -277,7 +345,8 @@ dc_bridge:
       force_path_style: true                  # path-style addressing for self-hosted stores
     files:
       delete_when_sent: true                  # delete locally once verified remotely
-      metadata_destination: "pgsql"
+      metadata_destination: "records_log"     # must name a `receives: records` Destination -- a passthrough sink id isn't eligible
+    custom_config_files: ["$HOME/.dc/example9_sink.toml"]
 
 measurement_server:
   ros__parameters:
@@ -294,6 +363,26 @@ measurement_server:
       remote_prefixes: [""]
 ```
 
+```toml
+# ~/.dc/example9_sink.toml -- consumes both routes records_log creates: the camera
+# measurement's own topic, and the dc.files Tag it gains from being named as
+# files.metadata_destination.
+[sinks.pgsql]
+type = "postgres"
+inputs = ["dc.dc.measurement.camera", "dc.dc.files"]
+endpoint = "postgres://dc:$DC_PG_PASSWORD@127.0.0.1:5432/dc"
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488
+```
+
+`rustfs` stays a blessed Destination: `receives: files` is served entirely by
+`dc_uploader` reading these same ROS params, never by a Vector sink, so there is no
+passthrough equivalent for it to migrate to (see
+[Destinations: Recipes](./destinations.md#recipes-postgres-s3-console-via-passthrough)).
+
 ### Example 10: A Destination DC does not bless, via the passthrough
 
 Any sink in [Vector's catalog](https://vector.dev/docs/reference/configuration/sinks/) is
@@ -305,11 +394,12 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/example10_records.ndjson"
     custom_config_files: ["$HOME/.dc/http_sink.toml"]
 
 measurement_server:

--- a/doc/src/dc/demos.md
+++ b/doc/src/dc/demos.md
@@ -17,7 +17,7 @@ the [ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md) passthrough.
 | Tier                                    | Infrastructure to run                                                          | DC machinery involved                                                                               |
 | ------------------------------------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | [Beginner](./demos/beginner.md)         | None. Nothing but the built workspace                                          | Measurements and the blessed `console` Destination, configured in YAML                              |
-| [Intermediate](./demos/intermediate.md) | At most one stack from `tools/infrastructure/docker/`, that you start yourself | The blessed `postgres`/`s3` Destinations, or the [ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md) [passthrough](./destinations.md)          |
+| [Intermediate](./demos/intermediate.md) | At most one stack from `tools/infrastructure/docker/`, that you start yourself | PostgreSQL/RustFS reached via the [ADR-0003](./adr/0003-blessed-destinations-plus-passthrough.md) [passthrough](./destinations.md#recipes-postgres-s3-console-via-passthrough), or a store with no blessed type at all |
 | [Advanced](./demos/advanced.md)         | The full inspection stack — PostgreSQL, RustFS and Grafana at once             | Code you write yourself, or Measurements, Conditions, Groups, Files and dashboards wired end to end |
 
 When adding a demo, find the heaviest thing it asks of the reader — a service to stand up,

--- a/doc/src/dc/demos/elasticsearch.md
+++ b/doc/src/dc/demos/elasticsearch.md
@@ -52,13 +52,13 @@ colcon build
 ros2 launch dc_demos elasticsearch.launch.py
 ```
 
-The `console` Destination prints every Record as it is shipped, so the terminal doubles as
-a local view of what Elasticsearch is receiving:
+The `file` Destination writes every Record as it is shipped to `/tmp/dc/elasticsearch_records.ndjson`,
+so `tail -f` on that path doubles as a local view of what Elasticsearch is receiving:
 
 ```
-[dc_bridge-2] {"cpu":{"average":0,"processes":9,"sorted":[]},"custom_keys":["robot_name"],"date":1788504548.4015868,"flattened":false,"host":"127.0.0.1","name":"cpu","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.cpu","timestamp":"2026-09-04T06:49:08.401586806Z"}
-[dc_bridge-2] {"custom_keys":["robot_name"],"date":1788504548.404685,"flattened":false,"host":"127.0.0.1","memory":{"used":96.89765167236328},"name":"memory","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.memory","timestamp":"2026-09-04T06:49:08.404685157Z"}
-[dc_bridge-2] {"custom_keys":["robot_name"],"date":1788504548.4057963,"flattened":false,"host":"127.0.0.1","name":"uptime","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.uptime","timestamp":"2026-09-04T06:49:08.405796359Z","uptime":{"time":1636933}}
+{"cpu":{"average":0,"processes":9,"sorted":[]},"custom_keys":["robot_name"],"date":1788504548.4015868,"flattened":false,"host":"127.0.0.1","name":"cpu","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.cpu","timestamp":"2026-09-04T06:49:08.401586806Z"}
+{"custom_keys":["robot_name"],"date":1788504548.404685,"flattened":false,"host":"127.0.0.1","memory":{"used":96.89765167236328},"name":"memory","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.memory","timestamp":"2026-09-04T06:49:08.404685157Z"}
+{"custom_keys":["robot_name"],"date":1788504548.4057963,"flattened":false,"host":"127.0.0.1","name":"uptime","nested":true,"robot_name":"C3PO","run_id":"170","source_type":"fluent","tag":"dc.measurement.uptime","timestamp":"2026-09-04T06:49:08.405796359Z","uptime":{"time":1636933}}
 ```
 
 ## Visualize the data
@@ -191,9 +191,9 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs:
         [
@@ -202,6 +202,7 @@ dc_bridge:
           "/dc/measurement/os",
           "/dc/measurement/uptime",
         ]
+      path: "/tmp/dc/elasticsearch_records.ndjson"
       time_key: "date"
       time_format: "double"
     custom_config_files: ["$HOME/.dc/elasticsearch_sink.toml"]
@@ -220,9 +221,14 @@ snippet is a topic the Bridge never subscribes to and never routes — the snipp
 `inputs` would resolve to routes that don't exist. Every topic you want in Elasticsearch
 must therefore appear in some blessed Destination's `inputs` too.
 
-`console` is the cheapest thing to put there — it needs no infrastructure and no
-credentials — and it earns its place by giving you the local view shown above. A `file`
-Destination works equally well if you'd rather not have the output in your terminal.
+`file` is the anchor here — it needs no infrastructure and no credentials, and writes
+`path` to disk rather than your terminal. An earlier version of this demo used a
+blessed `console` Destination for the same job (`console` also gave you a local view of
+what was landing in Elasticsearch), but per [ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md)
+`console` — along with `postgres` and `s3` — has since moved to the passthrough recipe
+itself, being a pure Vector-sink wrapper with no DC-specific logic; see
+[Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough)
+for that recipe if you still want a terminal echo alongside Elasticsearch.
 
 ```admonish warning
 `destinations: []` does not work. rclcpp cannot load an empty YAML sequence (it has no

--- a/doc/src/dc/demos/fastdds_stats_pgsql_grafana.md
+++ b/doc/src/dc/demos/fastdds_stats_pgsql_grafana.md
@@ -16,8 +16,9 @@ this one plugin — but launching *this* demo fails: `measurement_server` can't 
 ```
 
 This is the smallest hardware-free way to see Fast DDS's own Statistics Module land in DC: one
-Measurement ([Fast DDS statistics](../measurements/fastdds_stats.md)), a `postgres` Destination,
-and a Grafana dashboard provisioned automatically — the same convention #304 established for the
+Measurement ([Fast DDS statistics](../measurements/fastdds_stats.md)), a passthrough `postgres`
+sink ([ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md)), and a Grafana dashboard
+provisioned automatically — the same convention #304 established for the
 [KPI dashboard](../kpi_views.md).
 
 ## Setup Infrastructure
@@ -35,6 +36,7 @@ configuration file does not need change.
 
 ```bash
 colcon build
+mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/fastdds_stats_pgsql_grafana_sink.toml" ~/.dc/
 export FASTDDS_STATISTICS="HISTORY_LATENCY_TOPIC;PUBLICATION_THROUGHPUT_TOPIC;SUBSCRIPTION_THROUGHPUT_TOPIC;RTPS_SENT_TOPIC;RTPS_LOST_TOPIC"
 ros2 launch dc_demos fastdds_stats_pgsql_grafana.launch.py
 ```
@@ -108,22 +110,37 @@ measurement_server:
 
 dc_bridge:
   ros__parameters:
-    destinations: ["pgsql"]
-    pgsql:
-      type: postgres
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/fastdds_stats"]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
+      path: "/tmp/dc/fastdds_stats_pgsql_grafana_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/fastdds_stats_pgsql_grafana_sink.toml"]
 ```
 
-`domain_id` is the DDS domain to monitor — the same value `ROS_DOMAIN_ID` would use for every
-other node in the deployment. `include_measurement_name: true` writes `"name": "fastdds_stats"`
-onto every Record, which every panel's `WHERE name = 'fastdds_stats'` clause relies on to tell
-this Measurement's rows apart from any other demo sharing the same `dc` table.
+```toml
+# ~/.dc/fastdds_stats_pgsql_grafana_sink.toml
+[sinks.pgsql]
+type = "postgres"
+inputs = ["dc.dc.measurement.fastdds_stats"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488
+```
+
+`postgres` — along with `s3` and `console` — moved from the blessed ROS-param form to this
+passthrough recipe ([ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md)); `records_log`
+is the cheap `file` anchor the passthrough still needs, since `dc_bridge` derives its ROS
+subscriptions and `dc.<tag>` routes from `destinations` alone. See
+[Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough) for the
+full recipe. `domain_id` is the DDS domain to monitor — the same value `ROS_DOMAIN_ID` would use
+for every other node in the deployment. `include_measurement_name: true` writes
+`"name": "fastdds_stats"` onto every Record, which every panel's `WHERE name = 'fastdds_stats'`
+clause relies on to tell this Measurement's rows apart from any other demo sharing the same `dc`
+table.

--- a/doc/src/dc/demos/mcap_recording.md
+++ b/doc/src/dc/demos/mcap_recording.md
@@ -42,10 +42,14 @@ ros2 launch dc_demos mcap_recording.launch.py
 
 `dc_bringup.launch.py` starts `dc_mcap_writer` before the rest of the stack, so its TCP
 listener is up before Vector's generated `socket` sink (re)connects to it — the very
-first Record lands instead of relying on Vector's own retry. The `console` Destination
-prints every Record as it is shipped, so the terminal doubles as a local view of what
-`dc_mcap_writer` is receiving; `dc_mcap_writer`'s own log lines (also on this terminal —
-it runs alongside `dc_bridge`, not in the background) show each file it opens and closes.
+first Record lands instead of relying on Vector's own retry. The `records_log` `file`
+Destination writes every Record as it is shipped to `/tmp/dc/mcap_recording_records.ndjson`,
+so `tail -f` on that path doubles as a local view of what `dc_mcap_writer` is receiving
+(an earlier version of this demo used a blessed `console` Destination for the same job —
+see [Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough)
+for why that moved to a passthrough recipe); `dc_mcap_writer`'s own log lines (on this
+terminal — it runs alongside `dc_bridge`, not in the background) show each file it opens
+and closes.
 
 ## Verify the recording
 

--- a/doc/src/dc/demos/qrcodes_minio_pgsql.md
+++ b/doc/src/dc/demos/qrcodes_minio_pgsql.md
@@ -135,9 +135,9 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql", "pgsql_files", "rustfs"]
-    pgsql:
-      type: postgres
+    destinations: ["records_log", "rustfs"]
+    records_log:
+      type: file
       receives: records
       inputs:
         [
@@ -146,14 +146,9 @@ dc_bridge:
           "/dc/measurement/left_camera",
           "/dc/group/robot",
         ]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
+      path: "/tmp/dc/qrcodes_minio_pgsql_records.ndjson"
       time_key: "date"
-      time_format: "double"
+    custom_config_files: ["$HOME/.dc/qrcodes_minio_pgsql_sink.toml"]
 
 group_server:
   ros__parameters:
@@ -217,14 +212,51 @@ In the measurement server, we set 3 measurements: cmd_vel, position and speed be
 
 Note the `include_measurement_name` which include measurement name in the JSON, which is used when grouping. The group collects the data from those 3 measurement and republishes it on the group topic `/dc/group/robot`.
 
-`dc_bridge` owns every Destination this demo uses. `pgsql` is a `postgres` Destination — its `inputs` list already names every topic this demo produces (`/dc/group/robot` for this section, plus `/dc/measurement/map`, `/dc/measurement/right_camera` and `/dc/measurement/left_camera` for the sections below): unlike the retired per-measurement `tags: [...]` mechanism, a Destination's `inputs` is the single place that decides what reaches it, so we declare it once and simply grow the measurements that feed those topics as we go.
+`dc_bridge` owns every Destination this demo uses. `records_log`'s `inputs` list already
+names every topic this demo produces (`/dc/group/robot` for this section, plus
+`/dc/measurement/map`, `/dc/measurement/right_camera` and `/dc/measurement/left_camera` for
+the sections below): unlike the retired per-measurement `tags: [...]` mechanism, a
+Destination's `inputs` is the single place that decides what reaches it, so we declare it
+once and simply grow the measurements that feed those topics as we go.
+
+`records_log` is a `file` Destination, not `postgres` — PostgreSQL is reached through the
+[ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md) passthrough instead. The
+actual `postgres` sink lives in `qrcodes_minio_pgsql_sink.toml`, a raw Vector config
+snippet loaded via `custom_config_files`:
+
+```toml
+# ~/.dc/qrcodes_minio_pgsql_sink.toml
+[sinks.pgsql]
+type = "postgres"
+inputs = [
+  "dc.dc.measurement.map",
+  "dc.dc.measurement.right_camera",
+  "dc.dc.measurement.left_camera",
+  "dc.dc.group.robot",
+]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488
+```
+
+`dc_bridge` derives its ROS subscriptions and `dc.<tag>` routes from `destinations` alone,
+never from a passthrough snippet's `inputs` — that's why `records_log` still lists every
+topic even though the snippet above is what actually reaches PostgreSQL. Copy the snippet
+into place before launching:
+
+```bash
+mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/qrcodes_minio_pgsql_sink.toml" ~/.dc/
+```
 
 ```admonish warning
 
 Be sure to change the login and password to your current infrastructure configuration. Do it in production setup!
 ```
 
-You can find more about the `postgres` Destination type [here](../destinations.md)
+You can find more about the `postgres` sink recipe [here](../destinations.md#recipes-postgres-s3-console-via-passthrough)
 
 To take a look at records, go to Adminer. It is by default started at [http://localhost:8080](http://localhost:8080), it is a database GUI.:
 
@@ -263,18 +295,7 @@ Then, the Destinations that make this work:
 dc_bridge:
   ros__parameters:
     ...
-    destinations: ["pgsql", "pgsql_files", "rustfs"]
-    pgsql_files:
-      type: postgres
-      receives: records
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc_files"
-      time_key: "date"
-      time_format: "double"
+    destinations: ["records_log", "rustfs"]
     rustfs:
       type: s3
       receives: files
@@ -292,14 +313,27 @@ dc_bridge:
       force_path_style: true
     files:
       delete_when_sent: true
-      metadata_destination: "pgsql_files"
+      metadata_destination: "records_log"
+```
+
+```toml
+# ~/.dc/qrcodes_minio_pgsql_sink.toml (continued)
+[sinks.pgsql_files]
+type = "postgres"
+inputs = ["dc.dc.files"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc_files"
+
+[sinks.pgsql_files.buffer]
+type = "disk"
+max_size = 268435488
 ```
 
 This introduces the two-way PostgreSQL split this demo relies on:
 
-- **`pgsql`** (already declared above) is a plain `receives: records` Destination — it carries the map's own metadata Record (dimensions, resolution, local/remote paths) like any other measurement.
-- **`pgsql_files`** is a *second* `postgres` Destination, dedicated to the Uploader's own bookkeeping. It has no `inputs` of its own — it is never subscribed to directly, and is fed internally whenever `files.metadata_destination` names it, which is how every `receives: files` Destination in this file (here, `rustfs`) reports upload status.
-- **`rustfs`** is the `s3` Destination that actually uploads the pgm/yaml bytes. `receives: files` marks it as owned by **`dc_uploader`** — a separate process from `dc_bridge` ([ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md)) — rather than a Vector sink: `dc_bridge` subscribes to `rustfs`'s `inputs`, and durably enqueues an intent for any Record with `remote_paths` entries whose key matches a Destination name — here `rustfs`, matching the map measurement's `remote_keys` above. `dc_uploader` reads that intent, uploads the referenced Files, verifies they landed, and emits a status Record under `dc.files`, routed to whatever `pgsql_files` names.
+- **`pgsql`** (the passthrough sink declared above) carries the map's own metadata Record (dimensions, resolution, local/remote paths) like any other measurement.
+- **`pgsql_files`** is a *second* `postgres` sink in the same passthrough snippet, dedicated to the Uploader's own bookkeeping. It has no ROS topic `inputs` of its own — it consumes the `dc.dc.files` route instead, which `records_log` gains from being named as `files.metadata_destination` below. `files.metadata_destination` must name a configured `receives: records` Destination (`dc_bridge` rejects anything else at startup), which is why it names `records_log` rather than the passthrough sink directly — a passthrough-only sink id isn't eligible.
+- **`rustfs`** is the `s3` Destination that actually uploads the pgm/yaml bytes. `receives: files` marks it as owned by **`dc_uploader`** — a separate process from `dc_bridge` ([ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md)) — rather than a Vector sink: `dc_bridge` subscribes to `rustfs`'s `inputs`, and durably enqueues an intent for any Record with `remote_paths` entries whose key matches a Destination name — here `rustfs`, matching the map measurement's `remote_keys` above. `dc_uploader` reads that intent, uploads the referenced Files, verifies they landed, and emits a status Record under `dc.files`, routed to `records_log` (and, from there, consumed by the `pgsql_files` passthrough sink). Unlike `pgsql`/`pgsql_files`, `rustfs` stays blessed: `receives: files` is served entirely by `dc_uploader` reading these same ROS params, never by a Vector sink, so there is no passthrough equivalent for it to migrate to.
 
 See [Destinations](../destinations.md) for the full `files:`/Uploader contract, and [ADR-0005](../adr/0005-file-uploads-are-bridge-responsibility.md) / [ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md) for why file uploads are a DC responsibility rather than a Vector sink, and why that logic now runs as its own process.
 
@@ -405,9 +439,9 @@ Taking a look at the cameras, we can understand that:
 
 `include_measurement_name` matters here too: the Uploader relies on it to know which top-level field of the Record holds the `local_paths`/`remote_paths` it should act on.
 
-No new Destination block is needed for the cameras: `pgsql` and `rustfs` already list `/dc/measurement/right_camera` and `/dc/measurement/left_camera` in their `inputs` (see the first section above) — a Destination's `inputs` is a single, global list of topics rather than something declared per measurement, so adding a measurement that feeds an already-configured Destination requires no `dc_bridge` change at all.
+No new Destination block is needed for the cameras: `records_log` and `rustfs` already list `/dc/measurement/right_camera` and `/dc/measurement/left_camera` in their `inputs` (see the first section above), and the passthrough `pgsql` sink already consumes the matching `dc.<tag>` routes those `inputs` create — a Destination's `inputs` is a single, global list of topics rather than something declared per measurement, so adding a measurement that feeds an already-configured Destination requires no `dc_bridge` change at all.
 
-Here, we collect images with the `rustfs` Destination, and their metadata (which record they belong to, remote path once uploaded, image dimensions where relevant) through `pgsql`. `pgsql_files`, fed by the Uploader, tracks when each image is sent to RustFS and — with `files.delete_when_sent: true` — is deleted locally once confirmed. Note that a Record's `remote_paths` can name several Destinations at once; the Uploader sends to every one whose name appears there.
+Here, we collect images with the `rustfs` Destination, and their metadata (which record they belong to, remote path once uploaded, image dimensions where relevant) through the passthrough `pgsql` sink. `pgsql_files`, fed by the Uploader, tracks when each image is sent to RustFS and — with `files.delete_when_sent: true` — is deleted locally once confirmed. Note that a Record's `remote_paths` can name several Destinations at once; the Uploader sends to every one whose name appears there.
 
 An example Record for `right_camera`, once the image is inspected:
 

--- a/doc/src/dc/demos/tb3_aws_influxdb.md
+++ b/doc/src/dc/demos/tb3_aws_influxdb.md
@@ -264,10 +264,14 @@ dc_bridge:
 
 `dc_bridge` derives both its ROS subscriptions and its `dc.<tag>` route branches from
 `destinations`, and never reads a passthrough snippet's `inputs` — so a passthrough always
-accompanies at least one blessed Destination covering the same topics. `file` is used here
-rather than `console` only because this demo collects base64 camera and map images, which
-make for unreadable terminal output; the [Elasticsearch tutorial](./elasticsearch.md) uses
-`console` for the same job and explains the rule in more detail.
+accompanies at least one blessed Destination covering the same topics. `file` is the
+anchor in every passthrough demo in this repo now, including this one — blessed `console`
+moved to a passthrough recipe of its own ([ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md),
+[Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough)) —
+but it would have been the wrong anchor for this demo regardless, even back when it was
+still blessed: this demo collects base64 camera and map images, which make for unreadable
+terminal output. The [Elasticsearch tutorial](./elasticsearch.md) explains the `file`
+anchor mechanics in more detail.
 
 ```admonish warning
 `destinations: []` does not work as a way to say "passthrough only". rclcpp cannot load an

--- a/doc/src/dc/demos/tb3_aws_minio_pgsql.md
+++ b/doc/src/dc/demos/tb3_aws_minio_pgsql.md
@@ -231,16 +231,16 @@ They are used in the distance traveled measurement to only take values in a cert
 
 ### Destination server
 
-Here we enable the `pgsql`, `pgsql_files` and `rustfs` Destinations:
+Here we enable the `records_log` and `rustfs` Destinations, plus a passthrough for PostgreSQL:
 
 ```yaml
 dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["pgsql", "pgsql_files", "rustfs"]
-    pgsql:
-      type: postgres
+    destinations: ["records_log", "rustfs"]
+    records_log:
+      type: file
       receives: records
       inputs: [
           # System
@@ -261,25 +261,8 @@ dc_bridge:
           "/dc/measurement/rustfs_health",
           "/dc/measurement/pgsql_health",
         ]
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc"
+      path: "/tmp/dc/tb3_simulation_pgsql_minio_records.ndjson"
       time_key: "date"
-      time_format: "double"
-    pgsql_files:
-      type: postgres
-      receives: records
-      host: "127.0.0.1"
-      port: 5432
-      user: "dc"
-      password: "password"
-      database: "dc"
-      table: "dc_files"
-      time_key: "date"
-      time_format: "double"
     rustfs:
       type: s3
       receives: files
@@ -292,15 +275,63 @@ dc_bridge:
       force_path_style: true
     files:
       delete_when_sent: true
-      metadata_destination: "pgsql_files"
+      metadata_destination: "records_log"
+    custom_config_files: ["$HOME/.dc/tb3_simulation_pgsql_minio_sink.toml"]
+```
+
+```toml
+# ~/.dc/tb3_simulation_pgsql_minio_sink.toml
+[sinks.pgsql]
+type = "postgres"
+inputs = [
+  "dc.dc.measurement.cpu", "dc.dc.measurement.memory", "dc.dc.measurement.os",
+  "dc.dc.measurement.uptime", "dc.dc.measurement.camera", "dc.dc.measurement.cmd_vel",
+  "dc.dc.measurement.distance_traveled", "dc.dc.measurement.driving_type",
+  "dc.dc.measurement.position", "dc.dc.measurement.speed", "dc.dc.measurement.map",
+  "dc.dc.measurement.rustfs_health", "dc.dc.measurement.pgsql_health",
+]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc"
+
+[sinks.pgsql.buffer]
+type = "disk"
+max_size = 268435488
+
+[sinks.pgsql_files]
+type = "postgres"
+inputs = ["dc.dc.files"]
+endpoint = "postgres://dc:password@127.0.0.1:5432/dc"
+table = "dc_files"
+
+[sinks.pgsql_files.buffer]
+type = "disk"
+max_size = 268435488
+```
+
+Copy the snippet into place before launching:
+
+```bash
+mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/tb3_simulation_pgsql_minio_sink.toml" ~/.dc/
 ```
 
 #### PostgreSQL Destinations
 
-`pgsql` carries almost every measurement and the two infrastructure health checks as plain Records. Note that not all data needs to go to PostgreSQL — only topics listed in a Destination's `inputs` reach it.
+PostgreSQL is reached through the [ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md)
+passthrough now, not a blessed `postgres` Destination — see
+[Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough). The
+passthrough `pgsql` sink carries almost every measurement and the two infrastructure health
+checks as plain Records. Note that not all data needs to go to PostgreSQL — only topics whose
+`dc.<tag>` route exists (i.e. listed in `records_log`'s `inputs`) reach it.
 
-`pgsql_files` is a second, dedicated `postgres` Destination for `dc_uploader`'s status Records — it has no `inputs` of its own; it only receives data because `files.metadata_destination` names it. See [Destinations](../destinations.md), [ADR-0005](../adr/0005-file-uploads-are-bridge-responsibility.md) and [ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md) for the full split, and the [QR codes demo](./qrcodes_minio_pgsql.md) for a worked example of the same pattern.
+`pgsql_files` is a second, dedicated `postgres` sink in the same passthrough snippet for
+`dc_uploader`'s status Records — it has no ROS topic `inputs` of its own; it consumes the
+`dc.dc.files` route instead, which `records_log` gains from being named as
+`files.metadata_destination` (that parameter must name a configured `receives: records`
+Destination, so it can't point at a passthrough-only sink id directly). See
+[Destinations](../destinations.md), [ADR-0005](../adr/0005-file-uploads-are-bridge-responsibility.md)
+and [ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md) for the full split, and the
+[QR codes demo](./qrcodes_minio_pgsql.md) for a worked example of the same pattern.
 
 #### RustFS Destination
 
-We list only `map` and `camera` in `rustfs`'s `inputs` since those are the only measurements referencing Files. `rustfs`'s `type: s3` and `receives: files` mark it as owned by `dc_uploader` — a separate process from `dc_bridge` ([ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md)) — rather than a Vector sink target: it uploads whatever File the measurement's `remote_keys: ["rustfs"]` pointed at it, verifies the object landed, and (with `files.delete_when_sent: true`) deletes the local copy only once that's confirmed.
+We list only `map` and `camera` in `rustfs`'s `inputs` since those are the only measurements referencing Files. `rustfs`'s `type: s3` and `receives: files` mark it as owned by `dc_uploader` — a separate process from `dc_bridge` ([ADR-0014](../adr/0014-uploader-runs-as-its-own-process.md)) — rather than a Vector sink target: it uploads whatever File the measurement's `remote_keys: ["rustfs"]` pointed at it, verifies the object landed, and (with `files.delete_when_sent: true`) deletes the local copy only once that's confirmed. Unlike PostgreSQL, `rustfs` stays a blessed Destination: `receives: files` is served entirely by `dc_uploader` reading these same ROS params, never by a Vector sink, so there is no passthrough equivalent for it to migrate to.

--- a/doc/src/dc/demos/uptime_stdout.md
+++ b/doc/src/dc/demos/uptime_stdout.md
@@ -2,16 +2,17 @@
 
 This is the most minimal example to run DC, it collects the system uptime every 5 seconds and sends it to Stdout.
 
-Let's run it:
+Copy the passthrough sink into place, then run it:
 
 ```bash
+mkdir -p ~/.dc && cp "$(ros2 pkg prefix dc_demos)/share/dc_demos/config/uptime_stdout_sink.toml" ~/.dc/
 ros2 launch dc_demos uptime_stdout.launch.py
 ```
 
-At the end, the data is displayed. Every Destination — `console` included — goes
-through the external Vector Shipper ([ADR-0002](../adr/0002-vector-as-default-shipper.md),
-[Destinations](../destinations.md)), so
-this is Vector's own event object after ingesting the Record over the Fluent-forward
+At the end, the data is displayed. Every Destination — the passthrough `console` sink
+below included — goes through the external Vector Shipper
+([ADR-0002](../adr/0002-vector-as-default-shipper.md), [Destinations](../destinations.md)),
+so this is Vector's own event object after ingesting the Record over the Fluent-forward
 protocol: `source_type`, `tag`, `host` and `timestamp` are Vector's, not the Bridge's:
 ```
 [dc_bridge-2] {"custom_keys":["robot_name","time"],"date":1788476609.152106,"flattened":false,"host":"127.0.0.1","name":"uptime","nested":false,"robot_name":"C3PO","run_id":"169","source_type":"fluent","tag":"dc.measurement.uptime","time":1608993,"timestamp":"2026-09-03T23:03:29.152105868Z"}
@@ -70,7 +71,7 @@ measurement_server:
 
 **run_id.uuid (Optional)**: Generate a new run ID by using a random UUID
 
-This will collect the uptime every 5 seconds (including when the node starts), will forward it to the *console* destination.
+This will collect the uptime every 5 seconds (including when the node starts), will forward it to the *console* passthrough sink below.
 
 #### Inject custom data for each record
 
@@ -103,15 +104,28 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["console"]
-    console:
-      type: console
+    destinations: ["records_log"]
+    records_log:
+      type: file
       receives: records
       inputs: ["/dc/measurement/uptime"]
+      path: "/tmp/dc/uptime_stdout_records.ndjson"
       time_key: "date"
       time_format: "double"
+    custom_config_files: ["$HOME/.dc/uptime_stdout_sink.toml"]
     vector_forward_host: "127.0.0.1"
     vector_forward_port: 24224
+```
+
+```toml
+# ~/.dc/uptime_stdout_sink.toml
+[sinks.debug_console]
+type = "console"
+inputs = ["dc.dc.measurement.uptime"]
+target = "stdout"
+
+[sinks.debug_console.encoding]
+codec = "json"
 ```
 
 #### Destinations
@@ -120,15 +134,19 @@ Let's analyze piece by piece. `dc_bridge` is the single C++ node that owns every
 
 **destinations (Mandatory)**: List all the Destinations to enable. Each name must have a matching section at the same level.
 
-**console.type (Mandatory)**: One of the blessed Destination types (`postgres`, `s3`, `file`, `console`, `vector`). `console` prints JSON to `dc_bridge`'s own stdout — handy for demos and debugging.
+**records_log.type (Mandatory)**: One of the blessed Destination types (`postgres`, `s3`, `file`, `console`, `vector`). `file` writes each Record as a JSON line to `path`, and is the cheapest anchor to give `destinations` when the actual output you want comes from a `custom_config_files` passthrough sink below — dc_bridge derives its ROS subscriptions and `dc.<tag>` routes from `destinations` alone, never from a passthrough snippet's `inputs`. (Printing straight to stdout used a blessed `console` Destination in earlier versions of this demo; per [ADR-0003](../adr/0003-blessed-destinations-plus-passthrough.md), `console` — along with `postgres` and `s3` — has moved to the passthrough recipe below, since it's a pure Vector-sink wrapper with no DC-specific logic. See [Destinations: Recipes](../destinations.md#recipes-postgres-s3-console-via-passthrough).)
 
-**console.receives (Optional)**: `records` (default) or `files`.
+**records_log.receives (Optional)**: `records` (default) or `files`.
 
-**console.inputs (Mandatory)**: Topics to which to listen to get the data.
+**records_log.inputs (Mandatory)**: Topics to which to listen to get the data.
 
-**console.time_format (Optional)**: Format the data's timestamp will be printed as (`epoch_nanos` (default), `iso8601` or `double`).
+**records_log.path (Mandatory for `file`)**: Absolute path Vector writes each JSON line to (Vector, not the Bridge, expands this — no `$HOME`).
 
-**console.time_key (Optional)**: Dictionary key the timestamp is written under.
+**records_log.time_format (Optional)**: Format the data's timestamp will be printed as (`epoch_nanos` (default), `iso8601` or `double`).
+
+**records_log.time_key (Optional)**: Dictionary key the timestamp is written under.
+
+**custom_config_files (Optional)**: Raw Vector config snippets, merged as-is alongside what `dc_bridge` itself renders. The `uptime_stdout_sink.toml` above defines a plain Vector `console` sink consuming the public `dc.dc.measurement.uptime` route that `records_log`'s `inputs` created — this is what actually prints to stdout; `records_log` itself just writes the same Records to disk as the passthrough's required anchor. See [Destinations: Passthrough](../destinations.md#passthrough-custom_config_files).
 
 `dc_bridge` itself needs no engine tuning of the kind the old embedded Fluent Bit shipper required (buffering, scheduler backoff, HTTP stats server, …) — Vector, the external shipper process it forwards to, owns its own on-disk buffering and is configured from the `dc_bridge`/`destinations` block above; see [ADR-0002](../adr/0002-vector-as-default-shipper.md) for why that split exists.
 
@@ -154,7 +172,7 @@ Measurement server and `dc_bridge` are started in the Lifecycle, you can read mo
 
 `dc_bridge` renders the `destinations` block above into a Vector config and launches (or reloads) the external Vector process pointed at it; `bridge_ready_gate` only lets the launch continue once Vector is actually accepting connections — see [ADR-0002](../adr/0002-vector-as-default-shipper.md) for why Vector runs as its own process rather than embedded in the Bridge.
 
-Finally, we see the data, now printed by Vector's own `console` sink rather than by the Bridge itself:
+Finally, we see the data, now printed by the passthrough `console` sink rather than by the Bridge itself:
 ```
 [dc_bridge-2] {"custom_keys":["robot_name","time"],"date":1788476609.152106,"flattened":false,"host":"127.0.0.1","name":"uptime","nested":false,"robot_name":"C3PO","run_id":"169","source_type":"fluent","tag":"dc.measurement.uptime","time":1608993,"timestamp":"2026-09-03T23:03:29.152105868Z"}
 [dc_bridge-2] {"custom_keys":["robot_name","time"],"date":1788476614.1494331,"flattened":false,"host":"127.0.0.1","name":"uptime","nested":false,"robot_name":"C3PO","run_id":"169","source_type":"fluent","tag":"dc.measurement.uptime","time":1608998,"timestamp":"2026-09-03T23:03:34.149433151Z"}
@@ -166,5 +184,5 @@ So...what happened?
 1. The measurement plugin starts publishing data to /dc/measurement/uptime, which contains the JSON and timestamp of the message
 2. Run ID and robot_name is appended in the JSON
 3. `dc_bridge`, which subscribes to this topic directly, receives the data and forwards it to Vector over the shipper ingest protocol
-4. Vector's generated config applies a `remap` transform that writes the configured `time_key` in the requested `time_format`
-5. Vector's `console` sink, the only one matching the `console` Destination we configured, prints the JSON to stdout
+4. Vector's generated config applies a `remap` transform that writes the configured `time_key` in the requested `time_format`, and routes the Record onto its public `dc.dc.measurement.uptime` route
+5. The passthrough `console` sink from `uptime_stdout_sink.toml`, consuming that route, prints the JSON to stdout — `records_log`'s own `file` sink writes the same Record to disk in parallel

--- a/doc/src/dc/raw_topics.md
+++ b/doc/src/dc/raw_topics.md
@@ -14,14 +14,16 @@ dc_bridge:
   ros__parameters:
     shipper:
       data_dir: "$HOME/.dc/buffer"
-    destinations: ["raw_console"]
-    raw_console:
-      type: console          # any blessed type works: postgres | s3 | file | console | vector
+    destinations: ["raw_log"]
+    raw_log:
+      type: file              # any blessed type works: postgres | s3 | file | vector, or console
+                               # via its passthrough recipe (destinations.md#recipes-postgres-s3-console-via-passthrough)
       receives: records
+      path: "/tmp/dc/raw_records.ndjson"
       time_key: "date"
     raw:
       enabled: true
-      destination: "raw_console"
+      destination: "raw_log"
 ```
 
 ```bash


### PR DESCRIPTION
## Summary

Per ADR-0003 and the #470 recipes, `postgres`, `s3` (for `receives: records`) and
`console` are pure Vector-sink wrappers with no DC-specific logic, so every demo, deploy
param file and doc example that configured them via the blessed ROS-param form now uses
the ADR-0003 passthrough (`custom_config_files`) instead — ahead of #472's removal of
that blessed code path.

- Migrated all 10 in-scope `dc_demos/params/*.yaml` demos, plus
  `deploy/robot/params/aio_params_local.yaml`, to the passthrough recipe. A `file`
  Destination is the passthrough's required anchor throughout, since `dc_bridge` derives
  its ROS subscriptions and `dc.<tag>` routes from `destinations` alone, never from a
  snippet's `inputs`.
- Updated every doc page in the issue's list that actually showed a blessed
  `postgres`/`s3`/`console` example: `demos/uptime_stdout.md`, `demos/elasticsearch.md`,
  `demos/mcap_recording.md`, `demos/fastdds_stats_pgsql_grafana.md`,
  `demos/qrcodes_minio_pgsql.md`, `demos/tb3_aws_minio_pgsql.md`,
  `demos/tb3_aws_influxdb.md` (a stale cross-reference), `configuration_examples.md`,
  `concepts.md`, `raw_topics.md`, `demos.md`. Pages with no actual blessed example
  (`faq.md`, `cli.md`, `demos/intermediate.md`, `infrastructure_setup/{rustfs,influxdb}.md`,
  `measurements/camera.md`) were checked and left as-is — they were already accurate.

## Two things deliberately did not move (verified against `dc_bridge`'s own source)

- **`s3`/`receives: files` stays blessed** everywhere it appears
  (`qrcodes_minio_pgsql`, `tb3_simulation_pgsql_minio`, `camera.md`,
  `configuration_examples.md` Example 9): it's served entirely by `dc_uploader` reading
  these same ROS params, never by a Vector sink — there's no passthrough equivalent.
- **`deploy/robot/params/robot_params_local.yaml` keeps blessed `postgres`**: that
  scenario runs `shipper.managed: false` (the three-container split). I stood the split
  topology up with a passthrough sink and found `custom_config_files` snippets never
  reach the separate `vector` container's rendered config in unmanaged mode — only
  `shipper.config_path` gets written there; the passthrough mechanism only works in
  *managed*-shipper mode today. Left it blessed with a comment explaining the gap rather
  than shipping a silently-broken config. **This is a real gap worth its own follow-up
  issue** against `dc_bridge`/the split-deployment compose+quadlet units (options: merge
  passthrough content into the single rendered file in unmanaged mode too, or extend the
  compose/quadlet vector service to load multiple `--config` paths).

## Test plan

Every touched demo was actually launched and its passthrough sink's delivery confirmed,
not just visually inspected:

- [x] `uptime_stdout`, `uptime_custom_stdout`, `group_memory_uptime_stdout`,
      `qrcodes_stdout`, `tb3_simulation_stdout`: passthrough `console` sink prints
      correctly
- [x] `mcap_recording`: `.mcap` file written + `file`-anchor ndjson log correct
- [x] `elasticsearch`: documents actually landed in a live Elasticsearch instance
- [x] `fastdds_stats_pgsql_grafana`: rows landed in PostgreSQL via the passthrough sink
      (measurement plugin itself unbuildable in this image — bypassed with a synthetic
      publish on the same topic to prove sink delivery)
- [x] `qrcodes_minio_pgsql`, `tb3_simulation_pgsql_minio`: DC-only launch (synthetic
      messages standing in for Nav2/camera output — navigation itself is untouched by
      this change), passthrough `pgsql` sink delivers rows; `pgsql_files`/`dc.files`
      routing verified structurally (Bridge accepted the config with no error)
- [x] `deploy/robot`'s `aio_params_local.yaml` (managed mode): full compose stack up,
      `vector validate` passed against the rendered config + passthrough snippet, rows
      confirmed in PostgreSQL
- [x] `git add -A && prek run --all-files --skip build-doc` — all green
- [x] `mdbook build` against the doc changes — no new warnings/errors

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WYVDzgJx2xLAzixNFm7b7H