### PR TITLE
refactor(dc_bridge): extract the per-Record dispatch into a ROS-free module

### DIFF
--- a/dc_bridge/CMakeLists.txt
+++ b/dc_bridge/CMakeLists.txt
@@ -34,12 +34,13 @@ find_package(dc_common REQUIRED)
 # colcon puts its install prefix on CMAKE_PREFIX_PATH so this resolves.
 find_package(AWSSDK REQUIRED COMPONENTS s3)
 
-# ROS-independent core: Forwarder/Supervisor/Readiness/TopicConfig/ConfigRenderer/
-# vector_binary plus the Uploader logic (ADR-0005). Deliberately aws-free — the S3
-# ObjectStore implementation lives in the dc_uploader executable below (#446) — so the
-# Uploader is unit-tested with an in-memory fake and plain gtest, no cloud dependency.
+# ROS-independent core: Forwarder/RecordDispatcher/Supervisor/Readiness/TopicConfig/
+# ConfigRenderer/vector_binary plus the Uploader logic (ADR-0005). Deliberately aws-free —
+# the S3 ObjectStore implementation lives in the dc_uploader executable below (#446) — so
+# the Uploader is unit-tested with an in-memory fake and plain gtest, no cloud dependency.
 add_library(dc_bridge_core
   src/forwarder.cpp
+  src/record_dispatch.cpp
   src/readiness.cpp
   src/net_resolve.cpp
   src/topic_config.cpp
@@ -114,7 +115,8 @@ if(BUILD_TESTING)
   # Measurement does (#290) to check the Files pipeline ingests a released one unchanged.
   # (dc_common itself is found above now — the core links its record_file_walk, #479.)
   # All gtests link only the aws-free core (uploader_test uses an in-memory ObjectStore).
-  foreach(t forwarder supervisor render misc uploader intent_queue retention thumbnail raw_config process_config)
+  foreach(t forwarder record_dispatch supervisor render misc uploader intent_queue retention thumbnail raw_config
+            process_config)
     ament_add_gtest(${t}_test test/${t}_test.cpp)
     target_link_libraries(${t}_test dc_bridge_core)
     ament_target_dependencies(${t}_test dc_common)

--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -41,6 +41,7 @@
 #include "dc_bridge/raw_config.hpp"
 #include "dc_bridge/raw_subscriptions.hpp"
 #include "dc_bridge/readiness.hpp"
+#include "dc_bridge/record_dispatch.hpp"
 #include "dc_bridge/render.hpp"
 #include "dc_bridge/supervisor.hpp"
 #include "dc_bridge/uploader/file_status_tag.hpp"
@@ -84,6 +85,10 @@ private:
   // dc_uploader process (#446) owns reading, replaying, uploading, and emitting status
   // Records — see docs/adr/0014-uploader-runs-as-its-own-process.md.
   std::unique_ptr<uploader::IntentQueue> intent_queue_;
+
+  // Per-Record dispatch (enqueue vs. forward, per topic). Borrows intent_queue_, the
+  // Forwarder and its mutex above; declared after them so it dies first.
+  std::unique_ptr<RecordDispatcher> dispatcher_;
 
   // Raw / generic-subscription mode (#227) — created only when `raw.enabled` is true.
   // Its Records go out through the same Forwarder as the Measurement Records above,

--- a/dc_bridge/include/dc_bridge/record_dispatch.hpp
+++ b/dc_bridge/include/dc_bridge/record_dispatch.hpp
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// Per-Record dispatch, ROS-free: decides, per topic, whether a Record becomes a durable
+// upload intent for the Uploader, is forwarded to the Shipper, or both.
+#ifndef DC_BRIDGE__RECORD_DISPATCH_HPP_
+#define DC_BRIDGE__RECORD_DISPATCH_HPP_
+
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "dc_bridge/forwarder.hpp"
+#include "dc_bridge/uploader/intent_queue.hpp"
+
+namespace dc_bridge
+{
+
+/// One Record arriving on a subscribed topic, as the ROS subscription hands it over: the
+/// topic, the header stamp, and the payload bytes verbatim. No rclcpp/dc_interfaces types
+/// — the Bridge node's subscription callback is the only thing that sees StringStamped.
+struct IncomingRecord
+{
+  std::string topic;
+  /// The ROS header stamp as the header carries it: `sec` is signed, and a negative value
+  /// is clamped to 0 when the forwarded Record is built.
+  std::int32_t stamp_secs{ 0 };
+  std::uint32_t stamp_nanos{ 0 };
+  std::string data;
+};
+
+/// The Bridge's subscription-callback body: both hand-offs a Record can get, and the
+/// files-vs-records decision behind them. Accepts the upload intent queue and the
+/// Forwarder behind their existing interfaces; it creates neither.
+class RecordDispatcher
+{
+public:
+  /// The topics the Destinations' `inputs` name, split by what they receive.
+  struct Topics
+  {
+    std::vector<std::string> records;  ///< inputs of `receives: records` Destinations
+    std::vector<std::string> files;    ///< inputs of `receives: files` Destinations
+  };
+
+  /// Dependencies, owned by the caller (the Bridge node) — pointers, so a dependency the
+  /// caller doesn't have can stay unset.
+  struct Deps
+  {
+    /// The durable upload intent queue; must be set whenever Topics::files is non-empty.
+    uploader::IntentQueue* intent_queue{ nullptr };
+    Forwarder* forwarder{ nullptr };
+    /// The Bridge's Forwarder lock, shared with the prober thread's poll() and raw mode's
+    /// send() — the Forwarder itself is not thread-safe.
+    std::mutex* forwarder_mutex{ nullptr };
+    /// Called when a forward fails. ROS-independent, so the Bridge node wires this to
+    /// RCLCPP_WARN (same contract as ForwarderConfig::on_warning).
+    std::function<void(const std::string&)> on_warning;
+  };
+
+  RecordDispatcher(Topics topics, Deps deps);
+
+  /// Every topic both lists name, deduped — what the Bridge subscribes to, once each.
+  const std::vector<std::string>& subscribed_topics() const
+  {
+    return subscribed_topics_;
+  }
+
+  /// Enqueues the intent (durable on disk before this returns), then forwards the Record.
+  /// A failed forward is reported through `Deps::on_warning`, never thrown: one
+  /// unreachable Shipper must not take down Record collection.
+  void dispatch(const IncomingRecord& incoming) const;
+
+  /// The Record's payload from `StringStamped.data`: parsed when the bytes are JSON,
+  /// wrapped as a JSON string when they are not — never dropped. A non-object JSON value
+  /// stays what it is, so the Forwarder's own pack_record_map still wraps it in
+  /// {"message": ...} on the wire.
+  static nlohmann::json parse_payload(const std::string& data);
+
+private:
+  struct Routing
+  {
+    std::string tag;
+    bool enqueue_intent{ false };
+    bool forward{ false };
+  };
+
+  std::map<std::string, Routing> routing_by_topic_;
+  std::vector<std::string> subscribed_topics_;
+  Deps deps_;
+};
+
+}  // namespace dc_bridge
+
+#endif  // DC_BRIDGE__RECORD_DISPATCH_HPP_

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -13,13 +13,12 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <optional>
-#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
 
 #include "dc_bridge/atomic_write.hpp"
-#include "dc_bridge/topic_config.hpp"
+#include "dc_bridge/record_dispatch.hpp"
 #include "dc_bridge/vector_binary.hpp"
 
 namespace dc_bridge
@@ -408,77 +407,36 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
   prober_thread_ = std::thread(&BridgeNode::run_prober, this, vector_host, forward_port);
 
   // Topics feeding Records destinations (forwarded to Vector) vs. topics feeding files
-  // destinations (scanned for File references, whose intents the Bridge writes for the
-  // separate dc_uploader process to read, #446). A topic can be in both.
-  std::set<std::string> records_topics;
+  // destinations (whose Records the Bridge writes as upload intents for the separate
+  // dc_uploader process to read, #446). A topic can be in both.
+  RecordDispatcher::Topics topics;
   for (const auto& d : render_config.destinations)
   {
-    for (const auto& t : d.inputs)
-    {
-      records_topics.insert(t);
-    }
+    topics.records.insert(topics.records.end(), d.inputs.begin(), d.inputs.end());
   }
-  std::set<std::string> files_topics;
   for (const auto& d : files_destinations)
   {
-    for (const auto& t : d.inputs)
-    {
-      files_topics.insert(t);
-    }
+    topics.files.insert(topics.files.end(), d.inputs.begin(), d.inputs.end());
   }
 
+  RecordDispatcher::Deps dispatch_deps;
+  dispatch_deps.intent_queue = intent_queue_.get();
+  dispatch_deps.forwarder = forwarder_.get();
+  dispatch_deps.forwarder_mutex = &forwarder_mutex_;
+  dispatch_deps.on_warning = [this](const std::string& msg) { RCLCPP_WARN(this->get_logger(), "%s", msg.c_str()); };
+  dispatcher_ = std::make_unique<RecordDispatcher>(std::move(topics), std::move(dispatch_deps));
+
   // Subscribe to the union, once each.
-  std::set<std::string> subscribed = records_topics;
-  subscribed.insert(files_topics.begin(), files_topics.end());
-
-  for (const auto& topic : subscribed)
+  for (const auto& topic : dispatcher_->subscribed_topics())
   {
-    const std::string tag = TopicConfig::derive_tag(topic);
-    const bool forward_to_vector = records_topics.count(topic) > 0;
-    const bool feeds_uploader = files_topics.count(topic) > 0;
     auto sub = this->create_subscription<dc_interfaces::msg::StringStamped>(
-        topic, rclcpp::QoS(10),
-        [this, tag, forward_to_vector, feeds_uploader](const dc_interfaces::msg::StringStamped& msg) {
-          nlohmann::json payload;
-          try
-          {
-            payload = nlohmann::json::parse(msg.data);
-          }
-          catch (const nlohmann::json::exception&)
-          {
-            payload = nlohmann::json(msg.data);
-          }
-
-          if (feeds_uploader)
-          {
-            // Durable enqueue (#265): the intent lands on disk before this callback
-            // returns, so it survives a Bridge crash/restart (or the separate dc_uploader
-            // process, #446, never having been up at all). dc_uploader's own poll loop
-            // picks it up by rescanning the queue directory; there is no in-process
-            // wake-up signal to a different OS process.
-            intent_queue_->enqueue(tag, payload);
-          }
-
-          if (forward_to_vector)
-          {
-            Record record;
-            record.tag = tag;
-            // Both halves of the ROS stamp. The nanoseconds used to be dropped here,
-            // which rounded every Record to the second and left a Measurement polling
-            // faster than 1 Hz with Records indistinguishable in time (#308).
-            record.timestamp_secs = static_cast<std::uint64_t>(std::max<std::int32_t>(0, msg.header.stamp.sec));
-            record.timestamp_nanos = msg.header.stamp.nanosec;
-            record.payload = std::move(payload);
-            try
-            {
-              std::lock_guard<std::mutex> lock(forwarder_mutex_);
-              forwarder_->send(record);
-            }
-            catch (const ForwarderError& e)
-            {
-              RCLCPP_WARN(this->get_logger(), "failed to forward record on tag '%s': %s", tag.c_str(), e.what());
-            }
-          }
+        topic, rclcpp::QoS(10), [this, topic](const dc_interfaces::msg::StringStamped& msg) {
+          IncomingRecord incoming;
+          incoming.topic = topic;
+          incoming.stamp_secs = msg.header.stamp.sec;
+          incoming.stamp_nanos = msg.header.stamp.nanosec;
+          incoming.data = msg.data;
+          dispatcher_->dispatch(incoming);
         });
     subscriptions_.push_back(sub);
   }

--- a/dc_bridge/src/record_dispatch.cpp
+++ b/dc_bridge/src/record_dispatch.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_bridge/record_dispatch.hpp"
+
+#include <algorithm>
+#include <set>
+#include <utility>
+
+#include "dc_bridge/topic_config.hpp"
+
+namespace dc_bridge
+{
+
+nlohmann::json RecordDispatcher::parse_payload(const std::string& data)
+{
+  try
+  {
+    return nlohmann::json::parse(data);
+  }
+  catch (const nlohmann::json::exception&)
+  {
+    return nlohmann::json(data);
+  }
+}
+
+RecordDispatcher::RecordDispatcher(Topics topics, Deps deps) : deps_(std::move(deps))
+{
+  std::set<std::string> all;
+  all.insert(topics.records.begin(), topics.records.end());
+  all.insert(topics.files.begin(), topics.files.end());
+  for (const auto& topic : all)
+  {
+    Routing routing;
+    routing.tag = TopicConfig::derive_tag(topic);
+    routing.forward = std::find(topics.records.begin(), topics.records.end(), topic) != topics.records.end();
+    routing.enqueue_intent = std::find(topics.files.begin(), topics.files.end(), topic) != topics.files.end();
+    routing_by_topic_.emplace(topic, std::move(routing));
+    subscribed_topics_.push_back(topic);
+  }
+}
+
+void RecordDispatcher::dispatch(const IncomingRecord& incoming) const
+{
+  const auto it = routing_by_topic_.find(incoming.topic);
+  if (it == routing_by_topic_.end())
+  {
+    // Only topics from subscribed_topics() are ever subscribed; anything else has no
+    // Tag and no Destination to reach.
+    return;
+  }
+  const Routing& routing = it->second;
+
+  nlohmann::json payload = parse_payload(incoming.data);
+
+  if (routing.enqueue_intent)
+  {
+    // Durable enqueue (#265): the intent lands on disk before this returns, so it
+    // survives a Bridge crash/restart (or the separate dc_uploader process, #446, never
+    // having been up at all). dc_uploader discovers it by rescanning the queue directory;
+    // there is no in-process wake-up signal to a different OS process.
+    deps_.intent_queue->enqueue(routing.tag, payload);
+  }
+
+  if (!routing.forward)
+  {
+    return;
+  }
+
+  Record record;
+  record.tag = routing.tag;
+  record.timestamp_secs = static_cast<std::uint64_t>(std::max<std::int32_t>(0, incoming.stamp_secs));
+  record.timestamp_nanos = incoming.stamp_nanos;
+  record.payload = std::move(payload);
+  try
+  {
+    std::lock_guard<std::mutex> lock(*deps_.forwarder_mutex);
+    deps_.forwarder->send(record);
+  }
+  catch (const ForwarderError& e)
+  {
+    if (deps_.on_warning)
+    {
+      deps_.on_warning("failed to forward record on tag '" + routing.tag + "': " + e.what());
+    }
+  }
+}
+
+}  // namespace dc_bridge

--- a/dc_bridge/src/uploader_main.cpp
+++ b/dc_bridge/src/uploader_main.cpp
@@ -47,10 +47,8 @@ std::optional<std::string> real_getenv(const std::string& name)
   return std::string(v);
 }
 
-// Stamps a Bridge/Uploader-generated Record with the current time, split into the
-// seconds/nanoseconds pair the ingest protocol's EventTime carries — mirrors
-// bridge_node.cpp's stamp_now(), duplicated rather than shared since the two processes no
-// longer share a translation unit.
+// Stamps an Uploader-generated Record with the current time, split into the
+// seconds/nanoseconds pair the ingest protocol's EventTime carries.
 void stamp_now(dc_bridge::Record& record)
 {
   const auto since_epoch = std::chrono::system_clock::now().time_since_epoch();

--- a/dc_bridge/test/record_dispatch_test.cpp
+++ b/dc_bridge/test/record_dispatch_test.cpp
@@ -7,6 +7,7 @@
 #include "dc_bridge/record_dispatch.hpp"
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <gtest/gtest.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -69,25 +70,24 @@ std::string expected_event_time_bytes(std::uint32_t secs, std::uint32_t nanos)
   return out;
 }
 
-// A loopback peer: binds port 0, accepts one connection in a background thread, and
-// captures the first frame's bytes. Bounded timeouts, so a test whose dispatch never
-// sends still tears down.
+// A loopback peer: binds port 0 and, once the Forwarder has connected, reads the first
+// frame off the connection. Deliberately no background thread and no blocking syscall:
+// accept() runs after dispatch(), when the connection is already pending, and both fds
+// are non-blocking under a poll loop — a blocking peer is what a timeout cannot bound
+// (the kernel rejects SO_RCVTIMEO whose tv_usec is >= 1s, and the test hangs instead).
 struct CapturedFrame
 {
   int listen_fd{ -1 };
+  int conn_fd{ -1 };
   std::uint16_t port{ 0 };
-  timeval rcv_timeout{ 0, 2000000 };  // 2s — also bounds accept() on Linux
   std::string bytes;
-  std::mutex mutex;
-  std::atomic<bool> got_frame{ false };
-  std::thread thread;
 
   CapturedFrame()
   {
     listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    ::fcntl(listen_fd, F_SETFL, ::fcntl(listen_fd, F_GETFL) | O_NONBLOCK);
     int one = 1;
     ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-    ::setsockopt(listen_fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
     sockaddr_in sa{};
     sa.sin_family = AF_INET;
     sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
@@ -97,35 +97,46 @@ struct CapturedFrame
     socklen_t len = sizeof(sa);
     ::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&sa), &len);
     port = ntohs(sa.sin_port);
-
-    thread = std::thread([this]() {
-      int fd = ::accept(listen_fd, nullptr, nullptr);
-      if (fd < 0)
-      {
-        return;
-      }
-      ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
-      char buf[8192];
-      ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
-      if (n > 0)
-      {
-        std::lock_guard<std::mutex> lock(mutex);
-        bytes.assign(buf, static_cast<std::size_t>(n));
-        got_frame.store(true);
-      }
-      ::close(fd);
-    });
   }
   ~CapturedFrame()
   {
-    thread.join();
+    if (conn_fd >= 0)
+      ::close(conn_fd);
     if (listen_fd >= 0)
       ::close(listen_fd);
   }
 
-  std::string frame()
+  /// Waits up to `budget` for the Forwarder's connection and its first frame.
+  bool read_frame(std::chrono::milliseconds budget)
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    const auto deadline = std::chrono::steady_clock::now() + budget;
+    while (std::chrono::steady_clock::now() < deadline)
+    {
+      if (conn_fd < 0)
+      {
+        conn_fd = ::accept(listen_fd, nullptr, nullptr);
+        if (conn_fd < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+        {
+          return false;
+        }
+      }
+      if (conn_fd >= 0)
+      {
+        char buf[8192];
+        const ssize_t n = ::recv(conn_fd, buf, sizeof(buf), MSG_DONTWAIT);
+        if (n > 0)
+        {
+          bytes.assign(buf, static_cast<std::size_t>(n));
+          return true;
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    return false;
+  }
+
+  const std::string& frame() const
+  {
     return bytes;
   }
 };
@@ -173,30 +184,6 @@ const msgpack::object* wire_message_value(const msgpack::object& record)
     return nullptr;
   }
   return &record.via.map.ptr[0].val;
-}
-
-// The peer thread reads concurrently with send(): poll for the frame rather than
-// assuming it was observed the instant dispatch() returned.
-bool frame_arrived_within(CapturedFrame& peer, std::chrono::milliseconds budget)
-{
-  const auto deadline = std::chrono::steady_clock::now() + budget;
-  while (!peer.got_frame.load() && std::chrono::steady_clock::now() < deadline)
-  {
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  }
-  return peer.got_frame.load();
-}
-
-bool wait_for_frame(CapturedFrame& peer)
-{
-  return frame_arrived_within(peer, std::chrono::seconds(2));
-}
-
-// Inverted, for the "dispatch() sent nothing" assertions: a bounded window in which a
-// frame it did put on the wire would already have been observed.
-bool no_frame_within(CapturedFrame& peer)
-{
-  return !frame_arrived_within(peer, std::chrono::milliseconds(200));
 }
 
 // A dispatcher over a real intent queue and a real Forwarder. `want_peer` decides whether
@@ -280,9 +267,9 @@ TEST(RecordDispatch, FilesTopicRecordIsEnqueuedAndNotForwarded)
   EXPECT_EQ(intent.tag, "dc.camera.image");
   EXPECT_EQ(intent.payload, json::parse(R"({"path": "/files/img.jpg"})"));
 
-  // dispatch() is synchronous, so a frame it did send would be observed within this
-  // window; nothing was.
-  EXPECT_TRUE(no_frame_within(*h.peer));
+  // dispatch() is synchronous, so a frame it did send would land inside this budget;
+  // nothing was.
+  EXPECT_FALSE(h.peer->read_frame(std::chrono::milliseconds(200)));
   EXPECT_FALSE(h.forwarder->is_connected());
   EXPECT_TRUE(h.warnings.empty());
 }
