### PR TITLE
Resolve the Vector version in one place and guard the copies in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,7 @@
 #                                                                      └─▶ build-dc-uploader-coverage-image (dc-uploader:jazzy-coverage)
 #   kpi-views (standalone: SQL + a throwaway Postgres, no workspace image needed)
 #   raw-volume (standalone: stdlib Python fixtures over the shared volume accounting)
+#   vector-pin (standalone: Vector version literals vs the .repos pin, #484)
 #
 # dc-ros/dc-uploader FROM the `runtime` stage (tools/e2e/Containerfile) now, not the
 # raw `workspace` image — install/ plus exec-only deps, not the full source/build/
@@ -991,6 +992,17 @@ jobs:
 
       - name: Fixture test for the KPI views
         run: ./tools/infrastructure/scripts/test_kpi_views.sh
+
+  # The deployment trees pin the Vector image as literals (compose, quadlet, Kubernetes
+  # pod, kind manifests, Helm values, compose.split.yaml's default) that must track the
+  # canonical ros2_data_collection.repos pin (#484) — plain YAML can't interpolate it.
+  vector-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Check Vector version literals against the .repos pin
+        run: ./tools/ci/check_vector_pin.sh
 
   e2e:
     needs: [build-workspace, build-e2e-image]

--- a/tools/ci/check_vector_pin.sh
+++ b/tools/ci/check_vector_pin.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The deployment/rendering trees pin the Vector image as literals — compose.yaml, the
+# quadlet, the Kubernetes pod, the kind manifests, the Helm values, and
+# compose.split.yaml's ${VECTOR_VERSION:-...} default — because neither Quadlet nor
+# plain YAML can read ros2_data_collection.repos, where the canonical pin lives. This
+# check fails when any of those copies stops matching the pin, so a bump that misses
+# one surfaces in CI instead of at deploy time on a robot (#484). Runs standalone:
+#   ./tools/ci/check_vector_pin.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/tools/e2e/scripts/lib/version.sh"
+pin="$(vector_version)"
+
+# `-debian` semver tags are Vector's alone in these trees (dc-ros/dc-uploader pin
+# shas or branch refs), so any literal not equal to the pin is a stale copy.
+stale_tags="$(grep -rn --include='*.yaml' --include='*.yml' --include='*.container' \
+  -E '[0-9]+\.[0-9]+\.[0-9]+-debian' "$REPO_ROOT/deploy" "$REPO_ROOT/tools" \
+  | grep -v "${pin}-debian" || true)"
+
+stale_defaults="$(grep -rn -E 'VECTOR_VERSION:-[0-9]+\.[0-9]+\.[0-9]+' "$REPO_ROOT/tools" \
+  | grep -v "VECTOR_VERSION:-${pin}" || true)"
+
+if [[ -n "$stale_tags" || -n "$stale_defaults" ]]; then
+  {
+    echo "Vector version literals out of step with the ros2_data_collection.repos pin (v${pin}):"
+    echo "$stale_tags"
+    echo "$stale_defaults"
+    echo "Update these to ${pin}-debian (or bump them together with the .repos pin)."
+  } >&2
+  exit 1
+fi
+echo "All Vector version literals match the ros2_data_collection.repos pin (v${pin})."

--- a/tools/e2e/scripts/lib/harness.sh
+++ b/tools/e2e/scripts/lib/harness.sh
@@ -22,6 +22,11 @@
 HARNESS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS_E2E_DIR="$(dirname "$HARNESS_SCRIPT_DIR")"
 
+# vector_version() lives in its own lib file (#484) so the limits/load and release
+# scripts can source it without pulling in this e2e-only skeleton.
+# shellcheck disable=SC1091
+source "$HARNESS_SCRIPT_DIR/lib/version.sh"
+
 # rustfs/rustfs 1.0.0-beta.11 — pinned by digest, not :latest, so an upstream image
 # change can't silently alter harness behavior. Bump deliberately: check
 # https://hub.docker.com/r/rustfs/rustfs/tags for the new digest.

--- a/tools/e2e/scripts/lib/version.sh
+++ b/tools/e2e/scripts/lib/version.sh
@@ -1,0 +1,25 @@
+# shellcheck shell=bash
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+# The one reader of the canonical Vector version pin, ros2_data_collection.repos'
+# vector_vendor entry (#484). Its own file, not part of lib/harness.sh, so the
+# limits/load and release scripts can source it without pulling in that e2e-only
+# skeleton; harness.sh sources it too, for the scenario scripts. Sourced, never
+# executed, and harmless to source twice.
+
+VERSION_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION_REPO_ROOT="$(cd "$VERSION_LIB_DIR/../../../.." && pwd)"
+
+# Prints the pinned version without its leading "v" ("0.57.0") — the form the
+# timberio/vector image tags carry. -A3 scopes the parse to vector_vendor's own
+# block: aws_sdk_vendor's `version: v...` line would otherwise match too.
+vector_version() {
+  local version
+  version="$(grep -A3 'vector_vendor:' \
+    "$VERSION_REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')" || {
+    echo "vector_version: cannot read the vector_vendor pin in $VERSION_REPO_ROOT/ros2_data_collection.repos" >&2
+    return 1
+  }
+  echo "$version"
+}

