### PR TITLE
fix(dc_group): merge a member payload that is not a JSON object

### DIFF
--- a/dc_group/dc_group/flatten.py
+++ b/dc_group/dc_group/flatten.py
@@ -6,7 +6,8 @@
 `GroupServer` calls these from a synchroniser callback, where an exception takes the node
 down, so both directions are total: no payload a Measurement publishes makes them raise, and
 no shape they cannot express silently drops a value — a key that cannot be nested keeps its
-scalar and the key under it keeps its literal dotted key.
+scalar and the key under it keeps its literal dotted key. A payload that is not an object at
+all keeps its value under its `group_key` instead of being reshaped or dropped (#514).
 """
 
 from collections.abc import Iterable

--- a/dc_group/dc_group/group_merge.py
+++ b/dc_group/dc_group/group_merge.py
@@ -6,6 +6,10 @@
 Plain dicts in, plain dict out: no `rclpy`, no clock, no messages. `GroupServer` converts
 at the edges and hands over already-parsed payloads, so these rules are testable without a
 ROS install.
+
+A member payload is whatever `json.loads` made of its Record — object, array, or bare
+scalar (#514). Only an object can carry the envelope fields, so a non-object member is
+merged as its value under its `group_key`, the same never-raise, never-drop rule as #508.
 """
 
 from fnmatch import fnmatchcase
@@ -52,7 +56,8 @@ def merge_records(
     Args:
         parsed_payloads (list): One entry per member Record, ordered by the input it came
             from: `{"group_key": <the member's group_key>, "data": <its parsed payload>}`.
-            Two members sharing a `group_key` collapse into the last one's fields
+            Two members sharing a `group_key` collapse into the last one's fields. A `data`
+            that is not an object — a bare scalar or an array — is merged as it is
         group (str): Name of the group being published
         group_cfg (dict): The group's parameters — `exclude_keys`, `tags`, `nested_data`
             and `include_group_name`
@@ -68,21 +73,29 @@ def merge_records(
     plugins_list = []
     incident_id = None
     for payload in parsed_payloads:
-        m_data = dict(payload["data"])
-        m_data.pop("tags", None)
-        # `incident_id` is an envelope field, not measurement data (#291): merged under a
-        # member's `group_key` it would become `<group_key>.incident_id`, which is no
-        # column any Destination table has and so is silently dropped by the Postgres
-        # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
-        # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
-        # FlushEvent mints one id for every Measurement listening, so the members of a
-        # released window all carry the same one — first non-null wins, and a partial
-        # Record built from a mix of released and live members still carries it.
-        member_incident_id = m_data.pop("incident_id", None)
-        if incident_id is None:
-            incident_id = member_incident_id
-        if collect_plugins and "plugin" in m_data:
-            plugins_list.append(m_data["plugin"])
+        m_data = payload["data"]
+        if isinstance(m_data, dict):
+            # A copy: the pops below must not reach back into the caller's payload.
+            m_data = dict(m_data)
+            m_data.pop("tags", None)
+            # `incident_id` is an envelope field, not measurement data (#291): merged under a
+            # member's `group_key` it would become `<group_key>.incident_id`, which is no
+            # column any Destination table has and so is silently dropped by the Postgres
+            # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
+            # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
+            # FlushEvent mints one id for every Measurement listening, so the members of a
+            # released window all carry the same one — first non-null wins, and a partial
+            # Record built from a mix of released and live members still carries it.
+            member_incident_id = m_data.pop("incident_id", None)
+            if incident_id is None:
+                incident_id = member_incident_id
+            if collect_plugins and "plugin" in m_data:
+                plugins_list.append(m_data["plugin"])
+        # else: a payload that is not an object (#514) — a bare scalar or an array. It has
+        # no `tags`, `incident_id` or `plugin` to lift, and `dict()` on it is what used to
+        # raise from the callback. It goes under the member's `group_key` as it is: the
+        # same never-raise, never-drop rule as #508, and the flatten round trip below
+        # already brings a scalar or an array back unchanged.
         data_dict = data_dict | flatten(
             nested_dict={payload["group_key"]: m_data}, separator=SEPARATOR
         )

--- a/dc_group/test/test_group_merge.py
+++ b/dc_group/test/test_group_merge.py
@@ -91,6 +91,77 @@ def test_merge_does_not_mutate_the_payloads_it_is_given():
     assert payloads[1]["data"] == {"free": 34.0}
 
 
+# --- payloads that are not objects ----------------------------------------------------------
+# A Measurement can publish any JSON value `json.loads` accepts, and `dict()` on the ones
+# that are not objects used to raise out of the Group node's callback, killing it (#514).
+# The rule, the same never-raise, never-drop one as #508: the value keeps its place under
+# its `group_key`, and only an object can carry envelope fields.
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ['"hi"', "42", "3.25", "true", "false", "null", "[1, 2]", "[]", '{"used": 12.0}'],
+)
+def test_every_json_payload_merges_without_raising(raw):
+    record = merge([payload("a", json.loads(raw))])
+
+    assert record["name"] == GROUP
+
+
+@pytest.mark.parametrize(
+    ("raw", "value"),
+    [
+        ('"hi"', "hi"),
+        ("42", 42),
+        ("3.25", 3.25),
+        ("true", True),
+        ("false", False),
+        ("null", None),
+        ("[1, 2]", [1, 2]),
+        ("[]", []),
+    ],
+)
+def test_a_non_object_payload_is_kept_as_it_is_under_its_group_key(raw, value):
+    record = merge([payload("a", json.loads(raw))])
+
+    assert record["a"] == value
+
+
+def test_an_array_payload_survives_the_flatten_round_trip():
+    record = merge([payload("a", {"samples": [1.0, 2.0]}), payload("b", [1.0, 2.0])])
+
+    assert record["a"] == {"samples": [1.0, 2.0]}
+    assert record["b"] == [1.0, 2.0]
+
+
+def test_an_array_payload_is_indexed_when_nesting_is_off():
+    record = merge([payload("a", [1.0, 2.0])], nested_data=False)
+
+    assert record == {"a.0": 1.0, "a.1": 2.0, "tags": ["dc"], "name": GROUP}
+
+
+def test_a_non_object_member_carries_no_envelope_field():
+    record = merge(
+        [
+            payload("a", "hi"),
+            payload("b", {"plugin": "memory", "free": 1.0, "incident_id": "incident-42"}),
+        ]
+    )
+
+    # Nothing to lift off a scalar: no plugin of its own in the list, and the incident id
+    # comes from the member that actually carried one.
+    assert record["plugins"] == ["memory"]
+    assert record["incident_id"] == "incident-42"
+
+
+def test_merge_does_not_mutate_a_non_object_payload():
+    data = [1.0, 2.0]
+
+    merge([payload("a", data)], tags=[""])
+
+    assert data == [1.0, 2.0]
+
+
 # --- exclude_keys -------------------------------------------------------------------------
 
 

--- a/doc/src/dc/groups.md
+++ b/doc/src/dc/groups.md
@@ -20,7 +20,8 @@ Envelope fields do not get nested under a member's key: a member's `tags` is rep
 Group's own, and its `incident_id` — the id a Measurement stamps on a Record it released as
 part of an [incident](./measurements.md) — is lifted to the merged Record's top level, where
 a `postgres` Destination has a column for it. Buried under `<group_key>.incident_id` it would
-simply be dropped by that sink.
+simply be dropped by that sink. A member payload that is not a JSON object — a bare scalar or
+an array — has no such fields to lift, and is merged as it is under its `group_key`.
 
 ```admonish info
 The Group node is written in Python: allocating and passing a variable number of inputs to


### PR DESCRIPTION
Closes #514

## Problem

`merge_records` copied every member payload with `dict(payload["data"])`. A Measurement that publishes a bare JSON scalar or a JSON array made that call raise `TypeError` from the Group node's subscription callback, killing the node before the merge — or any of the #508 totality guards — could run. #513 scoped this out; this PR is that edge.

## Contract

A member payload is whatever `json.loads` made of its Record, and the merge no longer assumes it is an object. Only an object can carry the envelope fields, so the rule is:

| `payload["data"]` | Behaviour |
| --- | --- |
| object | unchanged: copied, `tags`/`incident_id`/`plugin` lifted as before |
| string | kept as it is under the member's `group_key` (`{"a": "hi"}`) |
| number | kept as it is under the member's `group_key` (`{"a": 42}`) |
| bool | kept as it is under the member's `group_key` (`{"a": true}`) |
| null | kept as it is under the member's `group_key` (`{"a": null}`) |
| array | kept as it is under the member's `group_key`; `nested_data` on, the flatten round trip brings it back as the same array, off, it appears as the indexed `a.0`/`a.1` keys |

Nothing is dropped, nothing is wrapped under an invented key, and nothing raises — the same never-raise, never-drop rule #508 chose for `unflatten`/`unflatten_list`. A non-object member contributes no `plugins` entry and no `incident_id`, because a scalar cannot carry either. Documented beside the #508 decisions in `flatten.py`'s and `group_merge.py`'s module docstrings, plus one sentence in `doc/src/dc/groups.md`.

## Tests

`dc_group/test/test_group_merge.py` gains 21 cases: every JSON value `json.loads` accepts merging without raising; each of string/number/bool/null/array/empty-array pinned to the value it leaves under the `group_key`; array round trip with nesting on and off; no envelope field lifted off a scalar member; non-object payload not mutated.

- `uv run --project . python -m pytest dc_group/test/ -q` in the worktree: **88 passed** (`--ignore=dc_group/test/test_group_sync_timeout.py`, which needs `rclpy`). The main checkout sits on an older commit than `origin/jazzy`, so it has no `test_group_merge.py` to run — the same command there collects nothing.
- The ROS-side node tests (`test_group_sync_timeout.py`, and the callback path end to end) are CI-authoritative: `build-workspace` runs them under `colcon test` in the Podman workspace.