### PR TITLE
refactor(dc_group): extract the Group merge into a ROS-free module

### DIFF
--- a/dc_group/dc_group/group_merge.py
+++ b/dc_group/dc_group/group_merge.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Merge the Records of one synchronised window into a single Record payload.
+
+Plain dicts in, plain dict out: no `rclpy`, no clock, no messages. `GroupServer` converts
+at the edges and hands over already-parsed payloads, so these rules are testable without a
+ROS install.
+"""
+
+from .flatten import flatten, unflatten_list
+
+SEPARATOR = "."
+
+
+def apply_exclude_keys(data_dict: dict, exclude_keys: list) -> dict:
+    """Drop the flattened keys an `exclude_keys` entry names.
+
+    Args:
+        data_dict (dict): Flattened Record, filtered in place of being copied
+        exclude_keys (list): Patterns applied in order, each narrowing the Record further.
+            A `*`-free entry is a key prefix; an entry holding `*` matches when every
+            `*`-separated fragment appears in the key
+
+    Returns:
+        dict: The Record minus the excluded keys
+    """
+    for exclude_key in exclude_keys:
+        if exclude_key == "":
+            continue
+        if "*" not in exclude_key:
+            data_dict = {k: v for k, v in data_dict.items() if not k.startswith(exclude_key)}
+        else:
+            data_dict = {
+                k: v
+                for k, v in data_dict.items()
+                if not all(x in k for x in exclude_key.split("*"))
+            }
+    return data_dict
+
+
+def merge_records(
+    parsed_payloads: list,
+    group: str,
+    group_cfg: dict,
+    missing_inputs: list | None = None,
+    collect_plugins: bool = True,
+) -> dict:
+    """Merge parsed Measurement payloads into one Record payload.
+
+    Args:
+        parsed_payloads (list): One entry per member Record, ordered by the input it came
+            from: `{"group_key": <the member's group_key>, "data": <its parsed payload>}`.
+            Two members sharing a `group_key` collapse into the last one's fields
+        group (str): Name of the group being published
+        group_cfg (dict): The group's parameters — `exclude_keys`, `tags`, `nested_data`
+            and `include_group_name`
+        missing_inputs (list, optional): Input topics that contributed no Record. Empty for
+            a complete Record, non-empty for a partial one. Defaults to None
+        collect_plugins (bool, optional): Gather the members' `plugin` fields into a
+            top-level `plugins` list. Defaults to True
+
+    Returns:
+        dict: The Record payload, ready to serialize
+    """
+    data_dict = {}
+    plugins_list = []
+    incident_id = None
+    for payload in parsed_payloads:
+        m_data = dict(payload["data"])
+        m_data.pop("tags", None)
+        # `incident_id` is an envelope field, not measurement data (#291): merged under a
+        # member's `group_key` it would become `<group_key>.incident_id`, which is no
+        # column any Destination table has and so is silently dropped by the Postgres
+        # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
+        # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
+        # FlushEvent mints one id for every Measurement listening, so the members of a
+        # released window all carry the same one — first non-null wins, and a partial
+        # Record built from a mix of released and live members still carries it.
+        member_incident_id = m_data.pop("incident_id", None)
+        if incident_id is None:
+            incident_id = member_incident_id
+        if collect_plugins and "plugin" in m_data:
+            plugins_list.append(m_data["plugin"])
+        data_dict = data_dict | flatten(
+            nested_dict={payload["group_key"]: m_data}, separator=SEPARATOR
+        )
+
+    data_dict = apply_exclude_keys(data_dict, group_cfg["exclude_keys"])
+    if group_cfg["nested_data"]:
+        data_dict = unflatten_list(flat_dict=data_dict, separator=SEPARATOR)
+    # A member's own Tags are dropped above: the Record carries the group's.
+    data_dict["tags"] = group_cfg["tags"]
+    # Only when a member actually carried one: a Record collected outside an incident must
+    # leave the column NULL rather than write an explicit null into every grouped Record.
+    if incident_id is not None:
+        data_dict["incident_id"] = incident_id
+    if collect_plugins and plugins_list:
+        data_dict["plugins"] = plugins_list
+
+    if group_cfg["include_group_name"]:
+        data_dict["name"] = group
+
+    # A Record assembled by the sync timeout rather than by the synchroniser is marked
+    # so consumers can tell it apart. A complete Record carries neither key, keeping its
+    # shape identical to what DC published before the timeout existed. The keys of the
+    # inputs that never showed up are simply absent: the Group node only knows a missing
+    # input's *topic*, never its `group_key` or its fields (both come from the Record
+    # itself), so it cannot synthesise a correctly shaped null placeholder for it.
+    if missing_inputs:
+        data_dict["partial"] = True
+        data_dict["missing_inputs"] = list(missing_inputs)
+
+    return data_dict

--- a/dc_group/dc_group/group_server.py
+++ b/dc_group/dc_group/group_server.py
@@ -14,7 +14,7 @@ from rclpy_message_converter import message_converter
 
 from dc_interfaces.msg import StringStamped
 
-from .flatten import flatten, unflatten_list
+from .group_merge import merge_records
 
 # Values accepted by the per-group `on_sync_timeout` parameter. `message_filters` has no
 # timeout of its own, so DC runs a timer alongside the synchroniser (see
@@ -69,69 +69,25 @@ class GroupServer(Node):
             missing_inputs (list): Input topics that contributed no Record. Empty for a
                 complete Record, non-empty for a partial one
         """