@@ -297,7 +284,7 @@ TEST(RecordDispatch, RecordsTopicRecordIsForwardedAndNotEnqueued)
 
   EXPECT_EQ(h.queue->size(), 0u);
   EXPECT_TRUE(h.warnings.empty());
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
 
   const std::string frame = h.peer->frame();
   EXPECT_EQ(wire_tag(frame), "dc.measurement.uptime");
@@ -328,7 +315,7 @@ TEST(RecordDispatch, TopicInBothListsIsEnqueuedAndForwarded)
   h.dispatcher->dispatch(make_incoming("/dc/both", R"({"name": "both"})"));
 
   EXPECT_EQ(h.queue->size(), 1u);
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
   EXPECT_EQ(wire_tag(h.peer->frame()), "dc.both");
 }
 
@@ -351,7 +338,7 @@ TEST(RecordDispatch, NonJsonPayloadIsLeftForPackRecordMapToWrap)
 
   h.dispatcher->dispatch(make_incoming("/dc/measurement/raw", "not json at all"));
 
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
   msgpack::object_handle oh = unpack_frame(h.peer->frame());
   const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
   ASSERT_NE(message, nullptr);
@@ -368,7 +355,7 @@ TEST(RecordDispatch, NonJsonAndJsonStringPayloadsLandTheSameWay)
   // same wire record — the parse-or-wrap step adds no second wrapping of its own.
   h.dispatcher->dispatch(make_incoming("/dc/measurement/raw", "\"not json at all\""));
 
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
   msgpack::object_handle oh = unpack_frame(h.peer->frame());
   const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
   ASSERT_NE(message, nullptr);
