### PR TITLE
One MeasurementConfig struct replaces the 38-argument Measurement::configure()

### DIFF
--- a/dc_core/include/dc_core/measurement.hpp
+++ b/dc_core/include/dc_core/measurement.hpp
@@ -4,9 +4,11 @@
 #ifndef DC_CORE_MEASUREMENT_HPP_
 #define DC_CORE_MEASUREMENT_HPP_
 
+#include <map>
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <vector>
 
 #include "dc_core/condition.hpp"
 #include "pluginlib/class_loader.hpp"
@@ -16,6 +18,74 @@
 
 namespace dc_core
 {
+
+// Every setting handed to a Measurement's configure() beyond its node, name, Conditions and TF
+// buffer. One field per setting, so a caller can't swap two same-typed arguments unnoticed.
+struct MeasurementConfig
+{
+  // Plugin identification and output
+  std::string measurement_plugin;  ///< Name of the plugin
+  std::string group_key;           ///< Key the Group node merges Records of several Measurements by
+  std::string topic_output;        ///< Topic where the result is published
+  int polling_interval{ 1000 };    ///< Interval to which data is collected in milliseconds
+  bool debug{ false };             ///< Print debug lines
+
+  // Validation and routing
+  bool enable_validator{ true };  ///< Validate the data against a JSON schema
+  std::string json_schema_path;   ///< Path to the JSON schema
+  std::vector<std::string> tags;  ///< Used to match to destination
+
+  // Collection gating and counters
+  bool init_collect{ true };                    ///< Collect when the node starts instead of waiting for the
+                                                ///< polling_interval time to pass
+  int init_max_measurements{ 0 };               ///< Collect a maximum of n measurements when starting the node
+                                                ///< (-1 = never, 0 = infinite)
+  int condition_max_measurements{ 0 };          ///< Collect a maximum of n measurements when conditions are
+                                                ///< activated (-1 = never, 0 = infinite)
+  std::vector<std::string> if_all_conditions;   ///< Collect only if all conditions are activated
+  std::vector<std::string> if_any_conditions;   ///< Collect if any conditions is activated
+  std::vector<std::string> if_none_conditions;  ///< Collect only if all conditions are not activated
+  std::string gate_condition;                   ///< Name of a Condition that must become true once before any
+                                                ///< collection is published; empty disables gating. Once true, the
+                                                ///< gate latches open permanently and the condition is no longer
+                                                ///< consulted -- distinct from if_all/if_any/if_none, which are
+                                                ///< re-evaluated on every collection
+
+  // Record shaping
+  bool include_measurement_name{ true };     ///< Include measurement name in the JSON
+  bool include_measurement_plugin{ false };  ///< Include measurement plugin name in the JSON
+  std::vector<std::string> remote_keys;      ///< Destination names a remote path is computed for
+  std::vector<std::string> remote_prefixes;  ///< Prefixes paired positionally with remote_keys,
+                                             ///< prepended under all_base_path
+  bool nested{ false };                      ///< Nest the collected JSON under the measurement name
+  bool flatten{ false };                     ///< Flatten the collected JSON
+
+  // Server-level settings, filled once by the MeasurementServer for every Measurement
+  std::string save_local_base_path;           ///< Unexpanded base path Files are saved under
+  std::string save_local_base_path_expanded;  ///< Same, with env vars and custom keys expanded
+  std::string all_base_path;                  ///< Unexpanded base path of everything collected
+  std::string all_base_path_expanded;         ///< Same, with env vars and custom keys expanded
+  std::string run_id;                         ///< Unique ID of the current run
+  bool run_id_enabled{ true };                ///< Whether the run ID is added to Records
+  std::vector<nlohmann::json> custom_keys;    ///< Vector of JSON with custom keys
+
+  // Incident capture
+  double buffer_duration_sec{ 0.0 };     ///< Seconds of history to buffer instead of publishing live;
+                                         ///< 0 (the default) disables buffering and preserves normal
+                                         ///< live publishing (#287)
+  double post_roll_duration_sec{ 0.0 };  ///< Seconds to keep publishing live after a flush, still
+                                         ///< tagged with the same incident_id; 0 (the default)
+                                         ///< means pre-roll only (#288)
+  double cooldown_sec{ 0.0 };            ///< Seconds to ignore further FlushEvents once post-roll ends,
+                                         ///< before buffering re-arms itself; 0 (the default) re-arms
+                                         ///< immediately (#288)
+  double max_flush_rate_hz{ 0.0 };       ///< Ceiling on how fast the buffered window is emitted once a
+                                         ///< flush releases it, protecting Bridge/network bandwidth; 0
+                                         ///< (the default) releases it in one burst (#289)
+  std::string flush_topic;               ///< Topic to receive the FlushEvent that releases the buffered window,
+                                         ///< tagging each released Record with the event's incident_id
+};
+
 class Measurement
 {
 public:
@@ -33,57 +103,11 @@ public:
    * @param  parent pointer to user's node
    * @param  name The name of this measurement
    * @param  tf A pointer to a TF buffer
-   * @param  measurement_plugin The name of the plugin
-   * @param  topic_output The topic where result will be published
-   * @param  polling_interval Interval to which data is collected in milliseconds
-   * @param  debug Print debug lines
-   * @param  enable_validator Will validate the data against a JSON schema
-   * @param  json_schema_path Path to the JSON schema
-   * @param  tags Used to match to destination
-   * @param  init_collect Collect when the node starts instead of waiting for the polling_interval time to pass
-   * @param  init_max_measurements Collect a maximum of n measurements when starting the node (-1 = never, 0 = infinite)
-   * @param  include_measurement_name Include measurement name in the JSON
-   * @param  include_measurement_plugin Include measurement plugin name in the JSON
-   * @param  condition_max_measurements Collect a maximum of n measurements when conditions are activated (-1 = never, 0
-   * = infinite)
-   * @param  if_all_conditions Collect only if all conditions are activated
-   * @param  if_any_conditions Collect if any conditions is activated
-   * @param  if_none_conditions Collect only if all conditions are not activated
-   * @param  gate_condition Name of a Condition that must become true once before any collection is published; empty
-   * disables gating. Once true, the gate latches open permanently and the condition is no longer consulted -- distinct
-   * from if_all/if_any/if_none, which are re-evaluated on every collection
-   * @param  run_id Unique ID of the current run
-   * @param  run_id Whether Run Id is enabled
-   * @param  custom_keys Vector of JSON with custom keys
-   * @param  buffer_duration_sec Seconds of history to buffer instead of publishing live; 0 (the
-   * default) disables buffering and preserves normal live publishing (#287)
-   * @param  post_roll_duration_sec Seconds to keep publishing live after a flush, still tagged
-   * with the same incident_id; 0 (the default) means pre-roll only (#288)
-   * @param  cooldown_sec Seconds to ignore further FlushEvents once post-roll ends, before
-   * buffering re-arms itself; 0 (the default) re-arms immediately (#288)
-   * @param  max_flush_rate_hz Ceiling on how fast the buffered window is emitted once a flush
-   * releases it, protecting Bridge/network bandwidth; 0 (the default) releases it in one burst
-   * (#289)
-   * @param  flush_topic Topic to receive the FlushEvent that releases the buffered window,
-   * tagging each released Record with the event's incident_id
+   * @param  config Every other setting of this Measurement, one field each -- see MeasurementConfig
    */
-  virtual void
-  configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
-            const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
-            std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin, const std::string& group_key,
-            const std::string& topic_output, const int& polling_interval, const bool& debug,
-            const bool& enable_validator, const std::string& json_schema_path, const std::vector<std::string>& tags,
-            const bool& init_collect, const int& init_max_measurements, const bool& include_measurement_name,
-            const bool& include_measurement_plugin, const int& condition_max_measurements,
-            const std::vector<std::string>& if_all_conditions, const std::vector<std::string>& if_any_conditions,
-            const std::vector<std::string>& if_none_conditions, const std::string& gate_condition,
-            const std::vector<std::string>& remote_keys, const std::vector<std::string>& remote_prefixes,
-            const bool& nest, const bool& flatten, const std::string& save_local_base_path,
-            const std::string& all_base_path, const std::string& all_base_path_expanded,
-            const std::string& save_local_base_path_expanded, const std::string& run_id, const bool& run_id_enabled,
-            const std::vector<json>& custom_keys, const double& buffer_duration_sec,
-            const double& post_roll_duration_sec, const double& cooldown_sec, const double& max_flush_rate_hz,
-            const std::string& flush_topic) = 0;
+  virtual void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
+                         const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
+                         std::shared_ptr<tf2_ros::Buffer> tf, const MeasurementConfig& config) = 0;
 
   /**
    * @brief Method to cleanup resources used on shutdown.

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -809,20 +809,7 @@ public:
   // configure the server on lifecycle setup
   void configure(const rclcpp_lifecycle::LifecycleNode::WeakPtr& parent, const std::string& name,
                  const std::map<std::string, std::shared_ptr<dc_core::Condition>>& conditions,
-                 std::shared_ptr<tf2_ros::Buffer> tf, const std::string& measurement_plugin,
-                 const std::string& group_key, const std::string& topic_output, const int& polling_interval,
-                 const bool& debug, const bool& enable_validator, const std::string& json_schema_path,
-                 const std::vector<std::string>& tags, const bool& init_collect, const int& init_max_measurements,
-                 const bool& include_measurement_name, const bool& include_measurement_plugin,
-                 const int& condition_max_measurements, const std::vector<std::string>& if_all_conditions,
-                 const std::vector<std::string>& if_any_conditions, const std::vector<std::string>& if_none_conditions,
-                 const std::string& gate_condition, const std::vector<std::string>& remote_keys,
-                 const std::vector<std::string>& remote_prefixes, const bool& nested, const bool& flatten,
-                 const std::string& save_local_base_path, const std::string& all_base_path,
-                 const std::string& all_base_path_expanded, const std::string& save_local_base_path_expanded,
-                 const std::string& run_id, const bool& run_id_enabled, const std::vector<json>& custom_keys,
-                 const double& buffer_duration_sec, const double& post_roll_duration_sec, const double& cooldown_sec,
-                 const double& max_flush_rate_hz, const std::string& flush_topic) override
+                 std::shared_ptr<tf2_ros::Buffer> tf, const dc_core::MeasurementConfig& config) override
   {
     node_ = parent;
     auto node = node_.lock();
@@ -831,37 +818,38 @@ public:
 
     RCLCPP_INFO(logger_, "Configuring %s", name.c_str());
 
-    measurement_plugin_ = measurement_plugin;
+    measurement_plugin_ = config.measurement_plugin;
     conditions_ = conditions;
     tf_ = tf;
     measurement_name_ = name;
-    topic_output_ = topic_output;
-    polling_interval_ = polling_interval;
-    debug_ = debug;
-    enable_validator_ = enable_validator;
-    json_schema_path_ = json_schema_path;
-    group_key_ = group_key;
-    tags_ = tags;
-    init_collect_ = init_collect;
-    init_max_measurements_ = init_max_measurements;
-    include_measurement_name_ = include_measurement_name;
-    include_measurement_plugin_ = include_measurement_plugin;
-    remote_keys_ = remote_keys;
-    remote_prefixes_ = remote_prefixes;
-    nested_ = nested;
-    flatten_ = flatten;
-    all_base_path_ = all_base_path;
-    all_base_path_expanded_ = all_base_path_expanded;
-    save_local_base_path_ = save_local_base_path;
-    save_local_base_path_expanded_ = save_local_base_path_expanded;
-    run_id_ = run_id;
-    run_id_enabled_ = run_id_enabled;
-    custom_keys_ = custom_keys;
+    topic_output_ = config.topic_output;
+    polling_interval_ = config.polling_interval;
+    debug_ = config.debug;
+    enable_validator_ = config.enable_validator;
+    json_schema_path_ = config.json_schema_path;
+    group_key_ = config.group_key;
+    tags_ = config.tags;
+    init_collect_ = config.init_collect;
+    init_max_measurements_ = config.init_max_measurements;
+    include_measurement_name_ = config.include_measurement_name;
+    include_measurement_plugin_ = config.include_measurement_plugin;
+    remote_keys_ = config.remote_keys;
+    remote_prefixes_ = config.remote_prefixes;
+    nested_ = config.nested;
+    flatten_ = config.flatten;
+    all_base_path_ = config.all_base_path;
+    all_base_path_expanded_ = config.all_base_path_expanded;
+    save_local_base_path_ = config.save_local_base_path;
+    save_local_base_path_expanded_ = config.save_local_base_path_expanded;
+    run_id_ = config.run_id;
+    run_id_enabled_ = config.run_id_enabled;
+    custom_keys_ = config.custom_keys;
 
-    condition_max_measurements_ = condition_max_measurements;
-    condition_set_ = dc_core::ConditionSet(if_all_conditions, if_any_conditions, if_none_conditions);
+    condition_max_measurements_ = config.condition_max_measurements;
+    condition_set_ =
+        dc_core::ConditionSet(config.if_all_conditions, config.if_any_conditions, config.if_none_conditions);
 
-    gate_condition_ = gate_condition;
+    gate_condition_ = config.gate_condition;
     // No gate configured means collection is never held back.
     gate_armed_ = gate_condition_.empty();
 
@@ -875,11 +863,11 @@ public:
     collect_timer_ = node->create_wall_timer(
         std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); }, client_cb_group_);
 
-    buffer_duration_sec_ = buffer_duration_sec;
-    post_roll_duration_sec_ = post_roll_duration_sec;
-    cooldown_sec_ = cooldown_sec;
-    max_flush_rate_hz_ = max_flush_rate_hz;
-    flush_topic_ = flush_topic.empty() ? std::string("/dc/flush") : flush_topic;
+    buffer_duration_sec_ = config.buffer_duration_sec;
+    post_roll_duration_sec_ = config.post_roll_duration_sec;
+    cooldown_sec_ = config.cooldown_sec;
+    max_flush_rate_hz_ = config.max_flush_rate_hz;
+    flush_topic_ = config.flush_topic.empty() ? std::string("/dc/flush") : config.flush_topic;
     if (buffer_duration_sec_ > 0.0)
     {
       releaser_ = std::make_shared<IncidentReleaser>(

--- a/dc_measurements/include/dc_measurements/measurement_config.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_config.hpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__MEASUREMENT_CONFIG_HPP_
+#define DC_MEASUREMENTS__MEASUREMENT_CONFIG_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "dc_core/measurement.hpp"
+#include "dc_util/node_utils.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+
+namespace dc_measurements
+{
+
+// Every per-Measurement parameter name and default, in one place. The server-level fields of the
+// returned MeasurementConfig (save paths, run id, custom keys) are the caller's to fill.
+inline dc_core::MeasurementConfig read_measurement_config(const rclcpp_lifecycle::LifecycleNode::SharedPtr& node,
+                                                          const std::string& measurement_name)
+{
+  dc_core::MeasurementConfig config;
+
+  // Mandatory parameters
+  config.measurement_plugin = dc_util::get_str_type_param(node, measurement_name, "plugin");
+
+  // Optional parameters
+  config.group_key = dc_util::get_str_type_param(node, measurement_name, "group_key", "");
+  config.topic_output = dc_util::get_str_type_param(node, measurement_name, "topic_output",
+                                                    std::string("/dc/measurement/") + measurement_name);
+  config.polling_interval = dc_util::get_int_type_param(node, measurement_name, "polling_interval", 1000);
+  config.debug = dc_util::get_bool_type_param(node, measurement_name, "debug", false);
+  config.enable_validator = dc_util::get_bool_type_param(node, measurement_name, "enable_validator", true);
+  config.json_schema_path = dc_util::get_str_type_param(node, measurement_name, "json_schema_path", "");
+  config.tags = dc_util::get_str_array_type_param(node, measurement_name, "tags", std::vector<std::string>());
+  config.init_collect = dc_util::get_bool_type_param(node, measurement_name, "init_collect", true);
+  config.init_max_measurements = dc_util::get_int_type_param(node, measurement_name, "init_max_measurements", 0);
+  config.condition_max_measurements =
+      dc_util::get_int_type_param(node, measurement_name, "condition_max_measurements", 0);
+  config.include_measurement_name =
+      dc_util::get_bool_type_param(node, measurement_name, "include_measurement_name", true);
+  config.include_measurement_plugin =
+      dc_util::get_bool_type_param(node, measurement_name, "include_measurement_plugin", false);
+  config.if_all_conditions =
+      dc_util::get_str_array_type_param(node, measurement_name, "if_all_conditions", std::vector<std::string>());
+  config.if_any_conditions =
+      dc_util::get_str_array_type_param(node, measurement_name, "if_any_conditions", std::vector<std::string>());
+  config.if_none_conditions =
+      dc_util::get_str_array_type_param(node, measurement_name, "if_none_conditions", std::vector<std::string>());
+  config.gate_condition = dc_util::get_str_type_param(node, measurement_name, "gate_condition", "");
+  config.remote_keys =
+      dc_util::get_str_array_type_param(node, measurement_name, "remote_keys", std::vector<std::string>());
+  config.remote_prefixes =
+      dc_util::get_str_array_type_param(node, measurement_name, "remote_prefixes", std::vector<std::string>());
+  config.nested = dc_util::get_bool_type_param(node, measurement_name, "nested", false);
+  config.flatten = dc_util::get_bool_type_param(node, measurement_name, "flatten", false);
+  config.buffer_duration_sec = dc_util::get_double_type_param(node, measurement_name, "buffer_duration_sec", 0.0);
+  config.post_roll_duration_sec = dc_util::get_double_type_param(node, measurement_name, "post_roll_duration_sec", 0.0);
+  config.cooldown_sec = dc_util::get_double_type_param(node, measurement_name, "cooldown_sec", 0.0);
+  config.max_flush_rate_hz = dc_util::get_double_type_param(node, measurement_name, "max_flush_rate_hz", 0.0);
+  config.flush_topic = dc_util::get_str_type_param(node, measurement_name, "flush_topic", std::string("/dc/flush"));
+
+  return config;
+}
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__MEASUREMENT_CONFIG_HPP_

--- a/dc_measurements/include/dc_measurements/measurement_server.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_server.hpp
@@ -52,13 +52,6 @@ public:
    */
   bool loadConditionPlugins();
 
-  std::vector<std::string> getMeasurementPlugins();
-  std::vector<std::string> getMeasurementTypes();
-  std::vector<std::string> getMeasurementGroupKeys();
-  std::vector<std::string> getMeasurementTopicOutput();
-  std::vector<int> getMeasurementPollingInterval();
-  std::vector<bool> getMeasurementInitCollect();
-
 protected:
   /**
    * @brief Configure lifecycle server
@@ -107,32 +100,7 @@ protected:
   std::vector<json> custom_keys_;
 
   // std::vector<std::string> measurement_plugins_;
-  std::vector<std::string> measurement_group_key_;
   std::vector<std::string> measurement_ids_;
-  std::vector<int> measurement_polling_interval_;
-  std::vector<std::string> measurement_topic_outputs_;
-  std::vector<std::string> measurement_types_;
-  std::vector<bool> measurement_debug_;
-  std::vector<bool> measurement_enable_validator_;
-  std::vector<std::string> measurement_json_schema_path_;
-  std::vector<std::vector<std::string>> measurement_tags_;
-  std::vector<bool> measurement_init_collect_;
-  std::vector<int> measurement_init_max_measurements_;
-  std::vector<bool> measurement_include_measurement_name_;
-  std::vector<bool> measurement_include_measurement_plugin_;
-  std::vector<std::vector<std::string>> measurement_if_all_conditions_;
-  std::vector<std::vector<std::string>> measurement_if_any_conditions_;
-  std::vector<std::vector<std::string>> measurement_if_none_conditions_;
-  std::vector<std::string> measurement_gate_condition_;
-  std::vector<std::vector<std::string>> measurement_remote_keys_;
-  std::vector<std::vector<std::string>> measurement_remote_prefixes_;
-  std::vector<bool> measurement_nested_;
-  std::vector<bool> measurement_flatten_;
-  std::vector<double> measurement_buffer_duration_sec_;
-  std::vector<double> measurement_post_roll_duration_sec_;
-  std::vector<double> measurement_cooldown_sec_;
-  std::vector<double> measurement_max_flush_rate_hz_;
-  std::vector<std::string> measurement_flush_topic_;
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;
   std::string all_base_path_;
@@ -146,7 +114,6 @@ protected:
   std::vector<std::string> condition_types_;
   pluginlib::ClassLoader<dc_core::Condition> condition_plugin_loader_;
   std::vector<std::string> condition_ids_;
-  std::vector<int> measurement_condition_max_measurements_;
 };
 
 }  // namespace measurement_server

--- a/dc_measurements/src/measurement_server.cpp
+++ b/dc_measurements/src/measurement_server.cpp
@@ -8,6 +8,8 @@
 #include <cerrno>
 #include <cstring>
 
+#include "dc_measurements/measurement_config.hpp"
+
 namespace measurement_server
 {
 
@@ -207,34 +209,6 @@ nav2_util::CallbackReturn MeasurementServer::on_configure(const rclcpp_lifecycle
   tf_->setCreateTimerInterface(timer_interface);
   transform_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_);
 
-  measurement_types_.resize(measurement_ids_.size());
-  measurement_topic_outputs_.resize(measurement_ids_.size());
-  measurement_polling_interval_.resize(measurement_ids_.size());
-  measurement_debug_.resize(measurement_ids_.size());
-  measurement_enable_validator_.resize(measurement_ids_.size());
-  measurement_json_schema_path_.resize(measurement_ids_.size());
-  measurement_group_key_.resize(measurement_ids_.size());
-  measurement_tags_.resize(measurement_ids_.size());
-  measurement_init_collect_.resize(measurement_ids_.size());
-  measurement_init_max_measurements_.resize(measurement_ids_.size());
-  measurement_include_measurement_name_.resize(measurement_ids_.size());
-  measurement_include_measurement_plugin_.resize(measurement_ids_.size());
-  measurement_remote_keys_.resize(measurement_ids_.size());
-  measurement_remote_prefixes_.resize(measurement_ids_.size());
-  measurement_nested_.resize(measurement_ids_.size());
-  measurement_flatten_.resize(measurement_ids_.size());
-  measurement_buffer_duration_sec_.resize(measurement_ids_.size());
-  measurement_post_roll_duration_sec_.resize(measurement_ids_.size());
-  measurement_cooldown_sec_.resize(measurement_ids_.size());
-  measurement_max_flush_rate_hz_.resize(measurement_ids_.size());
-  measurement_flush_topic_.resize(measurement_ids_.size());
-
-  measurement_if_all_conditions_.resize(measurement_ids_.size());
-  measurement_if_any_conditions_.resize(measurement_ids_.size());
-  measurement_if_none_conditions_.resize(measurement_ids_.size());
-  measurement_gate_condition_.resize(measurement_ids_.size());
-  measurement_condition_max_measurements_.resize(measurement_ids_.size());
-
   condition_types_.resize(condition_ids_.size());
 
   if (!loadConditionPlugins())
@@ -283,101 +257,49 @@ bool MeasurementServer::loadMeasurementPlugins()
 
   for (size_t i = 0; i != measurement_ids_.size(); i++)
   {
-    // Mandatory parameters
-    measurement_types_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "plugin");
+    dc_core::MeasurementConfig config = dc_measurements::read_measurement_config(node, measurement_ids_[i]);
 
-    // Optional parameters
-    measurement_group_key_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "group_key", "");
-    measurement_topic_outputs_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "topic_output",
-                                                                std::string("/dc/measurement/") + measurement_ids_[i]);
-    measurement_polling_interval_[i] = dc_util::get_int_type_param(node, measurement_ids_[i], "polling_interval", 1000);
-    measurement_debug_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "debug", false);
-    measurement_enable_validator_[i] =
-        dc_util::get_bool_type_param(node, measurement_ids_[i], "enable_validator", true);
-    measurement_json_schema_path_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "json_schema_path", "");
-    measurement_tags_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "tags", std::vector<std::string>());
-    measurement_init_collect_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "init_collect", true);
-    measurement_init_max_measurements_[i] =
-        dc_util::get_int_type_param(node, measurement_ids_[i], "init_max_measurements", 0);
-    measurement_include_measurement_name_[i] =
-        dc_util::get_bool_type_param(node, measurement_ids_[i], "include_measurement_name", true);
-    measurement_include_measurement_plugin_[i] =
-        dc_util::get_bool_type_param(node, measurement_ids_[i], "include_measurement_plugin", false);
-    measurement_remote_keys_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "remote_keys", std::vector<std::string>());
-    measurement_remote_prefixes_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "remote_prefixes", std::vector<std::string>());
-    measurement_nested_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "nested", false);
-    measurement_flatten_[i] = dc_util::get_bool_type_param(node, measurement_ids_[i], "flatten", false);
-    measurement_buffer_duration_sec_[i] =
-        dc_util::get_double_type_param(node, measurement_ids_[i], "buffer_duration_sec", 0.0);
-    measurement_post_roll_duration_sec_[i] =
-        dc_util::get_double_type_param(node, measurement_ids_[i], "post_roll_duration_sec", 0.0);
-    measurement_cooldown_sec_[i] = dc_util::get_double_type_param(node, measurement_ids_[i], "cooldown_sec", 0.0);
-    measurement_max_flush_rate_hz_[i] =
-        dc_util::get_double_type_param(node, measurement_ids_[i], "max_flush_rate_hz", 0.0);
-    measurement_flush_topic_[i] =
-        dc_util::get_str_type_param(node, measurement_ids_[i], "flush_topic", std::string("/dc/flush"));
-
-    measurement_if_all_conditions_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_all_conditions", std::vector<std::string>());
-    measurement_if_any_conditions_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_any_conditions", std::vector<std::string>());
-    measurement_if_none_conditions_[i] =
-        dc_util::get_str_array_type_param(node, measurement_ids_[i], "if_none_conditions", std::vector<std::string>());
-    measurement_gate_condition_[i] = dc_util::get_str_type_param(node, measurement_ids_[i], "gate_condition", "");
-    measurement_condition_max_measurements_[i] =
-        dc_util::get_int_type_param(node, measurement_ids_[i], "condition_max_measurements", 0);
+    // Server-level settings, shared by every Measurement
+    config.save_local_base_path = save_local_base_path_;
+    config.save_local_base_path_expanded = save_local_base_path_expanded_;
+    config.all_base_path = all_base_path_;
+    config.all_base_path_expanded = all_base_path_expanded_;
+    config.run_id = run_id_;
+    config.run_id_enabled = run_id_enabled_;
+    config.custom_keys = custom_keys_;
 
     try
     {
-      RCLCPP_INFO_STREAM(get_logger(),
-                         "Creating measurement plugin "
-                             << measurement_ids_[i].c_str() << ": Type " << measurement_types_[i].c_str()
-                             << ", Group key: " << measurement_group_key_[i] << ", Polling interval: "
-                             << measurement_polling_interval_[i] << ", Debug: " << (int)measurement_debug_[i]
-                             << ", Validator enabled: " << (int)measurement_enable_validator_[i]
-                             << ", Schema path: " << measurement_json_schema_path_[i].c_str() << ", Tags: ["
-                             << dc_util::join(measurement_tags_[i], ",")
-                             << "], Init collect: " << (int)measurement_init_collect_[i]
-                             << ", Init Max measurement: " << measurement_init_max_measurements_[i]
-                             << ", Include measurement name: " << measurement_include_measurement_name_[i]
-                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-                             << ", Remote keys: " << dc_util::join(measurement_remote_keys_[i])
-                             << ", Remote prefixes: " << dc_util::join(measurement_remote_prefixes_[i]) << ", Nest: "
-                             << (int)measurement_nested_[i] << ", Flatten: " << (int)measurement_flatten_[i]
-                             << ", Include measurement plugin name: " << measurement_include_measurement_plugin_[i]
-                             << ", Max measurement on condition: " << measurement_condition_max_measurements_[i]
-                             << ", If all condition: " << dc_util::join(measurement_if_all_conditions_[i], ",")
-                             << ", If any condition: " << dc_util::join(measurement_if_any_conditions_[i], ",")
-                             << ", If none condition: " << dc_util::join(measurement_if_none_conditions_[i], ",")
-                             << ", Gate condition: " << measurement_gate_condition_[i]
-                             << ", Buffer duration sec: " << measurement_buffer_duration_sec_[i]
-                             << ", Post roll duration sec: " << measurement_post_roll_duration_sec_[i]
-                             << ", Cooldown sec: " << measurement_cooldown_sec_[i] << ", Max flush rate hz: "
-                             << measurement_max_flush_rate_hz_[i] << ", Flush topic: " << measurement_flush_topic_[i]);
+      RCLCPP_INFO_STREAM(
+          get_logger(),
+          "Creating measurement plugin "
+              << measurement_ids_[i].c_str() << ": Type " << config.measurement_plugin.c_str()
+              << ", Group key: " << config.group_key << ", Polling interval: " << config.polling_interval
+              << ", Debug: " << (int)config.debug << ", Validator enabled: " << (int)config.enable_validator
+              << ", Schema path: " << config.json_schema_path.c_str() << ", Tags: [" << dc_util::join(config.tags, ",")
+              << "], Init collect: " << (int)config.init_collect << ", Init Max measurement: "
+              << config.init_max_measurements << ", Include measurement name: " << config.include_measurement_name
+              << ", Include measurement plugin name: " << config.include_measurement_plugin << ", Remote keys: "
+              << dc_util::join(config.remote_keys) << ", Remote prefixes: " << dc_util::join(config.remote_prefixes)
+              << ", Nest: " << (int)config.nested << ", Flatten: " << (int)config.flatten
+              << ", Include measurement plugin name: " << config.include_measurement_plugin
+              << ", Max measurement on condition: " << config.condition_max_measurements
+              << ", If all condition: " << dc_util::join(config.if_all_conditions, ",")
+              << ", If any condition: " << dc_util::join(config.if_any_conditions, ",") << ", If none condition: "
+              << dc_util::join(config.if_none_conditions, ",") << ", Gate condition: " << config.gate_condition
+              << ", Buffer duration sec: " << config.buffer_duration_sec << ", Post roll duration sec: "
+              << config.post_roll_duration_sec << ", Cooldown sec: " << config.cooldown_sec
+              << ", Max flush rate hz: " << config.max_flush_rate_hz << ", Flush topic: " << config.flush_topic);
 
-      measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(measurement_types_[i]));
-      measurements_.back()->configure(
-          node, measurement_ids_[i], conditions_, tf_, measurement_types_[i], measurement_group_key_[i],
-          measurement_topic_outputs_[i], measurement_polling_interval_[i], measurement_debug_[i],
-          measurement_enable_validator_[i], measurement_json_schema_path_[i], measurement_tags_[i],
-          measurement_init_collect_[i], measurement_init_max_measurements_[i], measurement_include_measurement_name_[i],
-          measurement_include_measurement_plugin_[i], measurement_condition_max_measurements_[i],
-          measurement_if_all_conditions_[i], measurement_if_any_conditions_[i], measurement_if_none_conditions_[i],
-          measurement_gate_condition_[i], measurement_remote_keys_[i], measurement_remote_prefixes_[i],
-          measurement_nested_[i], measurement_flatten_[i], save_local_base_path_, all_base_path_,
-          all_base_path_expanded_, save_local_base_path_expanded_, run_id_, run_id_enabled_, custom_keys_,
-          measurement_buffer_duration_sec_[i], measurement_post_roll_duration_sec_[i], measurement_cooldown_sec_[i],
-          measurement_max_flush_rate_hz_[i], measurement_flush_topic_[i]);
+      measurements_.push_back(measurement_plugin_loader_.createUniqueInstance(config.measurement_plugin));
+      measurements_.back()->configure(node, measurement_ids_[i], conditions_, tf_, config);
     }
     catch (const pluginlib::PluginlibException& ex)
     {
       RCLCPP_FATAL(get_logger(),
                    "Failed to create measurement %s of type %s."
                    " Exception: %s",
-                   measurement_ids_[i].c_str(), measurement_types_[i].c_str(), ex.what());
+                   measurement_ids_[i].c_str(), config.measurement_plugin.c_str(), ex.what());
       return false;
     }
   }
@@ -428,36 +350,6 @@ nav2_util::CallbackReturn MeasurementServer::on_shutdown(const rclcpp_lifecycle:
 {
   RCLCPP_INFO(get_logger(), "Shutting down");
   return nav2_util::CallbackReturn::SUCCESS;
-}
-
-std::vector<std::string> MeasurementServer::getMeasurementPlugins()
-{
-  return measurement_ids_;
-}
-
-std::vector<std::string> MeasurementServer::getMeasurementTypes()
-{
-  return measurement_types_;
-}
-
-std::vector<std::string> MeasurementServer::getMeasurementGroupKeys()
-{
-  return measurement_group_key_;
-}
-
-std::vector<std::string> MeasurementServer::getMeasurementTopicOutput()
-{
-  return measurement_topic_outputs_;
-}
-
-std::vector<int> MeasurementServer::getMeasurementPollingInterval()
-{
-  return measurement_polling_interval_;
-}
-
-std::vector<bool> MeasurementServer::getMeasurementInitCollect()
-{
-  return measurement_init_collect_;
 }
 
 }  // end namespace measurement_server

--- a/dc_measurements/test/test_measurement_parameters.cpp
+++ b/dc_measurements/test/test_measurement_parameters.cpp
@@ -84,19 +84,12 @@ TEST_F(MeasurementOSTest, PollingIntervalOneMeasurementOnePercentError)
   startLifecycleNode();
 
   // Verify parameters are set properly
-  std::vector<std::string> ms_plugins_desired = { "os" };
-  std::vector<std::string> ms_types_desired = { "dc_measurements/OS" };
-  std::vector<std::string> ms_group_key_desired = { "os" };
-  std::vector<std::string> ms_topic_output_desired = { "/dc/measurement/os" };
-  std::vector<int> ms_polling_interval_desired = { polling_interval };
-  std::vector<bool> ms_init_collect_desired = { false };
-
-  EXPECT_EQ(ms_plugins_desired, ms_node_->getMeasurementPlugins());
-  EXPECT_EQ(ms_types_desired, ms_node_->getMeasurementTypes());
-  EXPECT_EQ(ms_group_key_desired, ms_node_->getMeasurementGroupKeys());
-  EXPECT_EQ(ms_topic_output_desired, ms_node_->getMeasurementTopicOutput());
-  EXPECT_EQ(ms_polling_interval_desired, ms_node_->getMeasurementPollingInterval());
-  EXPECT_EQ(ms_init_collect_desired, ms_node_->getMeasurementInitCollect());
+  EXPECT_EQ(std::vector<std::string>({ "os" }), ms_node_->get_parameter("measurement_plugins").as_string_array());
+  EXPECT_EQ("dc_measurements/OS", ms_node_->get_parameter("os.plugin").as_string());
+  EXPECT_EQ("os", ms_node_->get_parameter("os.group_key").as_string());
+  EXPECT_EQ("/dc/measurement/os", ms_node_->get_parameter("os.topic_output").as_string());
+  EXPECT_EQ(polling_interval, static_cast<int>(ms_node_->get_parameter("os.polling_interval").as_int()));
+  EXPECT_FALSE(ms_node_->get_parameter("os.init_collect").as_bool());
 
   std::chrono::steady_clock::time_point start_time = std::chrono::steady_clock::now();
 


### PR DESCRIPTION
Closes #481

## The problem

Handing one Measurement plugin its settings took a 38-argument positional call, and the machinery around it was worse:

- the giant argument list was written twice and kept identical by hand — the pure virtual in `dc_core/include/dc_core/measurement.hpp` and the override in `dc_measurements/include/dc_measurements/measurement.hpp`;
- the caller (`measurement_server.cpp`) held ~30 parallel member vectors, each `.resize()`d separately, filled by ~40 `dc_util::get_*_type_param()` reads, then splatted positionally into `configure(...)`;
- 12+ of the arguments were same-typed strings sitting side by side.

## The impact

- Swapping two arguments compiled fine and silently configured the wrong plugin (wrong flush topic, wrong save path, ...). Nothing caught it until runtime misbehaviour.
- Adding one setting meant editing five places: the virtual, the override, a member vector, a resize, a param read (plus the call site).
- The 30 lists had to be kept in lockstep by hand forever.
- Six getters on MeasurementServer existed only so one test could echo parameters back.

## The fix

- New `dc_core::MeasurementConfig` struct: one field per setting, with the semantics each argument carried (defaults, "-1 = never, 0 = infinite", gate-vs-if_all distinction, incident-capture window meanings) documented on the fields instead of a 40-line parameter list on the virtual.
- New `read_measurement_config()` helper (`dc_measurements/measurement_config.hpp`) owning every per-Measurement parameter name and default, still declared and read through the ADR-0008 `dc_util` helpers — this builds on that decision, it does not undo it.
- The virtual becomes `configure(parent, name, conditions, tf, config)`, declared once. Plugins do not override `configure()` (verified: they all implement `onConfigure()`), so the blast radius is dc_core, the dc_measurements base, and the server. The ~30 member vectors, ~30 resizes and the giant call in `measurement_server.cpp` collapse into one struct per plugin; the server-level values (save paths, run id, custom keys) are filled once and merged in.
- The six test-only getters on MeasurementServer are gone; the one test using them (`test_measurement_parameters.cpp`) now reads the parameters back off the node directly, checking the same values.

A new setting now costs one field plus one line to read it, and swapped-argument bugs are impossible.

## Tests

- The ~60 existing dc_measurements plugin tests pass unchanged (except the one getter-using test, which now asserts the same values via `get_parameter`) — they drive the full `MeasurementServer` → `configure()` → plugin path, so they are the equivalence proof that behaviour is identical.
- Containerized `colcon build` + `colcon test` of `dc_core` and `dc_measurements`: all tests pass, 0 failures.
- Full `prek run --all-files --skip build-doc` passes.
