### PR TITLE
refactor(dc_measurements): derive each Measurement's validation schema from its plugin type

### DIFF
--- a/dc_demos/include/dc_demos/plugins/measurements/uptime_custom.hpp
+++ b/dc_demos/include/dc_demos/plugins/measurements/uptime_custom.hpp
@@ -18,7 +18,6 @@ class UptimeCustom : public dc_measurements::Uptime
 {
 protected:
   void onFailedValidation(json data_json) override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_demos

--- a/dc_demos/plugins/measurements/uptime_custom.cpp
+++ b/dc_demos/plugins/measurements/uptime_custom.cpp
@@ -12,14 +12,6 @@ void UptimeCustom::onFailedValidation(json data_json)
   RCLCPP_INFO(logger_, "Callback! Validation failed for uptime custom");
 }
 
-void UptimeCustom::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_demos", "uptime_custom.json");
-  }
-}
-
 }  // namespace dc_demos
 
 #include "pluginlib/class_list_macros.hpp"

--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -315,6 +315,7 @@ set(tests
   test_measurement_random
   test_measurement_ros2_control_status
   test_measurement_same_as_previous
+  test_measurement_schema
   test_measurement_serial_interface
   test_measurement_shared_flush
   test_measurement_slam_toolbox_quality

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -236,6 +236,16 @@ public:
     return out;
   }
 
+  // The schema file a plugin type validates against by default, relative to the registering
+  // package's plugins/measurements/json directory. Only the type after the '/' is converted:
+  // the package part is not a CamelCase word.
+  static std::string defaultSchemaFile(const std::string& plugin_lookup_name)
+  {
+    const size_t sep = plugin_lookup_name.find('/');
+    const std::string& plugin_type = sep == std::string::npos ? plugin_lookup_name : plugin_lookup_name.substr(sep + 1);
+    return snakeCase(plugin_type) + ".json";
+  }
+
   // The schema a Measurement validates against when json_schema_path is unset: one file per
   // plugin type, named after it, shipped by the package registering the plugin
   // (dc_measurements/Camera -> dc_measurements/plugins/measurements/json/camera.json).
@@ -246,9 +256,7 @@ public:
     const size_t sep = measurement_plugin_.find('/');
     const std::string package =
         sep == std::string::npos ? std::string("dc_measurements") : measurement_plugin_.substr(0, sep);
-    const std::string plugin_type =
-        sep == std::string::npos ? measurement_plugin_ : measurement_plugin_.substr(sep + 1);
-    validateSchema(package, snakeCase(plugin_type) + ".json");
+    validateSchema(package, defaultSchemaFile(measurement_plugin_));
   }
 
   // Current state of one of the configured Conditions, as dc_core::ConditionSet asks for it.

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -6,6 +6,7 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include <cctype>
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -95,18 +96,6 @@ public:
   }
 
   ~Measurement() override = default;
-
-  // an opportunity for derived classes to set the validation schema
-  // if they chose
-  virtual void setValidationSchema() = 0;
-
-  void setValidationSchemaFromPath(const std::string& json_schema_path)
-  {
-    if (enable_validator_)
-    {
-      validateSchema(json_schema_path);
-    }
-  }
 
   // an opportunity for derived classes to do something on configuration
   // if they chose
@@ -224,6 +213,42 @@ public:
     {
       RCLCPP_ERROR_STREAM(logger_, "Error parsing JSON file json_schema_path: " << json_schema_path);
     }
+  }
+
+  // CamelCase to snake_case, keeping an acronym run together with the word it precedes:
+  // TCPHealth -> tcp_health, Ros2ControlStatus -> ros2_control_status, OS -> os.
+  static std::string snakeCase(const std::string& camel)
+  {
+    std::string out;
+    for (size_t i = 0; i < camel.size(); i++)
+    {
+      const unsigned char c = static_cast<unsigned char>(camel[i]);
+      const unsigned char prev = i > 0 ? static_cast<unsigned char>(camel[i - 1]) : 0;
+      const unsigned char next = i + 1 < camel.size() ? static_cast<unsigned char>(camel[i + 1]) : 0;
+      const bool boundary = i > 0 && std::isupper(c) &&
+                            ((std::islower(prev) || std::isdigit(prev)) || (std::isupper(prev) && std::islower(next)));
+      if (boundary)
+      {
+        out += '_';
+      }
+      out += static_cast<char>(std::tolower(c));
+    }
+    return out;
+  }
+
+  // The schema a Measurement validates against when json_schema_path is unset: one file per
+  // plugin type, named after it, shipped by the package registering the plugin
+  // (dc_measurements/Camera -> dc_measurements/plugins/measurements/json/camera.json).
+  // Derived from the plugin type rather than the measurement name so an instance id like
+  // right_camera still finds the Camera schema.
+  void validateDefaultSchema()
+  {
+    const size_t sep = measurement_plugin_.find('/');
+    const std::string package =
+        sep == std::string::npos ? std::string("dc_measurements") : measurement_plugin_.substr(0, sep);
+    const std::string plugin_type =
+        sep == std::string::npos ? measurement_plugin_ : measurement_plugin_.substr(sep + 1);
+    validateSchema(package, snakeCase(plugin_type) + ".json");
   }
 
   // Current state of one of the configured Conditions, as dc_core::ConditionSet asks for it.
