### PR TITLE
fix(dc_group): make the Group merge total and its flags honest

### DIFF
--- a/dc_group/dc_group/flatten.py
+++ b/dc_group/dc_group/flatten.py
@@ -1,6 +1,14 @@
 # SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 # SPDX-License-Identifier: MPL-2.0
 
+"""Flatten a nested payload to `{key: scalar}` and back (#508).
+
+`GroupServer` calls these from a synchroniser callback, where an exception takes the node
+down, so both directions are total: no payload a Measurement publishes makes them raise, and
+no shape they cannot express silently drops a value — a key that cannot be nested keeps its
+scalar and the key under it keeps its literal dotted key.
+"""
+
 from collections.abc import Iterable
 
 
@@ -108,6 +116,11 @@ def flatten(
 def unflatten(flat_dict: dict, separator: str | None = "_") -> dict:
     """Creates a hierarchical dictionary from a flattened dictionary, assume no lists are present.
 
+    A key that is also a *prefix* of another one has no nested form: `{"a": 1, "a.b": 2}`
+    cannot put both a scalar and a dict under `a`. Rather than dropping the scalar, the deeper
+    key is kept as its literal dotted key, so the round trip loses nothing — Postgres holds the
+    result in one `jsonb` column, which accepts either shape.
+
     Args:
         flat_dict (dict): a dictionary with no hierarchy
         separator (str, optional): a string that separates keys. Defaults to "_".
@@ -117,27 +130,24 @@ def unflatten(flat_dict: dict, separator: str | None = "_") -> dict:
     """
     _unflatten_asserts(flat_dict, separator)
 
-    # This global dictionary is mutated and returned
+    # This dictionary is mutated and returned
     unflattened_dict = {}
 
-    def _unflatten(dic, keys, value):
-        for key in keys[:-1]:
-            dic = dic.setdefault(key, {})
-
-        dic[keys[-1]] = value
-
-    list_keys = sorted(flat_dict.keys())
-    for i, item in enumerate(list_keys):
-        if i != len(list_keys) - 1:
-            split_key = item.split(separator)
-            next_split_key = list_keys[i + 1].split(separator)
-            if not split_key == next_split_key[:-1]:
-                _unflatten(unflattened_dict, item.split(separator), flat_dict[item])
-            else:
-                pass  # if key contained in next key, json will be invalid.
+    for key in sorted(flat_dict):
+        dic = unflattened_dict
+        segments = key.split(separator)
+        for depth, segment in enumerate(segments[:-1]):
+            if segment not in dic:
+                dic[segment] = {}
+            child = dic[segment]
+            if not isinstance(child, dict):
+                # A scalar holds the prefix: nesting here would drop it, so the rest of the
+                # path stays a literal key and both values survive.
+                dic[separator.join(segments[depth:])] = flat_dict[key]
+                break
+            dic = child
         else:
-            #  last element
-            _unflatten(unflattened_dict, item.split(separator), flat_dict[item])
+            dic[segments[-1]] = flat_dict[key]
     return unflattened_dict
 
 
@@ -156,58 +166,51 @@ def check_if_numbers_are_consecutive(list_: list) -> bool:
     )
 
 
