### PR TITLE
refactor(tools/e2e): give the harness a topology seam and named verify profiles

### DIFF
--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -784,7 +784,17 @@ Not wired into `ci.yaml`, same as every scenario above.
 - `scripts/run.sh` — the one-command harness orchestrator described above. Builds the
   workspace + `dc-e2e` images locally, or runs a prebuilt `dc-e2e` image when handed one
   via `DC_E2E_IMAGE` (as CI's `e2e` job does).
+- `scripts/lib/harness.sh` — the shared skeleton every `run_*.sh` sources (#496): image
+  resolution, the cleanup trap, destination bring-up and readiness waits, volume
+  extraction, teardown. A scenario declares its topology once, to `harness_init`
+  (container/volume/network names, log captures, optionally a compose file), and the
+  harness does the rest — so a new scenario is a manifest plus its verify invocation.
 - `scripts/verify_zero_loss.py` — the hard-failing Postgres + passthrough verification.
+  `--profile` selects which scenario's verdicts it owns: `zero-loss` (default, the
+  checks below), `incident` (#291's, staged `armed`/`released` around the FlushEvent) or
+  `retention` (#267's, staged `shed`/`uploaded` around the store coming up). `--exec-sql`
+  runs one statement — `lib/harness.sh`'s `pg_exec()` shells out to it, so the module is
+  the only SQL author in the tree.
 - `scripts/measure_resources.sh` — the informational resource sampler.
 - `params/e2e_retention_params.yaml` / `scripts/run_retention.sh` — the files retention
   scenario (#267) described above; a separate, narrower harness reusing the same

--- a/tools/e2e/scripts/lib/harness.sh
+++ b/tools/e2e/scripts/lib/harness.sh
@@ -2,22 +2,33 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
-# Shared skeleton of the five e2e scenario scripts, run{,_split,_degraded,_incident,
-# _retention}.sh (#483): obtaining the DC image, the cleanup trap, destination bring-up
-# and readiness waits, volume extraction. Sourced, never executed — set -euo pipefail
-# comes from the caller.
+# Shared skeleton of the twelve e2e scenario scripts (#496): obtaining the DC image, the
+# cleanup trap, destination bring-up and readiness waits, volume extraction, teardown.
+# Sourced, never executed — set -euo pipefail comes from the caller.
 #
-# Contract with the sourcing script (set before the first call):
-#   PG_C, RUSTFS_C       destination container names (start_*/wait_*/pg_exec)
-#   RUN_DIR              teardown log captures land here
-#   remove_stack()       the caller's teardown — each scenario owns its own container,
-#                        volume (and, for run_split.sh, compose) cleanup
-#   HARNESS_TAG          log-line prefix (default "e2e")
-#   HARNESS_NETWORK      network for destinations, probes and the bucket CLI
-#                        (default "host")
-#   HARNESS_LOG_CAPTURES "container:file" pairs whose podman logs land in RUN_DIR on
-#                        teardown
-#   STATS_PID            optional resource-sampler PID killed on teardown
+# The scenario describes itself once, to harness_init, and everything else is a function
+# call — the harness reads nothing else out of the sourcing script, so a new scenario is
+# a manifest plus a verify invocation, with no pasted teardown:
+#
+#   source "$SCRIPT_DIR/lib/harness.sh"
+#   harness_init --tag e2e --run-dir "$RUN_DIR" --network host \
+#     --containers "$DC_C" "$PG_C" "$RUSTFS_C" \
+#     --volumes "${VOLUMES[*]}" \
+#     --log-captures "$DC_C:dc.log" \
+#     --pg-container "$PG_C" --rustfs-container "$RUSTFS_C"
+#
+#   --containers/--volumes/--teardown-networks/--log-captures  what remove_stack tears
+#       down and what harness_capture_logs saves on the way out ("container:file" pairs)
+#   --compose    a compose file to `down --volumes --remove-orphans` instead of removing
+#       containers one by one (its services and volumes *are* the manifest)
+#   --network    where destinations, probes and the bucket CLI run (default host);
+#       --teardown-networks lists the ones remove_stack deletes, which is the same network
+#       for every scenario that creates one and nothing for --network host
+#   --pg-container/--rust-container  opt into pg_exec/wait_postgres_ready/wait_rustfs_ready
+#
+# Outputs, not inputs: DC_IMAGE (resolve_image) and FIRST_RECORD_LATENCY
+# (wait_first_record). run_limits_drain_rate.sh overrides harness_rustfs_probe — the one
+# hook, because it has no DC image to probe with.
 
 HARNESS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 HARNESS_E2E_DIR="$(dirname "$HARNESS_SCRIPT_DIR")"
@@ -27,12 +38,141 @@ HARNESS_E2E_DIR="$(dirname "$HARNESS_SCRIPT_DIR")"
 # shellcheck disable=SC1091
 source "$HARNESS_SCRIPT_DIR/lib/version.sh"
 
-# rustfs/rustfs 1.0.0-beta.11 — pinned by digest, not :latest, so an upstream image
-# change can't silently alter harness behavior. Bump deliberately: check
-# https://hub.docker.com/r/rustfs/rustfs/tags for the new digest.
+# rustfs/rustfs 1.0.0-beta.11 — the one bash copy of the digest. Bump deliberately: check
+# https://hub.docker.com/r/rustfs/rustfs/tags for the new digest. compose.split.yaml and
+# compose.test.yaml carry their own literal (plain YAML can't source this, the same
+# reason compose.split.yaml's Vector tag keeps a literal default — see the vector-pin job).
 RUSTFS_IMAGE="docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c"
 
 log() { echo "[${HARNESS_TAG:-e2e} $(date -u +%H:%M:%S)] $*"; }
+
+# --- the manifest ---------------------------------------------------------------------
+
+HARNESS_STATS_PID=""
+
+# harness_init <manifest>: record the scenario's shape, create its run dir, install the
+# EXIT trap. List flags consume every following argument that isn't another flag.
+harness_init() {
+  HARNESS_TAG="e2e"
+  HARNESS_NETWORK="host"
+  HARNESS_RUN_DIR=""
+  HARNESS_COMPOSE_FILE=""
+  HARNESS_PG_C=""
+  HARNESS_RUSTFS_C=""
+  HARNESS_CONTAINERS=()
+  HARNESS_VOLUMES=()
+  HARNESS_TEARDOWN_NETWORKS=()
+  HARNESS_LOG_CAPTURES=()
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --tag)
+        [ "$#" -ge 2 ] || { log "harness_init: --tag needs a value"; return 1; }
+        HARNESS_TAG="$2"
+        shift 2
+        ;;
+      --run-dir|--network|--compose|--pg-container|--rustfs-container)
+        [ "$#" -ge 2 ] || { log "harness_init: $1 needs a value"; return 1; }
+        case "$1" in
+          --run-dir) HARNESS_RUN_DIR="$2" ;;
+          --network) HARNESS_NETWORK="$2" ;;
+          --compose) HARNESS_COMPOSE_FILE="$2" ;;
+          --pg-container) HARNESS_PG_C="$2" ;;
+          --rustfs-container) HARNESS_RUSTFS_C="$2" ;;
+        esac
+        shift 2
+        ;;
+      --containers|--volumes|--teardown-networks|--log-captures)
+        local flag="$1" list=()
+        shift
+        while [ "$#" -gt 0 ] && [ "${1#--}" = "$1" ]; do
+          list+=("$1")
+          shift
+        done
+        case "$flag" in
+          --containers) HARNESS_CONTAINERS=("${list[@]}") ;;
+          --volumes) HARNESS_VOLUMES=("${list[@]}") ;;
+          --teardown-networks) HARNESS_TEARDOWN_NETWORKS=("${list[@]}") ;;
+          --log-captures) HARNESS_LOG_CAPTURES=("${list[@]}") ;;
+        esac
+        ;;
+      *)
+        log "harness_init: unknown flag $1"
+        return 1
+        ;;
+    esac
+  done
+
+  [ -n "$HARNESS_RUN_DIR" ] || { log "harness_init: --run-dir is required"; return 1; }
+  mkdir -p "$HARNESS_RUN_DIR"
+  trap harness_cleanup EXIT
+}
+
+# The resource sampler's PID (measure_resources.sh) — unknown until the sampler starts,
+# so set after harness_init. harness_cleanup kills it only if it is still running.
+harness_stats_pid() { HARNESS_STATS_PID="$1"; }
+
+# --- teardown -------------------------------------------------------------------------
+
+# Building blocks remove_stack is made of, exposed for a scenario that tears a phase down
+# mid-run (run_limits_shipper_fanin.sh) with the same teardown-safe semantics: a name that
+# doesn't exist is not an error, a real failure still is.
+harness_rm_containers() { [ "$#" -eq 0 ] || podman rm -f --ignore "$@" >/dev/null; }
+
+harness_rm_volumes() {
+  local v
+  for v in "$@"; do
+    if podman volume exists "$v"; then
+      podman volume rm "$v" >/dev/null
+    fi
+  done
+}
+
+harness_rm_networks() {
+  local n
+  for n in "$@"; do
+    podman network rm "$n" >/dev/null 2>&1 || true
+  done
+}
+
+# Podman logs for every --log-captures pair, into the manifest's run dir.
+harness_capture_logs() {
+  local pair container
+  for pair in "${HARNESS_LOG_CAPTURES[@]}"; do
+    container="${pair%%:*}"
+    if podman container exists "$container"; then
+      podman logs "$container" > "$HARNESS_RUN_DIR/${pair##*:}" 2>&1 || true
+    fi
+  done
+}
+
+remove_stack() {
+  if [ -n "$HARNESS_COMPOSE_FILE" ]; then
+    podman compose -f "$HARNESS_COMPOSE_FILE" down --volumes --remove-orphans >/dev/null 2>&1 || true
+  fi
+  harness_rm_containers "${HARNESS_CONTAINERS[@]}"
+  harness_rm_volumes "${HARNESS_VOLUMES[@]}"
+  harness_rm_networks "${HARNESS_TEARDOWN_NETWORKS[@]}"
+}
+
+# The EXIT trap harness_init installs: kill a running resource sampler, honour DC_E2E_KEEP,
+# capture the --log-captures logs, then remove the manifest's stack.
+harness_cleanup() {
+  local exit_code=$?
+  if [ -n "$HARNESS_STATS_PID" ] && kill -0 "$HARNESS_STATS_PID" 2>/dev/null; then
+    kill "$HARNESS_STATS_PID"
+  fi
+  if [ "$exit_code" -ne 0 ] && [ "${DC_E2E_KEEP:-false}" = "true" ]; then
+    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
+    exit "$exit_code"
+  fi
+  log "tearing down"
+  harness_capture_logs
+  remove_stack
+  exit "$exit_code"
+}
+
+# --- the DC image ---------------------------------------------------------------------
 
 # Sets DC_IMAGE: DC_E2E_IMAGE (prebuilt, no build) > DC_WORKSPACE_IMAGE (prebuilt base)
 # > a local build.sh + Containerfile.e2e. CI's e2e jobs set DC_E2E_IMAGE to the :<sha>
@@ -60,38 +200,20 @@ resolve_image() {
   fi
 }
 