@@ -678,13 +703,16 @@ public:
 
     RCLCPP_INFO(logger_, "Done configuring %s", measurement_name_.c_str());
 
-    if (json_schema_path_.empty())
+    if (enable_validator_)
     {
-      setValidationSchema();
-    }
-    else
-    {
-      setValidationSchemaFromPath(json_schema_path_);
+      if (json_schema_path_.empty())
+      {
+        validateDefaultSchema();
+      }
+      else
+      {
+        validateSchema(json_schema_path_);
+      }
     }
     // If error during measurement initialization, stop it from publishing
     try

--- a/dc_measurements/include/dc_measurements/plugins/measurements/battery.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/battery.hpp
@@ -49,7 +49,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/camera.hpp
@@ -49,7 +49,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
   void rotateImage(cv_bridge::CvImagePtr& cv_ptr);
   std::string getLocalPath(const std::string& param_reference, const rclcpp::Time& now);
   void saveRemoteKeys(json& data_json, const std::string& key, const std::string& relative_path,

--- a/dc_measurements/include/dc_measurements/plugins/measurements/cmd_vel.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/cmd_vel.hpp
@@ -33,7 +33,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/cpu.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/cpu.hpp
@@ -30,10 +30,8 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
   void setProcessesUsage(json& data_json);
   void setAverageCpu(json& data_json);
-  void setValidationSchema(json& data_json);
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/diagnostics.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/diagnostics.hpp
@@ -39,7 +39,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/distance_traveled.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/distance_traveled.hpp
@@ -25,7 +25,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 
   std::string global_frame_;
   std::string robot_base_frame_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/driving_type.hpp
@@ -28,7 +28,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/dummy.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/dummy.hpp
@@ -22,7 +22,6 @@ protected:
   /**
    * @brief Set validation schema used to confirm data before collecting it
    */
-  void setValidationSchema() override;
   void onConfigure() override;
   std::string record_;
 };

--- a/dc_measurements/include/dc_measurements/plugins/measurements/fastdds_stats.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/fastdds_stats.hpp
@@ -31,7 +31,6 @@ public:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 
 private:
   uint32_t domain_id_{ 0 };

--- a/dc_measurements/include/dc_measurements/plugins/measurements/fault.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/fault.hpp
@@ -67,7 +67,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/intervention.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/intervention.hpp
@@ -36,7 +36,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/ip_camera.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/ip_camera.hpp
@@ -45,7 +45,6 @@ protected:
   /**
    * @brief Configuration of behavior action
    */
-  void setValidationSchema() override;
   void onConfigure() override;
 };
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/manipulation.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/manipulation.hpp
@@ -93,7 +93,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/map.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/map.hpp
@@ -46,7 +46,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/memory.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/memory.hpp
@@ -24,7 +24,6 @@ protected:
   /**
    * @brief Configuration of behavior action
    */
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2.hpp
@@ -82,7 +82,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.hpp
@@ -82,7 +82,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_nav2_through_poses.hpp
@@ -81,7 +81,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/mission_open_rmf.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/mission_open_rmf.hpp
@@ -68,7 +68,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/network.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/network.hpp
@@ -74,7 +74,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/os.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/os.hpp
@@ -23,7 +23,6 @@ protected:
   /**
    * @brief Configuration of behavior action
    */
-  void setValidationSchema() override;
   unsigned long long getTotalSystemMemory();
 };
 

--- a/dc_measurements/include/dc_measurements/plugins/measurements/permissions.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/permissions.hpp
@@ -42,7 +42,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/position.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/position.hpp
@@ -24,7 +24,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 
   std::string global_frame_;
   std::string robot_base_frame_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/random.hpp
@@ -26,7 +26,6 @@ protected:
   /**
    * @brief Set validation schema used to confirm data before collecting it
    */
-  void setValidationSchema() override;
   void onConfigure() override;
 
   std::string value_type_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/ros2_control_status.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/ros2_control_status.hpp
@@ -64,7 +64,6 @@ private:
 protected:
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/serial_interface.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/serial_interface.hpp
@@ -46,7 +46,6 @@ protected:
    */
   void onConfigure() override;
   void onCleanup() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/slam_toolbox_quality.hpp
@@ -78,7 +78,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/speed.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/speed.hpp
@@ -24,7 +24,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
   void odomCb(const nav_msgs::msg::Odometry& msg);
 
   std::string odom_topic_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/storage.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/storage.hpp