-def unflatten_list(flat_dict: dict, separator="_") -> dict:
+def _list_indices(object_) -> list:
+    """Returns the indices `object_` needs to become a list, empty if it is not shaped like one."""
+    try:
+        indices = sorted(int(key) for key in object_)
+    except (ValueError, TypeError):
+        return []
+    # Read back through the canonical `str(index)` form: `00` parses as the index 0 but is not
+    # the key `0`, so a zero-padded index keeps the dict it unflattened to rather than raising
+    # on a key that is not there.
+    if set(object_) != {str(index) for index in indices}:
+        return []
+    return indices
+
+
+def _convert_dict_to_list(object_):
+    """Returns `object_` with every dict of consecutive indices inside it rebuilt as a list."""
+    if not isinstance(object_, dict):
+        return object_
+    # Children first, so a list nested inside a list member is rebuilt too
+    # https://github.com/amirziai/flatten/issues/15
+    for key, value in object_.items():
+        object_[key] = _convert_dict_to_list(value)
+    indices = _list_indices(object_)
+    if indices and indices[0] == 0 and check_if_numbers_are_consecutive(indices):
+        return [object_[str(index)] for index in indices]
+    return object_
+
+
+def unflatten_list(flat_dict: dict, separator="_") -> dict | list:
     """Unflatten a dictionary, first assuming no lists exist and then tries to
-    identify lists and replaces them
-    This is probably not very efficient and has not been tested extensively
-    Feel free to add test cases or rewrite the logic
-    Issues that stand out to me:
-    - Sorting all the keys in the dictionary, which specially for the root
-    dictionary can be a lot of keys
-    - Checking that numbers are consecutive is O(N) in number of keys
+    identify lists and replaces them.
+
+    A dict is read as a list only when its keys are exactly the canonical indices `0` to
+    `n - 1`, at the root as well as deeper: `{"0.a": 1, "1.b": 2}` comes back as
+    `[{"a": 1}, {"b": 2}]`. Anything else stays the dict it unflattened to, so a payload a
+    Measurement publishes can only ever reshape, never raise.
 
     Args:
         flat_dict (dict): dictionary with no hierarchy
         separator (str, optional): a string that separates keys. Defaults to "_".
 
     Returns:
-        dict: a dictionary with hierarchy
+        dict: a dictionary with hierarchy, or a list if the root itself is index-keyed
     """
     _unflatten_asserts(flat_dict, separator)
 
     # First unflatten the dictionary assuming no lists exist
-    unflattened_dict = unflatten(flat_dict, separator)
-
-    def _convert_dict_to_list(object_, parent_object, parent_object_key):
-        if isinstance(object_, dict):
-            for key in object_:
-                if isinstance(object_[key], dict):
-                    _convert_dict_to_list(object_[key], object_, key)
-            try:
-                keys = [int(key) for key in object_]
-                keys.sort()
-            except (ValueError, TypeError):
-                keys = []
-            keys_len = len(keys)
-
-            if (
-                keys_len > 0
-                and sum(keys) == int(((keys_len - 1) * keys_len) / 2)
-                and keys[0] == 0
-                and keys[-1] == keys_len - 1
-                and check_if_numbers_are_consecutive(keys)
-            ):
-                # The dictionary looks like a list so we're going to replace it
-                parent_object[parent_object_key] = []
-                for key_index, key in enumerate(keys):
-                    parent_object[parent_object_key].append(object_[str(key)])
-                    # The list item we just added might be a list itself
-                    # https://github.com/amirziai/flatten/issues/15
-                    _convert_dict_to_list(
-                        parent_object[parent_object_key][-1],
-                        parent_object[parent_object_key],
-                        key_index,
-                    )
-
-    _convert_dict_to_list(unflattened_dict, None, None)
-    return unflattened_dict
+    return _convert_dict_to_list(unflatten(flat_dict, separator))