--- a/tools/e2e/scripts/run_limits_drain_rate.sh
+++ b/tools/e2e/scripts/run_limits_drain_rate.sh
@@ -123,9 +123,11 @@ cleanup() {
 trap cleanup EXIT
 
 # The exact Vector version dc_bridge is built and tested against, same as
-# run_limits_two_tier.sh / run_load_driver_shipper_test.sh -- read out of the .repos pin
-# that fetches vector_vendor, not duplicated as a second source of truth.
-VECTOR_VERSION="$(grep -A3 'vector_vendor:' "$REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')"
+# run_limits_two_tier.sh / run_load_driver_shipper_test.sh — resolved from the .repos
+# pin by lib/version.sh (#484), not duplicated as a second source of truth.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/version.sh"
+VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
 remove_stack

--- a/tools/e2e/scripts/run_limits_shipper_fanin.sh
+++ b/tools/e2e/scripts/run_limits_shipper_fanin.sh
@@ -59,7 +59,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E_DIR="$(dirname "$SCRIPT_DIR")"
-REPO_ROOT="$(cd "$E2E_DIR/../.." && pwd)"
 RUN_DIR="$E2E_DIR/.run/limits_shipper_fanin"
 
 REAL_STACKS="${DC_E2E_FANIN_REAL_STACKS:-1}"
@@ -162,9 +161,12 @@ else
   DC_IMAGE="dc-e2e:latest"
 fi
 
-# Read out of the .repos pin that fetches vector_vendor (its own repo as of #424's
-# follow-up split), not duplicated here as a second source of truth.
-VECTOR_VERSION="$(grep -A3 'vector_vendor:' "$REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')"
+# Resolved from the .repos pin that fetches vector_vendor (its own repo as of #424's
+# follow-up split) by lib/version.sh (#484), not duplicated here as a second source
+# of truth.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/version.sh"
+VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
 remove_all

--- a/tools/e2e/scripts/run_limits_two_tier.sh
+++ b/tools/e2e/scripts/run_limits_two_tier.sh
@@ -199,9 +199,11 @@ else
 fi
 
 # The exact Vector version dc_bridge is built and tested against, for the standalone
-# aggregating Shipper — read out of the .repos pin that fetches vector_vendor (same as
-# run_load_driver_shipper_test.sh), not duplicated as a second source of truth.
-VECTOR_VERSION="$(grep -A3 'vector_vendor:' "$REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')"
+# aggregating Shipper — resolved from the .repos pin by lib/version.sh (same as
+# run_load_driver_shipper_test.sh, #484), not duplicated as a second source of truth.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/version.sh"
+VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
 # Clean any leftovers from a previous (possibly DC_E2E_KEEP=true) run.

--- a/tools/e2e/scripts/run_load_driver_shipper_test.sh
+++ b/tools/e2e/scripts/run_load_driver_shipper_test.sh
@@ -48,11 +48,13 @@ KEEP="${DC_E2E_KEEP:-false}"
 
 VECTOR_C=dc_e2e_ldtest_vector
 
-# The exact version dc_bridge is built and tested against -- read out of the .repos pin
-# that fetches vector_vendor (its own repo as of #424's follow-up split; see
-# docs/adr/0002-vector-as-default-shipper.md), not duplicated here as a second source of
-# truth that could drift from it.
-VECTOR_VERSION="$(grep -A3 'vector_vendor:' "$REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')"
+# The exact version dc_bridge is built and tested against — resolved from the .repos
+# pin that fetches vector_vendor (its own repo as of #424's split; see
+# docs/adr/0002-vector-as-default-shipper.md) by lib/version.sh (#484), not duplicated
+# here as a second source of truth.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/version.sh"
+VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
 log() { echo "[load-driver-shipper-test $(date -u +%H:%M:%S)] $*"; }

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -46,13 +46,6 @@ QUEUE_DRAIN_TIMEOUT_SECONDS="${DC_E2E_SPLIT_QUEUE_DRAIN_TIMEOUT_SECONDS:-120}"
 # Docker"; matches ci.yaml's own compose.test.yaml usage) — it needs no Podman API socket.
 export PODMAN_COMPOSE_PROVIDER="${PODMAN_COMPOSE_PROVIDER:-podman-compose}"
 
-# compose.split.yaml's vector service interpolates this (#448: the Vector image tag and
-# vector_vendor's pinned version come from one place) — same grep already used by
-# run_limits_two_tier.sh / run_load_driver_shipper_test.sh / run_limits_drain_rate.sh /
-# run_limits_shipper_fanin.sh, so the apt and container paths cannot drift apart.
-VECTOR_VERSION="$(grep -A3 'vector_vendor:' "$E2E_DIR/../../ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')"
-export VECTOR_VERSION
-
 PG_C=dc_e2e_split_postgres
 RUSTFS_C=dc_e2e_split_rustfs
 DC_ROS_C=dc_e2e_split_dc_ros
@@ -65,6 +58,12 @@ HARNESS_NETWORK=dc_e2e_split_net
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
+
+# compose.split.yaml's vector service interpolates this (#448: the Vector image tag and
+# vector_vendor's pinned version come from one place) — vector_version() arrives via
+# lib/harness.sh, which sources lib/version.sh (#484).
+VECTOR_VERSION="$(vector_version)"
+export VECTOR_VERSION
 
 mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"

--- a/tools/release/scripts/verify_published_images.sh
+++ b/tools/release/scripts/verify_published_images.sh
@@ -20,7 +20,8 @@
 #   DC_ROS_IMAGE       (required) the dc-ros image ref to pull and run.
 #   DC_UPLOADER_IMAGE  (required) the dc-uploader image ref to pull and run.
 #   VECTOR_VERSION     Vector image tag; defaults to ros2_data_collection.repos'
-#                      vector_vendor pin (#448: single source, same grep run_split.sh uses).
+#                      vector_vendor pin (#484: single source, lib/version.sh's
+#                      resolver — the same one run_split.sh uses).
 #   DC_RELEASE_TIMEOUT_SECONDS  deadline for the first Record to land (default 60).
 set -euo pipefail
 
@@ -32,9 +33,11 @@ mkdir -p "$RUN_DIR"
 
 DC_ROS_IMAGE="${DC_ROS_IMAGE:?DC_ROS_IMAGE must be set to a published dc-ros image ref}"
 DC_UPLOADER_IMAGE="${DC_UPLOADER_IMAGE:?DC_UPLOADER_IMAGE must be set to a published dc-uploader image ref}"
-# -A3, not a bare grep across the whole file: aws_sdk_vendor's own `version: v...` line
-# would otherwise match too, embedding a second version (and a newline) in this value.
-VECTOR_VERSION="${VECTOR_VERSION:-$(grep -A3 'vector_vendor:' "$REPO_ROOT/ros2_data_collection.repos" | grep -oP 'version: v\K[0-9.]+')}"
+# The resolver lives with the e2e lib it was extracted from (#484) — this script already
+# borrows tools/e2e fixtures (compose.test.yaml) rather than duplicating them.
+# shellcheck disable=SC1091
+source "$REPO_ROOT/tools/e2e/scripts/lib/version.sh"
+VECTOR_VERSION="${VECTOR_VERSION:-$(vector_version)}"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 TIMEOUT_SECONDS="${DC_RELEASE_TIMEOUT_SECONDS:-60}"
 


### PR DESCRIPTION
Closes #484

Stacked on #487 (the harness library the resolver lives in) — merges there first, then retargets to `jazzy`.

## The problem

One fact — the Vector version — was written down in eleven places: the canonical pin in `ros2_data_collection.repos`, five scripts each running their own grep to parse it back out, and six deployment/rendering files hard-coding the literal, each carrying its own "bump this by hand" comment.

## The impact

A version bump meant finding eleven spots across scripts and deployment trees. Miss one and the drift surfaced at deploy time on a robot, never in CI.

## The fix

Two small owners:

- `tools/e2e/scripts/lib/version.sh` — a `vector_version()` function that reads the `.repos` pin. Its own lib file, not part of `harness.sh`, so the release script can source it without pulling in the e2e skeleton. The five scripts (`run_split.sh`, the three `run_limits_*.sh`s, `run_load_driver_shipper_test.sh`) now source it instead of each carrying a grep; `verify_published_images.sh` uses it too, and still honors an explicit `VECTOR_VERSION` override.
- `tools/ci/check_vector_pin.sh` — fails when any hard-coded literal stops matching the pin. It sweeps `deploy/` and `tools/` for Vector's `-debian` semver tags (unique to Vector in those trees — dc-ros/dc-uploader pin shas or branch refs) and for `compose.split.yaml`'s `${VECTOR_VERSION:-...}` interpolation default, covering all seven copies: compose.yaml, the quadlet, the Kubernetes pod, the Helm values, the two kind manifests, and compose.split.yaml. New standalone `vector-pin` job in `ci.yaml` runs it on every PR, in seconds, over the whole tree.

Turning six "bump this by hand" comments into one enforced invariant: bump the `.repos` pin, run the check, and it names every file still carrying the old version.

## Tests

`./tools/ci/check_vector_pin.sh` verified both ways: passes on the current tree, and fails with the full list of seven stale files when the `.repos` pin is bumped without touching the copies. shellcheck and the full prek suite pass. The resolver was also exercised by every script that sources it (`vector_version` returns `0.57.0` against the current pin).