@@ -31,7 +31,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/string_stamped.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/string_stamped.hpp
@@ -12,6 +12,8 @@
 namespace dc_measurements
 {
 
+// Republishes another Measurement's Record verbatim, so no schema can describe its data: run it
+// with enable_validator: false, or configure() fails on the schema it would otherwise look for.
 class StringStamped : public dc_measurements::Measurement
 {
 public:
@@ -22,10 +24,6 @@ public:
   void onConfigure() override;
 
 protected:
-  /**
-   * @brief Set validation schema used to confirm data before collecting it
-   */
-  void setValidationSchema() override;
   dc_interfaces::msg::StringStamped last_data_;
   std::string topic_;
   rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr subscription_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/tcp_health.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/tcp_health.hpp
@@ -27,7 +27,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
   std::string host_;
   std::string name_;
   unsigned short port_;

--- a/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/thermal.hpp
@@ -32,7 +32,6 @@ protected:
    * @brief Configuration of behavior action
    */
   void onConfigure() override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/plugins/measurements/uptime.hpp
+++ b/dc_measurements/include/dc_measurements/plugins/measurements/uptime.hpp
@@ -23,7 +23,6 @@ protected:
   /**
    * @brief Set validation schema used to confirm data before collecting it
    */
-  void setValidationSchema() override;
   System system_;
 };
 

--- a/dc_measurements/plugins/measurements/battery.cpp
+++ b/dc_measurements/plugins/measurements/battery.cpp
@@ -117,14 +117,6 @@ void Battery::onConfigure()
       battery_topic_, rclcpp::SensorDataQoS(), std::bind(&Battery::batteryStateCb, this, std::placeholders::_1));
 }
 
-void Battery::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "battery.json");
-  }
-}
-
 void Battery::batteryStateCb(const sensor_msgs::msg::BatteryState& msg)
 {
   const auto now = getNode()->get_clock()->now();

--- a/dc_measurements/plugins/measurements/camera.cpp
+++ b/dc_measurements/plugins/measurements/camera.cpp
@@ -107,14 +107,6 @@ void Camera::cameraInfoCb(const sensor_msgs::msg::CameraInfo& msg)
   camera_info_received_ = true;
 }
 
-void Camera::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "camera.json");
-  }
-}
-
 void Camera::saveRemoteKeys(json& data_json, const std::string& key, const std::string& relative_path,
                             const rclcpp::Time& now)
 {

--- a/dc_measurements/plugins/measurements/cmd_vel.cpp
+++ b/dc_measurements/plugins/measurements/cmd_vel.cpp
@@ -35,14 +35,6 @@ void CmdVel::onConfigure()
       cmd_vel_topic_, 10, std::bind(&CmdVel::cmdVelCb, this, std::placeholders::_1));
 }
 
-void CmdVel::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "cmd_vel.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped CmdVel::collect()
 {
   dc_interfaces::msg::StringStamped msg = last_data_;

--- a/dc_measurements/plugins/measurements/cpu.cpp
+++ b/dc_measurements/plugins/measurements/cpu.cpp
@@ -20,14 +20,6 @@ void Cpu::onConfigure()
   cpu_min_ = dc_util::get_double_type_param(node, measurement_name_, "cpu_min", 5.0);
 }
 
-void Cpu::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "cpu.json");
-  }
-}
-
 void Cpu::setAverageCpu(json& data_json)
 {
   std::vector<float> values;

--- a/dc_measurements/plugins/measurements/diagnostics.cpp
+++ b/dc_measurements/plugins/measurements/diagnostics.cpp
@@ -50,14 +50,6 @@ void Diagnostics::onConfigure()
       topic_, rclcpp::SystemDefaultsQoS(), std::bind(&Diagnostics::diagnosticsCb, this, std::placeholders::_1));
 }
 
-void Diagnostics::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "diagnostics.json");
-  }
-}
-
 void Diagnostics::diagnosticsCb(const diagnostic_msgs::msg::DiagnosticArray& msg)
 {
   json statuses = json::array();

--- a/dc_measurements/plugins/measurements/distance_traveled.cpp
+++ b/dc_measurements/plugins/measurements/distance_traveled.cpp
@@ -27,14 +27,6 @@ void DistanceTraveled::onConfigure()
   node->get_parameter(measurement_name_ + ".transform_timeout", transform_timeout_);
 }
 
-void DistanceTraveled::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "distance_traveled.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped DistanceTraveled::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/driving_type.cpp
+++ b/dc_measurements/plugins/measurements/driving_type.cpp
@@ -17,14 +17,6 @@ void DrivingType::onConfigure()
   mode_source_.configure(getNode(), measurement_name_, logger_);
 }
 
-void DrivingType::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "driving_type.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped DrivingType::collect()
 {
   json data_json;

--- a/dc_measurements/plugins/measurements/dummy.cpp
+++ b/dc_measurements/plugins/measurements/dummy.cpp
@@ -12,14 +12,6 @@ Dummy::Dummy() : dc_measurements::Measurement()
 
 Dummy::~Dummy() = default;
 
-void Dummy::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "dummy.json");
-  }
-}
-
 void Dummy::onConfigure()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/fastdds_stats.cpp
+++ b/dc_measurements/plugins/measurements/fastdds_stats.cpp
@@ -81,14 +81,6 @@ void FastddsStats::onCleanup()
   }
 }
 
-void FastddsStats::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "fastdds_stats.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped FastddsStats::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/fault.cpp
+++ b/dc_measurements/plugins/measurements/fault.cpp
@@ -76,14 +76,6 @@ void Fault::onCleanup()
   }
 }
 
