### PR TITLE
refactor(tools/e2e): one shared harness library for the five scenario scripts

### DIFF
--- a/tools/e2e/scripts/lib/harness.sh
+++ b/tools/e2e/scripts/lib/harness.sh
@@ -1,0 +1,146 @@
+# shellcheck shell=bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# Shared skeleton of the five e2e scenario scripts, run{,_split,_degraded,_incident,
+# _retention}.sh (#483): obtaining the DC image, the cleanup trap, destination bring-up
+# and readiness waits, volume extraction. Sourced, never executed — set -euo pipefail
+# comes from the caller.
+#
+# Contract with the sourcing script (set before the first call):
+#   PG_C, RUSTFS_C       destination container names (start_*/wait_*/pg_exec)
+#   RUN_DIR              teardown log captures land here
+#   remove_stack()       the caller's teardown — each scenario owns its own container,
+#                        volume (and, for run_split.sh, compose) cleanup
+#   HARNESS_TAG          log-line prefix (default "e2e")
+#   HARNESS_NETWORK      network for destinations, probes and the bucket CLI
+#                        (default "host")
+#   HARNESS_LOG_CAPTURES "container:file" pairs whose podman logs land in RUN_DIR on
+#                        teardown
+#   STATS_PID            optional resource-sampler PID killed on teardown
+
+HARNESS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS_E2E_DIR="$(dirname "$HARNESS_SCRIPT_DIR")"
+
+# rustfs/rustfs 1.0.0-beta.11 — pinned by digest, not :latest, so an upstream image
+# change can't silently alter harness behavior. Bump deliberately: check
+# https://hub.docker.com/r/rustfs/rustfs/tags for the new digest.
+RUSTFS_IMAGE="docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c"
+
+log() { echo "[${HARNESS_TAG:-e2e} $(date -u +%H:%M:%S)] $*"; }
+
+# Sets DC_IMAGE: DC_E2E_IMAGE (prebuilt, no build) > DC_WORKSPACE_IMAGE (prebuilt base)
+# > a local build.sh + Containerfile.e2e. CI's e2e jobs set DC_E2E_IMAGE to the :<sha>
+# image their build job pushed, so the harness runs the exact built artifact.
+resolve_image() {
+  if [ -n "${DC_E2E_IMAGE:-}" ]; then
+    log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
+    podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
+    DC_IMAGE="$DC_E2E_IMAGE"
+  else
+    local workspace_image
+    if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
+      log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
+      podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
+      workspace_image="$DC_WORKSPACE_IMAGE"
+    else
+      log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
+      "$HARNESS_SCRIPT_DIR/build.sh"
+      workspace_image="dc-workspace:latest"
+    fi
+    log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
+    podman build --build-arg "BASE_IMAGE=$workspace_image" -t dc-e2e:latest \
+      -f "$HARNESS_E2E_DIR/Containerfile.e2e" "$HARNESS_E2E_DIR"
+    DC_IMAGE="dc-e2e:latest"
+  fi
+}
+
+# The EXIT trap: kill a running resource sampler, honour DC_E2E_KEEP, capture the
+# HARNESS_LOG_CAPTURES logs, then run the caller's remove_stack. Install with
+# `trap harness_cleanup EXIT`.
+harness_cleanup() {
+  local exit_code=$?
+  if [ -n "${STATS_PID:-}" ] && kill -0 "$STATS_PID" 2>/dev/null; then
+    kill "$STATS_PID"
+  fi
+  if [ "$exit_code" -ne 0 ] && [ "${DC_E2E_KEEP:-false}" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  local pair container
+  for pair in ${HARNESS_LOG_CAPTURES[@]+"${HARNESS_LOG_CAPTURES[@]}"}; do
+    container="${pair%%:*}"
+    if podman container exists "$container"; then
+      podman logs "$container" > "$RUN_DIR/${pair##*:}" 2>&1 || true
+    fi
+  done
+  remove_stack
+  exit "$exit_code"
+}
+
+pg_exec() {
+  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
+}
+
+# start_postgres <pgdata-volume>: the destination Postgres, with sql/init.sql applied
+# on the volume's first boot.
+start_postgres() {
+  podman run -d --network "${HARNESS_NETWORK:-host}" --name "$PG_C" \
+    -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
+    -v "$1:/var/lib/postgresql/data" \
+    -v "$HARNESS_E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
+    docker.io/library/postgres:13 >/dev/null
+}
+
+start_rustfs() {
+  podman run -d --network "${HARNESS_NETWORK:-host}" --name "$RUSTFS_C" \
+    -v "$1:/data" \
+    "$RUSTFS_IMAGE" >/dev/null
+}
+
+# Deliberately not pg_isready: the postgres image applies /docker-entrypoint-initdb.d
+# against a *temporary* server that pg_isready happily answers, racing init.sql. Waiting
+# for dc_records to resolve gates on the only state that matters — the real server is up
+# and init.sql applied.
+wait_postgres_ready() {
+  local timeout="${1:-120}"
+  timeout "$timeout" bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
+    || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+}
+
+# On the host network RustFS is probed directly; otherwise from a one-off container on
+# HARNESS_NETWORK. That probe needs --entrypoint python3: the image's own ENTRYPOINT is
+# entrypoint.sh (the full DC stack), so without the override the probe args land as
+# extra ros2-launch arguments and the container always exits non-zero regardless of
+# RustFS's actual reachability.
+wait_rustfs_ready() {
+  local timeout="${1:-60}"
+  if [ "${HARNESS_NETWORK:-host}" = "host" ]; then
+    timeout "$timeout" bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
+      || { log "FAIL: RustFS never became ready"; exit 1; }
+  else
+    log "waiting for RustFS to accept TCP connections on $HARNESS_NETWORK"
+    timeout "$timeout" bash -c "until podman run --rm --network $HARNESS_NETWORK --entrypoint python3 '$DC_IMAGE' /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
+      || { log "FAIL: RustFS never became reachable on $HARNESS_NETWORK"; exit 1; }
+  fi
+}
+
+# The AWS CLI talks plain S3 to RustFS via --endpoint-url — same protocol dc_bridge's
+# Uploader uses (aws-sdk-cpp), so no extra vendor in the loop. Neither the S3 sink nor
+# the Uploader creates the bucket; someone has to.
+create_rustfs_bucket() {
+  podman run --rm --network "${HARNESS_NETWORK:-host}" \
+    -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
+    docker.io/amazon/aws-cli:latest \
+    --endpoint-url "$1" s3 mb s3://dc-e2e
+}
+
+# extract_from_volume <volume> <entrypoint> [args...]: a one-off read-only container on
+# <volume> (mounted at /vol) from the DC image; stdout passes through to the caller's
+# redirect or command substitution.
+extract_from_volume() {
+  local volume="$1" entrypoint="$2"
+  shift 2
+  podman run --rm --entrypoint "$entrypoint" -v "$volume:/vol:ro" "$DC_IMAGE" "$@"
+}

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -40,6 +40,9 @@
 #   DC_WORKSPACE_IMAGE           a prebuilt DC workspace image to use as the base for the
 #                                locally-built dc-e2e image (skips build.sh). Ignored when
 #                                DC_E2E_IMAGE is set. Unset: build.sh builds it.
+#
+# The shared harness skeleton (image resolution, cleanup trap, destination bring-up and
+# readiness waits, volume extraction) lives in lib/harness.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -50,7 +53,6 @@ OUTAGE_SECONDS="${DC_E2E_OUTAGE_SECONDS:-600}"
 STEADY_STATE_SECONDS="${DC_E2E_STEADY_STATE_SECONDS:-30}"
 DRAIN_SECONDS="${DC_E2E_DRAIN_SECONDS:-30}"
 STARTUP_TIMEOUT_SECONDS="${DC_E2E_STARTUP_TIMEOUT_SECONDS:-10}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 # Container + volume names. Volumes are named (not host bind-mounts) so a full stack
 # restart (podman restart / stop+start) preserves dc_bridge's on-disk state
@@ -67,10 +69,11 @@ RUSTFS_C=dc_e2e_rustfs
 DC_C=dc_e2e_dc
 VOLUMES=(dc_e2e_pgdata dc_e2e_rustfs_data dc_e2e_buffer dc_e2e_uploader dc_e2e_data)
 
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
+
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e $(date -u +%H:%M:%S)] $*"; }
 
 remove_stack() {
   # --ignore makes "no such container" a clean success while still surfacing real errors
@@ -83,78 +86,26 @@ remove_stack() {
   done
 }
 
-pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
-}
-
-STATS_PID=""
-cleanup() {
-  local exit_code=$?
-  if [ -n "$STATS_PID" ] && kill -0 "$STATS_PID" 2>/dev/null; then
-    kill "$STATS_PID"
-  fi
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$DC_C"; then
-    podman logs "$DC_C" > "$RUN_DIR/dc.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
+HARNESS_LOG_CAPTURES=("$DC_C:dc.log")
+trap harness_cleanup EXIT
 
 # --- obtain the DC stack image ------------------------------------------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 # Clean any leftovers from a previous (possibly DC_E2E_KEEP=true) run.
 remove_stack
 
 # --- bring up the destinations ------------------------------------------------------
 log "starting Postgres + RustFS"
-podman run -d --network host --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-# rustfs/rustfs 1.0.0-beta.11 — pinned by digest, not :latest, so an upstream image
-# change can't silently alter harness behavior. Bump deliberately: check
-# https://hub.docker.com/r/rustfs/rustfs/tags for the new digest.
-podman run -d --network host --name "$RUSTFS_C" \
-  -v dc_e2e_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never became ready"; exit 1; }
-timeout 60 bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
-  || { log "RustFS never became ready"; exit 1; }
+start_postgres dc_e2e_pgdata
+start_rustfs dc_e2e_rustfs_data
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket (the S3 sink / Uploader doesn't create it)"
-# The AWS CLI talks plain S3 to RustFS via --endpoint-url — same protocol dc_bridge's
-# Uploader uses (aws-sdk-cpp), so no extra vendor (the retired minio/mc client) in the loop.
-podman run --rm --network host \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-e2e
+create_rustfs_bucket http://127.0.0.1:9000
 
 # Resource usage (CPU/RSS) is informational per the PRD, not gating — sampled for the
 # whole run so tools/e2e/scripts/measure_resources.sh's summary covers steady state.
@@ -205,8 +156,7 @@ podman restart "$DC_C" >/dev/null
 
 log "restoring Postgres + RustFS"
 podman start "$PG_C" "$RUSTFS_C" >/dev/null
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never came back"; exit 1; }
+wait_postgres_ready
 
 log "draining for ${DRAIN_SECONDS}s"
 sleep "$DRAIN_SECONDS"
@@ -234,8 +184,7 @@ STATS_PID=""
 # The queue lives under uploader.data_dir (#441), not shipper.data_dir — on its own
 # dc_e2e_uploader volume here, separate from the Shipper's dc_e2e_buffer.
 log "verifying the durable upload intent queue drained (no orphaned intents after the outage+restart)"
-LEFTOVER_INTENTS=$(podman run --rm --entrypoint bash \
-  -v dc_e2e_uploader:/vol:ro "$DC_IMAGE" \
+LEFTOVER_INTENTS=$(extract_from_volume dc_e2e_uploader bash \
   -c 'find /vol/queue/upload -maxdepth 1 -name "*.json" 2>/dev/null | wc -l')
 if [ "${LEFTOVER_INTENTS:-0}" -ne 0 ]; then
   log "FAIL: ${LEFTOVER_INTENTS} orphaned upload intent(s) left in the queue after the run"
@@ -251,8 +200,7 @@ log "PASS: upload intent queue empty (0 orphaned intents)"
 # an empty file would otherwise be indistinguishable from a passthrough that shipped
 # nothing. verify_zero_loss.py hard-fails on a missing or empty file either way.
 log "extracting the passthrough sink's output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_data bash \
   -c 'cat /vol/passthrough/records.ndjson 2>/dev/null || true' > "$RUN_DIR/passthrough.ndjson"
 
 # --- extract raw / generic-subscription mode's output (#227) -------------------------
@@ -261,8 +209,7 @@ podman run --rm --entrypoint bash \
 # for the same reason — a failed extraction must not be mistakable for an empty result;
 # verify_zero_loss.py's check_raw() hard-fails on a missing or empty file.
 log "extracting raw mode's Destination output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_data bash \
   -c 'cat /vol/raw/records.ndjson 2>/dev/null || true' > "$RUN_DIR/raw.ndjson"
 
 # --- summarize the MCAP passthrough writer's output (ADR-0009, #210) -----------------
@@ -271,17 +218,15 @@ podman run --rm --entrypoint bash \
 # dc_e2e_data volume dc_mcap_writer wrote to, same as every other extraction above,
 # rather than parsing the binary .mcap files on this script's own host runner.
 log "summarizing the MCAP passthrough writer's output"
-podman run --rm --entrypoint python3 \
-  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
-  /opt/e2e/mcap_summary.py /vol/mcap > "$RUN_DIR/mcap_summary.json"
+extract_from_volume dc_e2e_data python3 /opt/e2e/mcap_summary.py /vol/mcap \
+  > "$RUN_DIR/mcap_summary.json"
 
 # --- verify -------------------------------------------------------------------------
 # The generator's ledger of what it published (#312) — the independent side of the
 # comparison. It lives on the dc_e2e_data volume so it survives the restart above; read it
 # back the same way the intent-queue check does, via a one-off container on that volume.
 log "extracting the workload ledger (what the generator published)"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_data bash \
   -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger.txt"
 
 log "verifying zero-loss against the published ledger"

--- a/tools/e2e/scripts/run_degraded.sh
+++ b/tools/e2e/scripts/run_degraded.sh
@@ -68,6 +68,10 @@
 #   DC_E2E_KEEP                     "true" to leave the stack (and its network) up after a
 #                                    failure for debugging
 #   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE   same meaning as run.sh
+#
+# The shared harness skeleton (lib/harness.sh) is parameterized for this scenario by
+# HARNESS_NETWORK=$NET: destinations, readiness probes and the bucket CLI all run on the
+# shaped bridge network.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -79,7 +83,6 @@ STEADY_STATE_SECONDS="${DC_E2E_STEADY_STATE_SECONDS:-30}"
 LINK_OUTAGE_SECONDS="${DC_E2E_LINK_OUTAGE_SECONDS:-60}"
 DRAIN_SECONDS="${DC_E2E_DRAIN_SECONDS:-30}"
 STARTUP_TIMEOUT_SECONDS="${DC_E2E_STARTUP_TIMEOUT_SECONDS:-10}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 NET=dc_e2e_deg_net
 SHAPER_IMAGE=dc-e2e-shaper:latest
@@ -87,11 +90,16 @@ PG_C=dc_e2e_deg_postgres
 RUSTFS_C=dc_e2e_deg_rustfs
 DC_C=dc_e2e_deg_dc
 VOLUMES=(dc_e2e_deg_pgdata dc_e2e_deg_rustfs_data dc_e2e_deg_buffer dc_e2e_deg_data)
+# shellcheck disable=SC2034  # consumed by lib/harness.sh
+HARNESS_TAG=e2e-degraded
+# shellcheck disable=SC2034
+HARNESS_NETWORK="$NET"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e-degraded $(date -u +%H:%M:%S)] $*"; }
 
 remove_stack() {
   podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
@@ -103,24 +111,9 @@ remove_stack() {
   podman network rm "$NET" >/dev/null 2>&1 || true
 }
 
-pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$DC_C"; then
-    podman logs "$DC_C" > "$RUN_DIR/dc_degraded.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
+HARNESS_LOG_CAPTURES=("$DC_C:dc_degraded.log")
+trap harness_cleanup EXIT
 
 # --- resolve the network profile (scripts/network_profiles.py — one declarative place) --
 log "resolving network profile '$PROFILE_NAME'"
@@ -134,24 +127,8 @@ NETEM_ARGS="$(python3 "$SCRIPT_DIR/network_profiles.py" "$PROFILE_NAME" --tc-arg
 log "profile '$PROFILE_NAME': delay=${PROFILE_DELAY_MS}ms jitter=${PROFILE_JITTER_MS}ms loss=${PROFILE_LOSS_PCT}% rate=${PROFILE_RATE_KBIT}kbit shaped=${PROFILE_IS_SHAPED}"
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 # --- the netem shaper helper image: alpine + iproute2, built once and reused -----------
 if ! podman image exists "$SHAPER_IMAGE"; then
@@ -200,30 +177,13 @@ log "creating the shaped bridge network ($NET)"
 podman network create "$NET" >/dev/null
 
 log "starting Postgres + RustFS on $NET (unmodified — no special capabilities on either)"
-podman run -d --network "$NET" --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_deg_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-podman run -d --network "$NET" --name "$RUSTFS_C" \
-  -v dc_e2e_deg_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
-  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
-
-log "waiting for RustFS to accept TCP connections on $NET"
-timeout 60 bash -c "
-  until podman run --rm --network $NET '$DC_IMAGE' python3 /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do
-    sleep 1
-  done
-" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+start_postgres dc_e2e_deg_pgdata
+start_rustfs dc_e2e_deg_rustfs_data
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket"
-podman run --rm --network "$NET" \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+create_rustfs_bucket "http://$RUSTFS_C:9000"
 
 # --- apply the profile's steady-state shaping, then verify it actually took effect -----
 if [ "$PROFILE_IS_SHAPED" = "true" ]; then
@@ -236,8 +196,12 @@ else
   log "profile '$PROFILE_NAME' is unshaped — no qdisc applied (today's loopback behaviour)"
 fi
 
+# --entrypoint python3 on the one-off probe containers below, for the reason
+# lib/harness.sh's wait_rustfs_ready spells out: the image's own ENTRYPOINT would
+# otherwise swallow the probe as extra ros2-launch arguments.
 log "shaping pre-check: measuring the actual TCP connect-time round trip to $PG_C"
-RTT_JSON="$(podman run --rm --network "$NET" "$DC_IMAGE" python3 /opt/e2e/measure_rtt.py "$PG_C" 5432 --count 10 --timeout 3)"
+RTT_JSON="$(podman run --rm --network "$NET" --entrypoint python3 "$DC_IMAGE" \
+  /opt/e2e/measure_rtt.py "$PG_C" 5432 --count 10 --timeout 3)"
 echo "$RTT_JSON" > "$RUN_DIR/rtt_precheck.json"
 AVG_MS="$(python3 -c "import json; print(json.load(open('$RUN_DIR/rtt_precheck.json'))['avg_ms'])")"
 log "measured avg connect time: ${AVG_MS}ms"
@@ -342,26 +306,22 @@ sleep 5
 
 # --- extract the passthrough sink's output (ADR-0003) --------------------------------
 log "extracting the passthrough sink's output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_deg_data bash \
   -c 'cat /vol/passthrough/records.ndjson 2>/dev/null || true' > "$RUN_DIR/passthrough_degraded.ndjson"
 
 # --- extract raw / generic-subscription mode's output (#227) -------------------------
 log "extracting raw mode's Destination output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_deg_data bash \
   -c 'cat /vol/raw/records.ndjson 2>/dev/null || true' > "$RUN_DIR/raw_degraded.ndjson"
 
 # --- summarize the MCAP passthrough writer's output (ADR-0009, #210) -----------------
 log "summarizing the MCAP passthrough writer's output"
-podman run --rm --entrypoint python3 \
-  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
-  /opt/e2e/mcap_summary.py /vol/mcap > "$RUN_DIR/mcap_summary_degraded.json"
+extract_from_volume dc_e2e_deg_data python3 /opt/e2e/mcap_summary.py /vol/mcap \
+  > "$RUN_DIR/mcap_summary_degraded.json"
 
 # --- verify (verify_zero_loss.py's own logic, unmodified — only conditions are added) --
 log "extracting the workload ledger (what the generator published)"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_deg_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_deg_data bash \
   -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger_degraded.txt"
 
 log "verifying zero-loss against the published ledger, under profile '$PROFILE_NAME'"

--- a/tools/e2e/scripts/run_incident.sh
+++ b/tools/e2e/scripts/run_incident.sh
@@ -36,6 +36,10 @@
 # observed shipping nothing; generous because it covers the whole stack's startup, Vector
 # included); DC_E2E_INCIDENT_TIMEOUT_SECONDS (default 120 — from the FlushEvent to the
 # released window being committed, which includes the post-roll phase and Vector's own batch).
+#
+# The shared harness skeleton (image resolution, cleanup trap, Postgres bring-up and its
+# init.sql-aware readiness wait) lives in lib/harness.sh. No RustFS here: both Measurements
+# route to Postgres only.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,7 +48,6 @@ RUN_DIR="$E2E_DIR/.run"
 
 LIVE_TIMEOUT_SECONDS="${DC_E2E_LIVE_TIMEOUT_SECONDS:-180}"
 INCIDENT_TIMEOUT_SECONDS="${DC_E2E_INCIDENT_TIMEOUT_SECONDS:-120}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 # Fixed rather than random: a failed run leaves rows in the Postgres volume that are worth
 # being able to find again by name, and the whole point is that the id the event carried is
@@ -57,11 +60,14 @@ LIVE_TAG="dc.measurement.memory"
 PG_C=dc_e2e_inc_postgres
 DC_C=dc_e2e_inc_dc
 VOLUMES=(dc_e2e_inc_pgdata dc_e2e_inc_buffer dc_e2e_inc_data)
+# shellcheck disable=SC2034  # consumed by lib/harness.sh
+HARNESS_TAG=e2e-incident
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e-incident $(date -u +%H:%M:%S)] $*"; }
 
 remove_stack() {
   podman rm -f --ignore "$DC_C" "$PG_C" >/dev/null
@@ -72,68 +78,20 @@ remove_stack() {
   done
 }
 
-pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
-}
-
-# A count query that reads 0 rather than aborting the run while Postgres/the table is still
-# settling — every call site is inside a deadline loop that fails loudly on its own.
-pg_count() {
-  pg_exec "$1" 2>/dev/null | tr -d '[:space:]' || true
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$DC_C"; then
-    podman logs "$DC_C" > "$RUN_DIR/dc_incident.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
+HARNESS_LOG_CAPTURES=("$DC_C:dc_incident.log")
+trap harness_cleanup EXIT
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 remove_stack
 
 # --- Postgres ------------------------------------------------------------------------
 log "starting Postgres (sql/init.sql — dc_records has the incident_id column under test)"
-podman run -d --network host --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_inc_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-
-# Deliberately not `pg_isready`: the postgres image runs /docker-entrypoint-initdb.d against a
-# *temporary* server that is then shut down and restarted, and pg_isready answers yes to that
-# one. Waiting for `dc_records` to resolve instead gates on the only state that matters — the
-# real server is up and init.sql has been applied — and cannot match the throwaway one, whose
-# shutdown otherwise lands in the middle of the first query below.
-timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
-  || { log "Postgres never came up with sql/init.sql applied"; exit 1; }
+start_postgres dc_e2e_inc_pgdata
+wait_postgres_ready
 
 # The column has to be a column. A table without it would make every assertion below fail
 # for a reason that has nothing to do with the pipeline, so say so here instead.
@@ -152,6 +110,12 @@ podman run -d --network host --name "$DC_C" \
   -v "$E2E_DIR/params/e2e_incident_params.yaml:/opt/e2e/e2e_params.yaml:ro" \
   -v "$E2E_DIR/params/e2e_incident_pgsql_sink.toml:/opt/e2e/e2e_incident_pgsql_sink.toml:ro" \
   "$DC_IMAGE" >/dev/null
+
+# A count query that reads 0 rather than aborting the run while Postgres/the table is still
+# settling — every call site is inside a deadline loop that fails loudly on its own.
+pg_count() {
+  pg_exec "$1" 2>/dev/null | tr -d '[:space:]' || true
+}
 
 # --- 1. armed means silent, live means flowing -------------------------------------------
 log "waiting up to ${LIVE_TIMEOUT_SECONDS}s for the live Measurement's first rows"

--- a/tools/e2e/scripts/run_retention.sh
+++ b/tools/e2e/scripts/run_retention.sh
@@ -31,6 +31,9 @@
 # a minute — verified empirically in this environment, same pre-existing characteristic
 # #265's own notes call out — not something this scenario's timeout should race against);
 # DC_E2E_UPLOAD_TIMEOUT_SECONDS (default 60, once RustFS is up connections are fast).
+#
+# The shared harness skeleton (image resolution, cleanup trap, destination bring-up and
+# readiness waits) lives in lib/harness.sh.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -39,17 +42,19 @@ RUN_DIR="$E2E_DIR/.run"
 
 SHED_TIMEOUT_SECONDS="${DC_E2E_SHED_TIMEOUT_SECONDS:-480}"
 UPLOAD_TIMEOUT_SECONDS="${DC_E2E_UPLOAD_TIMEOUT_SECONDS:-60}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 PG_C=dc_e2e_ret_postgres
 RUSTFS_C=dc_e2e_ret_rustfs
 DC_C=dc_e2e_ret_dc
 VOLUMES=(dc_e2e_ret_pgdata dc_e2e_ret_rustfs_data dc_e2e_ret_buffer dc_e2e_ret_data)
+# shellcheck disable=SC2034  # consumed by lib/harness.sh
+HARNESS_TAG=e2e-retention
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e-retention $(date -u +%H:%M:%S)] $*"; }
 
 remove_stack() {
   podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
@@ -60,57 +65,20 @@ remove_stack() {
   done
 }
 
-pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$DC_C"; then
-    podman logs "$DC_C" > "$RUN_DIR/dc_retention.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
+HARNESS_LOG_CAPTURES=("$DC_C:dc_retention.log")
+trap harness_cleanup EXIT
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ----------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 remove_stack
 
 # --- bring up Postgres only — RustFS deliberately stays down ------------------------
 log "starting Postgres (RustFS deliberately NOT started yet — this scenario's 'store down')"
-podman run -d --network host --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_ret_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never became ready"; exit 1; }
+start_postgres dc_e2e_ret_pgdata
+wait_postgres_ready
 
 # --- start the DC stack against the retention params ---------------------------------
 log "starting the DC stack (files.retention.max_bytes configured small; RustFS unreachable)"
@@ -155,15 +123,9 @@ fi
 
 # --- bring RustFS up; remaining (unshed) Files must upload normally ------------------
 log "starting RustFS — remaining/future Files must now upload and verify normally"
-podman run -d --network host --name "$RUSTFS_C" \
-  -v dc_e2e_ret_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-timeout 60 bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
-  || { log "RustFS never became ready"; exit 1; }
-podman run --rm --network host \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-e2e >/dev/null
+start_rustfs dc_e2e_ret_rustfs_data
+wait_rustfs_ready
+create_rustfs_bucket http://127.0.0.1:9000 >/dev/null
 
 log "waiting up to ${UPLOAD_TIMEOUT_SECONDS}s for a normal upload (uploaded=true) in dc_files now that RustFS is up"
 DEADLINE=$(( $(date +%s) + UPLOAD_TIMEOUT_SECONDS ))

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -24,6 +24,10 @@
 #                                          DC_E2E_SPLIT_DRAIN_SECONDS; see the check)
 #   DC_E2E_KEEP                            "true" to leave the stack up on failure
 #   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE      same meaning as run.sh
+#
+# The shared harness skeleton (lib/harness.sh) is parameterized for this scenario by
+# HARNESS_NETWORK=dc_e2e_split_net: readiness probes and the bucket CLI run as one-off
+# containers on the compose network rather than the host.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -37,7 +41,6 @@ STEADY_STATE_SECONDS="${DC_E2E_SPLIT_STEADY_STATE_SECONDS:-15}"
 OUTAGE_SECONDS="${DC_E2E_SPLIT_OUTAGE_SECONDS:-60}"
 DRAIN_SECONDS="${DC_E2E_SPLIT_DRAIN_SECONDS:-30}"
 QUEUE_DRAIN_TIMEOUT_SECONDS="${DC_E2E_SPLIT_QUEUE_DRAIN_TIMEOUT_SECONDS:-120}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 # podman-compose, not the docker-compose cli-plugin (CLAUDE.md "Containers: Podman, not
 # Docker"; matches ci.yaml's own compose.test.yaml usage) — it needs no Podman API socket.
@@ -55,11 +58,16 @@ RUSTFS_C=dc_e2e_split_rustfs
 DC_ROS_C=dc_e2e_split_dc_ros
 UPLOADER_C=dc_e2e_split_dc_uploader
 VECTOR_C=dc_e2e_split_vector
+# shellcheck disable=SC2034  # consumed by lib/harness.sh
+HARNESS_TAG=e2e-split
+# shellcheck disable=SC2034
+HARNESS_NETWORK=dc_e2e_split_net
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e-split $(date -u +%H:%M:%S)] $*"; }
 
 compose() { podman compose -f "$COMPOSE_FILE" "$@"; }
 
@@ -67,44 +75,13 @@ remove_stack() {
   compose down --volumes --remove-orphans >/dev/null 2>&1 || true
 }
 
-pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  podman logs "$DC_ROS_C" > "$RUN_DIR/dc-ros.log" 2>&1 || true
-  podman logs "$UPLOADER_C" > "$RUN_DIR/dc-uploader.log" 2>&1 || true
-  podman logs "$VECTOR_C" > "$RUN_DIR/vector.log" 2>&1 || true
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
+HARNESS_LOG_CAPTURES=("$DC_ROS_C:dc-ros.log" "$UPLOADER_C:dc-uploader.log" "$VECTOR_C:vector.log")
+trap harness_cleanup EXIT
 
 # --- obtain the DC stack image (same logic as run.sh) --------------------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 export DC_E2E_IMAGE="$DC_IMAGE"
 
 remove_stack
@@ -113,17 +90,8 @@ remove_stack
 log "starting Postgres + RustFS"
 compose up -d postgres rustfs
 
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never became ready"; exit 1; }
-# No --network host here (unlike run.sh) — probe from a container on dc_e2e_split_net,
-# same as run_degraded.sh. --entrypoint python3 is required: $DC_IMAGE's own ENTRYPOINT
-# is entrypoint.sh (the full DC stack), so without overriding it the probe args land as
-# extra ros2-launch arguments instead of actually running measure_rtt.py — the container
-# would always exit non-zero regardless of RustFS's actual reachability.
-log "waiting for RustFS to accept TCP connections on dc_e2e_split_net"
-timeout 60 bash -c "until podman run --rm --network dc_e2e_split_net --entrypoint python3 '$DC_IMAGE' \
-  /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
-  || { log "RustFS never became reachable on dc_e2e_split_net"; exit 1; }
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket (the S3 sink doesn't create it)"
 # The compose service name, not $RUSTFS_C: aws-cli's own --endpoint-url validation
@@ -132,10 +100,7 @@ log "creating the RustFS bucket (the S3 sink doesn't create it)"
 # dc_e2e_split_net and has none. dc-uploader's DC_UPLOADER_S3_ENDPOINT and
 # e2e_split_params.yaml's rustfs.endpoint already use the service name for the same
 # reason.
-podman run --rm --network dc_e2e_split_net \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://rustfs:9000" s3 mb s3://dc-e2e
+create_rustfs_bucket "http://rustfs:9000"
 
 # --- start dc-ros + dc-uploader, prove no orchestrator-level ordering is needed ------
 # vector deliberately isn't up yet: no depends_on in compose.split.yaml. dc-uploader
@@ -192,15 +157,12 @@ podman restart "$DC_ROS_C" >/dev/null
 
 log "restoring Postgres + RustFS"
 podman start "$PG_C" "$RUSTFS_C" >/dev/null
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "Postgres never came back"; exit 1; }
-# RustFS too, same probe as bring-up above — not just Postgres: a pg_isready-only gate
+wait_postgres_ready
+# RustFS too, same probe as bring-up above — not just Postgres: a Postgres-only gate
 # lets the uploader's first post-restore attempt hit a still-warming object store,
 # fail, and double that intent's retry backoff (doubling is what pushes it past the
 # fixed drain window below).
-timeout 60 bash -c "until podman run --rm --network dc_e2e_split_net --entrypoint python3 '$DC_IMAGE' \
-  /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
-  || { log "RustFS never came back"; exit 1; }
+wait_rustfs_ready
 
 log "draining for ${DRAIN_SECONDS}s"
 sleep "$DRAIN_SECONDS"
@@ -221,8 +183,7 @@ sleep 5
 log "verifying the durable upload intent queue drained (no orphaned intents after the outage+restart)"
 QUEUE_DEADLINE=$(( $(date +%s) + QUEUE_DRAIN_TIMEOUT_SECONDS ))
 while :; do
-  LEFTOVER_INTENTS=$(podman run --rm --entrypoint bash \
-    -v dc_e2e_split_uploader:/vol:ro "$DC_IMAGE" \
+  LEFTOVER_INTENTS=$(extract_from_volume dc_e2e_split_uploader bash \
     -c 'find /vol/queue/upload -maxdepth 1 -name "*.json" 2>/dev/null | wc -l')
   if [ "${LEFTOVER_INTENTS:-0}" -eq 0 ]; then
     break
@@ -240,8 +201,7 @@ podman stop "$UPLOADER_C" "$VECTOR_C" >/dev/null
 
 # --- verify -----------------------------------------------------------------------
 log "extracting the workload ledger (what the generator published)"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_split_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_split_data bash \
   -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger_split.txt"
 
 log "verifying zero-loss against the published ledger (no passthrough/MCAP/raw checks — see params/e2e_split_params.yaml's header)"


### PR DESCRIPTION
Closes #483

## The problem

The five e2e scenario scripts — `tools/e2e/scripts/run{,_split,_degraded,_incident,_retention}.sh`, ~1,362 lines — were five near-verbatim copies of one skeleton: obtain the image, cleanup trap (+ `DC_E2E_KEEP`), `pg_exec`, start Postgres and RustFS, wait for readiness, extract results from volumes.

The copies had drifted. `run.sh`, `run_split.sh` and `run_retention.sh` waited for Postgres with `pg_isready`, which answers "ready" during the postgres image's temporary init server — a wait that can race `init.sql`. The correct wait (`to_regclass('public.dc_records')` — real server *and* schema applied) was only used by `run_degraded.sh`/`run_incident.sh`. The RustFS digest pin and the three-way image decision were copy-pasted five times each.

## The impact

- A harness fix had to be hand-applied five times, and the `pg_isready` drift shows what happens when it isn't.
- Writing scenario #6 means copying ~200 lines and hoping you edit the right ones.
- `run_split.sh` gates merges (the `e2e-split` CI job), so a skeleton bug is suddenly everyone's blocker.

## The fix

The shared skeleton now lives in one sourced helper, `tools/e2e/scripts/lib/harness.sh` (146 lines):

- `resolve_image` — the `DC_E2E_IMAGE` / `DC_WORKSPACE_IMAGE` / build.sh + `Containerfile.e2e` decision, sets `DC_IMAGE`;
- `harness_cleanup` — the EXIT-trap handler: optional resource-sampler kill, `DC_E2E_KEEP` handling, `HARNESS_LOG_CAPTURES` (`container:file` pairs) log capture, then the caller's `remove_stack`;
- `pg_exec`;
- `start_postgres` (init.sql mount) / `start_rustfs` (digest-pinned image);
- `wait_postgres_ready` — the `to_regclass('public.dc_records')` form everywhere, 120s timeout, hard failure;
- `wait_rustfs_ready` — curl probe on the host network, `measure_rtt.py` probe from a one-off container otherwise;
- `create_rustfs_bucket` (was also copy-pasted five times);
- `extract_from_volume` — the one-off `podman run --rm --entrypoint … -v <vol>:/vol:ro` + cat pattern.

Each `run_*.sh` stays the one top-to-bottom script CLAUDE.md requires — sourcing a library is not an up/down split. What stays per-script: container/volume names, `remove_stack` itself (the split scenario tears down via compose, degraded also removes its network), and the scenario choreography and assertions. The lib is parameterized by `HARNESS_TAG` (log prefix) and `HARNESS_NETWORK` (default `host`; `dc_e2e_split_net` for split, the shaped bridge for degraded).

**Waits switched from `pg_isready` to `to_regclass`:** `run.sh` (bring-up + post-restore), `run_split.sh` (bring-up + post-restore), `run_retention.sh` (bring-up). `run_degraded.sh`/`run_incident.sh` already used `to_regclass`.

Two deliberate behaviour changes beyond the mechanical move, both fixes for known-worse code:

- `run_degraded.sh`'s one-off probe containers (RustFS readiness wait + the two shaping pre-check probes) were missing `--entrypoint python3`, so the probe args landed as extra ros2-launch arguments and the containers always exited non-zero regardless of RustFS's actual reachability — the exact reason `run_split.sh`'s own comment documents for its override. The readiness probe now goes through the lib (which uses the override); the two pre-check probes get the override inline.
- The `pg_isready` timeouts (60s) widened to the lib's 120s default, matching what the `to_regclass` form already used in degraded/incident — the wait now covers init.sql application, not just server start.

Everything else is behaviour-preserving: same env vars, same log-line information (prefixes come from `HARNESS_TAG`), same exit codes, per-script teardown untouched. The five scripts drop from 1,357 to 1,148 lines (−209); with the 146-line lib the change is net −63.

The limits/load scripts (`run_limits_*.sh`, `run_load_driver_shipper_test.sh`) share parts of the skeleton (four of them already use the `to_regclass` wait) but have their own multi-stack teardown, agg-container log captures and `/dev/tcp` probes. Migrating them would mean parameterizing teardown for stacks CI never exercises, so they are left as-is; a follow-up can adopt the lib piecewise.

## Tests

- `bash -n` on all six touched scripts; `shellcheck` via `prek run --all-files --skip build-doc` passes every hook.
- Side-by-side mapping of every removed line to its lib equivalent (per-script `git diff origin/jazzy` review).
- Not run locally (heavy podman stack): CI's `e2e` and `e2e-split` jobs exercise `run.sh` and `run_split.sh` — including the new `to_regclass` waits at bring-up and post-restore — on this PR.

## Repo usage

Unchanged — no build, workflow or doc changes; the scripts keep their invocation and env-var contract.