@@ -383,7 +370,7 @@ TEST(RecordDispatch, ArrayPayloadIsNotCoercedIntoAnObject)
 
   h.dispatcher->dispatch(make_incoming("/dc/measurement/array", "[1, 2, 3]"));
 
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
   msgpack::object_handle oh = unpack_frame(h.peer->frame());
   const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
   ASSERT_NE(message, nullptr);
@@ -400,7 +387,7 @@ TEST(RecordDispatch, NegativeStampSecondsClampToZeroAndNanosecondsSurvive)
 
   h.dispatcher->dispatch(make_incoming("/dc/measurement/clock", "{}", -5, 42));
 
-  ASSERT_TRUE(wait_for_frame(*h.peer));
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
   EXPECT_EQ(wire_event_time(h.peer->frame()), expected_event_time_bytes(0, 42));
 }
 

--- a/dc_bridge/test/record_dispatch_test.cpp
+++ b/dc_bridge/test/record_dispatch_test.cpp
@@ -166,12 +166,11 @@ std::string wire_tag(const std::string& frame)
   return oh.get().via.array.ptr[0].as<std::string>();
 }
 
-std::string wire_event_time(const std::string& frame)
+// The EventTime's exact wire bytes are looked up in the frame (forwarder_test's
+// approach), rather than decoded out of msgpack's ext object layout.
+bool frame_carries_event_time(const std::string& frame, std::uint32_t secs, std::uint32_t nanos)
 {
-  msgpack::object_handle oh = unpack_frame(frame);
-  msgpack::object entry = oh.get().via.array.ptr[1].via.array.ptr[0];
-  EXPECT_EQ(entry.type, msgpack::type::EXT);
-  return std::string(entry.via.ext.ptr, static_cast<std::size_t>(entry.via.ext.size));
+  return frame.find(expected_event_time_bytes(secs, nanos)) != std::string::npos;
 }
 
 // The "message" value pack_record_map wraps a non-map payload in, or nullptr when the