-void Fault::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "fault.json");
-  }
-}
-
 bool Fault::isWatched(const std::string& name) const
 {
   return names_.empty() || std::find(names_.begin(), names_.end(), name) != names_.end();

--- a/dc_measurements/plugins/measurements/intervention.cpp
+++ b/dc_measurements/plugins/measurements/intervention.cpp
@@ -48,14 +48,6 @@ void Intervention::onCleanup()
   }
 }
 
-void Intervention::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "intervention.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped Intervention::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/ip_camera.cpp
+++ b/dc_measurements/plugins/measurements/ip_camera.cpp
@@ -119,14 +119,6 @@ void IpCamera::onConfigure()
   ffmpeg_thread_.detach();
 }
 
-void IpCamera::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "ip_camera.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped IpCamera::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/manipulation.cpp
+++ b/dc_measurements/plugins/measurements/manipulation.cpp
@@ -88,14 +88,6 @@ void Manipulation::onCleanup()
   }
 }
 
-void Manipulation::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "manipulation.json");
-  }
-}
-
 void Manipulation::statusCb(const action_msgs::msg::GoalStatusArray& msg)
 {
   const rclcpp::Time stamp = getNode()->get_clock()->now();

--- a/dc_measurements/plugins/measurements/map.cpp
+++ b/dc_measurements/plugins/measurements/map.cpp
@@ -22,14 +22,6 @@ void Map::onConfigure()
   save_base64_ = dc_util::get_bool_type_param(node, measurement_name_, "save_base64", false);
 }
 
-void Map::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "map.json");
-  }
-}
-
 std::string Map::getAbsolutePath(const std::string& param_reference, const rclcpp::Time& now)
 {
   std::string file_save_path = getSavePath(param_reference, now);

--- a/dc_measurements/plugins/measurements/memory.cpp
+++ b/dc_measurements/plugins/measurements/memory.cpp
@@ -12,14 +12,6 @@ Memory::Memory() : dc_measurements::Measurement()
 
 Memory::~Memory() = default;
 
-void Memory::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "memory.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped Memory::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/mission_nav2.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2.cpp
@@ -68,14 +68,6 @@ void MissionNav2::onCleanup()
   result_client_.reset();
 }
 
-void MissionNav2::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "mission_nav2.json");
-  }
-}
-
 void MissionNav2::enqueue(json data, const rclcpp::Time& stamp)
 {
   // One Record leaves per poll, so missions starting/ending far faster than the polling interval

--- a/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_follow_waypoints.cpp
@@ -65,14 +65,6 @@ void MissionNav2FollowWaypoints::onCleanup()
   result_client_.reset();
 }
 
-void MissionNav2FollowWaypoints::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "mission_nav2_follow_waypoints.json");
-  }
-}
-
 void MissionNav2FollowWaypoints::enqueue(json data, const rclcpp::Time& stamp)
 {
   if (pending_records_.push(std::move(data), stamp))

--- a/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
+++ b/dc_measurements/plugins/measurements/mission_nav2_through_poses.cpp
@@ -42,14 +42,6 @@ void MissionNav2ThroughPoses::onCleanup()
   }
 }
 
-void MissionNav2ThroughPoses::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "mission_nav2_through_poses.json");
-  }
-}
-
 void MissionNav2ThroughPoses::emit(json data, const rclcpp::Time& stamp)
 {
   // One Record leaves per poll, so missions starting/ending far faster than the polling interval

--- a/dc_measurements/plugins/measurements/mission_open_rmf.cpp
+++ b/dc_measurements/plugins/measurements/mission_open_rmf.cpp
@@ -139,14 +139,6 @@ void MissionOpenRmf::onCleanup()
   }
 }
 
-void MissionOpenRmf::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "mission_open_rmf.json");
-  }
-}
-
 void MissionOpenRmf::emit(json data, const rclcpp::Time& stamp)
 {
   // One Record leaves per poll, same overflow policy as MissionNav2ThroughPoses::emit().

--- a/dc_measurements/plugins/measurements/network.cpp
+++ b/dc_measurements/plugins/measurements/network.cpp
@@ -57,14 +57,6 @@ void Network::onConfigure()
   setsockopt(skt_, IPPROTO_IP, IP_TTL, (char*)&ttl_, sizeof(ttl_));
 }
 
-void Network::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "network.json");
-  }
-}
-
 Network::~Network() = default;
 
 bool Network::ping()

--- a/dc_measurements/plugins/measurements/os.cpp
+++ b/dc_measurements/plugins/measurements/os.cpp
@@ -13,14 +13,6 @@ OS::OS() : dc_measurements::Measurement()
 
 OS::~OS() = default;
 
-void OS::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "os.json");
-  }
-}
-
 unsigned long long OS::getTotalSystemMemory()
 {
   long pages = sysconf(_SC_PHYS_PAGES);

--- a/dc_measurements/plugins/measurements/permissions.cpp
+++ b/dc_measurements/plugins/measurements/permissions.cpp
@@ -30,14 +30,6 @@ void Permissions::onConfigure()
   }
 }
 