-        data_dict = {}
-        plugins_list = []
-        incident_id = None
         collected_time = self.get_clock().now()
+        parsed_payloads = []
         for measurement in measurements:
             # https://github.com/ros2/rosidl_python/blob/0f5c8f360be92566ad86f4b29f3db1febfca2242/rosidl_generator_py/resource/_msg.py.em#L187-L189
             measurement_dict = message_converter.convert_ros_message_to_dictionary(measurement)
-            m_data = json.loads(measurement.data)
-            m_data.pop("tags", None)
-            # `incident_id` is an envelope field, not measurement data (#291): merged under a
-            # member's `group_key` it would become `<group_key>.incident_id`, which is no
-            # column any Destination table has and so is silently dropped by the Postgres
-            # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
-            # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
-            # FlushEvent mints one id for every Measurement listening, so the members of a
-            # released window all carry the same one — first non-null wins, and a partial
-            # Record built from a mix of released and live members still carries it.
-            member_incident_id = m_data.pop("incident_id", None)
-            if incident_id is None:
-                incident_id = member_incident_id
-            if self.group_measurement_plugins:
-                if "plugin" in m_data:
-                    plugins_list.append(m_data["plugin"])
-            tmp_data_dict = flatten(
-                nested_dict={measurement_dict["group_key"]: m_data}, separator="."
+            parsed_payloads.append(
+                {"group_key": measurement_dict["group_key"], "data": json.loads(measurement.data)}
             )
-            data_dict = data_dict | tmp_data_dict
 
-        for exclude_key in self.params[group]["exclude_keys"]:
-            if exclude_key != "":
-                if "*" not in exclude_key:
-                    data_dict = {
-                        k: v for k, v in data_dict.items() if not k.startswith(exclude_key)
-                    }
-                else:
-                    # Split by *
-                    data_dict = {
-                        k: v
-                        for k, v in data_dict.items()
-                        if not all(x in k for x in exclude_key.split("*"))
-                    }
-        if self.params[group]["nested_data"]:
-            data_dict = unflatten_list(flat_dict=data_dict, separator=".")
-        data_dict["tags"] = self.params[group]["tags"]
-        # Only when a member actually carried one: a Record collected outside an incident must
-        # leave the column NULL rather than write an explicit null into every grouped Record.
-        if incident_id is not None:
-            data_dict["incident_id"] = incident_id
-        if self.group_measurement_plugins and plugins_list:
-            data_dict["plugins"] = plugins_list
-
-        if self.params[group]["include_group_name"]:
-            data_dict["name"] = group
-
-        # A Record assembled by the sync timeout rather than by the synchroniser is marked
-        # so consumers can tell it apart. A complete Record carries neither key, keeping its
-        # shape identical to what DC published before the timeout existed. The keys of the
-        # inputs that never showed up are simply absent: the Group node only knows a missing
-        # input's *topic*, never its `group_key` or its fields (both come from the Record
-        # itself), so it cannot synthesise a correctly shaped null placeholder for it.
-        if missing_inputs:
-            data_dict["partial"] = True
-            data_dict["missing_inputs"] = list(missing_inputs)
+        # `group_measurement_plugins` is stored as a Parameter, and a Parameter is always
+        # truthy, so `bool()` is what the merge used to test inline — the flag's value is
+        # still ignored today. Passing `.value` would be a behaviour change, not a move.
+        data_dict = merge_records(
+            parsed_payloads,
+            group,
+            self.params[group],
+            missing_inputs=missing_inputs,
+            collect_plugins=bool(self.group_measurement_plugins),
+        )
 
         msg = StringStamped()
         msg.data = json.dumps(data_dict)

--- a/dc_group/test/test_group_merge.py
+++ b/dc_group/test/test_group_merge.py
@@ -1,0 +1,466 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Tests for the Group merge rules (#497), extracted out of `GroupServer.publish_record`.
+
+Plain dicts in, plain dicts out — no ROS, no executor, no clock. The live-graph side of the
+same behaviour stays in `test_group_sync_timeout.py`, which CI drives on a real `GroupServer`.
+"""
+
+import json
+
+import pytest
+from dc_group.flatten import (
+    check_if_numbers_are_consecutive,
+    flatten,
+    unflatten,
+    unflatten_list,
+)
+from dc_group.group_merge import SEPARATOR, apply_exclude_keys, merge_records
+
+GROUP = "test_group"
+
+
+def cfg(**overrides):
+    """The group parameters the merge reads, at their declared defaults."""
+    group_cfg = {
+        "exclude_keys": [""],
+        "tags": ["dc"],
+        "nested_data": True,
+        "include_group_name": True,
+    }
+    group_cfg.update(overrides)
+    return group_cfg
+
+
+def payload(group_key, data):
+    return {"group_key": group_key, "data": data}
+
+
+def merge(payloads, **overrides):
+    return merge_records(payloads, GROUP, cfg(**overrides))
+
+
+# --- the merge itself ---------------------------------------------------------------------
+
+
+def test_members_merge_under_their_own_group_keys():
+    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})])
+
+    assert record == {
+        "a": {"used": 12.0},
+        "b": {"free": 34.0},
+        "tags": ["dc"],
+        "name": GROUP,
+    }
+
+
+def test_members_sharing_a_group_key_collapse_into_the_last_one():
+    # Pinning current behaviour: a member whose `group_key` equals another's silently
+    # replaces it, because the merge is a dict union keyed by `group_key`.
+    record = merge([payload("a", {"used": 1.0}), payload("a", {"used": 2.0})])
+
+    assert record["a"] == {"used": 2.0}
+
+
+def test_empty_member_data_is_kept_as_an_empty_object():
+    record = merge([payload("a", {}), payload("b", {"free": 1.0})])
+
+    assert record["a"] == {}
+    assert record["b"] == {"free": 1.0}
+
+
+def test_an_empty_group_key_leaves_the_members_keys_unprefixed():
+    # Pinning current behaviour: `flatten` treats an empty key as no key at all, so a
+    # member publishing an empty `group_key` lands at the top level of the Record.
+    record = merge([payload("", {"used": 12.0})])
+
+    assert record["used"] == 12.0
+    assert "a" not in record
+
+
+def test_merge_does_not_mutate_the_payloads_it_is_given():
+    payloads = [
+        payload("a", {"used": 12.0, "tags": ["x"], "incident_id": "incident-1"}),
+        payload("b", {"free": 34.0}),
+    ]
+
+    merge(payloads, tags=[""])
+
+    assert payloads[0]["data"] == {"used": 12.0, "tags": ["x"], "incident_id": "incident-1"}
+    assert payloads[1]["data"] == {"free": 34.0}
+
+
+# --- exclude_keys -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("exclude_keys", "kept"),
+    [
+        # The declared default: nothing excluded.
+        ([""], {"a.cpu", "a.cpuload", "ab.used", "b.free"}),
+        # A `*`-free entry is a key prefix, so it takes the member's whole subtree — and
+        # the *member* named `ab` with it, the prefix having no key boundary.
+        (["a"], {"b.free"}),
+        (["a.cpu"], {"ab.used", "b.free"}),
+        (["b"], {"a.cpu", "a.cpuload", "ab.used"}),
+        (["c"], {"a.cpu", "a.cpuload", "ab.used", "b.free"}),
+        # Entries compose: each one narrows what is left.
+        (["a", "b.free"], set()),
+        # The prefix has no key boundary: `a.cpu` also catches `a.cpuload`.
+        (["a.c"], {"ab.used", "b.free"}),
+        # `*` in an entry matches when every `*`-separated fragment appears in the key.
+        (["a.*"], {"ab.used", "b.free"}),
+        (["*load"], {"a.cpu", "ab.used", "b.free"}),
+        (["*.*"], set()),
+        (["*"], set()),
+        # The `b.` fragment lives inside the member named `ab`, so it takes that one too.
+        (["a.*", "b.*"], set()),
+    ],
+)
+def test_exclude_keys_filters_flattened_keys(exclude_keys, kept):
+    payloads = [
+        payload("a", {"cpu": 1.0, "cpuload": 2.0}),
+        payload("ab", {"used": 3.0}),
+        payload("b", {"free": 4.0}),
+    ]
+
+    record = merge(payloads, exclude_keys=exclude_keys, nested_data=False)
+
+    assert set(record) == kept | {"tags", "name"}
+
+
+def test_exclude_keys_glob_is_substring_matching_not_a_glob():
+    # Pinning current behaviour: the `*` branch splits and checks substrings, so a
+    # fragment matches anywhere in the key, in any position a glob would not allow.
+    record = merge([payload("a", {"used": 1.0})], exclude_keys=["u*d"])
+
+    assert set(record) == {"tags", "name"}
+
+
+def test_apply_exclude_keys_returns_the_flattened_keys():
+    flat = {"a.used": 1.0, "b.free": 2.0}
+
+    assert apply_exclude_keys(flat, ["a"]) == {"b.free": 2.0}
+    assert apply_exclude_keys(flat, []) == flat
+
+
+# --- nested_data --------------------------------------------------------------------------
+
+
+def test_nested_data_off_leaves_the_flattened_keys_in_the_record():
+    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})], nested_data=False)
+
+    assert record == {"a.used": 12.0, "b.free": 34.0, "tags": ["dc"], "name": GROUP}
+
+
+def test_lists_survive_the_flatten_round_trip():
+    record = merge([payload("a", {"samples": [1.0, 2.0]})])
+
+    assert record == {"a": {"samples": [1.0, 2.0]}, "tags": ["dc"], "name": GROUP}
+
+
+def test_deeply_nested_member_data_is_rebuilt():
+    record = merge([payload("a", {"pose": {"position": {"x": 1.0}}})])
+
+    assert record["a"] == {"pose": {"position": {"x": 1.0}}}
+
+
+# --- plugins --------------------------------------------------------------------------------
+
+
+def test_plugin_fields_are_collected_into_a_top_level_list():
+    record = merge(
+        [
+            payload("a", {"plugin": "cpu", "used": 1.0}),
+            payload("b", {"plugin": "memory", "free": 2.0}),
+        ]
+    )
+
+    assert record["plugins"] == ["cpu", "memory"]
+    # Collected, not lifted: the member keeps its own field.
+    assert record["a"]["plugin"] == "cpu"
+
+
+def test_plugins_key_is_absent_when_no_member_carries_one():
+    record = merge([payload("a", {"used": 1.0})])
+
+    assert "plugins" not in record
+
+
+def test_plugins_key_is_absent_when_collection_is_off():
+    record = merge_records(
+        [payload("a", {"plugin": "cpu", "used": 1.0})], GROUP, cfg(), collect_plugins=False
+    )
+
+    assert "plugins" not in record
+    assert record["a"] == {"plugin": "cpu", "used": 1.0}
+
+
+def test_plugins_keep_the_member_order_and_their_duplicates():
+    record = merge_records(
+        [
+            payload("a", {"plugin": "cpu"}),
+            payload("b", {"plugin": "cpu"}),
+            payload("c", {}),
+        ],
+        GROUP,
+        cfg(),
+    )
+
+    assert record["plugins"] == ["cpu", "cpu"]
+
+
+# --- tags -----------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "member_data",
+    [{"used": 12.0, "tags": ["measurement-tag"]}, {"used": 12.0}],
+    ids=["member-carries-tags", "member-has-no-tags"],
+)
+def test_record_carries_the_group_tags_not_the_members(member_data):
+    record = merge([payload("a", member_data)], tags=["robot-7"])
+
+    assert record["tags"] == ["robot-7"]
+
+
+def test_tags_key_is_present_even_when_the_group_declares_none():
+    record = merge([payload("a", {"used": 12.0})], tags=[""])
+
+    assert record["tags"] == [""]
+
+
+# --- incident_id ----------------------------------------------------------------------------
+
+
+def test_incident_id_is_lifted_to_the_records_top_level():
+    # Nested under the member's `group_key` it would become `a.incident_id`, which is no
+    # column any Destination table has — the Postgres sink drops it silently (#291).
+    record = merge(
+        [
+            payload("a", {"used": 12.0, "incident_id": "incident-42"}),
+            payload("b", {"free": 34.0, "incident_id": "incident-42"}),
+        ]
+    )
+
+    assert record["incident_id"] == "incident-42"
+    # Lifted, not copied: it must not also stay behind inside the members' own data.
+    assert record["a"] == {"used": 12.0}
+    assert record["b"] == {"free": 34.0}
+
+
+@pytest.mark.parametrize(
+    ("member_ids", "expected"),
+    [
+        # One FlushEvent mints one id for every Measurement listening: all agree.
+        (["incident-42", "incident-42"], "incident-42"),
+        # First non-null wins, so a partial Record built from a mix of released and live
+        # members still carries the id of the one that arrived.
+        ([None, "incident-42"], "incident-42"),
+        (["incident-42", None], "incident-42"),
+    ],
+)
+def test_first_non_null_incident_id_wins(member_ids, expected):
+    payloads = [
+        payload(group_key, {"incident_id": incident_id} if incident_id else {})
+        for group_key, incident_id in zip(["a", "b"], member_ids, strict=True)
+    ]
+
+    assert merge(payloads)["incident_id"] == expected
+
+
+def test_incident_id_is_absent_when_no_member_carries_one():
+    # A Record collected outside an incident leaves the column NULL, not empty or null.
+    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})])
+
+    assert "incident_id" not in record
+
+
+def test_an_empty_string_incident_id_is_still_lifted():
+    # Pinning current behaviour: the lift is on `is None`, so an empty string counts as an
+    # id and shadows a real one arriving from a later member.
+    record = merge(
+        [payload("a", {"incident_id": ""}), payload("b", {"incident_id": "incident-42"})]
+    )
+
+    assert record["incident_id"] == ""
+
+
+# --- the envelope ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "missing_inputs",
+    [[], None],
+    ids=["empty-list", "none"],
+)
+def test_a_complete_record_is_left_unmarked(missing_inputs):
+    record = merge_records([payload("a", {"used": 12.0})], GROUP, cfg(), missing_inputs)
+
+    assert "partial" not in record
+    assert "missing_inputs" not in record
+
+
+def test_a_partial_record_names_the_inputs_that_never_show_up():
+    record = merge_records(
+        [payload("a", {"used": 12.0})], GROUP, cfg(), missing_inputs=["/dc/test/b"]
+    )
+
+    assert record["partial"] is True
+    assert record["missing_inputs"] == ["/dc/test/b"]
+
+
+def test_missing_inputs_is_copied_not_aliased():
+    missing = ["/dc/test/b"]
+
+    record = merge_records([payload("a", {"used": 12.0})], GROUP, cfg(), missing)
+    missing.append("/dc/test/c")
+
+    assert record["missing_inputs"] == ["/dc/test/b"]
+
+
+def test_a_complete_record_keeps_its_pre_timeout_shape():
+    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})])
+
+    assert "partial" not in record
+    assert "missing_inputs" not in record
+
+
+def test_envelope_keys_are_appended_after_the_merged_data():
+    # The Group node serializes this dict straight to JSON, so its key order is the
+    # column order every Destination sees.
+    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})])
+
+    assert list(record) == ["a", "b", "tags", "name"]
+
+
+def test_envelope_keys_follow_the_same_order_without_the_optionals():
+    record = merge_records(
+        [payload("a", {"used": 12.0})],
+        GROUP,
+        cfg(include_group_name=False),
+        missing_inputs=["/dc/test/b"],
+    )
+
+    assert list(record) == ["a", "tags", "partial", "missing_inputs"]
+
+
+def test_serialized_record_is_stable():
+    record = merge(
+        [
+            payload("a", {"used": 12.0, "incident_id": "incident-42", "plugin": "cpu"}),
+            payload("b", {"free": 34.0, "incident_id": "incident-42"}),
+        ],
+        tags=["robot-7"],
+    )
+
+    assert json.dumps(record) == (
+        '{"a": {"plugin": "cpu", "used": 12.0}, "b": {"free": 34.0}, "tags": ["robot-7"], '
+        '"incident_id": "incident-42", "plugins": ["cpu"], "name": "test_group"}'
+    )
+
+
+# --- flatten / unflatten --------------------------------------------------------------------
+# First tests for the vendored `amirziai/flatten` copy: it decides the key of every column
+# every Destination sees, and upstream admits it "has not been tested extensively".
+
+
+def test_flatten_turns_nesting_into_separator_joined_keys():
+    assert flatten({"a": {"b": {"c": 1}}, "d": 2}, separator=SEPARATOR) == {
+        "a.b.c": 1,
+        "d": 2,
+    }
+
+
+def test_flatten_indexes_list_elements():
+    assert flatten({"a": {"samples": [10, [20, 30]]}}, separator=SEPARATOR) == {
+        "a.samples.0": 10,
+        "a.samples.1.0": 20,
+        "a.samples.1.1": 30,
+    }
+
+
+def test_flatten_flattens_tuples_like_lists():
+    assert flatten({"a": (1, 2)}, separator=SEPARATOR) == {"a.0": 1, "a.1": 2}
+
+
+def test_flatten_takes_an_empty_value_as_is():
+    assert flatten({"a": {}, "b": {"c": []}}, separator=SEPARATOR) == {"a": {}, "b.c": []}
+
+
+def test_flatten_of_an_empty_dict_is_empty():
+    assert flatten({}, separator=SEPARATOR) == {}
+
+
+def test_flatten_can_skip_root_keys():
+    assert flatten({"a": 1, "b": 2}, root_keys_to_ignore=["a"], separator=SEPARATOR) == {"b": 2}
+
+
+def test_flatten_requires_a_dictionary():
+    with pytest.raises(AssertionError, match="flatten requires a dictionary input"):
+        flatten([1, 2], separator=SEPARATOR)
+
+
+def test_unflatten_rebuilds_nesting():
+    assert unflatten({"a.b.c": 1, "a.d": 2, "e": 3}, separator=SEPARATOR) == {
+        "a": {"b": {"c": 1}, "d": 2},
+        "e": 3,
+    }
+
+
+def test_unflatten_requires_a_flat_dictionary():
+    with pytest.raises(AssertionError, match="provided dict is not flat"):
+        unflatten({"a": [1, 2]}, separator=SEPARATOR)
+
+
+def test_unflatten_silently_drops_a_key_nested_under_another():
+    # Pinning current behaviour: a scalar sitting at a prefix of another key is assumed to
+    # be an artifact and skipped, so `a` disappears from the Record.
+    assert unflatten({"a": 1, "a.b": 2}, separator=SEPARATOR) == {"a": {"b": 2}}
+
+
+def test_unflatten_list_rebuilds_lists_from_consecutive_indices():
+    assert unflatten_list({"a.samples.0": 10, "a.samples.1": 20}, separator=SEPARATOR) == {
+        "a": {"samples": [10, 20]}
+    }
+
+
+def test_unflatten_list_rebuilds_lists_of_dicts():
+    assert unflatten_list({"a.0.b": 1, "a.1.c": 2}, separator=SEPARATOR) == {
+        "a": [{"b": 1}, {"c": 2}]
+    }
+
+
+def test_unflatten_list_keeps_a_dict_when_indices_are_not_consecutive():
+    assert unflatten_list({"a.0": 1, "a.2": 3}, separator=SEPARATOR) == {"a": {"0": 1, "2": 3}}
+
+
+def test_unflatten_list_keeps_a_dict_of_non_numeric_keys():
+    assert unflatten_list({"a.x": 1, "a.y": 2}, separator=SEPARATOR) == {"a": {"x": 1, "y": 2}}
+
+
+def test_unflatten_list_of_an_empty_dict_is_empty():
+    assert unflatten_list({}, separator=SEPARATOR) == {}
+
+
+def test_unflatten_list_crashes_on_a_zero_padded_index():
+    # Pinning current behaviour: `00` is recognised as index 0 but then read back as the
+    # string `"0"`, so the round trip raises. A Measurement nesting a zero-padded key under
+    # a dict takes the Group node down with it.
+    with pytest.raises(KeyError):
+        unflatten_list({"a.00": 1}, separator=SEPARATOR)
+
+
+def test_unflatten_list_crashes_on_a_top_level_list():
+    # Pinning current behaviour: only nested lists are rebuilt — the root has no parent to
+    # replace the list in, so the conversion raises instead.
+    with pytest.raises(TypeError):
+        unflatten_list({"0.a": 1, "1.b": 2}, separator=SEPARATOR)
+
+
+def test_check_if_numbers_are_consecutive():
+    assert check_if_numbers_are_consecutive([0, 1, 2])
+    assert not check_if_numbers_are_consecutive([0, 2])
+    # Vacuously true: an empty dict of indices counts as a list.
+    assert check_if_numbers_are_consecutive([])


### PR DESCRIPTION
Closes #497

## Problem

`GroupServer.publish_record` held ~75 lines of pure dict-in/dict-out logic inside the node: the merge keyed by `group_key`, `exclude_keys` prefix and `*`-fragment filtering, flatten/unflatten, the `tags`/`incident_id`/`plugins`/`name` envelope assembly and the `partial`/`missing_inputs` marking. The only coverage was the live-graph suite, which drives a real `GroupServer` under a real executor — `exclude_keys`, `nested_data`, `plugins` and `include_group_name` had no test at all, and neither did the vendored `flatten.py` that decides the column name every Destination sees.

## Fix

New `dc_group/dc_group/group_merge.py`, which imports no `rclpy`, no messages and no clock:

- `merge_records(parsed_payloads, group, group_cfg, missing_inputs=None, collect_plugins=True) -> dict` — `parsed_payloads` is one `{"group_key": ..., "data": <parsed payload>}` entry per member, `group_cfg` is the group's parameter dict. Returns the finished Record payload, ready for `json.dumps`.
- `apply_exclude_keys(data_dict, exclude_keys) -> dict` — the prefix / `*`-fragment filter, extracted so it is testable on its own.

`GroupServer.publish_record` is now the edges only: parse the incoming `StringStamped` into payloads, take the stamp, call `merge_records`, serialize and publish. The synchroniser, the deadline-timer timeout and the purge machinery are untouched, and `test_group_sync_timeout.py` is untouched.

The nine-line `incident_id` pop-and-lift rationale (#291) moved with the code, and now has table tests instead of living only in a comment.

## Tests

New `dc_group/test/test_group_merge.py` — 61 cases, first tests for the merge rules and for `flatten.py`:

- basic merge, two members sharing a `group_key`, empty member data, empty `group_key`;
- `exclude_keys`: 12-case table over prefix and `*`-fragment entries, plus a case pinning that the `*` branch is substring matching rather than a real glob;
- `nested_data` on/off, lists and deep nesting surviving the flatten round trip;
- `plugins`: collected into a top-level list, kept inside the member too, absent when no member carries one, absent when `collect_plugins=False`, order and duplicates preserved;
- `tags`: the member's own are dropped, the group's win, the key is always present;
- `incident_id`: lifted to the top level and removed from the member's data, first non-null wins, absent when no member carries one, an empty string still lifted (pinned);
- envelope: `partial`/`missing_inputs` only on a partial Record, copied not aliased, key order pinned, and one test pinning the exact `json.dumps` string of a full Record;
- `flatten`/`unflatten`/`unflatten_list` directly, including their documented edge cases.

Byte-identical output: beyond the table tests, the pre-extraction `publish_record` body was transcribed verbatim into a throwaway harness and compared against `merge_records` over 20,000 randomized member sets × group configs (nested data, tags, `incident_id`, `plugin` fields, `exclude_keys` patterns, partials, `collect_plugins`), comparing the serialized payload — 20000/20000 identical, including identical exception types.

Local: `cd dc_group && uv run --project .. python -m pytest test/test_group_merge.py -q` → `61 passed` (no ROS install needed; `group_merge` imports with no `rclpy` in `sys.modules`).

CI's `build-workspace` job is the authoritative check of the live-graph suite, which needs a real ROS workspace (PR #493 precedent).

## Pinned behaviour worth a follow-up (not fixed here — this is a move, not a redesign)

- `group_measurement_plugins` is kept as a `Parameter` object and the old code tested its truthiness; a `Parameter` is always truthy, so the flag's value is ignored and plugins are always collected. The node now passes `bool(self.group_measurement_plugins)`, which is exactly that behaviour; `.value` would be a fix.
- `exclude_keys` entries containing `*` do substring matching on `*`-separated fragments, so `u*d` matches `a.used` and `b.*` matches a member named `ab`.
- `unflatten_list` raises `KeyError` on a zero-padded index (`{"a.00": 1}`) and `TypeError` on a top-level list (`{"0.a": 1}`) — either would take the Group node down from a Measurement payload with such a key.
- `unflatten` silently drops a scalar sitting at a prefix of another key (`{"a": 1, "a.b": 2}` → `{"a": {"b": 2}}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)