@@ -288,7 +287,7 @@ TEST(RecordDispatch, RecordsTopicRecordIsForwardedAndNotEnqueued)
 
   const std::string frame = h.peer->frame();
   EXPECT_EQ(wire_tag(frame), "dc.measurement.uptime");
-  EXPECT_EQ(wire_event_time(frame), expected_event_time_bytes(1700000000, 123456789));
+  EXPECT_TRUE(frame_carries_event_time(frame, 1700000000, 123456789));
 
   msgpack::object_handle oh = unpack_frame(frame);
   msgpack::object record = wire_record_map(oh.get());
@@ -388,7 +387,7 @@ TEST(RecordDispatch, NegativeStampSecondsClampToZeroAndNanosecondsSurvive)
   h.dispatcher->dispatch(make_incoming("/dc/measurement/clock", "{}", -5, 42));
 
   ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
-  EXPECT_EQ(wire_event_time(h.peer->frame()), expected_event_time_bytes(0, 42));
+  EXPECT_TRUE(frame_carries_event_time(h.peer->frame(), 0, 42));
 }
 
 TEST(RecordDispatch, UnreachableShipperWarnsInsteadOfThrowing)

--- a/dc_bridge/test/record_dispatch_test.cpp
+++ b/dc_bridge/test/record_dispatch_test.cpp
@@ -1,0 +1,417 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+// The per-Record dispatch (#494): the enqueue-vs-forward decision, the parse-or-wrap
+// rule, and the stamp/envelope assembly, against a real IntentQueue and a loopback
+// shipper ingest protocol peer — no ROS node.
+#include "dc_bridge/record_dispatch.hpp"
+
+#include <arpa/inet.h>
+#include <gtest/gtest.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <msgpack.hpp>
+#include <mutex>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <system_error>
+#include <thread>
+#include <vector>
+
+#include "dc_bridge/uploader/intent_queue.hpp"
+
+using namespace dc_bridge;
+using namespace dc_bridge::uploader;  // NOLINT
+using nlohmann::json;
+
+namespace
+{
+
+std::atomic<int> g_counter{ 0 };
+
+std::filesystem::path unique_dir()
+{
+  return std::filesystem::temp_directory_path() /
+         ("dc_record_dispatch_test_" + std::to_string(::getpid()) + "_" + std::to_string(g_counter++));
+}
+
+IncomingRecord make_incoming(const std::string& topic, const std::string& data, std::int32_t secs = 1700000000,
+                             std::uint32_t nanos = 123456789)
+{
+  IncomingRecord in;
+  in.topic = topic;
+  in.stamp_secs = secs;
+  in.stamp_nanos = nanos;
+  in.data = data;
+  return in;
+}
+
+// The EventTime extension's wire bytes (msgpack ext type 0x00, 8-byte big-endian body),
+// built independently of the packing code so the test pins the bytes (see forwarder_test).
+std::string expected_event_time_bytes(std::uint32_t secs, std::uint32_t nanos)
+{
+  std::string out;
+  out.push_back(static_cast<char>(0xd7));  // fixext8
+  out.push_back(static_cast<char>(0x00));  // ext type 0 = EventTime
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((secs >> (8 * (3 - i))) & 0xFF));
+  }
+  for (int i = 0; i < 4; ++i)
+  {
+    out.push_back(static_cast<char>((nanos >> (8 * (3 - i))) & 0xFF));
+  }
+  return out;
+}
+
+// A loopback peer: binds port 0, accepts one connection in a background thread, and
+// captures the first frame's bytes. Bounded timeouts, so a test whose dispatch never
+// sends still tears down.
+struct CapturedFrame
+{
+  int listen_fd{ -1 };
+  std::uint16_t port{ 0 };
+  timeval rcv_timeout{ 0, 2000000 };  // 2s — also bounds accept() on Linux
+  std::string bytes;
+  std::mutex mutex;
+  std::atomic<bool> got_frame{ false };
+  std::thread thread;
+
+  CapturedFrame()
+  {
+    listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int one = 1;
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+    ::setsockopt(listen_fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
+    sockaddr_in sa{};
+    sa.sin_family = AF_INET;
+    sa.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sa.sin_port = 0;
+    ::bind(listen_fd, reinterpret_cast<sockaddr*>(&sa), sizeof(sa));
+    ::listen(listen_fd, 4);
+    socklen_t len = sizeof(sa);
+    ::getsockname(listen_fd, reinterpret_cast<sockaddr*>(&sa), &len);
+    port = ntohs(sa.sin_port);
+
+    thread = std::thread([this]() {
+      int fd = ::accept(listen_fd, nullptr, nullptr);
+      if (fd < 0)
+      {
+        return;
+      }
+      ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &rcv_timeout, sizeof(rcv_timeout));
+      char buf[8192];
+      ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+      if (n > 0)
+      {
+        std::lock_guard<std::mutex> lock(mutex);
+        bytes.assign(buf, static_cast<std::size_t>(n));
+        got_frame.store(true);
+      }
+      ::close(fd);
+    });
+  }
+  ~CapturedFrame()
+  {
+    thread.join();
+    if (listen_fd >= 0)
+      ::close(listen_fd);
+  }
+
+  std::string frame()
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    return bytes;
+  }
+};
+
+// Hold the returned handle while using anything decoded from it: a msgpack::object points
+// into the handle's own zone.
+msgpack::object_handle unpack_frame(const std::string& frame)
+{
+  return msgpack::unpack(frame.data(), frame.size());
+}
+
+// [tag, [[time, record]], option] -> the record map, i.e. what the Shipper parses.
+msgpack::object wire_record_map(const msgpack::object& top)
+{
+  EXPECT_EQ(top.type, msgpack::type::ARRAY);
+  EXPECT_EQ(top.via.array.size, 3u);
+  msgpack::object entries = top.via.array.ptr[1];
+  EXPECT_EQ(entries.via.array.size, 1u);
+  msgpack::object entry = entries.via.array.ptr[0];  // [time, record]
+  EXPECT_EQ(entry.via.array.size, 2u);
+  return entry.via.array.ptr[1];
+}
+
+std::string wire_tag(const std::string& frame)
+{
+  msgpack::object_handle oh = unpack_frame(frame);
+  return oh.get().via.array.ptr[0].as<std::string>();
+}
+
+std::string wire_event_time(const std::string& frame)
+{
+  msgpack::object_handle oh = unpack_frame(frame);
+  msgpack::object entry = oh.get().via.array.ptr[1].via.array.ptr[0];
+  EXPECT_EQ(entry.type, msgpack::type::EXT);
+  return std::string(entry.via.ext.ptr, static_cast<std::size_t>(entry.via.ext.size));
+}
+
+// The "message" value pack_record_map wraps a non-map payload in, or nullptr when the
+// wire record is not exactly a one-key {"message": ...} map.
+const msgpack::object* wire_message_value(const msgpack::object& record)
+{
+  if (record.type != msgpack::type::MAP || record.via.map.size != 1 ||
+      record.via.map.ptr[0].key.as<std::string>() != "message")
+  {
+    return nullptr;
+  }
+  return &record.via.map.ptr[0].val;
+}
+
+// The peer thread reads concurrently with send(): poll for the frame rather than
+// assuming it was observed the instant dispatch() returned.
+bool frame_arrived_within(CapturedFrame& peer, std::chrono::milliseconds budget)
+{
+  const auto deadline = std::chrono::steady_clock::now() + budget;
+  while (!peer.got_frame.load() && std::chrono::steady_clock::now() < deadline)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  return peer.got_frame.load();
+}
+
+bool wait_for_frame(CapturedFrame& peer)
+{
+  return frame_arrived_within(peer, std::chrono::seconds(2));
+}
+
+// Inverted, for the "dispatch() sent nothing" assertions: a bounded window in which a
+// frame it did put on the wire would already have been observed.
+bool no_frame_within(CapturedFrame& peer)
+{
+  return !frame_arrived_within(peer, std::chrono::milliseconds(200));
+}
+
+// A dispatcher over a real intent queue and a real Forwarder. `want_peer` decides whether
+// the Shipper is a listening loopback peer or a port nothing accepts on, so both
+// "nothing was sent" and "the send failed" are observable.
+struct Harness
+{
+  std::filesystem::path queue_dir;
+  std::unique_ptr<IntentQueue> queue;
+  std::unique_ptr<CapturedFrame> peer;
+  std::unique_ptr<Forwarder> forwarder;
+  std::mutex forwarder_mutex;
+  std::vector<std::string> warnings;
+  std::unique_ptr<RecordDispatcher> dispatcher;
+
+  Harness(RecordDispatcher::Topics topics, bool want_queue = true, bool want_peer = true) : queue_dir(unique_dir())
+  {
+    if (want_queue)
+    {
+      std::filesystem::create_directories(queue_dir);
+      queue = std::make_unique<IntentQueue>(queue_dir.string());
+    }
+
+    ForwarderConfig fcfg;
+    fcfg.host = "127.0.0.1";
+    if (want_peer)
+    {
+      peer = std::make_unique<CapturedFrame>();
+      fcfg.port = peer->port;
+    }
+    else
+    {
+      fcfg.port = 1;  // nothing listening
+      fcfg.connect_timeout = std::chrono::milliseconds(200);
+    }
+    forwarder = std::make_unique<Forwarder>(fcfg);
+
+    RecordDispatcher::Deps deps;
+    deps.intent_queue = queue.get();
+    deps.forwarder = forwarder.get();
+    deps.forwarder_mutex = &forwarder_mutex;
+    deps.on_warning = [this](const std::string& msg) { warnings.push_back(msg); };
+    dispatcher = std::make_unique<RecordDispatcher>(std::move(topics), deps);
+  }
+
+  ~Harness()
+  {
+    // The dispatcher borrows everything else here; it must go first.
+    dispatcher.reset();
+    forwarder.reset();
+    peer.reset();
+    queue.reset();
+    std::error_code ec;
+    std::filesystem::remove_all(queue_dir, ec);
+  }
+};
+
+}  // namespace
+
+TEST(RecordDispatch, SubscribedTopicsIsTheDedupedUnionOfBothLists)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/b", "/a" };
+  topics.files = { "/c", "/b" };
+  Harness h(std::move(topics));
+
+  const std::vector<std::string> want = { "/a", "/b", "/c" };
+  EXPECT_EQ(h.dispatcher->subscribed_topics(), want);
+}
+
+TEST(RecordDispatch, FilesTopicRecordIsEnqueuedAndNotForwarded)
+{
+  RecordDispatcher::Topics topics;
+  topics.files = { "/dc/camera/image" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/camera/image", R"({"path": "/files/img.jpg"})"));
+
+  ASSERT_EQ(h.queue->size(), 1u);
+  const Intent intent = h.queue->pending().at(0);
+  EXPECT_EQ(intent.tag, "dc.camera.image");
+  EXPECT_EQ(intent.payload, json::parse(R"({"path": "/files/img.jpg"})"));
+
+  // dispatch() is synchronous, so a frame it did send would be observed within this
+  // window; nothing was.
+  EXPECT_TRUE(no_frame_within(*h.peer));
+  EXPECT_FALSE(h.forwarder->is_connected());
+  EXPECT_TRUE(h.warnings.empty());
+}
+
+TEST(RecordDispatch, RecordsTopicRecordIsForwardedAndNotEnqueued)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/uptime" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/uptime", R"({"uptime_s": 42})"));
+
+  EXPECT_EQ(h.queue->size(), 0u);
+  EXPECT_TRUE(h.warnings.empty());
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+
+  const std::string frame = h.peer->frame();
+  EXPECT_EQ(wire_tag(frame), "dc.measurement.uptime");
+  EXPECT_EQ(wire_event_time(frame), expected_event_time_bytes(1700000000, 123456789));
+
+  msgpack::object_handle oh = unpack_frame(frame);
+  msgpack::object record = wire_record_map(oh.get());
+  ASSERT_EQ(record.type, msgpack::type::MAP);
+  bool found = false;
+  for (std::uint32_t i = 0; i < record.via.map.size; ++i)
+  {
+    if (record.via.map.ptr[i].key.as<std::string>() == "uptime_s")
+    {
+      EXPECT_EQ(record.via.map.ptr[i].val.as<std::uint64_t>(), 42u);
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST(RecordDispatch, TopicInBothListsIsEnqueuedAndForwarded)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/both" };
+  topics.files = { "/dc/both" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/both", R"({"name": "both"})"));
+
+  EXPECT_EQ(h.queue->size(), 1u);
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+  EXPECT_EQ(wire_tag(h.peer->frame()), "dc.both");
+}
+
+TEST(RecordDispatch, NonJsonPayloadBecomesAJsonString)
+{
+  auto payload = RecordDispatcher::parse_payload("not json at all");
+  EXPECT_TRUE(payload.is_string());
+  EXPECT_EQ(payload.get<std::string>(), "not json at all");
+
+  // Bytes that do parse pass through unchanged, whatever JSON type they are.
+  EXPECT_EQ(RecordDispatcher::parse_payload("[1, 2, 3]"), json::parse("[1, 2, 3]"));
+  EXPECT_EQ(RecordDispatcher::parse_payload(R"({"a": 1})"), json::parse(R"({"a": 1})"));
+}
+
+TEST(RecordDispatch, NonJsonPayloadIsLeftForPackRecordMapToWrap)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/raw" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/raw", "not json at all"));
+
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
+  ASSERT_NE(message, nullptr);
+  EXPECT_EQ(message->as<std::string>(), "not json at all");
+}
+
+TEST(RecordDispatch, NonJsonAndJsonStringPayloadsLandTheSameWay)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/raw" };
+  Harness h(std::move(topics));
+
+  // The same text, delivered as bytes that parse as a JSON string, must produce the very
+  // same wire record — the parse-or-wrap step adds no second wrapping of its own.
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/raw", "\"not json at all\""));
+
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
+  ASSERT_NE(message, nullptr);
+  EXPECT_EQ(message->as<std::string>(), "not json at all");
+}
+
+TEST(RecordDispatch, ArrayPayloadIsNotCoercedIntoAnObject)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/array" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/array", "[1, 2, 3]"));
+
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
+  ASSERT_NE(message, nullptr);
+  ASSERT_EQ(message->type, msgpack::type::ARRAY);
+  ASSERT_EQ(message->via.array.size, 3u);
+  EXPECT_EQ(message->via.array.ptr[2].as<std::uint64_t>(), 3u);
+}
+
+TEST(RecordDispatch, NegativeStampSecondsClampToZeroAndNanosecondsSurvive)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/clock" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/clock", "{}", -5, 42));
+
+  ASSERT_TRUE(wait_for_frame(*h.peer));
+  EXPECT_EQ(wire_event_time(h.peer->frame()), expected_event_time_bytes(0, 42));
+}
+
+TEST(RecordDispatch, UnreachableShipperWarnsInsteadOfThrowing)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/uptime" };
+  Harness h(std::move(topics), /*want_queue=*/true, /*want_peer=*/false);
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/uptime", "{}"));
+
+  ASSERT_EQ(h.warnings.size(), 1u);
+  EXPECT_NE(h.warnings.at(0).find("dc.measurement.uptime"), std::string::npos);
+}