-void Permissions::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "permissions.json");
-  }
-}
-
 struct stat Permissions::getOwner(const std::string& path)
 {
   struct stat info;

--- a/dc_measurements/plugins/measurements/position.cpp
+++ b/dc_measurements/plugins/measurements/position.cpp
@@ -20,14 +20,6 @@ void Position::onConfigure()
   transform_timeout_ = dc_util::get_double_type_param(node, measurement_name_, "transform_timeout", 0.1);
 }
 
-void Position::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "position.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped Position::collect()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/random.cpp
+++ b/dc_measurements/plugins/measurements/random.cpp
@@ -12,14 +12,6 @@ Random::Random() : dc_measurements::Measurement()
 
 Random::~Random() = default;
 
-void Random::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "random.json");
-  }
-}
-
 void Random::onConfigure()
 {
   auto node = getNode();

--- a/dc_measurements/plugins/measurements/ros2_control_status.cpp
+++ b/dc_measurements/plugins/measurements/ros2_control_status.cpp
@@ -91,14 +91,6 @@ void Ros2ControlStatus::onCleanup()
   }
 }
 
-void Ros2ControlStatus::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "ros2_control_status.json");
-  }
-}
-
 void Ros2ControlStatus::processEntries(const std::vector<controller_manager_msgs::msg::NamedLifecycleState>& entries,
                                        const std::string& component_type, const rclcpp::Time& stamp,
                                        std::map<std::string, dc_common::StateTransitionDetector<uint8_t>>& detectors)

--- a/dc_measurements/plugins/measurements/serial_interface.cpp
+++ b/dc_measurements/plugins/measurements/serial_interface.cpp
@@ -99,14 +99,6 @@ void SerialInterface::onConfigure()
   // instead, so activation always succeeds and reconnection happens automatically.
 }
 
-void SerialInterface::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "serial_interface.json");
-  }
-}
-
 void SerialInterface::onCleanup()
 {
   closePort();

--- a/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
+++ b/dc_measurements/plugins/measurements/slam_toolbox_quality.cpp
@@ -78,14 +78,6 @@ void SlamToolboxQuality::tryCreateLoopClosureSubscription()
   loop_closure_discovery_timer_.reset();
 }
 
-void SlamToolboxQuality::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "slam_toolbox_quality.json");
-  }
-}
-
 void SlamToolboxQuality::poseCb(const geometry_msgs::msg::PoseWithCovarianceStamped& msg)
 {
   const std::lock_guard<std::mutex> lock(mutex_);

--- a/dc_measurements/plugins/measurements/speed.cpp
+++ b/dc_measurements/plugins/measurements/speed.cpp
@@ -41,14 +41,6 @@ void Speed::onConfigure()
       odom_topic_, 10, std::bind(&Speed::odomCb, this, std::placeholders::_1));
 }
 
-void Speed::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "speed.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped Speed::collect()
 {
   dc_interfaces::msg::StringStamped msg = last_data_;

--- a/dc_measurements/plugins/measurements/storage.cpp
+++ b/dc_measurements/plugins/measurements/storage.cpp
@@ -25,14 +25,6 @@ void Storage::onConfigure()
   else {}
 }
 
-void Storage::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "storage.json");
-  }
-}
-
 Storage::~Storage() = default;
 
 dc_interfaces::msg::StringStamped Storage::collect()

--- a/dc_measurements/plugins/measurements/string_stamped.cpp
+++ b/dc_measurements/plugins/measurements/string_stamped.cpp
@@ -22,10 +22,6 @@ void StringStamped::onConfigure()
       topic_, 10, std::bind(&StringStamped::dataCb, this, std::placeholders::_1));
 }
 
-void StringStamped::setValidationSchema()
-{
-}
-
 void StringStamped::dataCb(const dc_interfaces::msg::StringStamped& msg)
 {
   last_data_ = msg;

--- a/dc_measurements/plugins/measurements/tcp_health.cpp
+++ b/dc_measurements/plugins/measurements/tcp_health.cpp
@@ -20,14 +20,6 @@ void TCPHealth::onConfigure()
   name_ = dc_util::get_str_type_param(node, measurement_name_, "name");
 }
 
-void TCPHealth::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "tcp_health.json");
-  }
-}
-
 bool TCPHealth::getPortHealth(unsigned short port)
 {
   using namespace boost::asio;

--- a/dc_measurements/plugins/measurements/thermal.cpp
+++ b/dc_measurements/plugins/measurements/thermal.cpp
@@ -56,14 +56,6 @@ void Thermal::onConfigure()
   // on every poll instead, and simply reports whatever zones it can currently read.
 }
 
