### PR TITLE
fix(uploader): upload Files of flattened Records through one shared Record walk

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -27,6 +27,9 @@ find_package(Threads REQUIRED)
 find_package(rosidl_runtime_cpp REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 find_package(rcpputils REQUIRED)
+# record_file_walk.hpp (#479): the shared owner of where Files live in a Record, used by the
+# Uploader's collect_files() and the Measurement's staging side alike, so the two can't drift.
+find_package(dc_common REQUIRED)
 # The AWS SDK for C++ (s3) comes from the aws_sdk_vendor package (built from source);
 # colcon puts its install prefix on CMAKE_PREFIX_PATH so this resolves.
 find_package(AWSSDK REQUIRED COMPONENTS s3)
@@ -57,6 +60,10 @@ add_library(dc_bridge_core
 target_include_directories(dc_bridge_core PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>)
+# Header-only dc_common dep (record_file_walk.hpp, #479); not in any public header, and
+# ament_target_dependencies can't be used here — it would mix target_link_libraries
+# signatures on a target that already uses the keyword form above.
+target_include_directories(dc_bridge_core PRIVATE ${dc_common_INCLUDE_DIRS})
 target_link_libraries(dc_bridge_core PUBLIC
   nlohmann_json::nlohmann_json
   tomlplusplus::tomlplusplus
@@ -103,10 +110,9 @@ install(TARGETS dc_bridge dc_uploader DESTINATION lib/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
-  # Header-only, ROS-free utilities (#285). Tests only: uploader_test stages a File the way an
-  # armed Measurement does (#290) to check the Files pipeline ingests a released one unchanged.
-  # dc_bridge itself needs no part of it — the Bridge is deliberately unaware of incident capture.
-  find_package(dc_common REQUIRED)
+  # Header-only, ROS-free utilities (#285): uploader_test stages a File the way an armed
+  # Measurement does (#290) to check the Files pipeline ingests a released one unchanged.
+  # (dc_common itself is found above now — the core links its record_file_walk, #479.)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
   foreach(t forwarder supervisor render misc uploader intent_queue retention thumbnail raw_config process_config)
     ament_add_gtest(${t}_test test/${t}_test.cpp)

--- a/dc_bridge/include/dc_bridge/uploader/group.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/group.hpp
@@ -4,9 +4,11 @@
 // Parsing the Files a Record references out of its JSON payload — the
 // local_paths/remote_paths structure Measurements embed (camera/map), replacing the
 // Humble-era parallel src_fields/upload_fields arrays. remote_paths is keyed by
-// Destination name; the payload is walked recursively so a bare Measurement Record and a
-// Group-merged Record parse identically; base64 subtrees are skipped. All Files found in
-// one Record form one group (the unit ADR-0005's completion marker covers).
+// Destination name; the payload walk itself (nested or flattened form) is owned by
+// dc_common's record_file_walk (#479), shared with the Measurement's staging side, so a
+// bare Measurement Record and a Group-merged Record parse identically; base64 subtrees
+// are skipped. All Files found in one Record form one group (the unit ADR-0005's
+// completion marker covers).
 #ifndef DC_BRIDGE__UPLOADER__GROUP_HPP_
 #define DC_BRIDGE__UPLOADER__GROUP_HPP_
 

--- a/dc_bridge/package.xml
+++ b/dc_bridge/package.xml
@@ -38,6 +38,13 @@ SPDX-License-Identifier: MPL-2.0
        libtomlplusplus-dev / libmsgpack-cxx-dev so `rosdep install` resolves them. -->
   <depend>tomlplusplus</depend>
   <depend>msgpack-cxx</depend>
+  <!-- Header-only dc_common utilities. record_file_walk.hpp (#479) is a real build dep —
+       the shared owner of where Files live in a Record, used by the Uploader's
+       collect_files() and the Measurement's staging side so the two can't drift (before it,
+       a flattened Record's Files were staged but never uploaded). FileScratchRing stays
+       tests-only: uploader_test stages a File exactly the way an armed Measurement stages
+       it (#290), while the Bridge itself remains unaware of incident capture. -->
+  <depend>dc_common</depend>
   <!-- The AWS SDK for C++ (s3), built from source — the Uploader's object-storage client
        (ADR-0005). -->
   <depend>aws_sdk_vendor</depend>
@@ -53,10 +60,6 @@ SPDX-License-Identifier: MPL-2.0
   <exec_depend>ffmpeg</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <!-- Tests only (uploader_test, #290): dc_common's header-only FileScratchRing, so the Files
-       pipeline can be exercised against a File staged exactly the way an armed Measurement
-       stages it. The Bridge itself has no incident-capture code and depends on none of it. -->
-  <test_depend>dc_common</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/dc_bridge/src/uploader/group.cpp
+++ b/dc_bridge/src/uploader/group.cpp
@@ -3,6 +3,8 @@
 
 #include "dc_bridge/uploader/group.hpp"
 
+#include "dc_common/record_file_walk.hpp"
+
 namespace dc_bridge::uploader
 {
 
@@ -24,82 +26,41 @@ std::optional<std::string> str_field(const nlohmann::json& obj, const char* key)
   return std::nullopt;
 }
 
-void collect_files(const nlohmann::json& value, const std::set<std::string>& storages,
+void collect_files(const nlohmann::json& record, const std::set<std::string>& storages,
                    std::map<std::string, FileRef>& files)
 {
-  if (!value.is_object())
-  {
-    return;
-  }
-
-  auto local_paths_it = value.find("local_paths");
-  if (local_paths_it != value.end() && local_paths_it->is_object())
-  {
-    auto remote_paths_it = value.find("remote_paths");
-    for (auto it = local_paths_it->begin(); it != local_paths_it->end(); ++it)
+  // The walk — nested local_paths objects and a flattened Record's JSON-pointer keys alike —
+  // is owned by dc_common's record_file_walk (#479), the same one the Measurement's staging
+  // side goes through, so exactly the Files staged upstream are the ones collected here.
+  dc_common::record_file_walk::for_each_file_site(record, [&](const dc_common::record_file_walk::FileSite& site) {
+    std::map<std::string, std::string> remotes;
+    for (const auto& storage : storages)
     {
-      const std::string& key = it.key();
-      if (!it->is_string())
+      auto it = site.remote_paths.find(storage);
+      if (it != site.remote_paths.end())
       {
-        continue;
-      }
-      const std::string local_path = it->get<std::string>();
-      if (local_path.empty())
-      {
-        continue;
-      }
-      std::map<std::string, std::string> remotes;
-      if (remote_paths_it != value.end() && remote_paths_it->is_object())
-      {
-        for (const auto& storage : storages)
-        {
-          auto s_it = remote_paths_it->find(storage);
-          if (s_it == remote_paths_it->end() || !s_it->is_object())
-          {
-            continue;
-          }
-          auto k_it = s_it->find(key);
-          if (k_it != s_it->end() && k_it->is_string())
-          {
-            std::string remote = k_it->get<std::string>();
-            if (!remote.empty())
-            {
-              remotes.emplace(storage, remote);
-            }
-          }
-        }
-      }
-      if (remotes.empty())
-      {
-        continue;
-      }
-      // The same local path can appear in several sub-objects; merge their Destination
-      // sets rather than uploading twice.
-      auto existing = files.find(local_path);
-      if (existing != files.end())
-      {
-        for (auto& [k, v] : remotes)
-        {
-          existing->second.remote_paths[k] = v;
-        }
-      }
-      else
-      {
-        files.emplace(local_path, FileRef{ key, local_path, std::move(remotes) });
+        remotes.emplace(storage, it->second);
       }
     }
-  }
-
-  for (auto it = value.begin(); it != value.end(); ++it)
-  {
-    const std::string& key = it.key();
-    // base64 holds inline file content (potentially huge) and never Files.
-    if (key == "local_paths" || key == "remote_paths" || key == "base64")
+    if (remotes.empty())
     {
-      continue;
+      return;
     }
-    collect_files(*it, storages, files);
-  }
+    // The same local path can appear in several sub-objects; merge their Destination
+    // sets rather than uploading twice.
+    auto existing = files.find(site.local_path);
+    if (existing != files.end())
+    {
+      for (auto& [k, v] : remotes)
+      {
+        existing->second.remote_paths[k] = v;
+      }
+    }
+    else
+    {
+      files.emplace(site.local_path, FileRef{ site.key, site.local_path, std::move(remotes) });
+    }
+  });
 }
 
 }  // namespace

--- a/dc_bridge/test/uploader_test.cpp
+++ b/dc_bridge/test/uploader_test.cpp
@@ -186,6 +186,17 @@ json camera_payload(const std::string& local_path, const std::vector<std::string
                { "remote_paths", remote } };
 }
 
+// The same payload after a `flatten: true` Measurement's flattenSample(): json::flatten()
+// pointer keys plus the marker keys it adds afterwards. Built with the real flatten() so the
+// test can't diverge from what production writes.
+json flattened_camera_payload(const std::string& local_path, const std::vector<std::string>& storages)
+{
+  json flat = camera_payload(local_path, storages).flatten();
+  flat["flattened"] = true;
+  flat["nested"] = false;
+  return flat;
+}
+
 // An EmitFn collecting rows into `rows`.
 EmitFn collect_rows(std::shared_ptr<std::vector<json>> rows)
 {
@@ -227,6 +238,29 @@ TEST(Uploader, HappyPathUploadsVerifiesEmitsStatusRows)
   EXPECT_EQ(rows_of_kind(*rows, "file_status").size(), 2u);
   EXPECT_EQ(rows_of_kind(*rows, "group_complete").size(), 1u);
   EXPECT_TRUE(std::filesystem::exists(local));
+}
+
+TEST(Uploader, FlattenedRecordFilesStillUpload)
+{
+  // #479: a `flatten: true` Measurement's Record reaches the Bridge with JSON-pointer keys
+  // ("/local_paths/raw") instead of nested local_paths objects. Before the shared
+  // record_file_walk, collect_files() matched only nested objects, so these Files were
+  // staged by the Measurement yet silently never uploaded.
+  Fixture fx({ "minio" });
+  auto local = fx.write_file("img.jpg", JPEG_BYTES);
+  auto up = fx.uploader(false);
+  auto rows = std::make_shared<std::vector<json>>();
+
+  auto summary =
+      up.process_record(flattened_camera_payload(local, { "minio" }), "dc.measurement.camera", collect_rows(rows));
+
+  EXPECT_EQ(summary.files, 1u);
+  EXPECT_EQ(summary.verified, 1u);
+  EXPECT_TRUE(summary.group_complete);
+  for (auto& store : fx.stores)
+  {
+    EXPECT_EQ(store->object_bytes("cam/2026/img.jpg"), JPEG_BYTES);
+  }
 }
 
 TEST(Uploader, MetadataRecordHasHumbleShape)

--- a/dc_common/CMakeLists.txt
+++ b/dc_common/CMakeLists.txt
@@ -42,6 +42,15 @@ if(BUILD_TESTING)
     )
   endforeach()
 
+  # RecordFileWalk (#479) walks nlohmann::json Records, so it links nlohmann_json beyond the
+  # plain-header tests above.
+  ament_add_gtest(${PROJECT_NAME}_record_file_walk_test test/record_file_walk_test.cpp)
+  target_include_directories(${PROJECT_NAME}_record_file_walk_test PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+  )
+  target_link_libraries(${PROJECT_NAME}_record_file_walk_test nlohmann_json::nlohmann_json)
+
   # WebSocketJsonClient (#390) needs nlohmann_json and pthread beyond the other header-only
   # utilities above, and its fixture (a synchronous websocket echo server) needs Boost.Asio/Beast
   # too -- linked explicitly rather than relying on Boost's headers being found on the system

--- a/dc_common/include/dc_common/record_file_walk.hpp
+++ b/dc_common/include/dc_common/record_file_walk.hpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#pragma once
+// The one owner of "where Files live in a Record". Measurements embed Files as nested
+// `local_paths`/`remote_paths` objects (camera, map), and `flatten: true` rewrites those
+// into JSON-pointer keys. The Measurement's staging side (dc_measurements) and the
+// Bridge/Uploader's parse_file_group side (dc_bridge) both walk Records through this
+// module — consumers must not re-derive the rules, or the two sides drift (#479).
+
+#include <cstring>
+#include <functional>
+#include <map>
+#include <nlohmann/json.hpp>
+#include <string>
+
+namespace dc_common::record_file_walk
+{
+
+/// One File location in a Record: its key within local_paths, its local path, and where
+/// it must land per Destination (storage name -> remote path). Destinations the caller
+/// is not configured for are filtered by the caller, not the walk.
+struct FileSite
+{
+  std::string key;
+  std::string local_path;
+  std::map<std::string, std::string> remote_paths;
+};
+
+namespace detail
+{
+
+constexpr char kLocalPaths[] = "local_paths";
+constexpr char kRemotePaths[] = "remote_paths";
+constexpr char kBase64[] = "base64";
+
+// Nested form: remote_paths = {storage: {key: remote}} beside the local_paths object.
+inline void collect_remotes_nested(const nlohmann::json& remote_paths, const std::string& key, FileSite& site)
+{
+  if (!remote_paths.is_object())
+  {
+    return;
+  }
+  for (auto storage = remote_paths.begin(); storage != remote_paths.end(); ++storage)
+  {
+    if (!storage->is_object())
+    {
+      continue;
+    }
+    auto remote = storage->find(key);
+    if (remote != storage->end() && remote->is_string() && !remote->get<std::string>().empty())
+    {
+      site.remote_paths.emplace(storage.key(), remote->get<std::string>());
+    }
+  }
+}
+
+// Flattened form: parent holds pointer keys; local sits at "<prefix>/local_paths/<key>"
+// and remotes at "<prefix>/remote_paths/<storage>/<key>" (prefix is "" or "/<name>" when
+// the Record is also nested).
+inline void collect_remotes_flattened(const nlohmann::json& parent, const std::string& prefix, const std::string& key,
+                                      FileSite& site)
+{
+  const std::string remote_marker = prefix + "/remote_paths/";
+  for (auto it = parent.begin(); it != parent.end(); ++it)
+  {
+    if (!it->is_string() || it.key().rfind(remote_marker, 0) != 0)
+    {
+      continue;
+    }
+    const std::size_t key_start = remote_marker.size();
+    const std::size_t key_end = it.key().rfind('/');
+    if (key_end == std::string::npos || key_end < key_start ||
+        it.key().compare(key_end + 1, std::string::npos, key) != 0)
+    {
+      continue;
+    }
+    const std::string storage = it.key().substr(key_start, key_end - key_start);
+    if (!storage.empty() && !it->get<std::string>().empty())
+    {
+      site.remote_paths.emplace(storage, it->get<std::string>());
+    }
+  }
+}
+
+inline void walk(const nlohmann::json& value, const std::function<void(const FileSite&)>& visit)
+{
+  if (!value.is_object())
+  {
+    return;
+  }
+
+  auto local_paths = value.find(kLocalPaths);
+  if (local_paths != value.end() && local_paths->is_object())
+  {
+    auto remote_paths = value.find(kRemotePaths);
+    for (auto it = local_paths->begin(); it != local_paths->end(); ++it)
+    {
+      if (!it->is_string() || it->get<std::string>().empty())
+      {
+        continue;
+      }
+      FileSite site;
+      site.key = it.key();
+      site.local_path = it->get<std::string>();
+      if (remote_paths != value.end())
+      {
+        collect_remotes_nested(*remote_paths, site.key, site);
+      }
+      visit(site);
+    }
+  }
+
+  for (auto it = value.begin(); it != value.end(); ++it)
+  {
+    const std::string& key = it.key();
+    if (key == kLocalPaths || key == kRemotePaths || key == kBase64)
+    {
+      continue;
+    }
+    // A flattened Record has no nested objects left: its keys are JSON pointers, so the
+    // local paths show up as "/local_paths/raw" (or "/<name>/local_paths/raw" when also
+    // nested). base64 is inline content, never a File.
+    if (it->is_string() && key.find("/local_paths/") != std::string::npos)
+    {
+      if (it->get<std::string>().empty())
+      {
+        continue;
+      }
+      const std::size_t marker = key.find("/local_paths/");
+      FileSite site;
+      site.key = key.substr(marker + std::strlen("/local_paths/"));
+      site.local_path = it->get<std::string>();
+      collect_remotes_flattened(value, key.substr(0, marker), site.key, site);
+      visit(site);
+      continue;
+    }
+    walk(*it, visit);
+  }
+}
+
+inline bool rewrite_in(nlohmann::json& value, const std::function<bool(std::string&)>& rewrite)
+{
+  if (!value.is_object())
+  {
+    return false;
+  }
+
+  bool any = false;
+  auto local_paths = value.find(kLocalPaths);
+  if (local_paths != value.end() && local_paths->is_object())
+  {
+    for (auto it = local_paths->begin(); it != local_paths->end(); ++it)
+    {
+      if (!it->is_string() || it->get_ref<std::string&>().empty())
+      {
+        continue;
+      }
+      any = rewrite(it->get_ref<std::string&>()) || any;
+    }
+  }
+
+  for (auto it = value.begin(); it != value.end(); ++it)
+  {
+    const std::string& key = it.key();
+    if (key == kLocalPaths || key == kRemotePaths || key == kBase64)
+    {
+      continue;
+    }
+    if (it->is_string() && key.find("/local_paths/") != std::string::npos && !it->get_ref<std::string&>().empty())
+    {
+      any = rewrite(it->get_ref<std::string&>()) || any;
+      continue;
+    }
+    any = rewrite_in(*it, rewrite) || any;
+  }
+  return any;
+}
+
+}  // namespace detail
+
+/// Visit every File site in a Record, in either written form: nested local_paths objects
+/// at any depth, or flattened JSON-pointer keys. Empty local paths and base64 content are
+/// skipped. remote_paths entries with empty values are dropped.
+inline void for_each_file_site(const nlohmann::json& record, const std::function<void(const FileSite&)>& visit)
+{
+  detail::walk(record, visit);
+}
+
+/// Rewrite every local-path string in the Record in place — nested values and flattened
+/// pointer-key values alike — by calling `rewrite(path)`, which may replace the string and
+/// returns true when it did. Returns whether any path was rewritten. Remote paths and
+/// base64 content are never handed to `rewrite`.
+inline bool rewrite_local_paths(nlohmann::json& record, const std::function<bool(std::string&)>& rewrite)
+{
+  return detail::rewrite_in(record, rewrite);
+}
+
+}  // namespace dc_common::record_file_walk

--- a/dc_common/test/record_file_walk_test.cpp
+++ b/dc_common/test/record_file_walk_test.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Unit tests for dc_common::record_file_walk (#479): the shared owner of "where Files live in
+// a Record". The flattened forms below are exactly what nlohmann's json::flatten() produces
+// (leading-slash JSON-pointer keys), which is what Measurement::flattenSample() runs on every
+// Record -- these tests pin both written forms so the staging side (dc_measurements) and the
+// parse side (dc_bridge) can never drift apart again.
+
+#include "dc_common/record_file_walk.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+using dc_common::record_file_walk::for_each_file_site;
+using dc_common::record_file_walk::rewrite_local_paths;
+using nlohmann::json;
+
+namespace
+{
+
+struct Site
+{
+  std::string key;
+  std::string local_path;
+  std::map<std::string, std::string> remote_paths;
+};
+
+std::vector<Site> sites(const json& record)
+{
+  std::vector<Site> out;
+  for_each_file_site(record, [&](const dc_common::record_file_walk::FileSite& s) {
+    out.push_back({ s.key, s.local_path, s.remote_paths });
+  });
+  return out;
+}
+
+}  // namespace
+
+TEST(RecordFileWalk, NestedTopLevelLocalPaths)
+{
+  const json record = json::parse(R"({
+    "local_paths": {"raw": "/tmp/raw.jpg"},
+    "remote_paths": {"s3": {"raw": "s3://bucket/raw.jpg"}}
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found[0].key, "raw");
+  EXPECT_EQ(found[0].local_path, "/tmp/raw.jpg");
+  EXPECT_EQ(found[0].remote_paths, (std::map<std::string, std::string>{ { "s3", "s3://bucket/raw.jpg" } }));
+}
+
+TEST(RecordFileWalk, NestedUnderMeasurementName)
+{
+  // nested: true wraps the payload under the measurement name before flatten is even consulted.
+  const json record = json::parse(R"({
+    "camera": {
+      "local_paths": {"raw": "/tmp/raw.jpg", "rotated": "/tmp/rot.jpg"},
+      "remote_paths": {"minio": {"raw": "minio://raw.jpg"}}
+    },
+    "nested": true,
+    "flattened": false
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 2u);
+  EXPECT_EQ(found[0].key, "raw");
+  EXPECT_EQ(found[0].remote_paths, (std::map<std::string, std::string>{ { "minio", "minio://raw.jpg" } }));
+  EXPECT_EQ(found[1].key, "rotated");
+  EXPECT_TRUE(found[1].remote_paths.empty());
+}
+
+TEST(RecordFileWalk, FlattenedTopLevel)
+{
+  // Exactly json::flatten() output for the nested-top-level record above, plus the marker
+  // keys flattenSample() adds afterwards. Pre-fix (#479) the Bridge's walk missed these.
+  const json record = json::parse(R"({
+    "/local_paths/raw": "/tmp/raw.jpg",
+    "/remote_paths/s3/raw": "s3://bucket/raw.jpg",
+    "/local_paths/rotated": "/tmp/rot.jpg",
+    "flattened": true,
+    "nested": false
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 2u);
+  EXPECT_EQ(found[0].key, "raw");
+  EXPECT_EQ(found[0].local_path, "/tmp/raw.jpg");
+  EXPECT_EQ(found[0].remote_paths, (std::map<std::string, std::string>{ { "s3", "s3://bucket/raw.jpg" } }));
+  EXPECT_EQ(found[1].key, "rotated");
+  EXPECT_EQ(found[1].local_path, "/tmp/rot.jpg");
+}
+
+TEST(RecordFileWalk, FlattenedUnderMeasurementName)
+{
+  // nested + flatten: pointer keys carry the measurement name as their first segment.
+  const json record = json::parse(R"({
+    "/camera/local_paths/raw": "/tmp/raw.jpg",
+    "/camera/remote_paths/s3/raw": "s3://bucket/raw.jpg",
+    "/other/local_paths/aux": "/tmp/aux.dat",
+    "flattened": true,
+    "nested": true
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 2u);
+  EXPECT_EQ(found[0].key, "raw");
+  EXPECT_EQ(found[0].local_path, "/tmp/raw.jpg");
+  EXPECT_EQ(found[0].remote_paths, (std::map<std::string, std::string>{ { "s3", "s3://bucket/raw.jpg" } }));
+  // A different measurement's site in the same flat object must not steal camera's remotes.
+  EXPECT_EQ(found[1].key, "aux");
+  EXPECT_TRUE(found[1].remote_paths.empty());
+}
+
+TEST(RecordFileWalk, SkipsBase64EmptyAndNonStringEntries)
+{
+  const json record = json::parse(R"({
+    "local_paths": {"raw": "/tmp/raw.jpg", "empty": "", "inline": 42},
+    "base64": {"small": "aGVsbG8="},
+    "n": 1
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found[0].key, "raw");
+}
+
+TEST(RecordFileWalk, DropsEmptyRemotesAndKeepsSiteWithoutRemotePaths)
+{
+  const json record = json::parse(R"({
+    "local_paths": {"raw": "/tmp/raw.jpg"},
+    "remote_paths": {"s3": {"raw": ""}, "other": {"raw": "s3://ok"}}
+  })");
+  const auto found = sites(record);
+  ASSERT_EQ(found.size(), 1u);
+  EXPECT_EQ(found[0].remote_paths, (std::map<std::string, std::string>{ { "other", "s3://ok" } }));
+}
+
+TEST(RecordFileWalk, NoFilesInPlainRecord)
+{
+  EXPECT_TRUE(sites(json::parse(R"({"cpu": 0.4, "tags": ["a"]})")).empty());
+}
+
+TEST(RecordFileWalk, RewritesNestedLocalPathsInPlace)
+{
+  json record = json::parse(R"({
+    "camera": {"local_paths": {"raw": "/tmp/raw.jpg"}, "remote_paths": {"s3": {"raw": "s3://r"}}},
+    "local_paths": {"map": "/tmp/map.pgm"}
+  })");
+  const bool any = rewrite_local_paths(record, [&](std::string& path) {
+    path = "/staged" + path;
+    return true;
+  });
+  EXPECT_TRUE(any);
+  EXPECT_EQ(record["camera"]["local_paths"]["raw"], "/staged/tmp/raw.jpg");
+  EXPECT_EQ(record["local_paths"]["map"], "/staged/tmp/map.pgm");
+  // remotes untouched
+  EXPECT_EQ(record["camera"]["remote_paths"]["s3"]["raw"], "s3://r");
+}
+
+TEST(RecordFileWalk, RewritesFlattenedLocalPathsInPlace)
+{
+  json record = json::parse(R"({
+    "/camera/local_paths/raw": "/tmp/raw.jpg",
+    "/camera/remote_paths/s3/raw": "s3://r",
+    "/local_paths/map": "/tmp/map.pgm"
+  })");
+  const bool any = rewrite_local_paths(record, [&](std::string& path) {
+    path = "/staged" + path;
+    return true;
+  });
+  EXPECT_TRUE(any);
+  EXPECT_EQ(record["/camera/local_paths/raw"], "/staged/tmp/raw.jpg");
+  EXPECT_EQ(record["/local_paths/map"], "/staged/tmp/map.pgm");
+  EXPECT_EQ(record["/camera/remote_paths/s3/raw"], "s3://r");
+}
+
+TEST(RecordFileWalk, RewriteReturnsFalseWhenNothingRewritten)
+{
+  json record = json::parse(R"({"cpu": 0.4})");
+  EXPECT_FALSE(rewrite_local_paths(record, [&](std::string&) { return true; }));
+
+  json no_op = json::parse(R"({"local_paths": {"raw": "/tmp/raw.jpg"}})");
+  EXPECT_FALSE(rewrite_local_paths(no_op, [&](std::string&) { return false; }));
+  EXPECT_EQ(no_op["local_paths"]["raw"], "/tmp/raw.jpg");
+}

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "dc_common/file_scratch_ring.hpp"
+#include "dc_common/record_file_walk.hpp"
 #include "dc_core/condition.hpp"
 #include "dc_core/condition_set.hpp"
 #include "dc_core/measurement.hpp"
@@ -636,58 +637,22 @@ public:
   }
 
   // Stage every File `value` references, rewriting each local_paths entry to its staged copy.
-  // Returns whether anything was staged. Walks the Record the same way dc_bridge's
-  // parse_file_group() does, so exactly the paths the Bridge would have uploaded are the ones
-  // that move: local_paths at any depth (a `nested` Measurement puts it under its own name),
-  // never base64 (inline content, not a path).
+  // Returns whether anything was staged. The Record walk itself is owned by dc_common's
+  // record_file_walk (#479) -- the same one dc_bridge's parse_file_group() goes through, so
+  // exactly the paths the Bridge would have uploaded are the ones that move, in either written
+  // form (nested local_paths objects, or a flattened Record's JSON-pointer keys).
   bool stageRecordFiles(json& value, const std::chrono::system_clock::time_point& stamp)
   {
-    if (!value.is_object())
-    {
-      return false;
-    }
-
-    bool staged = false;
-    auto local_paths_it = value.find("local_paths");
-    if (local_paths_it != value.end() && local_paths_it->is_object())
-    {
-      for (auto it = local_paths_it->begin(); it != local_paths_it->end(); ++it)
-      {
-        staged = stageOneFile(*it, stamp) || staged;
-      }
-    }
-
-    for (auto it = value.begin(); it != value.end(); ++it)
-    {
-      const std::string& key = it.key();
-      if (key == "local_paths" || key == "remote_paths" || key == "base64")
-      {
-        continue;
-      }
-      // A `flatten`ed Record has no nested objects left: its keys are JSON pointers, so the File
-      // paths show up as "/local_paths/raw" (or "/<name>/local_paths/raw" when also nested).
-      if (it->is_string() && key.find("/local_paths/") != std::string::npos)
-      {
-        staged = stageOneFile(*it, stamp) || staged;
-        continue;
-      }
-      staged = stageRecordFiles(*it, stamp) || staged;
-    }
-    return staged;
+    return dc_common::record_file_walk::rewrite_local_paths(value, [&](std::string& path) {
+      return stageOneFile(path, stamp);
+    });
   }
 
-  // Move one File into the scratch ring and rewrite `path_value` to the staged copy.
-  bool stageOneFile(json& path_value, const std::chrono::system_clock::time_point& stamp)
+  // Move one File into the scratch ring and rewrite `path` to the staged copy. The walk hands
+  // over non-empty local-path strings only.
+  bool stageOneFile(std::string& path, const std::chrono::system_clock::time_point& stamp)
   {
-    if (!path_value.is_string())
-    {
-      return false;
-    }
-    const std::string original = path_value.get<std::string>();
-    if (original.empty())
-    {
-      return false;
-    }
+    const std::string original = path;
 
     try
     {
@@ -700,7 +665,7 @@ public:
       // to the unchanged remote_paths key the Measurement computed at collection time.
       std::error_code ec;
       std::filesystem::remove(original, ec);
-      path_value = staged_path.string();
+      path = staged_path.string();
       return true;
     }
     catch (const std::filesystem::filesystem_error& e)


### PR DESCRIPTION
Closes #479

## The problem

A Record can name the Files it carries in two shapes:

- **Nested** (default): a `local_paths` object — `{"local_paths": {"raw": "/tmp/img.jpg"}, "remote_paths": {...}}`.
- **Flattened** (`flatten: true`): the same structure after `json::flatten()` — `"/local_paths/raw": "/tmp/img.jpg"`, or `"/camera/local_paths/raw"` when the Record is also nested.

Two separate pieces of code each had their own private copy of the rules for finding Files in a Record:

- the Measurement's staging walk (`dc_measurements`), which moves Files into the scratch ring before buffering a Record, and
- the Uploader's `collect_files()` (`dc_bridge`), which decides what to upload.

The two copies drifted. The staging side learned to handle flattened Records; the Uploader's side never did — it only matched nested `local_paths` objects, so in a flattened Record it simply recursed past every File without seeing it.

## The impact

For any file-producing Measurement configured with `flatten: true` (camera, map with flatten), **the Files were never uploaded**. Nothing errored, nothing logged — the Record reached its Destinations fine, the metadata rows landed, and the Files themselves just silently never made it to object storage. On the staging side, the scratch-ring copies also lingered until eviction instead of being uploaded and cleaned up. And because the rules lived in two private copies with no owner, the same drift could happen again with the next shape change.

## The fix

One shared module now owns the walk — `dc_common/record_file_walk.hpp`, a header-only, ROS-free utility in the same shape as the existing `FileScratchRing`/`RecordRingBuffer`:

- `for_each_file_site(record, visit)` — visits every File (key, local path, remote paths per Destination) in either written form;
- `rewrite_local_paths(record, rewrite)` — rewrites each local-path string in place, for staging.

Both consumers became thin adapters over it:

- `Measurement::stageRecordFiles()` drops its hand-rolled recursion (net −40 lines) and calls `rewrite_local_paths`;
- `collect_files()` drops its nested-only walk and calls `for_each_file_site`, keeping only its own policy (configured Destinations, merging remotes per local path).

Because the rules now exist once, the two sides cannot drift apart again. `dc_common` moves from a tests-only to a real (header-only) dependency of `dc_bridge`.

## Tests

- New `dc_common` unit tests pin both written forms (nested, flattened, nested+flattened, remote scoping per measurement, base64/empty/non-string skipping, in-place rewrite) — one test surface for both consumers.
- New `dc_bridge` regression test `FlattenedRecordFilesStillUpload` builds the payload with the real `json::flatten()` and asserts the upload completes — this is the exact #479 scenario that silently passed before.
- Full containerized `colcon build` + `colcon test` of `dc_common`, `dc_measurements`, `dc_bridge`: 667 tests, 0 failures.

## Repo usage

Unchanged — same build/lint/test commands and conventions (CLAUDE.md needs no update). This is an internal refactor plus the bug fix; no new tooling or workflow.