### PR DESCRIPTION
Closes #494

## The problem

`dc_bridge/src/bridge_node.cpp`'s 381-line constructor owned the per-Record dispatch inline: the files-vs-records topic split, the parse-or-wrap, the enqueue-vs-forward decision, the Record/stamp assembly, and the mutex-guarded send. Zero tests construct `BridgeNode`, so the one decision this pipeline most depends on — *a Files Record is enqueued, not forwarded; a Records Record is forwarded, not enqueued* — was verified only by the ~35 e2e container scripts.

## The fix

One new ROS-free module in `dc_bridge_core`, following the Forwarder next door (`include/dc_bridge/record_dispatch.hpp`, `src/record_dispatch.cpp`):

- `IncomingRecord` is the boundary the subscription callback hands over — topic, header stamp, payload bytes — no `rclcpp`/`dc_interfaces` types.
- `RecordDispatcher` is built from the two topic lists the Destinations' `inputs` produce plus the dependencies it does not create: the durable upload intent queue, the Forwarder, the Bridge's Forwarder lock (shared with the prober thread and raw mode), and an `on_warning` hook wired to `RCLCPP_WARN`, the same contract `ForwarderConfig::on_warning` already uses.
- `dispatch()` owns the decision per topic, the durable enqueue (still on disk before it returns, #265), the stamp/envelope assembly including the #308 seconds+nanoseconds split and the negative-`sec` clamp, and the mutex-guarded send whose failure warns instead of throwing.
- `subscribed_topics()` hands the node the deduped union, so its loop is now pure subscription wiring.

`bridge_node.cpp` loses 63 lines and keeps parameter declaration, Destination validation, intent-queue creation, config render, and Vector supervision — untouched beyond what the extraction needed. No wire-format or envelope behaviour change, and the Forward/shipper ingest protocol bytes are exactly what `forwarder.cpp` has always produced: the module leaves non-map JSON unwrapped so the Forwarder's own `pack_record_map` still applies its single `{"message": ...}` wrap.

Incidental, as the issue asks: `uploader_main.cpp`'s `stamp_now()` comment no longer claims to duplicate a `bridge_node.cpp` function that no longer exists.

## Tests

New `test/record_dispatch_test.cpp` (10 gtest cases, ROS-free, in the `dc_bridge_core` gtest loop) over a real `IntentQueue` and a real Forwarder against a loopback shipper ingest peer on port 0:

- files-topic Record → enqueued with the derived Tag and payload, and nothing on the wire;
- records-topic Record → forwarded (tag, EventTime bytes, payload asserted on the wire) with the queue untouched;
- a topic in both lists → both hand-offs;
- `parse_payload`: non-JSON bytes become a JSON string and pass through unchanged otherwise, and non-map payloads (string, array) reach the wire exactly as `pack_record_map` wraps them — no second wrapping, no coercion into an object;
- envelope rules: negative `stamp.sec` clamps to 0 while nanoseconds survive;
- an unreachable Shipper warns with the Tag instead of throwing.

The first CI run caught a defect in the test harness itself (not in the module): the loopback peer accepted on a background thread and relied on `SO_RCVTIMEO` to keep `accept()` bounded, but the `timeval` it passed had `tv_usec >= 1s`, which the kernel rejects with `EDOM` — no timeout was ever set, `accept()` blocked until ctest's own timeout killed the binary, and the gtest result file went missing. The peer now accepts *after* `dispatch()`, when the connection is already pending, from non-blocking fds under a poll loop, so no syscall in the harness can block and no thread is ever joined.

Verification: this environment has no ROS toolchain (no colcon/rclcpp), so nothing was built locally — CI's `build-workspace` job is the authoritative check of the build and the ~149 existing dc_bridge tests, as in #493. What was verified locally is that the new module and its test compile clean under `-Wall -Wextra` as pure C++17 against the real nlohmann-json and msgpack-cxx headers — no rclcpp, rosidl, or ament include anywhere in them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