-void Thermal::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "thermal.json");
-  }
-}
-
 std::vector<std::string> Thermal::discoverZones()
 {
   std::vector<std::string> zones;

--- a/dc_measurements/plugins/measurements/uptime.cpp
+++ b/dc_measurements/plugins/measurements/uptime.cpp
@@ -13,14 +13,6 @@ Uptime::Uptime() : dc_measurements::Measurement()
 
 Uptime::~Uptime() = default;
 
-void Uptime::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_measurements", "uptime.json");
-  }
-}
-
 dc_interfaces::msg::StringStamped Uptime::collect()
 {
   auto uptime = system_.upTime();

--- a/dc_measurements/test/test_measurement_schema.cpp
+++ b/dc_measurements/test/test_measurement_schema.cpp
@@ -38,7 +38,7 @@ std::vector<std::string> registeredPluginTypes()
 std::string schemaPath(const std::string& plugin_type)
 {
   return ament_index_cpp::get_package_share_directory("dc_measurements") + "/plugins/measurements/json/" +
-         dc_measurements::Measurement::snakeCase(plugin_type) + ".json";
+         dc_measurements::Measurement::defaultSchemaFile(plugin_type);
 }
 
 TEST(MeasurementSchemaTest, SnakeCaseKeepsAcronymsWithTheWordTheyPrecede)
@@ -49,6 +49,15 @@ TEST(MeasurementSchemaTest, SnakeCaseKeepsAcronymsWithTheWordTheyPrecede)
   EXPECT_EQ(dc_measurements::Measurement::snakeCase("Ros2ControlStatus"), "ros2_control_status");
   EXPECT_EQ(dc_measurements::Measurement::snakeCase("MissionNav2ThroughPoses"), "mission_nav2_through_poses");
   EXPECT_EQ(dc_measurements::Measurement::snakeCase("StringStamped"), "string_stamped");
+}
+
+TEST(MeasurementSchemaTest, DefaultSchemaFileTakesTheTypeNotTheWholeLookupName)
+{
+  // The package part is not a CamelCase word: converting the whole lookup name would nest it
+  // under json/ as a directory, where nothing is installed.
+  EXPECT_EQ(dc_measurements::Measurement::defaultSchemaFile("dc_measurements/Battery"), "battery.json");
+  EXPECT_EQ(dc_measurements::Measurement::defaultSchemaFile("dc_measurements/TCPHealth"), "tcp_health.json");
+  EXPECT_EQ(dc_measurements::Measurement::defaultSchemaFile("dc_demos/UptimeCustom"), "uptime_custom.json");
 }
 
 TEST(MeasurementSchemaTest, EveryRegisteredPluginHasItsOwnSchemaFile)
@@ -72,7 +81,7 @@ TEST(MeasurementSchemaTest, EveryRegisteredPluginHasItsOwnSchemaFile)
     }
     EXPECT_TRUE(std::filesystem::exists(schemaPath(type)))
         << type << " derives a default schema of " << schemaPath(type) << ", which is not installed";
-    schema_names.insert(dc_measurements::Measurement::snakeCase(type));
+    schema_names.insert(dc_measurements::Measurement::defaultSchemaFile(type));
   }
 
   // Two plugins deriving the same file name would make one of them validate against a schema