-# The EXIT trap: kill a running resource sampler, honour DC_E2E_KEEP, capture the
-# HARNESS_LOG_CAPTURES logs, then run the caller's remove_stack. Install with
-# `trap harness_cleanup EXIT`.
-harness_cleanup() {
-  local exit_code=$?
-  if [ -n "${STATS_PID:-}" ] && kill -0 "$STATS_PID" 2>/dev/null; then
-    kill "$STATS_PID"
-  fi
-  if [ "$exit_code" -ne 0 ] && [ "${DC_E2E_KEEP:-false}" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  local pair container
-  for pair in ${HARNESS_LOG_CAPTURES[@]+"${HARNESS_LOG_CAPTURES[@]}"}; do
-    container="${pair%%:*}"
-    if podman container exists "$container"; then
-      podman logs "$container" > "$RUN_DIR/${pair##*:}" 2>&1 || true
-    fi
-  done
-  remove_stack
-  exit "$exit_code"
-}
+# --- destinations ---------------------------------------------------------------------
 
+# One way for bash to run SQL: verify_zero_loss.py owns query execution (and every
+# scenario's Record assertions), and this shells out to it — one psql seam for the whole
+# e2e tree, not an implementation here and another in the module. Needs --pg-container.
 pg_exec() {
-  podman exec "$PG_C" psql -U dc -d dc -tAc "$1"
+  python3 "$HARNESS_SCRIPT_DIR/verify_zero_loss.py" \
+    --postgres-container "$HARNESS_PG_C" --exec-sql "$1"
 }
 
 # start_postgres <pgdata-volume>: the destination Postgres, with sql/init.sql applied
 # on the volume's first boot.
 start_postgres() {
-  podman run -d --network "${HARNESS_NETWORK:-host}" --name "$PG_C" \
+  podman run -d --network "$HARNESS_NETWORK" --name "$HARNESS_PG_C" \
     -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
     -v "$1:/var/lib/postgresql/data" \
     -v "$HARNESS_E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
@@ -99,35 +221,51 @@ start_postgres() {
 }
 
 start_rustfs() {
-  podman run -d --network "${HARNESS_NETWORK:-host}" --name "$RUSTFS_C" \
+  podman run -d --network "$HARNESS_NETWORK" --name "$HARNESS_RUSTFS_C" \
     -v "$1:/data" \
     "$RUSTFS_IMAGE" >/dev/null
 }
 
 # Deliberately not pg_isready: the postgres image applies /docker-entrypoint-initdb.d
 # against a *temporary* server that pg_isready happily answers, racing init.sql. Waiting
-# for dc_records to resolve gates on the only state that matters — the real server is up
+# for the table to resolve gates on the only state that matters — the real server is up
 # and init.sql applied.
 wait_postgres_ready() {
   local timeout="${1:-120}"
-  timeout "$timeout" bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
-    || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+  local deadline=$(( $(date +%s) + timeout ))
+  until [ -n "$(pg_exec "SELECT to_regclass('public.dc_records')" 2>/dev/null || true)" ]; do
+    [ "$(date +%s)" -lt "$deadline" ] \
+      || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
+    sleep 2
+  done
+}
+
+# How the harness proves RustFS accepts connections on HARNESS_NETWORK. One hook: the
+# default probes from a one-off container on the DC image, and run_limits_drain_rate.sh
+# — which has no DC image at all — overrides it to probe from the Shipper image instead.
+harness_rustfs_probe() {
+  podman run --rm --network "$HARNESS_NETWORK" --entrypoint python3 "$DC_IMAGE" \
+    /opt/e2e/measure_rtt.py "$HARNESS_RUSTFS_C" 9000 --count 1 --timeout 2 >/dev/null 2>&1
 }
 
 # On the host network RustFS is probed directly; otherwise from a one-off container on
-# HARNESS_NETWORK. That probe needs --entrypoint python3: the image's own ENTRYPOINT is
-# entrypoint.sh (the full DC stack), so without the override the probe args land as
-# extra ros2-launch arguments and the container always exits non-zero regardless of
-# RustFS's actual reachability.
+# HARNESS_NETWORK. That probe needs --entrypoint python3 (or bash): the DC image's own
+# ENTRYPOINT is entrypoint.sh (the full DC stack), so without the override the probe args
+# land as extra ros2-launch arguments and the container always exits non-zero regardless
+# of RustFS's actual reachability.
 wait_rustfs_ready() {
   local timeout="${1:-60}"
-  if [ "${HARNESS_NETWORK:-host}" = "host" ]; then
+  if [ "$HARNESS_NETWORK" = "host" ]; then
     timeout "$timeout" bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
       || { log "FAIL: RustFS never became ready"; exit 1; }
   else
     log "waiting for RustFS to accept TCP connections on $HARNESS_NETWORK"
-    timeout "$timeout" bash -c "until podman run --rm --network $HARNESS_NETWORK --entrypoint python3 '$DC_IMAGE' /opt/e2e/measure_rtt.py $RUSTFS_C 9000 --count 1 --timeout 2 >/dev/null 2>&1; do sleep 1; done" \
-      || { log "FAIL: RustFS never became reachable on $HARNESS_NETWORK"; exit 1; }
+    local deadline=$(( $(date +%s) + timeout ))
+    until harness_rustfs_probe; do
+      [ "$(date +%s)" -lt "$deadline" ] \
+        || { log "FAIL: RustFS never became reachable on $HARNESS_NETWORK"; exit 1; }
+      sleep 1
+    done
   fi
 }
 
@@ -135,7 +273,7 @@ wait_rustfs_ready() {
 # Uploader uses (aws-sdk-cpp), so no extra vendor in the loop. Neither the S3 sink nor
 # the Uploader creates the bucket; someone has to.
 create_rustfs_bucket() {
-  podman run --rm --network "${HARNESS_NETWORK:-host}" \
+  podman run --rm --network "$HARNESS_NETWORK" \
     -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
     docker.io/amazon/aws-cli:latest \
     --endpoint-url "$1" s3 mb s3://dc-e2e
@@ -148,4 +286,27 @@ extract_from_volume() {
   local volume="$1" entrypoint="$2"
   shift 2
   podman run --rm --entrypoint "$entrypoint" -v "$volume:/vol:ro" "$DC_IMAGE" "$@"
+}
+
+# --- the launch-to-first-Record gate --------------------------------------------------
+
+# wait_first_record <timeout> <start-ts> <context>: poll dc_records every 0.2s until the
+# first Record lands, and print the seconds it took since <start-ts> — the caller's, so the
+# measurement covers whatever the caller is timing (the launch of the whole stack, or the
+# late start of the Shipper). No Record within <timeout> logs FAIL with <context> and
+# exits: the three scenario scripts each used to carry this loop verbatim.
+wait_first_record() {
+  local timeout="$1" start="$2" context="$3"
+  local deadline count
+  deadline="$(echo "$start + $timeout" | bc)"
+  while (( $(echo "$(date +%s.%N) < $deadline" | bc) )); do
+    count="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
+    if [ "${count:-0}" -gt 0 ] 2>/dev/null; then
+      echo "$(date +%s.%N) - $start" | bc
+      return 0
+    fi
+    sleep 0.2
+  done
+  log "FAIL: no Record landed in Postgres within ${timeout}s $context" >&2
+  exit 1
 }

--- a/tools/e2e/scripts/run.sh
+++ b/tools/e2e/scripts/run.sh
@@ -41,8 +41,8 @@
 #                                locally-built dc-e2e image (skips build.sh). Ignored when
 #                                DC_E2E_IMAGE is set. Unset: build.sh builds it.
 #
-# The shared harness skeleton (image resolution, cleanup trap, destination bring-up and
-# readiness waits, volume extraction) lives in lib/harness.sh.
+# The shared harness skeleton (lib/harness.sh) owns the image resolution, the cleanup
+# trap, destination bring-up and readiness waits, volume extraction and teardown.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -72,23 +72,17 @@ VOLUMES=(dc_e2e_pgdata dc_e2e_rustfs_data dc_e2e_buffer dc_e2e_uploader dc_e2e_d
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-remove_stack() {
-  # --ignore makes "no such container" a clean success while still surfacing real errors
-  # (a broken podman, a container that won't die); likewise only remove volumes that exist.
-  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
-  for v in "${VOLUMES[@]}"; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-}
-
-# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
-HARNESS_LOG_CAPTURES=("$DC_C:dc.log")
-trap harness_cleanup EXIT
+harness_init \
+  --tag e2e \
+  --run-dir "$RUN_DIR" \
+  --network host \
+  --containers "$DC_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${VOLUMES[*]}" \
+  --log-captures "$DC_C:dc.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image ------------------------------------------------------
 DC_IMAGE="" # set by resolve_image
@@ -110,7 +104,7 @@ create_rustfs_bucket http://127.0.0.1:9000
 # Resource usage (CPU/RSS) is informational per the PRD, not gating — sampled for the
 # whole run so tools/e2e/scripts/measure_resources.sh's summary covers steady state.
 "$SCRIPT_DIR/measure_resources.sh" "$RUN_DIR/resource_usage.csv" &
-STATS_PID=$!
+harness_stats_pid "$!"
 
 # --- start the DC stack, measure launch-to-first-Record -----------------------------
 log "starting the DC stack — measuring launch-to-first-Record latency"
@@ -121,21 +115,8 @@ podman run -d --network host --name "$DC_C" \
   -v dc_e2e_data:/root/.dc/e2e/data \
   "$DC_IMAGE" >/dev/null
 
-FIRST_RECORD_LATENCY=""
-DEADLINE=$(echo "$START_TS + $STARTUP_TIMEOUT_SECONDS + 5" | bc)
-while (( $(echo "$(date +%s.%N) < $DEADLINE" | bc) )); do
-  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
-  if [ "${COUNT:-0}" -gt 0 ] 2>/dev/null; then
-    FIRST_RECORD_LATENCY=$(echo "$(date +%s.%N) - $START_TS" | bc)
-    break
-  fi
-  sleep 0.2
-done
-
-if [ -z "$FIRST_RECORD_LATENCY" ]; then
-  log "FAIL: no Record landed in Postgres within $((STARTUP_TIMEOUT_SECONDS + 5))s of starting the stack"
-  exit 1
-fi
+FIRST_RECORD_LATENCY="$(wait_first_record \
+  "$((STARTUP_TIMEOUT_SECONDS + 5))" "$START_TS" "of starting the stack")"
 log "first Record landed after ${FIRST_RECORD_LATENCY}s"
 if (( $(echo "$FIRST_RECORD_LATENCY > $STARTUP_TIMEOUT_SECONDS" | bc) )); then
   log "FAIL: startup latency ${FIRST_RECORD_LATENCY}s exceeds the ${STARTUP_TIMEOUT_SECONDS}s gate"
@@ -165,10 +146,7 @@ log "stopping the workload so counts settle before verification"
 podman stop "$DC_C" >/dev/null
 sleep 5
 
-if [ -n "$STATS_PID" ] && kill -0 "$STATS_PID" 2>/dev/null; then
-  kill "$STATS_PID"
-fi
-STATS_PID=""
+harness_stats_pid ""
 
 # --- durable upload intent queue (#265) ----------------------------------------------
 # The outage+restart above is this harness's stand-in for #265's own e2e acceptance

--- a/tools/e2e/scripts/run_degraded.sh
+++ b/tools/e2e/scripts/run_degraded.sh
@@ -90,30 +90,22 @@ PG_C=dc_e2e_deg_postgres
 RUSTFS_C=dc_e2e_deg_rustfs
 DC_C=dc_e2e_deg_dc
 VOLUMES=(dc_e2e_deg_pgdata dc_e2e_deg_rustfs_data dc_e2e_deg_buffer dc_e2e_deg_data)
-# shellcheck disable=SC2034  # consumed by lib/harness.sh
-HARNESS_TAG=e2e-degraded
-# shellcheck disable=SC2034
-HARNESS_NETWORK="$NET"
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-remove_stack() {
-  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
-  for v in "${VOLUMES[@]}"; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-  podman network rm "$NET" >/dev/null 2>&1 || true
-}
-
-# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
-HARNESS_LOG_CAPTURES=("$DC_C:dc_degraded.log")
-trap harness_cleanup EXIT
+harness_init \
+  --tag e2e-degraded \
+  --run-dir "$RUN_DIR" \
+  --network "$NET" \
+  --containers "$DC_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${VOLUMES[*]}" \
+  --teardown-networks "$NET" \
+  --log-captures "$DC_C:dc_degraded.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- resolve the network profile (scripts/network_profiles.py — one declarative place) --
 log "resolving network profile '$PROFILE_NAME'"
@@ -255,21 +247,8 @@ podman run -d --network "$NET" --name "$DC_C" \
   -v "$E2E_DIR/params/e2e_degraded_pgsql_sink.toml:/opt/e2e/e2e_degraded_pgsql_sink.toml:ro" \
   "$DC_IMAGE" >/dev/null
 
-FIRST_RECORD_LATENCY=""
-DEADLINE=$(echo "$START_TS + $STARTUP_TIMEOUT_SECONDS + 5" | bc)
-while (( $(echo "$(date +%s.%N) < $DEADLINE" | bc) )); do
-  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
-  if [ "${COUNT:-0}" -gt 0 ] 2>/dev/null; then
-    FIRST_RECORD_LATENCY=$(echo "$(date +%s.%N) - $START_TS" | bc)
-    break
-  fi
-  sleep 0.2
-done
-
-if [ -z "$FIRST_RECORD_LATENCY" ]; then
-  log "FAIL: no Record landed in Postgres within $((STARTUP_TIMEOUT_SECONDS + 5))s of starting the stack"
-  exit 1
-fi
+FIRST_RECORD_LATENCY="$(wait_first_record \
+  "$((STARTUP_TIMEOUT_SECONDS + 5))" "$START_TS" "of starting the stack")"
 log "first Record landed after ${FIRST_RECORD_LATENCY}s"
 if (( $(echo "$FIRST_RECORD_LATENCY > $STARTUP_TIMEOUT_SECONDS" | bc) )); then
   log "FAIL: startup latency ${FIRST_RECORD_LATENCY}s exceeds the ${STARTUP_TIMEOUT_SECONDS}s gate"

--- a/tools/e2e/scripts/run_incident.sh
+++ b/tools/e2e/scripts/run_incident.sh
@@ -39,7 +39,9 @@
 #
 # The shared harness skeleton (image resolution, cleanup trap, Postgres bring-up and its
 # init.sql-aware readiness wait) lives in lib/harness.sh. No RustFS here: both Measurements
-# route to Postgres only.
+# route to Postgres only. Every Record assertion lives in verify_zero_loss.py's `incident`
+# profile (#496) — this script's own jobs are the topology, the FlushEvent, and the two
+# bounded waits those assertions sit on the far side of.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -60,27 +62,20 @@ LIVE_TAG="dc.measurement.memory"
 PG_C=dc_e2e_inc_postgres
 DC_C=dc_e2e_inc_dc
 VOLUMES=(dc_e2e_inc_pgdata dc_e2e_inc_buffer dc_e2e_inc_data)
-# shellcheck disable=SC2034  # consumed by lib/harness.sh
-HARNESS_TAG=e2e-incident
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-remove_stack() {
-  podman rm -f --ignore "$DC_C" "$PG_C" >/dev/null
-  for v in "${VOLUMES[@]}"; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-}
-
-# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
-HARNESS_LOG_CAPTURES=("$DC_C:dc_incident.log")
-trap harness_cleanup EXIT
+harness_init \
+  --tag e2e-incident \
+  --run-dir "$RUN_DIR" \
+  --network host \
+  --containers "$DC_C" "$PG_C" \
+  --volumes "${VOLUMES[*]}" \
+  --log-captures "$DC_C:dc_incident.log" \
+  --pg-container "$PG_C"
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ------------------
 DC_IMAGE="" # set by resolve_image
@@ -93,15 +88,6 @@ log "starting Postgres (sql/init.sql — dc_records has the incident_id column u
 start_postgres dc_e2e_inc_pgdata
 wait_postgres_ready
 
-# The column has to be a column. A table without it would make every assertion below fail
-# for a reason that has nothing to do with the pipeline, so say so here instead.
-COLUMN_TYPE="$(pg_exec "SELECT data_type FROM information_schema.columns WHERE table_name = 'dc_records' AND column_name = 'incident_id'" | tr -d '[:space:]')"
-if [ "$COLUMN_TYPE" != "text" ]; then
-  log "FAIL: dc_records has no text incident_id column (got '${COLUMN_TYPE:-none}') — check sql/init.sql"
-  exit 1
-fi
-log "PASS: dc_records.incident_id exists as a text column"
-
 # --- DC stack --------------------------------------------------------------------------
 log "starting the DC stack (uptime armed with buffer_duration_sec, memory collecting live)"
 podman run -d --network host --name "$DC_C" \
@@ -111,38 +97,19 @@ podman run -d --network host --name "$DC_C" \
   -v "$E2E_DIR/params/e2e_incident_pgsql_sink.toml:/opt/e2e/e2e_incident_pgsql_sink.toml:ro" \
   "$DC_IMAGE" >/dev/null
 
-# A count query that reads 0 rather than aborting the run while Postgres/the table is still
-# settling — every call site is inside a deadline loop that fails loudly on its own.
-pg_count() {
-  pg_exec "$1" 2>/dev/null | tr -d '[:space:]' || true
-}
-
 # --- 1. armed means silent, live means flowing -------------------------------------------
-log "waiting up to ${LIVE_TIMEOUT_SECONDS}s for the live Measurement's first rows"
-DEADLINE=$(( $(date +%s) + LIVE_TIMEOUT_SECONDS ))
-LIVE_COUNT=0
-while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-  LIVE_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$LIVE_TAG'")"
-  # Several rows, not one: enough collection has gone by that an unarmed Measurement would
-  # have shipped several Records too, which is what makes the armed one's silence meaningful.
-  if [ "${LIVE_COUNT:-0}" -ge 5 ] 2>/dev/null; then
-    break
-  fi
-  sleep 2
-done
-
-if [ "${LIVE_COUNT:-0}" -lt 5 ] 2>/dev/null; then
-  log "FAIL: the live Measurement produced only ${LIVE_COUNT:-0} rows in ${LIVE_TIMEOUT_SECONDS}s — the pipeline is not running"
-  exit 1
-fi
-log "PASS: ${LIVE_COUNT} live rows — the pipeline is delivering to Postgres"
-
-BUFFERED_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$BUFFERED_TAG'")"
-if [ "${BUFFERED_COUNT:-0}" -ne 0 ] 2>/dev/null; then
-  log "FAIL: the armed Measurement shipped ${BUFFERED_COUNT} rows before any FlushEvent — it is not buffering"
-  exit 1
-fi
-log "PASS: the armed Measurement shipped nothing while buffering"
+# Also where dc_records.incident_id is asserted to be a column at all: without it, nothing
+# below could mean what it claims to.
+log "waiting up to ${LIVE_TIMEOUT_SECONDS}s for the live Measurement's first rows, then asserting the armed one shipped nothing"
+python3 "$SCRIPT_DIR/verify_zero_loss.py" \
+  --postgres-container "$PG_C" \
+  --profile incident \
+  --stage armed \
+  --incident-id "$INCIDENT_ID" \
+  --live-tag "$LIVE_TAG" \
+  --buffered-tag "$BUFFERED_TAG" \
+  --timeout-seconds "$LIVE_TIMEOUT_SECONDS" \
+  --report "$RUN_DIR/verification_report_incident_armed.json"
 
 # --- 2. one FlushEvent, then the window is queryable by column ---------------------------
 log "publishing one FlushEvent on /dc/flush with incident_id='$INCIDENT_ID'"
@@ -161,43 +128,17 @@ if ! timeout 90 podman exec "$DC_C" bash -lc "
   exit 1
 fi
 
+# --- 3. the window is queryable by column, and by nothing else ----------------------------
+# The assertion this whole scenario exists for: a column predicate, not a payload match.
 log "waiting up to ${INCIDENT_TIMEOUT_SECONDS}s for the released window to reach Postgres"
-DEADLINE=$(( $(date +%s) + INCIDENT_TIMEOUT_SECONDS ))
-INCIDENT_COUNT=0
-while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-  # The assertion this whole scenario exists for: a column predicate, not a payload match.
-  INCIDENT_COUNT="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id = '$INCIDENT_ID'")"
-  if [ "${INCIDENT_COUNT:-0}" -ge 2 ] 2>/dev/null; then
-    break
-  fi
-  sleep 2
-done
-
-if [ "${INCIDENT_COUNT:-0}" -lt 2 ] 2>/dev/null; then
-  log "FAIL: only ${INCIDENT_COUNT:-0} row(s) matched WHERE incident_id = '$INCIDENT_ID' within ${INCIDENT_TIMEOUT_SECONDS}s"
-  log "      (a released *window* is several Records; 0 means the id never became a column value at all)"
-  exit 1
-fi
-log "PASS: ${INCIDENT_COUNT} rows are queryable as WHERE incident_id = '$INCIDENT_ID' — a column, not payload text"
-
-# --- 3. the id marks the incident and nothing else ----------------------------------------
-WRONG_TAG="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id = '$INCIDENT_ID' AND tag <> '$BUFFERED_TAG'")"
-if [ "${WRONG_TAG:-0}" -ne 0 ] 2>/dev/null; then
-  log "FAIL: ${WRONG_TAG} incident row(s) came from a Measurement other than $BUFFERED_TAG"
-  exit 1
-fi
-
-OTHER_IDS="$(pg_count "SELECT count(*) FROM dc_records WHERE incident_id IS NOT NULL AND incident_id <> '$INCIDENT_ID'")"
-if [ "${OTHER_IDS:-0}" -ne 0 ] 2>/dev/null; then
-  log "FAIL: ${OTHER_IDS} row(s) carry an incident_id other than the one the FlushEvent minted"
-  exit 1
-fi
-
-LIVE_TAGGED="$(pg_count "SELECT count(*) FROM dc_records WHERE tag = '$LIVE_TAG' AND incident_id IS NOT NULL")"
-if [ "${LIVE_TAGGED:-0}" -ne 0 ] 2>/dev/null; then
-  log "FAIL: ${LIVE_TAGGED} row(s) from the never-armed Measurement carry an incident_id"
-  exit 1
-fi
-log "PASS: the incident_id is on the released window only — the live Measurement's rows stay NULL"
+python3 "$SCRIPT_DIR/verify_zero_loss.py" \
+  --postgres-container "$PG_C" \
+  --profile incident \
+  --stage released \
+  --incident-id "$INCIDENT_ID" \
+  --live-tag "$LIVE_TAG" \
+  --buffered-tag "$BUFFERED_TAG" \
+  --timeout-seconds "$INCIDENT_TIMEOUT_SECONDS" \
+  --report "$RUN_DIR/verification_report_incident_released.json"
 
 log "PASS: incident_id E2E scenario (#291)"

--- a/tools/e2e/scripts/run_limits_capacity_baseline.sh
+++ b/tools/e2e/scripts/run_limits_capacity_baseline.sh
@@ -40,10 +40,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 E2E_DIR="$(dirname "$SCRIPT_DIR")"
 RUN_DIR="$E2E_DIR/.run/limits_capacity_baseline"
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-log() { echo "[e2e-baseline $(date -u +%H:%M:%S)] $*"; }
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
+
+# No topology of its own — it sequences the four axis scripts and combines what they
+# already produce; the manifest is just its run dir (and the log prefix).
+harness_init --tag e2e-baseline --run-dir "$RUN_DIR"
 
 log "=== axis 1/4: Shipper fan-in (#382) ==="
 "$SCRIPT_DIR/run_limits_shipper_fanin.sh"

--- a/tools/e2e/scripts/run_limits_drain_rate.sh
+++ b/tools/e2e/scripts/run_limits_drain_rate.sh
@@ -72,7 +72,6 @@ RATE_HZ="${DC_E2E_DRAIN_RATE_HZ:-10}"
 OUTAGE_LENGTHS="${DC_E2E_DRAIN_OUTAGE_LENGTHS:-30,60}"
 POLL_INTERVAL_SECONDS="${DC_E2E_DRAIN_POLL_INTERVAL_SECONDS:-5}"
 MAX_WAIT_SECONDS="${DC_E2E_DRAIN_MAX_WAIT_SECONDS:-120}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 # A dedicated bridge network, not --network host (unlike run.sh et al.): this scenario's
 # RustFS never needs to be host-reachable at all (only the Shipper talks to it, over
@@ -94,39 +93,32 @@ METRICS_PORT="${DC_E2E_DRAIN_METRICS_PORT:-9648}"
 BUFFER_ID=to_object_storage
 BUCKET=dc-e2e
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-log() { echo "[e2e-drain-rate $(date -u +%H:%M:%S)] $*"; }
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
-remove_stack() {
-  podman rm -f --ignore "$SHIPPER_C" "$RUSTFS_C" >/dev/null
-  if podman volume exists dc_e2e_drain_rustfs_data; then
-    podman volume rm dc_e2e_drain_rustfs_data >/dev/null
-  fi
-  podman network rm "$NET" >/dev/null 2>&1 || true
-}
+harness_init \
+  --tag e2e-drain-rate \
+  --run-dir "$RUN_DIR" \
+  --network "$NET" \
+  --containers "$SHIPPER_C" "$RUSTFS_C" \
+  --volumes dc_e2e_drain_rustfs_data \
+  --teardown-networks "$NET" \
+  --log-captures "$SHIPPER_C:shipper.log" \
+  --rustfs-container "$RUSTFS_C"
 
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$SHIPPER_C"; then
-    podman logs "$SHIPPER_C" > "$RUN_DIR/shipper.log" 2>&1 || true
-  fi
-  remove_stack
-  exit "$exit_code"
+# This scenario has no DC image at all (a bare Vector Shipper under test is the whole
+# stack), so the harness's own DC-image-based RustFS probe can't run here — probe from
+# the Vector image instead, the way this script always did.
+harness_rustfs_probe() {
+  podman run --rm --network "$NET" --entrypoint bash "$VECTOR_IMAGE" \
+    -c "exec 3<>/dev/tcp/$RUSTFS_C/9000" >/dev/null 2>&1
 }
-trap cleanup EXIT
 
 # The exact Vector version dc_bridge is built and tested against, same as
 # run_limits_two_tier.sh / run_load_driver_shipper_test.sh — resolved from the .repos
 # pin by lib/version.sh (#484), not duplicated as a second source of truth.
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/lib/version.sh"
 VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
@@ -137,22 +129,13 @@ podman network create "$NET" >/dev/null
 
 # --- RustFS: the Destination this scenario induces an outage on, internal-only --------
 log "starting RustFS on $NET (no host port published)"
-podman run -d --network "$NET" --name "$RUSTFS_C" \
-  -v dc_e2e_drain_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
+start_rustfs dc_e2e_drain_rustfs_data
+wait_rustfs_ready
 
-log "waiting for RustFS to accept TCP connections on $NET"
-timeout 60 bash -c "
-  until podman run --rm --network $NET --entrypoint bash '$VECTOR_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
-    sleep 1
-  done
-" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
-
+# Same bucket name the harness creates everywhere (dc-e2e) — the Shipper config below
+# reads it from $BUCKET.
 log "creating the RustFS bucket"
-podman run --rm --network "$NET" \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb "s3://$BUCKET"
+create_rustfs_bucket "http://$RUSTFS_C:9000"
 
 # --- Shipper under test: bare Vector, fluent source + aws_s3 sink with a disk buffer ---
 log "rendering the Shipper-under-test's Vector config"

--- a/tools/e2e/scripts/run_limits_shipper_fanin.sh
+++ b/tools/e2e/scripts/run_limits_shipper_fanin.sh
@@ -69,7 +69,6 @@ SUB_WINDOWS_PER_LEVEL="${DC_E2E_FANIN_SUB_WINDOWS_PER_LEVEL:-5}"
 CONSTRAINED_CPUS="${DC_E2E_FANIN_CONSTRAINED_CPUS:-0.5}"
 CONSTRAINED_MEMORY="${DC_E2E_FANIN_CONSTRAINED_MEMORY:-256m}"
 CEILING_DROP_RATIO="${DC_E2E_FANIN_CEILING_DROP_RATIO:-0.5}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 NET=dc-e2e-limits-net
 # Same names params/e2e_limits_params.yaml and params/e2e_limits_forward_sink.toml
@@ -82,124 +81,67 @@ AGG_FLUENT_PORT=24224
 STACK_PREFIX=dc-e2e-limits-stack-
 LEDGER_STACK_INDEX=0
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-log() { echo "[e2e-fanin $(date -u +%H:%M:%S)] $*"; }
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
 stack_name() { echo "${STACK_PREFIX}$1"; }
 
-all_stack_names() {
-  local i
-  for ((i = 0; i < REAL_STACKS; i++)); do
-    stack_name "$i"
-  done
-}
+STACKS=()
+STACK_VOLUMES=()
+STACK_LOG_CAPTURES=()
+i=0
+while [ "$i" -lt "$REAL_STACKS" ]; do
+  s="$(stack_name "$i")"
+  STACKS+=("$s")
+  STACK_VOLUMES+=("dc_e2e_limits_buffer_$i" "dc_e2e_limits_data_$i")
+  STACK_LOG_CAPTURES+=("$s:$s.log")
+  i=$((i + 1))
+done
 
+harness_init \
+  --tag e2e-fanin \
+  --run-dir "$RUN_DIR" \
+  --network "$NET" \
+  --containers "${STACKS[@]}" "$AGG_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${STACK_VOLUMES[*]}" dc_e2e_limits_pgdata dc_e2e_limits_rustfs_data \
+  --teardown-networks "$NET" \
+  --log-captures "${STACK_LOG_CAPTURES[@]}" "$AGG_C:agg.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
+
+# remove_stack is the whole-stack teardown; the per-phase teardown between the two ramp
+# phases is the same blocks minus the shared stores and network.
 remove_phase_containers() {
-  # shellcheck disable=SC2046
-  podman rm -f --ignore $(all_stack_names) "$AGG_C" >/dev/null
-  local i v
-  for ((i = 0; i < REAL_STACKS; i++)); do
-    for v in "dc_e2e_limits_buffer_$i" "dc_e2e_limits_data_$i"; do
-      if podman volume exists "$v"; then
-        podman volume rm "$v" >/dev/null
-      fi
-    done
-  done
+  harness_rm_containers "${STACKS[@]}" "$AGG_C"
+  harness_rm_volumes "${STACK_VOLUMES[@]}"
 }
-
-remove_all() {
-  remove_phase_containers
-  podman rm -f --ignore "$PG_C" "$RUSTFS_C" >/dev/null
-  for v in dc_e2e_limits_pgdata dc_e2e_limits_rustfs_data; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-  podman network rm "$NET" >/dev/null 2>&1 || true
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  local s
-  for s in $(all_stack_names); do
-    if podman container exists "$s"; then
-      podman logs "$s" > "$RUN_DIR/${s}.log" 2>&1
-    fi
-  done
-  if podman container exists "$AGG_C"; then
-    podman logs "$AGG_C" > "$RUN_DIR/agg.log" 2>&1
-  fi
-  remove_all
-  exit "$exit_code"
-}
-trap cleanup EXIT
 
 # --- obtain the DC stack image (shared with run.sh / run_limits_two_tier.sh) ------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 # Resolved from the .repos pin that fetches vector_vendor (its own repo as of #424's
-# follow-up split) by lib/version.sh (#484), not duplicated here as a second source
-# of truth.
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/lib/version.sh"
+# follow-up split) by lib/version.sh (#484, already sourced by lib/harness.sh), not
+# duplicated here as a second source of truth.
 VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
-remove_all
+remove_stack
 
 # --- bridge network + shared destinations (kept up across both phases) ------------------
 log "creating the bridge network ($NET)"
 podman network create "$NET" >/dev/null
 
 log "starting the shared Postgres + RustFS on $NET"
-podman run -d --network "$NET" --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_limits_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-podman run -d --network "$NET" --name "$RUSTFS_C" \
-  -v dc_e2e_limits_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
-  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
-
-log "waiting for RustFS to accept TCP connections on $NET"
-timeout 60 bash -c "
-  until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
-    sleep 1
-  done
-" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+start_postgres dc_e2e_limits_pgdata
+start_rustfs dc_e2e_limits_rustfs_data
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket"
-podman run --rm --network "$NET" \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+create_rustfs_bucket "http://$RUSTFS_C:9000"
 
 # --- the aggregating Shipper's Vector config, rendered once and reused across both phases
 cat > "$RUN_DIR/aggregator_vector.toml" <<EOF
@@ -230,8 +172,6 @@ max_size = 268435488
 type = "blackhole"
 inputs = ["from_synth"]
 EOF
-
-pg_exec() { podman exec "$PG_C" psql -U dc -d dc -tAc "$1"; }
 
 truncate_records() {
   log "truncating dc_records/dc_files so the next phase starts from a clean baseline"
@@ -280,8 +220,7 @@ run_phase() {
   done
 
   log "waiting for the first Record to reach Postgres through the two-tier chain"
-  timeout 90 bash -c "until [ \"\$(podman exec $PG_C psql -U dc -d dc -tAc 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)\" -gt 0 ] 2>/dev/null; do sleep 1; done" \
-    || { log "FAIL: no Record reached Postgres through the two-tier chain within 90s"; exit 1; }
+  wait_first_record 90 "$(date +%s.%N)" "through the two-tier chain" >/dev/null
   log "PASS: real-stack traffic is flowing through the aggregating Shipper — starting the ramp"
 
   local data_vol="dc_e2e_limits_data_${LEDGER_STACK_INDEX}"
@@ -307,7 +246,7 @@ run_phase() {
     | tee "$RUN_DIR/${label}_orchestrator.log"
 
   log "stopping $label's real DC stack(s)"
-  for s in $(all_stack_names); do
+  for s in "${STACKS[@]}"; do
     podman stop "$s" >/dev/null
   done
 
@@ -318,7 +257,7 @@ run_phase() {
 
 stop_phase() {
   local s
-  for s in $(all_stack_names); do
+  for s in "${STACKS[@]}"; do
     if podman container exists "$s"; then
       podman logs "$s" > "$RUN_DIR/${s}_$1.log" 2>&1
     fi

--- a/tools/e2e/scripts/run_limits_single_robot_ceiling.sh
+++ b/tools/e2e/scripts/run_limits_single_robot_ceiling.sh
@@ -47,86 +47,43 @@ LEVEL_DURATION="${DC_E2E_CEILING_LEVEL_DURATION:-30}"
 SAMPLE_INTERVAL="${DC_E2E_CEILING_SAMPLE_INTERVAL:-3}"
 TOPIC="${DC_E2E_CEILING_TOPIC:-synth00}"
 DRAIN_SECONDS="${DC_E2E_CEILING_DRAIN_SECONDS:-30}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 PG_C=dc_e2e_ceiling_postgres
 RUSTFS_C=dc_e2e_ceiling_rustfs
 DC_C=dc_e2e_ceiling_dc
 VOLUMES=(dc_e2e_ceiling_pgdata dc_e2e_ceiling_rustfs_data dc_e2e_ceiling_buffer dc_e2e_ceiling_data)
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-log() { echo "[e2e-ceiling $(date -u +%H:%M:%S)] $*"; }
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
-remove_stack() {
-  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
-  local v
-  for v in "${VOLUMES[@]}"; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$DC_C"; then
-    podman logs "$DC_C" > "$RUN_DIR/dc.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+harness_init \
+  --tag e2e-ceiling \
+  --run-dir "$RUN_DIR" \
+  --network host \
+  --containers "$DC_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${VOLUMES[*]}" \
+  --log-captures "$DC_C:dc.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image (same convention as run.sh — see its header) -----------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 remove_stack
 
 # --- destinations + the one real DC stack ----------------------------------------------
 log "starting Postgres + RustFS"
-podman run -d --network host --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_ceiling_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-podman run -d --network host --name "$RUSTFS_C" \
-  -v dc_e2e_ceiling_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 60 bash -c "until podman exec $PG_C pg_isready -U dc >/dev/null 2>&1; do sleep 1; done" \
-  || { log "FAIL: Postgres never became ready"; exit 1; }
-timeout 60 bash -c 'until curl -sf http://127.0.0.1:9000 >/dev/null 2>&1 || curl -s http://127.0.0.1:9000 >/dev/null 2>&1; do sleep 1; done' \
-  || { log "FAIL: RustFS never became ready"; exit 1; }
+start_postgres dc_e2e_ceiling_pgdata
+start_rustfs dc_e2e_ceiling_rustfs_data
+# 60, as before: the ramp's own level timing starts from the stack being up.
+wait_postgres_ready 60
+wait_rustfs_ready
 
 log "creating the RustFS bucket"
-podman run --rm --network host \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url http://127.0.0.1:9000 s3 mb s3://dc-e2e
+create_rustfs_bucket http://127.0.0.1:9000
 
 log "starting the DC stack"
 podman run -d --network host --name "$DC_C" \
@@ -135,8 +92,7 @@ podman run -d --network host --name "$DC_C" \
   "$DC_IMAGE" >/dev/null
 
 log "waiting for the first Record to reach Postgres"
-timeout 60 bash -c "until [ \"\$(podman exec $PG_C psql -U dc -d dc -tAc 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)\" -gt 0 ] 2>/dev/null; do sleep 1; done" \
-  || { log "FAIL: no Record landed in Postgres within 60s of starting the stack"; exit 1; }
+wait_first_record 60 "$(date +%s.%N)" "of starting the stack" >/dev/null
 log "PASS: the stack is up and publishing"
 
 # --- ramp the single-robot ceiling axis, via the *unmodified* ramp controller/probe ---
@@ -160,23 +116,19 @@ sleep 5
 
 # --- extract, then verify zero-loss with the existing, unmodified verifier -----------
 log "extracting the passthrough sink's output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_ceiling_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_ceiling_data bash \
   -c 'cat /vol/passthrough/records.ndjson 2>/dev/null || true' > "$RUN_DIR/passthrough.ndjson"
 
 log "extracting raw mode's Destination output"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_ceiling_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_ceiling_data bash \
   -c 'cat /vol/raw/records.ndjson 2>/dev/null || true' > "$RUN_DIR/raw.ndjson"
 
 log "summarizing the MCAP passthrough writer's output"
-podman run --rm --entrypoint python3 \
-  -v dc_e2e_ceiling_data:/vol:ro "$DC_IMAGE" \
-  /opt/e2e/mcap_summary.py /vol/mcap > "$RUN_DIR/mcap_summary.json"
+extract_from_volume dc_e2e_ceiling_data python3 /opt/e2e/mcap_summary.py /vol/mcap \
+  > "$RUN_DIR/mcap_summary.json"
 
 log "extracting the workload ledger"
-podman run --rm --entrypoint bash \
-  -v dc_e2e_ceiling_data:/vol:ro "$DC_IMAGE" \
+extract_from_volume dc_e2e_ceiling_data bash \
   -c 'cat /vol/workload_ledger.txt 2>/dev/null || true' > "$RUN_DIR/workload_ledger.txt"
 
 log "verifying zero-loss across the whole ramp"

--- a/tools/e2e/scripts/run_limits_two_tier.sh
+++ b/tools/e2e/scripts/run_limits_two_tier.sh
@@ -103,7 +103,6 @@ STEADY_STATE_SECONDS="${DC_E2E_LIMITS_STEADY_STATE_SECONDS:-30}"
 # before that capture's dc_files metadata row landed, failing check_files() on an
 # otherwise-correct run.
 DRAIN_SECONDS="${DC_E2E_LIMITS_DRAIN_SECONDS:-15}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 NET=dc-e2e-limits-net
 # Hyphens, not the underscored dc_e2e_* convention every other scenario script uses:
@@ -124,85 +123,43 @@ STACK_PREFIX=dc-e2e-limits-stack-
 # nominal-load mix, all going through the same aggregating Shipper as stack 0.
 LEDGER_STACK_INDEX=0
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
-
-log() { echo "[e2e-limits $(date -u +%H:%M:%S)] $*"; }
 
 stack_name() { echo "${STACK_PREFIX}$1"; }
 
-all_stack_names() {
-  local i
-  for ((i = 0; i < REAL_STACKS; i++)); do
-    stack_name "$i"
-  done
-}
+STACKS=()
+STACK_VOLUMES=()
+STACK_LOG_CAPTURES=()
+i=0
+while [ "$i" -lt "$REAL_STACKS" ]; do
+  s="$(stack_name "$i")"
+  STACKS+=("$s")
+  STACK_VOLUMES+=("dc_e2e_limits_buffer_$i" "dc_e2e_limits_data_$i")
+  STACK_LOG_CAPTURES+=("$s:$s.log")
+  i=$((i + 1))
+done
 
-remove_stack() {
-  # shellcheck disable=SC2046
-  podman rm -f --ignore $(all_stack_names) "$AGG_C" "$PG_C" "$RUSTFS_C" >/dev/null
-  local i v
-  for ((i = 0; i < REAL_STACKS; i++)); do
-    for v in "dc_e2e_limits_buffer_$i" "dc_e2e_limits_data_$i"; do
-      if podman volume exists "$v"; then
-        podman volume rm "$v" >/dev/null
-      fi
-    done
-  done
-  for v in dc_e2e_limits_pgdata dc_e2e_limits_rustfs_data; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-  podman network rm "$NET" >/dev/null 2>&1 || true
-}
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  local s
-  for s in $(all_stack_names); do
-    if podman container exists "$s"; then
-      podman logs "$s" > "$RUN_DIR/${s}.log" 2>&1
-    fi
-  done
-  if podman container exists "$AGG_C"; then
-    podman logs "$AGG_C" > "$RUN_DIR/agg.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+harness_init \
+  --tag e2e-limits \
+  --run-dir "$RUN_DIR" \
+  --network "$NET" \
+  --containers "${STACKS[@]}" "$AGG_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${STACK_VOLUMES[*]}" dc_e2e_limits_pgdata dc_e2e_limits_rustfs_data \
+  --teardown-networks "$NET" \
+  --log-captures "${STACK_LOG_CAPTURES[@]}" "$AGG_C:agg.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 # The exact Vector version dc_bridge is built and tested against, for the standalone
-# aggregating Shipper — resolved from the .repos pin by lib/version.sh (same as
-# run_load_driver_shipper_test.sh, #484), not duplicated as a second source of truth.
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/lib/version.sh"
+# aggregating Shipper — vector_version() arrives via lib/harness.sh, which sources
+# lib/version.sh (#484), not duplicated as a second source of truth.
 VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
@@ -214,35 +171,13 @@ log "creating the bridge network ($NET)"
 podman network create "$NET" >/dev/null
 
 log "starting the shared Postgres + RustFS on $NET"
-podman run -d --network "$NET" --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_limits_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-podman run -d --network "$NET" --name "$RUSTFS_C" \
-  -v dc_e2e_limits_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_records')\" 2>/dev/null | grep -q dc_records; do sleep 2; done" \
-  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
-
-log "waiting for RustFS to accept TCP connections on $NET"
-# --entrypoint bash: the image's own ENTRYPOINT (entrypoint.sh) launches the full DC
-# stack and appends any extra args to `ros2 launch` rather than running them as a
-# separate command, so a one-off diagnostic run needs an explicit override (verified
-# empirically) — a plain bash /dev/tcp probe rather than scripts/measure_rtt.py, so this
-# doesn't depend on that file happening to be baked into whatever $DC_IMAGE is passed in.
-timeout 60 bash -c "
-  until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
-    sleep 1
-  done
-" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+start_postgres dc_e2e_limits_pgdata
+start_rustfs dc_e2e_limits_rustfs_data
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket"
-podman run --rm --network "$NET" \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+create_rustfs_bucket "http://$RUSTFS_C:9000"
 
 # --- the aggregating Shipper: a standalone Vector instance, no dc_bridge involved -------
 log "rendering the aggregating Shipper's Vector config"
@@ -325,8 +260,7 @@ for ((i = 0; i < REAL_STACKS; i++)); do
 done
 
 log "waiting for the first Record to reach Postgres through the two-tier chain"
-timeout 90 bash -c "until [ \"\$(podman exec $PG_C psql -U dc -d dc -tAc 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)\" -gt 0 ] 2>/dev/null; do sleep 1; done" \
-  || { log "FAIL: no Record reached Postgres through the two-tier chain within 90s"; exit 1; }
+wait_first_record 90 "$(date +%s.%N)" "through the two-tier chain" >/dev/null
 log "PASS: at least one Record reached Postgres through the aggregating Shipper"
 
 # --- fixed nominal-load window: real stacks (already running) + M synthetic senders -----
@@ -351,7 +285,7 @@ log "draining for ${DRAIN_SECONDS}s (lets the last camera capture clear the Uplo
 sleep "$DRAIN_SECONDS"
 
 log "stopping the real DC stacks so counts settle before verification"
-for s in $(all_stack_names); do
+for s in "${STACKS[@]}"; do
   podman stop "$s" >/dev/null
 done
 sleep 5

--- a/tools/e2e/scripts/run_limits_upload_concurrency.sh
+++ b/tools/e2e/scripts/run_limits_upload_concurrency.sh
@@ -53,7 +53,6 @@ LEVELS="${DC_E2E_UPLOAD_LEVELS:-1,2,4,8}"
 CAMERA_PERIOD_S="${DC_E2E_UPLOAD_CAMERA_PERIOD_S:-2}"
 STEADY_STATE_SECONDS="${DC_E2E_UPLOAD_STEADY_STATE_SECONDS:-60}"
 SAMPLE_INTERVAL_SECONDS="${DC_E2E_UPLOAD_SAMPLE_INTERVAL_SECONDS:-5}"
-KEEP="${DC_E2E_KEEP:-false}"
 
 # Hyphens, not underscores — same reasoning as run_limits_two_tier.sh's PG_C/RUSTFS_C:
 # these names are embedded in URLs (RustFS/Postgres endpoints), and aws-cli 2.36's
@@ -62,61 +61,27 @@ NET=dc-e2e-upload-net
 PG_C=dc-e2e-upload-postgres
 RUSTFS_C=dc-e2e-upload-rustfs
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-log() { echo "[e2e-upload-axis $(date -u +%H:%M:%S)] $*"; }
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/lib/harness.sh"
 
-remove_stack() {
-  # Any per-level Bridge containers/volumes are already cleaned up by
-  # run_upload_concurrency_axis.py's own driver as each level finishes — only the
-  # shared storage + network this script itself started remain here.
-  podman rm -f --ignore "$PG_C" "$RUSTFS_C" >/dev/null
-  for v in dc_e2e_upload_pgdata dc_e2e_upload_rustfs_data; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-  podman network rm "$NET" >/dev/null 2>&1 || true
-}
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) — leaving the shared storage up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down shared storage"
-  if podman container exists "$PG_C"; then
-    podman logs "$PG_C" > "$RUN_DIR/postgres.log" 2>&1
-  fi
-  if podman container exists "$RUSTFS_C"; then
-    podman logs "$RUSTFS_C" > "$RUN_DIR/rustfs.log" 2>&1
-  fi
-  remove_stack
-  exit "$exit_code"
-}
-trap cleanup EXIT
+# The per-level Bridge containers/volumes are run_upload_concurrency_axis.py's own driver's
+# to clean up as each level finishes — only the shared storage this script starts is ours.
+harness_init \
+  --tag e2e-upload-axis \
+  --run-dir "$RUN_DIR" \
+  --network "$NET" \
+  --containers "$PG_C" "$RUSTFS_C" \
+  --volumes dc_e2e_upload_pgdata dc_e2e_upload_rustfs_data \
+  --teardown-networks "$NET" \
+  --log-captures "$PG_C:postgres.log" "$RUSTFS_C:rustfs.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ------------------
-if [ -n "${DC_E2E_IMAGE:-}" ]; then
-  log "using prebuilt E2E image: $DC_E2E_IMAGE (no build)"
-  podman image exists "$DC_E2E_IMAGE" || podman pull "$DC_E2E_IMAGE"
-  DC_IMAGE="$DC_E2E_IMAGE"
-else
-  if [ -n "${DC_WORKSPACE_IMAGE:-}" ]; then
-    log "using prebuilt DC workspace image: $DC_WORKSPACE_IMAGE (skipping build.sh)"
-    podman image exists "$DC_WORKSPACE_IMAGE" || podman pull "$DC_WORKSPACE_IMAGE"
-    WORKSPACE_IMAGE="$DC_WORKSPACE_IMAGE"
-  else
-    log "building the DC workspace image (tools/e2e/scripts/build.sh — the same build CI uses)"
-    "$SCRIPT_DIR/build.sh"
-    WORKSPACE_IMAGE="dc-workspace:latest"
-  fi
-  log "building the E2E image (Containerfile.e2e, FROM the workspace image)"
-  podman build --build-arg "BASE_IMAGE=$WORKSPACE_IMAGE" -t dc-e2e:latest -f Containerfile.e2e .
-  DC_IMAGE="dc-e2e:latest"
-fi
+DC_IMAGE="" # set by resolve_image
+resolve_image
 
 # Clean any leftovers from a previous (possibly DC_E2E_KEEP=true) run.
 remove_stack
@@ -126,34 +91,15 @@ log "creating the bridge network ($NET)"
 podman network create "$NET" >/dev/null
 
 log "starting the shared Postgres + RustFS on $NET"
-podman run -d --network "$NET" --name "$PG_C" \
-  -e POSTGRES_USER=dc -e POSTGRES_PASSWORD=password -e POSTGRES_DB=dc \
-  -v dc_e2e_upload_pgdata:/var/lib/postgresql/data \
-  -v "$E2E_DIR/sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro" \
-  docker.io/library/postgres:13 >/dev/null
-podman run -d --network "$NET" --name "$RUSTFS_C" \
-  -v dc_e2e_upload_rustfs_data:/data \
-  docker.io/rustfs/rustfs@sha256:84ce557a0245a06a9aae5516f55ee0f007fca78d41df356f419306fdc0cb168c >/dev/null
-
-timeout 120 bash -c "until podman exec $PG_C psql -U dc -d dc -tAc \"SELECT to_regclass('public.dc_files')\" 2>/dev/null | grep -q dc_files; do sleep 2; done" \
-  || { log "FAIL: Postgres never came up with sql/init.sql applied"; exit 1; }
-
-log "waiting for RustFS to accept TCP connections on $NET"
-# --entrypoint bash: the image's own ENTRYPOINT (entrypoint.sh) launches the full DC
-# stack and appends any extra args to `ros2 launch` rather than running them as a
-# separate command, so a one-off diagnostic run needs an explicit override — same
-# reasoning and probe run_limits_two_tier.sh uses.
-timeout 60 bash -c "
-  until podman run --rm --network $NET --entrypoint bash '$DC_IMAGE' -c 'exec 3<>/dev/tcp/$RUSTFS_C/9000' >/dev/null 2>&1; do
-    sleep 1
-  done
-" || { log "FAIL: RustFS never became reachable on $NET"; exit 1; }
+start_postgres dc_e2e_upload_pgdata
+start_rustfs dc_e2e_upload_rustfs_data
+# One pass of sql/init.sql creates dc_records and dc_files together, so gating on either
+# gates on the other — this axis's ramp only writes dc_files.
+wait_postgres_ready
+wait_rustfs_ready
 
 log "creating the RustFS bucket"
-podman run --rm --network "$NET" \
-  -e AWS_ACCESS_KEY_ID=rustfsadmin -e AWS_SECRET_ACCESS_KEY=rustfsadmin -e AWS_DEFAULT_REGION=us-east-1 \
-  docker.io/amazon/aws-cli:latest \
-  --endpoint-url "http://$RUSTFS_C:9000" s3 mb s3://dc-e2e
+create_rustfs_bucket "http://$RUSTFS_C:9000"
 
 # --- the ramp itself: run_upload_concurrency_axis.py owns everything from here --------
 log "running the Uploader concurrency ramp (levels: $LEVELS)"

--- a/tools/e2e/scripts/run_load_driver_shipper_test.sh
+++ b/tools/e2e/scripts/run_load_driver_shipper_test.sh
@@ -44,7 +44,6 @@ RATE_HZ="${DC_E2E_LOAD_DRIVER_RATE_HZ:-20}"
 DURATION_S="${DC_E2E_LOAD_DRIVER_DURATION_S:-3}"
 PORT="${DC_E2E_LOAD_DRIVER_PORT:-24224}"
 TAG="dc.e2e.load_driver_shipper_test"
-KEEP="${DC_E2E_KEEP:-false}"
 
 VECTOR_C=dc_e2e_ldtest_vector
 
@@ -53,29 +52,19 @@ VECTOR_C=dc_e2e_ldtest_vector
 # docs/adr/0002-vector-as-default-shipper.md) by lib/version.sh (#484), not duplicated
 # here as a second source of truth.
 # shellcheck disable=SC1091
-source "$SCRIPT_DIR/lib/version.sh"
+source "$SCRIPT_DIR/lib/harness.sh"
 VECTOR_VERSION="$(vector_version)"
 VECTOR_IMAGE="docker.io/timberio/vector:${VECTOR_VERSION}-debian"
 
-log() { echo "[load-driver-shipper-test $(date -u +%H:%M:%S)] $*"; }
-
-cleanup() {
-  local exit_code=$?
-  if [ "$exit_code" -ne 0 ] && [ "$KEEP" = "true" ]; then
-    log "FAILED (exit $exit_code) -- leaving the Vector container and $RUN_DIR up (DC_E2E_KEEP=true) for debugging"
-    exit "$exit_code"
-  fi
-  log "tearing down"
-  if podman container exists "$VECTOR_C"; then
-    podman logs "$VECTOR_C" > "$RUN_DIR/vector.log" 2>&1 || true
-  fi
-  podman rm -f --ignore "$VECTOR_C" >/dev/null
-  exit "$exit_code"
-}
-trap cleanup EXIT
-
 rm -rf "$RUN_DIR"
 mkdir -p "$RUN_DIR/output"
+
+harness_init \
+  --tag load-driver-shipper-test \
+  --run-dir "$RUN_DIR" \
+  --network host \
+  --containers "$VECTOR_C" \
+  --log-captures "$VECTOR_C:vector.log"
 
 cat > "$RUN_DIR/vector.toml" <<EOF
 data_dir = "/var/lib/vector"

--- a/tools/e2e/scripts/run_retention.sh
+++ b/tools/e2e/scripts/run_retention.sh
@@ -33,7 +33,10 @@
 # DC_E2E_UPLOAD_TIMEOUT_SECONDS (default 60, once RustFS is up connections are fast).
 #
 # The shared harness skeleton (image resolution, cleanup trap, destination bring-up and
-# readiness waits) lives in lib/harness.sh.
+# readiness waits) lives in lib/harness.sh. The two dc_files assertions live in
+# verify_zero_loss.py's `retention` profile (#496); what stays here is the topology (a
+# store that only comes up halfway through), the shed File's absence *on disk*, and the
+# bounded waits those assertions sit on the far side of.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -47,27 +50,21 @@ PG_C=dc_e2e_ret_postgres
 RUSTFS_C=dc_e2e_ret_rustfs
 DC_C=dc_e2e_ret_dc
 VOLUMES=(dc_e2e_ret_pgdata dc_e2e_ret_rustfs_data dc_e2e_ret_buffer dc_e2e_ret_data)
-# shellcheck disable=SC2034  # consumed by lib/harness.sh
-HARNESS_TAG=e2e-retention
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
-remove_stack() {
-  podman rm -f --ignore "$DC_C" "$PG_C" "$RUSTFS_C" >/dev/null
-  for v in "${VOLUMES[@]}"; do
-    if podman volume exists "$v"; then
-      podman volume rm "$v" >/dev/null
-    fi
-  done
-}
-
-# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
-HARNESS_LOG_CAPTURES=("$DC_C:dc_retention.log")
-trap harness_cleanup EXIT
+harness_init \
+  --tag e2e-retention \
+  --run-dir "$RUN_DIR" \
+  --network host \
+  --containers "$DC_C" "$PG_C" "$RUSTFS_C" \
+  --volumes "${VOLUMES[*]}" \
+  --log-captures "$DC_C:dc_retention.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image (shared with run.sh — see its header) ----------------
 DC_IMAGE="" # set by resolve_image
@@ -91,21 +88,13 @@ podman run -d --network host --name "$DC_C" \
 
 # --- verify the shed happens while the store is down ---------------------------------
 log "waiting up to ${SHED_TIMEOUT_SECONDS}s for a shed audit row (deleted=true, uploaded=false) in dc_files"
-DEADLINE=$(( $(date +%s) + SHED_TIMEOUT_SECONDS ))
-SHED_COUNT=0
-while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-  SHED_COUNT="$(pg_exec "SELECT count(*) FROM dc_files WHERE deleted = true AND uploaded = false" 2>/dev/null || echo 0)"
-  if [ "${SHED_COUNT:-0}" -gt 0 ] 2>/dev/null; then
-    break
-  fi
-  sleep 2
-done
-
-if [ "${SHED_COUNT:-0}" -eq 0 ]; then
-  log "FAIL: no shed-without-upload audit row landed within ${SHED_TIMEOUT_SECONDS}s"
-  exit 1
-fi
-log "PASS: ${SHED_COUNT} shed-without-upload audit row(s) — the oldest un-uploaded File(s) were shed while RustFS was down"
+python3 "$SCRIPT_DIR/verify_zero_loss.py" \
+  --postgres-container "$PG_C" \
+  --profile retention \
+  --stage shed \
+  --timeout-seconds "$SHED_TIMEOUT_SECONDS" \
+  --report "$RUN_DIR/verification_report_retention_shed.json"
+log "PASS: the oldest un-uploaded File(s) were shed while RustFS was down"
 
 # The shed local File must actually be gone (File+intent atomicity) — not just the row.
 SHED_LOCAL_PATH="$(pg_exec "SELECT local_path FROM dc_files WHERE deleted = true AND uploaded = false ORDER BY updated_at ASC LIMIT 1" 2>/dev/null || true)"
@@ -128,20 +117,12 @@ wait_rustfs_ready
 create_rustfs_bucket http://127.0.0.1:9000 >/dev/null
 
 log "waiting up to ${UPLOAD_TIMEOUT_SECONDS}s for a normal upload (uploaded=true) in dc_files now that RustFS is up"
-DEADLINE=$(( $(date +%s) + UPLOAD_TIMEOUT_SECONDS ))
-UPLOADED_COUNT=0
-while [ "$(date +%s)" -lt "$DEADLINE" ]; do
-  UPLOADED_COUNT="$(pg_exec "SELECT count(*) FROM dc_files WHERE uploaded = true" 2>/dev/null || echo 0)"
-  if [ "${UPLOADED_COUNT:-0}" -gt 0 ] 2>/dev/null; then
-    break
-  fi
-  sleep 2
-done
-
-if [ "${UPLOADED_COUNT:-0}" -eq 0 ]; then
-  log "FAIL: no File uploaded/verified within ${UPLOAD_TIMEOUT_SECONDS}s of RustFS coming up"
-  exit 1
-fi
-log "PASS: ${UPLOADED_COUNT} File(s) uploaded and verified normally once the store came back"
+python3 "$SCRIPT_DIR/verify_zero_loss.py" \
+  --postgres-container "$PG_C" \
+  --profile retention \
+  --stage uploaded \
+  --timeout-seconds "$UPLOAD_TIMEOUT_SECONDS" \
+  --report "$RUN_DIR/verification_report_retention_uploaded.json"
+log "PASS: File(s) uploaded and verified normally once the store came back"
 
 log "PASS: files retention E2E scenario (#267)"

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -17,11 +17,14 @@
 #   DC_E2E_SPLIT_STEADY_STATE_SECONDS      warmup before the outage (default 15)
 #   DC_E2E_SPLIT_OUTAGE_SECONDS            outage duration (default 60)
 #   DC_E2E_SPLIT_DRAIN_SECONDS             settle time before verifying (default 30)
-#   DC_E2E_SPLIT_QUEUE_DRAIN_TIMEOUT_SECONDS bound for the upload intent queue to drain
-#                                          after the drain window, before the check
-#                                          fails (default 120 — the uploader's
-#                                          exponential retry backoff can outlast
-#                                          DC_E2E_SPLIT_DRAIN_SECONDS; see the check)
+#   DC_E2E_SPLIT_QUEUE_DRAIN_TIMEOUT_SECONDS bound for the two settle waits after the
+#                                          drain window — the Shipper's Record buffer
+#                                          flushing into Postgres and the upload intent
+#                                          queue emptying — before the check fails
+#                                          (default 120 — Vector's reconnect and the
+#                                          uploader's exponential retry backoff can both
+#                                          outlast DC_E2E_SPLIT_DRAIN_SECONDS; see the
+#                                          checks)
 #   DC_E2E_KEEP                            "true" to leave the stack up on failure
 #   DC_E2E_IMAGE / DC_WORKSPACE_IMAGE      same meaning as run.sh
 #
@@ -157,6 +160,38 @@ log "stopping the workload so counts settle before verification"
 podman stop "$DC_ROS_C" >/dev/null
 sleep 5
 
+# --- the Shipper's Record buffer has to be in Postgres before vector is stopped -------
+# The workload is stopped, so dc_records only grows while vector is still flushing its
+# disk buffer (the outage backlog plus the post-restart tail). The fixed DRAIN_SECONDS
+# window above is how long we *give* that flush, not proof it happened — and vector's
+# buffer lives on a compose named volume that `compose down --volumes` deletes, so
+# stopping vector with a non-empty buffer is data loss the verifier would rightly
+# report. Wait for the count to stop growing, bounded; if it never settles the verify
+# below still hard-fails on whatever didn't land, so this only ever buys time, never
+# tolerance.
+log "waiting for the Shipper's buffer to flush into Postgres (dc_records stops growing)"
+RECORDS_STABLE_SECONDS=6
+FLUSH_DEADLINE=$(( $(date +%s) + QUEUE_DRAIN_TIMEOUT_SECONDS ))
+LAST_COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
+STABLE_SINCE="$(date +%s)"
+while :; do
+  sleep 2
+  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
+  if [ "$COUNT" = "$LAST_COUNT" ]; then
+    if [ $(( $(date +%s) - STABLE_SINCE )) -ge "$RECORDS_STABLE_SECONDS" ]; then
+      break
+    fi
+  else
+    LAST_COUNT="$COUNT"
+    STABLE_SINCE="$(date +%s)"
+  fi
+  if [ "$(date +%s)" -ge "$FLUSH_DEADLINE" ]; then
+    log "WARN: dc_records still at ${COUNT} row(s) after ${QUEUE_DRAIN_TIMEOUT_SECONDS}s — verifying anyway"
+    break
+  fi
+done
+log "PASS: Shipper buffer flushed (dc_records stable at ${LAST_COUNT})"
+
 # --- durable upload intent queue (#265) — same standard as run.sh ---------------------
 # The uploader retries a failed intent on an exponential backoff (5s base, doubling,
 # capped high — dc_bridge's intent_queue.hpp). In this split topology the uploader
@@ -182,7 +217,7 @@ while :; do
 done
 log "PASS: upload intent queue empty (0 orphaned intents)"
 
-log "stopping dc-uploader and vector (queue drained, nothing left in flight)"
+log "stopping dc-uploader and vector (Records flushed, queue drained, nothing left in flight)"
 podman stop "$UPLOADER_C" "$VECTOR_C" >/dev/null
 
 # --- verify -----------------------------------------------------------------------

--- a/tools/e2e/scripts/run_split.sh
+++ b/tools/e2e/scripts/run_split.sh
@@ -51,10 +51,6 @@ RUSTFS_C=dc_e2e_split_rustfs
 DC_ROS_C=dc_e2e_split_dc_ros
 UPLOADER_C=dc_e2e_split_dc_uploader
 VECTOR_C=dc_e2e_split_vector
-# shellcheck disable=SC2034  # consumed by lib/harness.sh
-HARNESS_TAG=e2e-split
-# shellcheck disable=SC2034
-HARNESS_NETWORK=dc_e2e_split_net
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/harness.sh"
@@ -65,18 +61,22 @@ source "$SCRIPT_DIR/lib/harness.sh"
 VECTOR_VERSION="$(vector_version)"
 export VECTOR_VERSION
 
-mkdir -p "$RUN_DIR"
 cd "$E2E_DIR"
 
 compose() { podman compose -f "$COMPOSE_FILE" "$@"; }
 
-remove_stack() {
-  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
-}
-
-# shellcheck disable=SC2034  # consumed by lib/harness.sh's teardown
-HARNESS_LOG_CAPTURES=("$DC_ROS_C:dc-ros.log" "$UPLOADER_C:dc-uploader.log" "$VECTOR_C:vector.log")
-trap harness_cleanup EXIT
+# compose.split.yaml *is* the manifest here — its services and named volumes are exactly
+# what comes down, so `down --volumes --remove-orphans` is the whole teardown and the
+# container list is only a backstop for a compose provider that failed to run.
+harness_init \
+  --tag e2e-split \
+  --run-dir "$RUN_DIR" \
+  --network dc_e2e_split_net \
+  --compose "$COMPOSE_FILE" \
+  --containers "$DC_ROS_C" "$UPLOADER_C" "$VECTOR_C" "$PG_C" "$RUSTFS_C" \
+  --log-captures "$DC_ROS_C:dc-ros.log" "$UPLOADER_C:dc-uploader.log" "$VECTOR_C:vector.log" \
+  --pg-container "$PG_C" \
+  --rustfs-container "$RUSTFS_C"
 
 # --- obtain the DC stack image (same logic as run.sh) --------------------------------
 DC_IMAGE="" # set by resolve_image
@@ -115,21 +115,8 @@ log "starting vector (the Shipper), ${VECTOR_DELAY_SECONDS}s after dc-ros — me
 VECTOR_START_TS=$(date +%s.%N)
 compose up -d vector
 
-FIRST_RECORD_LATENCY=""
-DEADLINE=$(echo "$VECTOR_START_TS + $RECOVERY_TIMEOUT_SECONDS" | bc)
-while (( $(echo "$(date +%s.%N) < $DEADLINE" | bc) )); do
-  COUNT="$(pg_exec 'SELECT count(*) FROM dc_records' 2>/dev/null || echo 0)"
-  if [ "${COUNT:-0}" -gt 0 ] 2>/dev/null; then
-    FIRST_RECORD_LATENCY=$(echo "$(date +%s.%N) - $VECTOR_START_TS" | bc)
-    break
-  fi
-  sleep 0.2
-done
-
-if [ -z "$FIRST_RECORD_LATENCY" ]; then
-  log "FAIL: no Record landed in Postgres within ${RECOVERY_TIMEOUT_SECONDS}s of starting vector — dc-ros did not recover from the Shipper starting late"
-  exit 1
-fi
+FIRST_RECORD_LATENCY="$(wait_first_record "$RECOVERY_TIMEOUT_SECONDS" "$VECTOR_START_TS" \
+  "of starting vector — dc-ros did not recover from the Shipper starting late")"
 log "PASS: dc-ros recovered on its own (first Record ${FIRST_RECORD_LATENCY}s after vector started, no restart needed)"
 
 # dc-uploader's own independent-restart proof (#447's per-container restart

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -57,6 +57,24 @@ Checks:
    standard as the NDJSON passthrough above, via a JSON summary of its `.mcap` capture
    (scripts/mcap_summary.py, which needs the `mcap` library and so runs inside the DC
    image via run.sh, not on the CI host runner).
+
+Profiles (#496). `--profile` selects which set of checks runs, so a scenario's Record
+assertions all live here instead of as inline SQL in its bash script:
+
+  - `zero-loss` (the default): the checks above, as run.sh and its siblings invoke them.
+  - `incident`: run_incident.sh's assertions (#291) — that `incident_id` really is a
+    column, that a Measurement armed with `buffer_duration_sec` ships nothing while a
+    live one flows, and that after one FlushEvent the released window is queryable by
+    column and carries no other Measurement's rows. Two stages, because a FlushEvent is
+    published between them: `--stage armed`, then `--stage released`.
+  - `retention`: run_retention.sh's assertions (#267) — that a File is shed without upload
+    once the pool exceeds `files.retention.max_bytes` against a down store, and that a
+    later File uploads normally once the store is back. One stage per half, `--stage
+    shed` then `--stage uploaded`; the shed File's absence *on disk* stays in bash, which
+    is where the volume mount is.
+
+Every check is still a hard assertion, in every profile: a query that can't run is a
+FAIL, not a skip.
 """
 
 import argparse
@@ -64,6 +82,7 @@ import json
 import os
 import subprocess
 import sys
+import time
 
 import raw_volume
 
@@ -293,6 +312,193 @@ def check_files(pg_container: str, violations: list, notes: list, details: dict)
             f"files: {dup_uploaded} local_path(s) have more than one 'uploaded' status row "
             "(at-least-once outage-boundary re-send; deduped on read)"
         )
+
+
+# --- incident profile (#291) -------------------------------------------------------------
+
+# "Armed means silent" is only meaningful against a pipeline known to be delivering: the
+# live Measurement has to have shipped several Records first, enough that an unarmed one
+# would have shipped several too.
+MIN_LIVE_ROWS = 5
+
+# A released *window* is several Records (the pre-event buffer plus the post-roll), so
+# one row would not prove a window came out at all.
+MIN_INCIDENT_ROWS = 2
+
+INCIDENT_STAGE_ARMED = "armed"
+INCIDENT_STAGE_RELEASED = "released"
+INCIDENT_STAGES = (INCIDENT_STAGE_ARMED, INCIDENT_STAGE_RELEASED)
+
+RETENTION_STAGE_SHED = "shed"
+RETENTION_STAGE_UPLOADED = "uploaded"
+RETENTION_STAGES = (RETENTION_STAGE_SHED, RETENTION_STAGE_UPLOADED)
+
+
+def check_incident_column(column_type: str, violations: list, details: dict) -> None:
+    """Assert dc_records.incident_id is a column, before anything queries it.
+
+    The point of #291 is that a released window is reachable by *column* predicate. A
+    table without the column would make every later assertion fail for a reason that has
+    nothing to do with the pipeline, so say so instead.
+
+    Args:
+        column_type: information_schema's data_type for the column, "" if absent.
+        violations: hard failures, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
+    details["incident_id_column"] = {"data_type": column_type or None}
+    if column_type != "text":
+        violations.append(
+            f"incident: dc_records has no text incident_id column (got "
+            f"'{column_type or 'none'}') — check sql/init.sql"
+        )
+
+
+def check_live_flowing(
+    live_count: int,
+    live_tag: str,
+    timeout_s: int,
+    violations: list,
+    details: dict,
+) -> None:
+    """Assert the never-armed Measurement delivered enough to make silence meaningful."""
+    details["live_measurement"] = {"tag": live_tag, "rows": live_count}
+    if live_count < MIN_LIVE_ROWS:
+        violations.append(
+            f"incident: the live Measurement produced only {live_count} row(s) in "
+            f"{timeout_s}s — the pipeline is not running"
+        )
+
+
+def check_armed_silent(
+    buffered_count: int, buffered_tag: str, violations: list, details: dict
+) -> None:
+    """Assert a Measurement armed with buffer_duration_sec shipped nothing pre-event."""
+    details["armed_measurement"] = {"tag": buffered_tag, "rows": buffered_count}
+    if buffered_count != 0:
+        violations.append(
+            f"incident: the armed Measurement shipped {buffered_count} row(s) before any "
+            "FlushEvent — it is not buffering"
+        )
+
+
+def check_released_window(
+    pg_container: str,
+    incident_id: str,
+    buffered_tag: str,
+    live_tag: str,
+    incident_count: int,
+    violations: list,
+    details: dict,
+) -> None:
+    """Assert one FlushEvent's window is queryable by column, and by nothing else.
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        incident_id: the id the FlushEvent carried.
+        buffered_tag: Tag of the armed Measurement the window must have come from.
+        live_tag: Tag of the never-armed Measurement, whose rows must stay NULL.
+        incident_count: rows already known to match WHERE incident_id = <id>.
+        violations: hard failures, appended to in place.
+        details: counters for the JSON report, populated in place.
+    """
+    wrong_tag = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM dc_records WHERE incident_id = '{incident_id}' "
+        f"AND tag <> '{buffered_tag}'",
+    )
+    other_ids = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM dc_records WHERE incident_id IS NOT NULL "
+        f"AND incident_id <> '{incident_id}'",
+    )
+    live_tagged = scalar_int(
+        pg_container,
+        f"SELECT count(*) FROM dc_records WHERE tag = '{live_tag}' AND incident_id IS NOT NULL",
+    )
+    details["released_window"] = {
+        "incident_id": incident_id,
+        "rows": incident_count,
+        "rows_from_another_measurement": wrong_tag,
+        "rows_with_another_incident_id": other_ids,
+        "live_measurement_rows_tagged": live_tagged,
+    }
+
+    if incident_count < MIN_INCIDENT_ROWS:
+        violations.append(
+            f"incident: only {incident_count} row(s) matched WHERE incident_id = "
+            f"'{incident_id}' (a released *window* is several Records; 0 means the id "
+            "never became a column value at all)"
+        )
+    if wrong_tag:
+        violations.append(
+            f"incident: {wrong_tag} row(s) of the window came from a Measurement other "
+            f"than {buffered_tag}"
+        )
+    if other_ids:
+        violations.append(
+            f"incident: {other_ids} row(s) carry an incident_id other than the one the "
+            "FlushEvent minted"
+        )
+    if live_tagged:
+        violations.append(
+            f"incident: {live_tagged} row(s) from the never-armed Measurement carry an "
+            "incident_id — the id marks the incident, it is not stamped on everything"
+        )
+
+
+# --- retention profile (#267) -------------------------------------------------------------
+
+
+def check_shed_row(shed_count: int, timeout_s: int, violations: list, details: dict) -> None:
+    """Assert a File was shed without upload while the object store was unreachable."""
+    details["shed"] = {"deleted_without_upload_rows": shed_count, "wait_seconds": timeout_s}
+    if shed_count == 0:
+        violations.append(
+            f"retention: no shed-without-upload audit row (deleted=true, uploaded=false) "
+            f"landed within {timeout_s}s"
+        )
+
+
+def check_uploaded_row(
+    uploaded_count: int, timeout_s: int, violations: list, details: dict
+) -> None:
+    """Assert a File uploaded and verified normally once the store came back."""
+    details["uploaded"] = {"uploaded_rows": uploaded_count, "wait_seconds": timeout_s}
+    if uploaded_count == 0:
+        violations.append(
+            f"retention: no File uploaded/verified within {timeout_s}s of the store coming back"
+        )
+
+
+def wait_for_count(
+    pg_container: str, query: str, minimum: int, timeout_s: int, poll_seconds: float = 2.0
+) -> int:
+    """Poll a scalar count until it reaches `minimum` or the deadline passes.
+
+    The bounded waits the incident/retention scenario scripts used to carry inline, next
+    to the verdicts they feed: the count is only ever *checked* after the wait, so a wait
+    that expires returns the last observed count and the caller's check fails on it.
+
+    Args:
+        pg_container: name of the Postgres container to query via podman exec.
+        query: scalar SQL statement to poll.
+        minimum: count that ends the wait early.
+        timeout_s: how long to keep polling.
+        poll_seconds: interval between polls.
+
+    Returns:
+        int: the last count seen, whether or not it reached `minimum`.
+    """
+    deadline = time.monotonic() + timeout_s
+    count = 0
+    while True:
+        count = scalar_int(pg_container, query)
+        if count >= minimum:
+            return count
+        if time.monotonic() >= deadline:
+            return count
+        time.sleep(poll_seconds)
 
 
 # The Measurement configured above 1 Hz in params/e2e_params.yaml. It is the only topic
@@ -756,6 +962,123 @@ def check_mcap_passthrough(
             )
 
 
+def verify_zero_loss(args, violations: list, notes: list, details: dict) -> None:
+    """The checks the zero-loss harness has always run, in the order it always ran them."""
+    pg = args.postgres_container
+    published = read_ledger(args.ledger_file)
+    boundaries = read_boundaries(args.ledger_file)
+    for i in range(args.num_synth_topics):
+        name = f"synth{i:02d}"
+        check_synth_topic(
+            pg,
+            name,
+            published.get(name, set()),
+            boundaries.get(name, set()),
+            violations,
+            notes,
+            details,
+        )
+    for tag in REAL_TAGS:
+        check_real_tag(pg, tag, violations, notes, details)
+    check_files(pg, violations, notes, details)
+    check_timestamp_resolution(pg, FAST_TAG, violations, notes, details)
+    if args.passthrough_file is not None:
+        check_passthrough(args.passthrough_file, published, boundaries, violations, notes, details)
+    if args.mcap_summary_file is not None:
+        check_mcap_passthrough(
+            args.mcap_summary_file, published, boundaries, violations, notes, details
+        )
+    if args.raw_file is not None:
+        check_raw(args.raw_file, boundaries, violations, notes, details)
+
+
+def verify_incident(args, violations: list, notes: list, details: dict) -> None:
+    """run_incident.sh's assertions, one stage per invocation (a FlushEvent is published
+    between them, which is an action for the scenario script, not a check of ours)."""
+    pg = args.postgres_container
+
+    if args.stage == INCIDENT_STAGE_ARMED:
+        column_type = psql(
+            pg,
+            "SELECT data_type FROM information_schema.columns "
+            "WHERE table_name = 'dc_records' AND column_name = 'incident_id'",
+        )
+        check_incident_column(column_type, violations, details)
+        if violations:
+            return
+        live_count = wait_for_count(
+            pg,
+            f"SELECT count(*) FROM dc_records WHERE tag = '{args.live_tag}'",
+            MIN_LIVE_ROWS,
+            args.timeout_seconds,
+        )
+        check_live_flowing(live_count, args.live_tag, args.timeout_seconds, violations, details)
+        buffered_count = scalar_int(
+            pg, f"SELECT count(*) FROM dc_records WHERE tag = '{args.buffered_tag}'"
+        )
+        check_armed_silent(buffered_count, args.buffered_tag, violations, details)
+        return
+
+    incident_count = wait_for_count(
+        pg,
+        f"SELECT count(*) FROM dc_records WHERE incident_id = '{args.incident_id}'",
+        MIN_INCIDENT_ROWS,
+        args.timeout_seconds,
+    )
+    check_released_window(
+        pg,
+        args.incident_id,
+        args.buffered_tag,
+        args.live_tag,
+        incident_count,
+        violations,
+        details,
+    )
+
+
+def verify_retention(args, violations: list, notes: list, details: dict) -> None:
+    """run_retention.sh's assertions, one stage per invocation (the store comes up between
+    them, and the shed File's absence on disk is the scenario script's volume mount)."""
+    pg = args.postgres_container
+    if args.stage == RETENTION_STAGE_SHED:
+        query = "SELECT count(*) FROM dc_files WHERE deleted = true AND uploaded = false"
+        check_shed_row(
+            wait_for_count(pg, query, 1, args.timeout_seconds),
+            args.timeout_seconds,
+            violations,
+            details,
+        )
+        return
+    query = "SELECT count(*) FROM dc_files WHERE uploaded = true"
+    check_uploaded_row(
+        wait_for_count(pg, query, 1, args.timeout_seconds),
+        args.timeout_seconds,
+        violations,
+        details,
+    )
+
+
+PROFILE_STAGES = {
+    "zero-loss": (),
+    "incident": INCIDENT_STAGES,
+    "retention": RETENTION_STAGES,
+}
+
+PROFILE_LABELS = {
+    "zero-loss": "ZERO-LOSS",
+    "incident": "INCIDENT",
+    "retention": "RETENTION",
+}
+
+# The unit the pass line counts: the zero-loss profile checks per-source detail blocks,
+# the other two run a handful of assertions over one table.
+PROFILE_COUNT_NOUN = {
+    "zero-loss": "sources checked",
+    "incident": "checks run",
+    "retention": "checks run",
+}
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -763,11 +1086,56 @@ def main() -> int:
         default="dc_e2e_postgres",
         help="name of the running Postgres container to query via podman exec",
     )
+    parser.add_argument(
+        "--exec-sql",
+        default=None,
+        help="run one SQL statement against the Postgres container, print the result and "
+        "exit. lib/harness.sh's pg_exec() shells out to this: the module is the only SQL "
+        "author in the e2e tree, so there is one psql seam, not one implementation in bash "
+        "and another here",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=sorted(PROFILE_STAGES),
+        default="zero-loss",
+        help="which set of checks to run (see the module docstring): the zero-loss harness's "
+        "own, run_incident.sh's (#291) or run_retention.sh's (#267)",
+    )
+    parser.add_argument(
+        "--stage",
+        default=None,
+        help="which half of an incident/retention run to verify — armed/released for "
+        "--profile incident, shed/uploaded for --profile retention. A FlushEvent is "
+        "published (or the store brought up) between the two halves, so no single "
+        "invocation can cover both",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=None,
+        help="bound for the one wait the incident/retention stage polls under",
+    )
+    parser.add_argument(
+        "--incident-id",
+        default=None,
+        help="the incident_id the FlushEvent carried (--profile incident)",
+    )
+    parser.add_argument(
+        "--live-tag",
+        default=None,
+        help="Tag of the Measurement that is never armed (--profile incident)",
+    )
+    parser.add_argument(
+        "--buffered-tag",
+        default=None,
+        help="Tag of the Measurement armed with buffer_duration_sec (--profile incident)",
+    )
     parser.add_argument("--num-synth-topics", type=int, default=14)
     parser.add_argument(
         "--ledger-file",
-        required=True,
-        help="workload ledger extracted from the dc_e2e_data volume (what was published)",
+        default=None,
+        help="workload ledger extracted from the dc_e2e_data volume (what was published); "
+        "required by --profile zero-loss, unused by the others",
     )
     parser.add_argument(
         "--passthrough-file",
@@ -800,38 +1168,45 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    pg = args.postgres_container
+    if args.exec_sql is not None:
+        print(psql(args.postgres_container, args.exec_sql))
+        return 0
+
+    stages = PROFILE_STAGES[args.profile]
+    if stages:
+        if args.stage not in stages:
+            parser.error(f"--profile {args.profile} needs --stage {'|'.join(stages)}")
+        if args.timeout_seconds is None:
+            parser.error(f"--profile {args.profile} needs --timeout-seconds")
+        if args.profile == "incident":
+            for name in ("incident-id", "live-tag", "buffered-tag"):
+                if getattr(args, name.replace("-", "_")) is None:
+                    parser.error(f"--profile incident needs --{name}")
+    elif args.stage is not None:
+        parser.error("--stage only applies to --profile incident/--profile retention")
+    elif args.ledger_file is None:
+        parser.error("--profile zero-loss needs --ledger-file")
+
     violations: list = []
     notes: list = []
     details: dict = {}
+    if args.profile == "zero-loss":
+        verify_zero_loss(args, violations, notes, details)
+    elif args.profile == "incident":
+        verify_incident(args, violations, notes, details)
+    else:
+        verify_retention(args, violations, notes, details)
 
-    published = read_ledger(args.ledger_file)
-    boundaries = read_boundaries(args.ledger_file)
-    for i in range(args.num_synth_topics):
-        name = f"synth{i:02d}"
-        check_synth_topic(
-            pg,
-            name,
-            published.get(name, set()),
-            boundaries.get(name, set()),
-            violations,
-            notes,
-            details,
-        )
-    for tag in REAL_TAGS:
-        check_real_tag(pg, tag, violations, notes, details)
-    check_files(pg, violations, notes, details)
-    check_timestamp_resolution(pg, FAST_TAG, violations, notes, details)
-    if args.passthrough_file is not None:
-        check_passthrough(args.passthrough_file, published, boundaries, violations, notes, details)
-    if args.mcap_summary_file is not None:
-        check_mcap_passthrough(
-            args.mcap_summary_file, published, boundaries, violations, notes, details
-        )
-    if args.raw_file is not None:
-        check_raw(args.raw_file, boundaries, violations, notes, details)
-
-    report = {"pass": not violations, "violations": violations, "notes": notes, "details": details}
+    label = PROFILE_LABELS[args.profile]
+    stage = f", stage={args.stage}" if args.stage else ""
+    report = {
+        "profile": args.profile,
+        "stage": args.stage,
+        "pass": not violations,
+        "violations": violations,
+        "notes": notes,
+        "details": details,
+    }
     if args.conditions_file:
         with open(args.conditions_file) as f:
             report["conditions"] = json.load(f)
@@ -840,19 +1215,22 @@ def main() -> int:
             json.dump(report, f, indent=2)
 
     # Notes (at-least-once boundary re-sends) print in both the pass and fail paths — they
-    # are expected and never affect the exit status; only violations (loss) do.
+    # are expected and never affect the exit status; only violations do.
     if notes:
         print(f"NOTES ({len(notes)} at-least-once duplicate(s), deduped on read):")
         for n in notes:
             print(f"  - {n}")
 
     if violations:
-        print("ZERO-LOSS VERIFICATION FAILED:", file=sys.stderr)
+        print(f"{label} VERIFICATION FAILED{stage}:", file=sys.stderr)
         for v in violations:
             print(f"  - {v}", file=sys.stderr)
         return 1
 
-    print(f"ZERO-LOSS VERIFICATION PASSED ({len(details)} sources checked, 0 violations)")
+    print(
+        f"{label} VERIFICATION PASSED{stage} "
+        f"({len(details)} {PROFILE_COUNT_NOUN[args.profile]}, 0 violations)"
+    )
     return 0
 
 

--- a/tools/e2e/test/test_verify_profiles.py
+++ b/tools/e2e/test/test_verify_profiles.py
@@ -1,0 +1,285 @@
+# SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+# SPDX-License-Identifier: MPL-2.0
+
+"""Unit tests for verify_zero_loss.py's incident/retention check profiles (#496).
+
+The two profiles absorbed run_incident.sh's and run_retention.sh's inline SQL, so their
+thresholds (what counts as "flowing", "silent", "a released window", "shed", "uploaded")
+are now verdicts of this module and get the same kind of unit coverage the zero-loss
+harness's own helpers get elsewhere in this directory. psql/scalar_int are fake; nothing
+here needs a container.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scripts"))
+
+import verify_zero_loss as vzl
+
+
+def test_incident_column_is_required_to_be_text():
+    violations = []
+    details = {}
+    vzl.check_incident_column("text", violations, details)
+    assert violations == []
+
+
+def test_a_missing_incident_column_fails_and_names_init_sql():
+    violations = []
+    vzl.check_incident_column("", violations, {})
+    assert len(violations) == 1
+    assert "init.sql" in violations[0]
+
+
+def test_the_live_measurement_must_be_actually_delivering():
+    violations = []
+    vzl.check_live_flowing(vzl.MIN_LIVE_ROWS, "dc.measurement.memory", 180, violations, {})
+    assert violations == []
+    vzl.check_live_flowing(vzl.MIN_LIVE_ROWS - 1, "dc.measurement.memory", 180, violations, {})
+    assert len(violations) == 1
+
+
+def test_armed_means_silent_means_zero_rows():
+    violations = []
+    vzl.check_armed_silent(0, "dc.measurement.uptime", violations, {})
+    assert violations == []
+    vzl.check_armed_silent(1, "dc.measurement.uptime", violations, {})
+    assert len(violations) == 1
+
+
+def test_a_released_window_is_checked_on_four_axes(monkeypatch):
+    counts = {"wrong_tag": 0, "other_ids": 0, "live_tagged": 0}
+
+    def fake_scalar_int(pg, query):
+        # The three side queries are told apart by their predicates, not by the id/tag
+        # literals they interpolate (those repeat across queries).
+        if "AND tag <>" in query:
+            return counts["wrong_tag"]
+        if "AND incident_id <>" in query:
+            return counts["other_ids"]
+        if "AND incident_id IS NOT NULL" in query:
+            return counts["live_tagged"]
+        return vzl.MIN_INCIDENT_ROWS
+
+    monkeypatch.setattr(vzl, "scalar_int", fake_scalar_int)
+
+    violations = []
+    details = {}
+    vzl.check_released_window(
+        "pg",
+        "e2e-incident-0001",
+        "dc.measurement.uptime",
+        "dc.measurement.memory",
+        vzl.MIN_INCIDENT_ROWS,
+        violations,
+        details,
+    )
+    assert violations == []
+
+    counts.update(wrong_tag=1, other_ids=2, live_tagged=3)
+    vzl.check_released_window(
+        "pg",
+        "e2e-incident-0001",
+        "dc.measurement.uptime",
+        "dc.measurement.memory",
+        vzl.MIN_INCIDENT_ROWS - 1,
+        violations,
+        details,
+    )
+    # A short window, a window row from another Measurement, a foreign id, and a tagged
+    # live row are four separate failures — not one lumped "window looks wrong".
+    assert len(violations) == 4
+
+
+def test_retention_verdicts_are_one_row_or_a_failure():
+    shed, uploaded = [], []
+    vzl.check_shed_row(1, 480, shed, {})
+    vzl.check_uploaded_row(1, 60, uploaded, {})
+    assert shed == [] and uploaded == []
+    vzl.check_shed_row(0, 480, shed, {})
+    vzl.check_uploaded_row(0, 60, uploaded, {})
+    assert len(shed) == 1 and len(uploaded) == 1
+
+
+def test_wait_for_count_stops_polling_once_the_minimum_is_reached(monkeypatch):
+    calls = []
+
+    def fake_scalar_int(pg, query):
+        calls.append(query)
+        return len(calls)
+
+    monkeypatch.setattr(vzl, "scalar_int", fake_scalar_int)
+    assert vzl.wait_for_count("pg", "SELECT count(*) FROM dc_records", 3, 60) == 3
+    assert len(calls) == 3
+
+
+def test_wait_for_count_returns_the_last_count_when_the_wait_expires(monkeypatch):
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        vzl,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda s: clock.__setitem__("now", clock["now"] + s),
+        ),
+    )
+    monkeypatch.setattr(vzl, "scalar_int", lambda pg, query: 1)
+    assert vzl.wait_for_count("pg", "SELECT count(*) FROM dc_records", 5, 10) == 1
+
+
+def _run_main(monkeypatch, argv, scalar_int=None, psql=None):
+    monkeypatch.setattr(sys, "argv", ["verify_zero_loss.py"] + argv)
+    if scalar_int is not None:
+        monkeypatch.setattr(vzl, "scalar_int", scalar_int)
+    if psql is not None:
+        monkeypatch.setattr(vzl, "psql", psql)
+    return vzl.main()
+
+
+def test_incident_and_retention_need_their_stage_and_its_arguments(monkeypatch):
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, ["--profile", "incident"])
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, ["--profile", "retention", "--stage", "shed"])
+    with pytest.raises(SystemExit):
+        _run_main(
+            monkeypatch,
+            [
+                "--profile",
+                "incident",
+                "--stage",
+                "armed",
+                "--timeout-seconds",
+                "5",
+            ],
+        )
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, ["--stage", "armed", "--ledger-file", "ledger.txt"])
+
+
+def test_the_zero_loss_profile_still_needs_the_ledger(monkeypatch):
+    with pytest.raises(SystemExit):
+        _run_main(monkeypatch, [])
+
+
+def test_incident_armed_stage_passes_when_the_pipeline_flows_and_the_armed_tag_is_silent(
+    monkeypatch,
+):
+    def fake_psql(pg, query):
+        if "information_schema" in query:
+            return "text"
+        if "dc.measurement.memory" in query:
+            return str(vzl.MIN_LIVE_ROWS)
+        return "0"
+
+    argv = [
+        "--profile",
+        "incident",
+        "--stage",
+        "armed",
+        "--timeout-seconds",
+        "180",
+        "--incident-id",
+        "e2e-incident-0001",
+        "--live-tag",
+        "dc.measurement.memory",
+        "--buffered-tag",
+        "dc.measurement.uptime",
+    ]
+    assert _run_main(monkeypatch, argv, psql=fake_psql) == 0
+
+
+def test_incident_released_stage_fails_when_no_row_carries_the_id(monkeypatch):
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        vzl,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda s: clock.__setitem__("now", clock["now"] + s),
+        ),
+    )
+    argv = [
+        "--profile",
+        "incident",
+        "--stage",
+        "released",
+        "--timeout-seconds",
+        "5",
+        "--incident-id",
+        "e2e-incident-0001",
+        "--live-tag",
+        "dc.measurement.memory",
+        "--buffered-tag",
+        "dc.measurement.uptime",
+    ]
+    assert _run_main(monkeypatch, argv, scalar_int=lambda pg, query: 0) == 1
+
+
+def test_retention_stage_fails_when_no_file_was_shed(monkeypatch):
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        vzl,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda s: clock.__setitem__("now", clock["now"] + s),
+        ),
+    )
+    assert (
+        _run_main(
+            monkeypatch,
+            ["--profile", "retention", "--stage", "shed", "--timeout-seconds", "5"],
+            scalar_int=lambda pg, query: 0,
+        )
+        == 1
+    )
+
+
+def test_exec_sql_is_the_psql_seam_the_harness_shells_out_to(monkeypatch, capsys):
+    monkeypatch.setattr(vzl, "psql", lambda pg, query: "7")
+    assert _run_main(monkeypatch, ["--exec-sql", "SELECT count(*) FROM dc_records"]) == 0
+    assert capsys.readouterr().out.strip() == "7"
+
+
+def test_the_profile_table_is_the_whole_surface():
+    assert sorted(vzl.PROFILE_STAGES) == ["incident", "retention", "zero-loss"]
+    assert vzl.PROFILE_STAGES["zero-loss"] == ()
+    assert vzl.PROFILE_STAGES["incident"] == ("armed", "released")
+    assert vzl.PROFILE_STAGES["retention"] == ("shed", "uploaded")
+
+
+def test_a_run_writes_its_profile_and_stage_into_the_report(monkeypatch, tmp_path):
+    report = tmp_path / "report.json"
+    argv = [
+        "--profile",
+        "retention",
+        "--stage",
+        "uploaded",
+        "--timeout-seconds",
+        "5",
+        "--report",
+        str(report),
+    ]
+    clock = {"now": 0.0}
+    monkeypatch.setattr(
+        vzl,
+        "time",
+        SimpleNamespace(
+            monotonic=lambda: clock["now"],
+            sleep=lambda s: clock.__setitem__("now", clock["now"] + s),
+        ),
+    )
+    monkeypatch.setattr(vzl, "scalar_int", lambda pg, query: 3)
+    assert _run_main(monkeypatch, argv) == 0
+
+    import json
+
+    written = json.loads(report.read_text())
+    assert written["profile"] == "retention"
+    assert written["stage"] == "uploaded"
+    assert written["pass"] is True


### PR DESCRIPTION
Closes #496

## Problem

Every one of the twelve `run_*.sh` scenario scripts carried its own copy of the same skeleton: an inline `log()`, an inline `remove_stack()`, an inline `cleanup()`/`trap`, an inline image-resolution block, inline Postgres/RustFS bring-up and readiness polling, and a first-Record poll loop. The RustFS digest literal existed in ten bash files. Two scenarios (`run_incident.sh`, `run_retention.sh`) additionally carried their verdict SQL inline in bash, next to an already-existing SQL author (`verify_zero_loss.py`) — two places to change when a table or threshold moves.

## Fix

**One topology seam — `tools/e2e/scripts/lib/harness.sh`.** A scenario now describes itself once, to `harness_init`, and everything else is a function call:

- `harness_init --tag … --run-dir … --network … --compose … --pg-container … --rustfs-container … --containers … --volumes … --teardown-networks … --log-captures …` records the manifest and installs the `EXIT` trap. The list flags consume every following argument that isn't another flag, so a variable-length stack list is just `"${STACKS[@]}"`.
- The harness owns what the twelve scripts each used to paste: `resolve_image` (`DC_E2E_IMAGE` > `DC_WORKSPACE_IMAGE` > build.sh + Containerfile.e2e), `remove_stack` (compose `down` when `--compose` is given, else container/volume/network removal from the manifest), `harness_capture_logs`, `start_postgres`/`start_rustfs`, `wait_postgres_ready` (gates on init.sql having applied, not on a server that answers from its temporary init instance), `wait_rustfs_ready` (host curl, or a one-off probe container on the scenario's network), `create_rustfs_bucket`, `extract_from_volume`, and `wait_first_record <timeout> <start-ts> <context>` — the launch-to-first-Record gate the three zero-loss scripts each carried, now printing the measured latency so the caller keeps its own startup gate.
- The one bash copy of the RustFS digest lives in `lib/harness.sh` (`RUSTFS_IMAGE`); the compose files keep their own literal (plain YAML can't source bash — the same reason compose.split.yaml's Vector tag keeps one and the `vector-pin` job exists).
- The seven limits/load scripts (`two_tier`, `single_robot_ceiling`, `upload_concurrency`, `drain_rate`, `shipper_fanin`, `load_driver_shipper_test`, `capacity_baseline`) stop inlining store bring-up; `run_limits_drain_rate.sh` — the one scenario with no DC image to probe from — overrides `harness_rustfs_probe` to probe from the Vector image instead.

**Named verification profiles — `verify_zero_loss.py --profile`.** `zero-loss` (default) is today's behaviour; `incident` (#291) and `retention` (#267) absorb the SQL those two bash scripts carried, staged because a real action sits between the halves (a `FlushEvent` published, or the object store brought up): `--profile incident --stage armed|released` and `--profile retention --stage shed|uploaded`. `wait_for_count` is the bounded poll those scripts used to hand-roll, next to the verdict it feeds. The module is now the only SQL author in the e2e tree: bash's `pg_exec()` shells out through the new `--exec-sql`, so there is one psql seam, not a bash implementation and a Python one.

Added `tools/e2e/test/test_verify_profiles.py` covering the incident/retention thresholds (armed-means-silent, the four released-window axes, one-row-or-fail retention, `wait_for_count`'s early return vs. expiry, and the argument validation), with `psql`/`scalar_int` faked — no container needed.

**What deliberately did not change:** no scenario's topology, workload, or verdict semantics. `check_synth_topic`'s kill-point tolerance logic is byte-identical (the diff only moves the former `main()` body into `verify_zero_loss()` unchanged). The startup-latency gates still measure from the caller's own start timestamp, so `run.sh`/`run_degraded.sh` still time the whole `podman run` launch and `run_split.sh` still times from vector's late start. Two gates read slightly differently by design and now say so: `run_limits_single_robot_ceiling.sh` and `run_limits_upload_concurrency.sh` both used to poll a different table/`pg_isready`; both now use `wait_postgres_ready`, which is equivalent because one pass of `sql/init.sql` creates `dc_records` and `dc_files` together.

## Verification

- `bash -n` + `shellcheck` clean on all 13 touched shell files; `python3 -m py_compile` clean on `verify_zero_loss.py`; `ruff check`/`ruff format` clean; `prek run --skip build-doc` passes on the staged tree.
- `uv run --frozen pytest tools/e2e/test -q` → 148 passed (the new profile tests included; CI's `raw-volume` job runs this same suite).
- No podman scenario was run locally (heavy image pulls), per the issue's constraint.

**CI is the authoritative check here:** the `e2e` (`run.sh`) and `e2e-split` (`run_split.sh`) jobs execute the migrated harness end to end against real containers, and the `vector-pin` job guards the compose literals this PR touches. Ask CI to confirm those jobs green before merge (same precedent as #493).

## Deferred

- The `topology.sh` up/down/exec/logs-per-service module from the issue's stretch goal: every scenario's topology is already expressed once, to `harness_init`, and only `run_split.sh` uses compose — a second abstraction on top would have to earn its keep against that.
- Single-sourcing `NUM_SYNTH_TOPICS`/`REAL_TAGS` between `verify_zero_loss.py` and the workload generator needs a new shared Python module plus a new `COPY` line in `Containerfile.e2e` — untestable locally without running podman, so left alone rather than half-wired.