--- a/dc_group/dc_group/group_merge.py
+++ b/dc_group/dc_group/group_merge.py
@@ -8,9 +8,14 @@ at the edges and hands over already-parsed payloads, so these rules are testable
 ROS install.
 """
 
-from .flatten import flatten, unflatten_list
+from fnmatch import fnmatchcase
+
+from .flatten import flatten, unflatten, unflatten_list
 
 SEPARATOR = "."
+
+# An entry holding any of these is a glob over the flattened key; anything else is a prefix.
+_GLOB_SPECIALS = "*?["
 
 
 def apply_exclude_keys(data_dict: dict, exclude_keys: list) -> dict:
@@ -19,8 +24,8 @@ def apply_exclude_keys(data_dict: dict, exclude_keys: list) -> dict:
     Args:
         data_dict (dict): Flattened Record, filtered in place of being copied
         exclude_keys (list): Patterns applied in order, each narrowing the Record further.
-            A `*`-free entry is a key prefix; an entry holding `*` matches when every
-            `*`-separated fragment appears in the key
+            An entry holding no glob syntax is a key prefix; otherwise it is a glob over the
+            whole flattened key (`fnmatch` syntax, case-sensitive, anchored at both ends)
 
     Returns:
         dict: The Record minus the excluded keys
@@ -28,14 +33,10 @@ def apply_exclude_keys(data_dict: dict, exclude_keys: list) -> dict:
     for exclude_key in exclude_keys:
         if exclude_key == "":
             continue
-        if "*" not in exclude_key:
+        if not any(char in exclude_key for char in _GLOB_SPECIALS):
             data_dict = {k: v for k, v in data_dict.items() if not k.startswith(exclude_key)}
         else:
-            data_dict = {
-                k: v
-                for k, v in data_dict.items()
-                if not all(x in k for x in exclude_key.split("*"))
-            }
+            data_dict = {k: v for k, v in data_dict.items() if not fnmatchcase(k, exclude_key)}
     return data_dict
 
 
@@ -88,7 +89,15 @@ def merge_records(
 
     data_dict = apply_exclude_keys(data_dict, group_cfg["exclude_keys"])
     if group_cfg["nested_data"]:
+        flat_data = data_dict
         data_dict = unflatten_list(flat_dict=data_dict, separator=SEPARATOR)
+        if not isinstance(data_dict, dict):
+            # Every group_key is numeric, so the merged Record unflattened into a JSON array.
+            # A Record is an object: its envelope (`tags`, `incident_id`, `plugins`) is made of
+            # top-level keys, and a top-level key is all a `postgres` sink maps onto a column,
+            # so an array would land in no column at all. The members stay nested under their
+            # numeric group_key instead, keeping the rest of the Record intact.
+            data_dict = unflatten(flat_data, separator=SEPARATOR)
     # A member's own Tags are dropped above: the Record carries the group's.
     data_dict["tags"] = group_cfg["tags"]
     # Only when a member actually carried one: a Record collected outside an incident must

--- a/dc_group/dc_group/group_server.py
+++ b/dc_group/dc_group/group_server.py
@@ -78,15 +78,12 @@ class GroupServer(Node):
                 {"group_key": measurement_dict["group_key"], "data": json.loads(measurement.data)}
             )
 
-        # `group_measurement_plugins` is stored as a Parameter, and a Parameter is always
-        # truthy, so `bool()` is what the merge used to test inline — the flag's value is
-        # still ignored today. Passing `.value` would be a behaviour change, not a move.
         data_dict = merge_records(
             parsed_payloads,
             group,
             self.params[group],
             missing_inputs=missing_inputs,
-            collect_plugins=bool(self.group_measurement_plugins),
+            collect_plugins=self.group_measurement_plugins,
         )
 
         msg = StringStamped()
@@ -100,7 +97,9 @@ class GroupServer(Node):
         # Jazzy, rclpy overwrites a descriptor's `type` with the type inferred from the
         # default value, so the descriptor form raises on a parameter that has no default.
         self.declare_parameter("groups", Parameter.Type.STRING_ARRAY)
-        self.group_measurement_plugins = self.declare_parameter("group_measurement_plugins", True)
+        self.group_measurement_plugins = self.declare_parameter(
+            "group_measurement_plugins", True
+        ).value
         try:
             self.params["groups"] = (
                 self.get_parameter("groups").get_parameter_value().string_array_value

--- a/dc_group/test/test_group_merge.py
+++ b/dc_group/test/test_group_merge.py
@@ -109,13 +109,17 @@ def test_merge_does_not_mutate_the_payloads_it_is_given():
         (["a", "b.free"], set()),
         # The prefix has no key boundary: `a.cpu` also catches `a.cpuload`.
         (["a.c"], {"ab.used", "b.free"}),
-        # `*` in an entry matches when every `*`-separated fragment appears in the key.
+        # An entry holding `*` is a glob over the flattened key, anchored at both ends.
         (["a.*"], {"ab.used", "b.free"}),
         (["*load"], {"a.cpu", "ab.used", "b.free"}),
         (["*.*"], set()),
         (["*"], set()),
-        # The `b.` fragment lives inside the member named `ab`, so it takes that one too.
-        (["a.*", "b.*"], set()),
+        # A glob has a key boundary the prefix form lacks: `b.*` leaves `ab.used` alone.
+        (["b.*"], {"a.cpu", "a.cpuload", "ab.used"}),
+        (["a.*", "b.*"], {"ab.used"}),
+        # `?` and `[seq]` are glob syntax too, so they no longer match literally.
+        (["a.?pu"], {"a.cpuload", "ab.used", "b.free"}),
+        (["a.cp[u]load"], {"a.cpu", "ab.used", "b.free"}),
     ],
 )
 def test_exclude_keys_filters_flattened_keys(exclude_keys, kept):
@@ -130,12 +134,13 @@ def test_exclude_keys_filters_flattened_keys(exclude_keys, kept):
     assert set(record) == kept | {"tags", "name"}
 
 
-def test_exclude_keys_glob_is_substring_matching_not_a_glob():
-    # Pinning current behaviour: the `*` branch splits and checks substrings, so a
-    # fragment matches anywhere in the key, in any position a glob would not allow.
+def test_exclude_keys_star_entry_is_a_glob_not_a_substring_match():
+    # Was pinned as substring matching: a `u*d` fragment took `a.used` down with it, though a
+    # glob has to start with a `u`. Fixed in #508 — the key survives, and so does its member.
     record = merge([payload("a", {"used": 1.0})], exclude_keys=["u*d"])
 
-    assert set(record) == {"tags", "name"}
+    assert record["a"] == {"used": 1.0}
+    assert set(record) == {"a", "tags", "name"}
 
 
 def test_apply_exclude_keys_returns_the_flattened_keys():
@@ -414,10 +419,21 @@ def test_unflatten_requires_a_flat_dictionary():
         unflatten({"a": [1, 2]}, separator=SEPARATOR)
 
 
-def test_unflatten_silently_drops_a_key_nested_under_another():
-    # Pinning current behaviour: a scalar sitting at a prefix of another key is assumed to
-    # be an artifact and skipped, so `a` disappears from the Record.
-    assert unflatten({"a": 1, "a.b": 2}, separator=SEPARATOR) == {"a": {"b": 2}}
+def test_unflatten_keeps_a_scalar_whose_key_prefixes_another():
+    # Was pinned as a silent drop: `a` vanished from the Record because `a.b` nested under it.
+    # A key that is also a prefix of another has no nested form — both cannot sit under it — so
+    # the deeper key keeps its literal dotted key instead and nothing is dropped (#508).
+    assert unflatten({"a": 1, "a.b": 2}, separator=SEPARATOR) == {"a": 1, "a.b": 2}
+
+
+def test_unflatten_keeps_every_scalar_of_a_deeper_collision():
+    # The rule holds all the way down: once `a.b` is a literal key, `a.b.c` cannot nest
+    # under the scalar it holds either.
+    assert unflatten({"a": 1, "a.b": 2, "a.b.c": 3}, separator=SEPARATOR) == {
+        "a": 1,
+        "a.b": 2,
+        "a.b.c": 3,
+    }
 
 
 def test_unflatten_list_rebuilds_lists_from_consecutive_indices():
@@ -444,19 +460,34 @@ def test_unflatten_list_of_an_empty_dict_is_empty():
     assert unflatten_list({}, separator=SEPARATOR) == {}
 
 
-def test_unflatten_list_crashes_on_a_zero_padded_index():
-    # Pinning current behaviour: `00` is recognised as index 0 but then read back as the
-    # string `"0"`, so the round trip raises. A Measurement nesting a zero-padded key under
-    # a dict takes the Group node down with it.
-    with pytest.raises(KeyError):
-        unflatten_list({"a.00": 1}, separator=SEPARATOR)
+def test_unflatten_list_keeps_a_zero_padded_index_as_a_dict():
+    # Was pinned as a KeyError: `00` is recognised as the index 0 but read back as the string
+    # `"0"`. A list needs the canonical `0`..`n-1` keys, so the dict is left as it unflattened
+    # — reshaped, not raised — and the Group node keeps its Record (#508).
+    assert unflatten_list({"a.00": 1}, separator=SEPARATOR) == {"a": {"00": 1}}
 
 
-def test_unflatten_list_crashes_on_a_top_level_list():
-    # Pinning current behaviour: only nested lists are rebuilt — the root has no parent to
-    # replace the list in, so the conversion raises instead.
-    with pytest.raises(TypeError):
-        unflatten_list({"0.a": 1, "1.b": 2}, separator=SEPARATOR)
+def test_unflatten_list_rebuilds_a_top_level_list():
+    # Was pinned as a TypeError: only nested lists were rebuilt, the root having no parent to
+    # replace the list in. The root is converted like any other level now (#508).
+    assert unflatten_list({"0.a": 1, "1.b": 2}, separator=SEPARATOR) == [{"a": 1}, {"b": 2}]
+
+
+def test_a_record_whose_group_keys_are_all_numeric_stays_an_object():
+    # Numeric group_keys would unflatten the merged Record into a JSON array. A Record is an
+    # object — `tags`, `incident_id` and `plugins` are top-level keys, which is all a `postgres`
+    # sink maps onto columns — so the members stay nested under their group_key instead (#508).
+    record = merge([payload("0", {"used": 1.0}), payload("1", {"free": 2.0})])
+
+    assert record == {"0": {"used": 1.0}, "1": {"free": 2.0}, "tags": ["dc"], "name": GROUP}
+
+
+def test_a_record_with_a_numeric_and_a_named_member_is_nested_normally():
+    # A single numeric group_key among named ones is not enough to make the Record a list.
+    record = merge([payload("0", {"used": 1.0}), payload("cpu", {"free": 2.0})])
+
+    assert record["0"] == {"used": 1.0}
+    assert record["cpu"] == {"free": 2.0}
 
 
 def test_check_if_numbers_are_consecutive():

--- a/dc_group/test/test_group_sync_timeout.py
+++ b/dc_group/test/test_group_sync_timeout.py
@@ -383,3 +383,8 @@ def test_unknown_policy_falls_back_to_drop(harness):
     group.publish(0, {"used": 12.0})
     group.spin_for(4 * SYNC_TIMEOUT)
     assert group.records == []
+
+
+def test_group_measurement_plugins_is_read_as_a_value(harness):
+    """The flag reaches the merge as a bool, not as the always-truthy `Parameter` (#508)."""
+    assert harness().server.group_measurement_plugins is True

--- a/doc/src/dc/groups.md
+++ b/doc/src/dc/groups.md
@@ -29,9 +29,10 @@ the `ApproximateTimeSynchronizer` is straightforward there and awkward in C++.
 
 ## Node parameters
 
-| Parameter | Description      | Type        | Default |
-| --------- | ---------------- | ----------- | ------- |
-| groups    | Groups to enable | list\[str\] | N/A     |
+| Parameter                 | Description                                                                        | Type        | Default |
+|----------------------------|-------------------------------------------------------------------------------------|--------------|----------|
+| groups                    | Groups to enable                                                                   | list\[str\] | N/A     |
+| group_measurement_plugins | Collect the members' `plugin` fields into the merged Record's `plugins` list       | bool        | true    |
 
 ## Group parameters
 
@@ -44,7 +45,7 @@ the `ApproximateTimeSynchronizer` is straightforward there and awkward in C++.
 | on_sync_timeout    | What to do with an incomplete set once `sync_timeout` elapses: `drop`/`emit_partial` | str         | "drop"              |
 | sync_timeout_log_throttle | Seconds between two sync-timeout warnings for this group. 0.0 logs every one  | float       | 60.0                |
 | group_key          | Dictionary key under which data is grouped                                          | str         | {group_name}        |
-| exclude_keys       | List of keys to exclude from the published data. Data depth is separated by a dot   | list\[str\] | N/A                 |
+| exclude_keys       | List of keys to exclude from the published data. Data depth is separated by a dot. An entry holding glob syntax (`*`, `?`, `[seq]`) is a glob over the flattened key, one without is a key prefix | list\[str\] | N/A                 |
 | nested_data        | Whether measurements are nested dictionaries or flat                                | bool        | true                |
 | include_group_name | Include group name in the JSON as key="name" and value=<group_key>                  | bool        | true                |
 


### PR DESCRIPTION
Closes #508.

Direct successor to #507: its 61 tests pinned these four bugs, and each pinned test now
asserts the fixed behaviour instead. No drift found between that extraction and jazzy's
behaviour — every pinning test passed as written, so nothing had to be reconciled.

## 1. `unflatten_list` raised on a zero-padded index and on a top-level list (crash-class)

**Pinned:** `unflatten_list({"a.00": 1})` → `KeyError` (`00` parses as the index `0` but is
read back as the string `"0"`), and `unflatten_list({"0.a": 1, "1.b": 2})` → `TypeError`
(only *nested* lists were rebuilt; the root had no parent to replace the list in).

**Fixed:** both functions are total. A dict is read as a list only when its keys are exactly
the canonical `0..n-1`, the root included, so `{"a.00": 1}` stays `{"a": {"00": 1}}` and
`{"0.a": 1, "1.b": 2}` now comes back as `[{"a": 1}, {"b": 2}]`. `merge_records` additionally
keeps the Record an *object* when every `group_key` is numeric — a numeric-keyed merge would
otherwise unflatten into a JSON array, and the Record envelope (`tags`, `incident_id`,
`plugins`) is made of top-level keys, which is all Vector's `postgres` sink maps onto a
column. An array would land in no column at all.

**Affected:** any group whose member publishes a zero-padded or otherwise non-canonical index
(`frame.00`), or whose `group_key`s are all numeric: the Group node previously died on the
callback and stopped publishing for every group it hosts. Now the payload is reshaped, never
raised, and the rest of the Record is intact.

## 2. `unflatten` silently dropped a scalar at a prefix of another key

**Pinned:** `unflatten({"a": 1, "a.b": 2})` → `{"a": {"b": 2}}` — the `1` was gone, with no
error and no trace. The old code skipped any key whose path was a prefix of the next one.

**Fixed:** keep both. A key that is also a prefix of another has no nested form — one key
cannot hold a scalar *and* a dict — so the deeper key is kept as its literal dotted key:
`{"a": 1, "a.b": 2}` round-trips unchanged. Postgres is why this shape and not a sentinel
key or a raise: the member payload is stored as one `jsonb` column, which accepts either
shape but could not hold both under `a`, and the flat Record keeps every field queryable.

**Affected:** a member publishing a bare scalar payload (or two members sharing a `group_key`
where one payload is a scalar) no longer loses a field. Flattened Records
(`nested_data: false`) are unchanged, and the round trip is now lossless.

## 3. `group_measurement_plugins` was read as a `Parameter`, so its value was ignored

**Pinned:** `bool(self.group_measurement_plugins)` tested a `Parameter` object, which is
always truthy, so plugins were collected even with `group_measurement_plugins: false`.

**Fixed:** the declared parameter is stored as `.value` and passed straight through as
`collect_plugins`. The flag is now in `doc/src/dc/groups.md`'s node parameter table, where it
was missing altogether.

**Affected:** anyone who set `group_measurement_plugins: false` to slim the merged Record:
it now works, and the `plugins` key disappears from that group's Records. Deployments leaving
the default (`true`) see no change.

The node's other booleans were checked for the same pattern: `nested_data` and
`include_group_name` already read `.get_parameter_value().bool_value`; `sync_timeout`,
`sync_delay` and `sync_timeout_log_throttle` read their `.double_value`/`.string_value`.

## 4. `*` exclude entries did substring matching, not globs

**Pinned:** an entry holding `*` matched when every `*`-separated fragment appeared *anywhere*
in the flattened key, so `u*d` took `a.used` and `b.*` took a member literally named `ab`.

**Fixed:** a `*`-free entry is still a key prefix (unchanged, and still boundary-free); an
entry holding glob syntax (`*`, `?`, `[seq]`) is now a `fnmatch` glob over the whole
flattened key, case-sensitive and anchored at both ends. The `exclude_keys` table tests gained
`b.*`, `?` and `[seq]` rows, and `doc/src/dc/groups.md`'s `exclude_keys` row describes both
forms.

**Affected:** existing configs whose glob entries were *relying* on substring behaviour
(e.g. `b.*` meant to also catch `ab`) now exclude less — the fix for those is to write the
prefix form (`b`), which is unchanged. Configs using globs the obvious way start doing what
they say.

## Tests

`uv run --project . python -m pytest dc_group/test/test_group_merge.py -q` (with
`PYTHONPATH=dc_group`): **67 passed**, up from 61 on `origin/jazzy`.

- 4 pinned tests flipped: the two `unflatten_list` crashes and the silent scalar drop in
  `unflatten`, plus the `u*d` substring pin (its `["a.*", "b.*"]` table row flipped with it).
- 6 added: the deeper-collision rule, the all-numeric-`group_key` Record staying an object,
  a mixed numeric/named group nesting normally, the glob `b.*`/`?`/`[seq]` table rows, and a
  live-graph assertion that `group_measurement_plugins` reaches the merge as a bool.

`prek run --skip build-doc` passes (ruff reflowed one comprehension). The live-graph suite in
`test_group_sync_timeout.py` needs a real ROS graph and stays CI-authoritative — it does not
run locally here; #507's merge-level suite is the local gate.

## Out of scope, spotted on the way

`merge_records` still does `dict(payload["data"])`, so a Measurement publishing a *scalar*
payload (valid JSON, not an object) raises `TypeError` from the callback before the merge is
ever reached. Same crash class as bug 1, but it is the parse edge rather than the merge, and
silently skipping a whole member's payload is a decision worth its own issue rather than a
rider on this one.