--- a/dc_measurements/test/test_measurement_schema.cpp
+++ b/dc_measurements/test/test_measurement_schema.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_interfaces/msg/string_stamped.hpp"
+#include "dc_measurements/measurement.hpp"
+#include "dc_measurements/measurement_server.hpp"
+
+// The schema a Measurement validates against defaults to one file per plugin type, named after
+// it (#498). Every plugin the package registers therefore needs a matching file installed, or
+// configure() throws "Enabled validation but didn't configure schema!" for that whole type.
+
+std::vector<std::string> registeredPluginTypes()
+{
+  std::ifstream xml(ament_index_cpp::get_package_share_directory("dc_measurements") + "/measurement_plugin.xml");
+  std::string content((std::istreambuf_iterator<char>(xml)), std::istreambuf_iterator<char>());
+
+  std::vector<std::string> types;
+  const std::string needle = "class name=\"";
+  for (size_t pos = content.find(needle); pos != std::string::npos; pos = content.find(needle, pos))
+  {
+    pos += needle.size();
+    types.push_back(content.substr(pos, content.find('"', pos) - pos));
+  }
+  return types;
+}
+
+std::string schemaPath(const std::string& plugin_type)
+{
+  return ament_index_cpp::get_package_share_directory("dc_measurements") + "/plugins/measurements/json/" +
+         dc_measurements::Measurement::snakeCase(plugin_type) + ".json";
+}
+
+TEST(MeasurementSchemaTest, SnakeCaseKeepsAcronymsWithTheWordTheyPrecede)
+{
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("OS"), "os");
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("TCPHealth"), "tcp_health");
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("IpCamera"), "ip_camera");
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("Ros2ControlStatus"), "ros2_control_status");
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("MissionNav2ThroughPoses"), "mission_nav2_through_poses");
+  EXPECT_EQ(dc_measurements::Measurement::snakeCase("StringStamped"), "string_stamped");
+}
+
+TEST(MeasurementSchemaTest, EveryRegisteredPluginHasItsOwnSchemaFile)
+{
+  // StringStamped republishes another Measurement's Record verbatim, so there is no shape to
+  // constrain: it is the one type with no schema, and a deployment of it must say so with
+  // enable_validator: false.
+  const std::set<std::string> schemaless = { "dc_measurements/StringStamped" };
+
+  const std::vector<std::string> types = registeredPluginTypes();
+  ASSERT_FALSE(types.empty());
+
+  std::set<std::string> schema_names;
+  for (const std::string& type : types)
+  {
+    if (schemaless.count(type) != 0)
+    {
+      EXPECT_FALSE(std::filesystem::exists(schemaPath(type)))
+          << type << " gained a schema; drop it from the schemaless list";
+      continue;
+    }
+    EXPECT_TRUE(std::filesystem::exists(schemaPath(type)))
+        << type << " derives a default schema of " << schemaPath(type) << ", which is not installed";
+    schema_names.insert(dc_measurements::Measurement::snakeCase(type));
+  }
+
+  // Two plugins deriving the same file name would make one of them validate against a schema
+  // written for the other.
+  EXPECT_EQ(schema_names.size(), types.size() - schemaless.size());
+}
+
+// The schema follows the plugin type, not the instance id: a Measurement may be named whatever
+// the deployment likes and still find its plugin's schema.
+class MeasurementAliasedSchemaTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    ms_node_ = std::make_shared<measurement_server::MeasurementServer>(rclcpp::NodeOptions(),
+                                                                       std::vector<std::string>{ "mem_alias" });
+    sub_data_ = ms_node_->create_subscription<dc_interfaces::msg::StringStamped>(
+        "/dc/measurement/mem_alias", rclcpp::SystemDefaultsQoS(), [this](const dc_interfaces::msg::StringStamped& msg) {
+          nlohmann::json data_json = nlohmann::json::parse(msg.data);
+          used_ = data_json["used"];
+          callback_ = true;
+        });
+  }
+
+  void TearDown() override
+  {
+    ms_node_->deactivate();
+    ms_node_->cleanup();
+  }
+
+  std::shared_ptr<measurement_server::MeasurementServer> ms_node_;
+  rclcpp::Subscription<dc_interfaces::msg::StringStamped>::SharedPtr sub_data_;
+  float used_{ 0.0 };
+
+public:
+  bool callback_{ false };
+};
+
+TEST_F(MeasurementAliasedSchemaTest, ConfiguresAndPublishesWithTheDefaultSchema)
+{
+  ms_node_->declare_parameter("mem_alias.plugin", std::string("dc_measurements/Memory"));
+  ms_node_->declare_parameter("mem_alias.topic_output", std::string("/dc/measurement/mem_alias"));
+  // enable_validator is left at its default of true: configuring at all is what proves the
+  // schema was found.
+
+  ms_node_->configure();
+  ms_node_->activate();
+
+  const auto start = std::chrono::steady_clock::now();
+  while (!callback_ && std::chrono::steady_clock::now() - start < std::chrono::seconds(10))
+  {
+    rclcpp::spin_some(ms_node_->get_node_base_interface());
+  }
+
+  EXPECT_TRUE(callback_);
+  EXPECT_GE(used_, 0.0);
+  EXPECT_LE(used_, 100.0);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  rclcpp::init(argc, argv);
+
+  bool all_successful = RUN_ALL_TESTS();
+
+  rclcpp::shutdown();
+
+  return all_successful;
+}

--- a/doc/src/dc/demos/custom_stdout.md
+++ b/doc/src/dc/demos/custom_stdout.md
@@ -54,7 +54,6 @@ class UptimeCustom : public dc_measurements::Uptime
 {
 protected:
   void onFailedValidation(json data_json) override;
-  void setValidationSchema() override;
 };
 
 }  // namespace dc_demos
@@ -84,21 +83,18 @@ void UptimeCustom::onFailedValidation(json data_json)
   RCLCPP_INFO(logger_, "Callback! Validation failed for uptime custom");
 }
 
-void UptimeCustom::setValidationSchema()
-{
-  if (enable_validator_)
-  {
-    validateSchema("dc_demos", "uptime_custom.json");
-  }
-}
-
 }  // namespace dc_demos
 
 #include "pluginlib/class_list_macros.hpp"
 PLUGINLIB_EXPORT_CLASS(dc_demos::UptimeCustom, dc_core::Measurement)
 ```
 
-We include the uptime_custom file header. Then, define the onFailedValidation function (triggered when validation fails) and the setValidationSchema function which sets the json with the new json schema
+We include the uptime_custom file header. Then, define the onFailedValidation function (triggered when validation fails).
+
+The schema is picked up without any code: a Measurement validates against
+`plugins/measurements/json/<plugin type>.json` from the package registering it, so `dc_demos/UptimeCustom`
+reads `dc_demos/plugins/measurements/json/uptime_custom.json`. Set `json_schema_path` to point elsewhere, or
+`enable_validator: false` to turn validation off.
 
 ```admonish info
 Do not forget to include the pluginlib statements at the end to export the plugin class.


### PR DESCRIPTION
Closes #498

## Problem

`Measurement::setValidationSchema()` was a pure virtual, so all 32 Measurement plugins carried the identical five-line override:

```cpp
void X::setValidationSchema()
{
  if (enable_validator_)
  {
    validateSchema("dc_measurements", "x.json");
  }
}
```

The only variation across all of them was the file name, which was always the plugin's own name. One plugin (`StringStamped`) overrode it with an empty body instead, silently switching validation off for itself — exactly the "did I remember the guard?" failure the interface invites.

The base class already had everything needed to do this itself.

## Fix

`configure()` now derives the default when `json_schema_path` is empty and `enable_validator_` is on:

- **package** and **file name** both come from the pluginlib lookup name, snake-cased by a small `snakeCase()` helper: `dc_measurements/Camera` → `dc_measurements/plugins/measurements/json/camera.json`, `dc_demos/UptimeCustom` → `dc_demos/plugins/measurements/json/uptime_custom.json`.
- an explicit `json_schema_path` still wins and takes the same path-overload branch as before, `$ref` resolution included.

`snakeCase` keeps an acronym run together with the word it follows it: `TCPHealth` → `tcp_health`, `Ros2ControlStatus` → `ros2_control_status`, `OS` → `os`, `IpCamera` → `ip_camera`. All 33 registered plugin types were checked against the files in `plugins/measurements/json/`.

**Why the plugin type and not `measurement_name_`** (a deviation from the issue's wording, and the reason the issue's literal `measurement_name_ + ".json"` would have been a behaviour change): the instance id is the deployment's name for the Measurement, not the plugin's. `dc_demos/params/qrcodes_stdout.yaml` runs two `dc_measurements/Camera` instances as `right_camera` and `left_camera` with `enable_validator: true` — under the issue's version both would go looking for `right_camera.json`/`left_camera.json`, find nothing, and die on the existing `enable_validator_ && schema_.empty()` guard. Deriving from the plugin type gives every Measurement the schema its plugin always loaded. Same reasoning keeps `uptime_custom` working with no code.

## Per-plugin validation decisions

- **`driving_type`** — validates, unchanged. The issue describes it as an empty override, but it never was: `driving_type.cpp` loaded `dc_measurements/driving_type.json` and that file exists and is installed. It now reaches it through the derived default instead of an override, nothing else.
- **`string_stamped`** — still does not validate, and that is deliberate and now explicit rather than hidden in an empty override. It republishes another Measurement's `Record` verbatim, so its payload is whatever the upstream plugin produced and no schema can describe it. There is no `string_stamped.json` and none was invented. Suppression moved to the sanctioned path: `enable_validator: false`, which `doc/src/dc/measurements/string_stamped.md` already prescribed and which all 14 in-tree configs (`tools/e2e/params/e2e_{,degraded_,split_,limits_}params.yaml`) already set. A deployment that omits the flag now fails loudly at configure (`"Enabled validation but didn't configure schema!"`) instead of silently passing unvalidated — that is the one behavioural difference in this PR, and it only bites where the flag was already documented as required.

No other plugin changed behaviour: the same 32 schema files load, guarded by the same `enable_validator_`, from the same paths.

## Out-of-package touches (two, both forced)

`dc_demos`' `UptimeCustom` is a `Measurement` subclass, so deleting the pure virtual would have broken its build:

- `dc_demos/include/dc_demos/plugins/measurements/uptime_custom.hpp` and `dc_demos/plugins/measurements/uptime_custom.cpp` — the `setValidationSchema() override` declaration and definition removed. `validateDefaultSchema()` now resolves `dc_demos/UptimeCustom` to `dc_demos/plugins/measurements/json/uptime_custom.json`, the same file the override loaded, so the demo's behaviour is unchanged.
- `doc/src/dc/demos/custom_stdout.md` — that override was the demo's own source; the walkthrough's snippets would have taught an API that no longer exists. Both snippet lines dropped and a short paragraph added describing the derive-by-plugin-type default.

Everything else is inside `dc_measurements/`. The `cpu.hpp` dead declaration `void setValidationSchema(json& data_json)` was never defined or called and went with the rest, since leaving a same-named declaration behind a deleted virtual invites a new overload trap.

## Tests

New `dc_measurements/test/test_measurement_schema.cpp`, added to `dc_measurements/CMakeLists.txt`:

- `SnakeCaseKeepsAcronymsWithTheWordTheyPrecede` — pins the acronym cases the conversion has to get right.
- `EveryRegisteredPluginHasItsOwnSchemaFile` — reads the installed `measurement_plugin.xml` and asserts every registered plugin type derives a schema file that is actually installed, and that no two derive the same one. Reads the XML rather than a hardcoded list, so a plugin added later is covered automatically; `dc_measurements/StringStamped` is the single explicit entry in the test's `schemaless` set, and the test fails if it ever *gains* a schema until it is removed from that set.
- `MeasurementAliasedSchemaTest.ConfiguresAndPublishesWithTheDefaultSchema` — a Measurement instance named `mem_alias` running the Memory plugin configures and publishes with `enable_validator` left at its default. This is the regression test for the plugin-type-vs-instance-id choice above: configuring at all proves the schema was found, since the old guard throws otherwise.

No existing test asserted on `setValidationSchema` — the suites exercise it only through the server's `configure()`, so they pass through unchanged and now cover the derived path.

## CI

No local ROS toolchain, so `colcon` was not run: the `build-workspace` job is the authority on whether this builds, and its `colcon test` run on the suites is the authority on the tests (same as #493). `prek run --skip build-doc` passes on the staged tree.
