### PR TITLE
refactor(dc_bridge): split the upload intent queue into writer and reader interfaces

### DIFF
--- a/dc_bridge/include/dc_bridge/bridge_node.hpp
+++ b/dc_bridge/include/dc_bridge/bridge_node.hpp
@@ -81,10 +81,10 @@ private:
 
   // The durable upload intent queue (ADR-0005/#265) — created only when a `receives:
   // files` destination is configured. Records on files-destination topics are enqueued
-  // here so they survive a Bridge crash/restart. The Bridge only writes; a separate
-  // dc_uploader process (#446) owns reading, replaying, uploading, and emitting status
-  // Records — see docs/adr/0014-uploader-runs-as-its-own-process.md.
-  std::unique_ptr<uploader::IntentQueue> intent_queue_;
+  // here so they survive a Bridge crash/restart. The Bridge holds only the queue's write
+  // half; a separate dc_uploader process (#446) owns reading, replaying, uploading, and
+  // emitting status Records — see docs/adr/0014-uploader-runs-as-its-own-process.md.
+  std::unique_ptr<uploader::IntentQueueWriter> intent_queue_;
 
   // Per-Record dispatch (enqueue vs. forward, per topic). Borrows intent_queue_, the
   // Forwarder and its mutex above; declared after them so it dies first.

--- a/dc_bridge/include/dc_bridge/record_dispatch.hpp
+++ b/dc_bridge/include/dc_bridge/record_dispatch.hpp
@@ -50,8 +50,9 @@ public:
   /// caller doesn't have can stay unset.
   struct Deps
   {
-    /// The durable upload intent queue; must be set whenever Topics::files is non-empty.
-    uploader::IntentQueue* intent_queue{ nullptr };
+    /// The durable upload intent queue's write half; must be set whenever Topics::files
+    /// is non-empty. Dispatch only ever appends, so the read half isn't visible here.
+    uploader::IntentWriter* intent_queue{ nullptr };
     Forwarder* forwarder{ nullptr };
     /// The Bridge's Forwarder lock, shared with the prober thread's poll() and raw mode's
     /// send() — the Forwarder itself is not thread-safe.

--- a/dc_bridge/include/dc_bridge/render.hpp
+++ b/dc_bridge/include/dc_bridge/render.hpp
@@ -163,6 +163,7 @@ enum class RenderErrorKind
   InvalidReceives,
   FilesRequireObjectStorage,
   FilesDestinationInShipperConfig,
+  TooManyFilesDestinations,
   UnexpectedDestinationKind,
   InvalidTimeFormat,
   MissingField,
@@ -243,6 +244,13 @@ VectorParams vector_from_raw(const std::string& name, const RawDestinationParams
 /// Validates and builds one Destination from the flat parameters ROS declares for it.
 Destination destination_from_raw(const std::string& name, const std::string& type_str, const std::string& receives_str,
                                  std::vector<std::string> inputs, const RawDestinationParams& raw);
+
+/// At most one `receives: files` Destination per deployment (#505): the upload intent
+/// queue is one store behind one dc_uploader process, and that process is configured with
+/// exactly one object-storage endpoint (DC_UPLOADER_STORAGE_NAME). Enforced here, beside
+/// destination_from_raw's per-Destination validation, rather than only in dc_bringup's
+/// launch translation. Throws RenderError naming every offending Destination.
+void validate_files_destinations(const std::vector<Destination>& files_destinations);
 
 /// Thrown by expand_env for an undefined variable reference.
 class ExpandError : public std::runtime_error

--- a/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/intent_queue.hpp
@@ -1,22 +1,11 @@
 // SPDX-FileCopyrightText: 2022-2026 David Bensoussan
 // SPDX-License-Identifier: MPL-2.0
 
-// A disk-backed durable intent queue for the Uploader (ADR-0005 follow-up, #265):
-// Humble's embedded Fluent Bit made ingestion and durable buffering atomic (`in_ros2`
-// wrote straight into FLB's own filesystem chunks; chunk retry was the durable upload
-// state). The Bridge/Shipper split broke that for the File pipeline — an in-memory
-// queue forgets every pending upload on a Bridge restart, silently orphaning Files that
-// will never upload, report, or clean up. This restores that durability: every Record a
-// files-Destination's subscription receives is written to disk as one intent file before
-// it's ever handed to the Uploader, and it leaves the queue only via ack() after
-// processing actually succeeds — no cap, no drop-oldest, no dead-letter. An upload
-// intent and its Files live and die together.
-//
-// This directory is the crash-recovery state, not a notification channel: on startup
-// every unacked intent left over from a previous run is replayed, oldest-first, alongside
-// live traffic. Since #446 split the Uploader into its own process, there is no
-// in-process wake-up signal at all — a Bridge process enqueues and a separate dc_uploader
-// process discovers new intents purely by polling rescan() (see that method below).
+// The durable upload intent queue (ADR-0005/#265, ADR-0014): one intent file on disk per
+// Record a files-Destination receives, removed only by ack() after processing succeeds —
+// no cap, no drop-oldest, no dead-letter. Two classes over one store: IntentQueueWriter
+// is the Bridge's write half, IntentQueue is dc_uploader's read half — the queue *is* the
+// interface, and each process now holds only its own half of it.
 #ifndef DC_BRIDGE__UPLOADER__INTENT_QUEUE_HPP_
 #define DC_BRIDGE__UPLOADER__INTENT_QUEUE_HPP_
 
@@ -49,12 +38,57 @@ struct Intent
 inline constexpr std::chrono::milliseconds DEFAULT_BASE_BACKOFF{ 5000 };
 inline constexpr std::chrono::milliseconds DEFAULT_MAX_BACKOFF{ 2000000 };
 
-/// A crash-atomic, disk-backed FIFO of upload intents with oldest-first scheduling and
-/// per-entry exponential backoff, so one permanently-failing intent can't starve the
-/// rest of the backlog behind it. Thread-safe: enqueue() is expected to run on the
-/// subscription callback's thread while next_ready()/ack()/record_failure() run on the
-/// uploader worker thread.
-class IntentQueue
+/// `<uploader.data_dir>/queue/upload` — the one C++ derivation of the queue path
+/// (ADR-0014: both processes derive it from the same `uploader.data_dir`; dc_bringup hands
+/// the result to dc_uploader as DC_UPLOADER_QUEUE_DIR).
+std::string intent_queue_dir(const std::string& uploader_data_dir);
+
+/// The queue's write half — what the Bridge sees. Append an intent, count the backlog;
+/// nothing else. replay/backoff/ack/rescan are the reader's half, so they aren't on this
+/// type and writer-side code cannot call them.
+class IntentWriter
+{
+public:
+  virtual ~IntentWriter() = default;
+
+  /// Writes one intent — `{version: 1, tag, timestamp, payload}` — to disk via tmp+write
+  /// +rename (crash-atomic; no fsync, matching FLB's `storage.sync normal`) and returns
+  /// its id. Durable before this returns, and visible to a reader's rescan() — there is
+  /// no in-process wake-up across the process boundary (#446).
+  virtual std::string enqueue(const std::string& tag, const nlohmann::json& payload) = 0;
+
+  /// Number of intents currently in the queue.
+  virtual std::size_t size() const = 0;
+};
+
+/// A writer over the store holding none of the reader's in-memory state: the constructor
+/// scans nothing and keeps nothing but `dir` (the Bridge used to construct a full queue
+/// and load every pending intent's payload it would never read back). `size()` therefore
+/// counts the `*.json` files on disk — the only depth a writer-side caller can observe
+/// truthfully anyway, since acks happen in the reader's address space.
+class IntentQueueWriter final : public IntentWriter
+{
+public:
+  /// `dir` is created if missing; anything already in it is left for the reader.
+  explicit IntentQueueWriter(std::string dir);
+
+  std::string enqueue(const std::string& tag, const nlohmann::json& payload) override;
+
+  std::size_t size() const override;
+
+private:
+  std::string dir_;
+  std::mutex mutex_;  ///< guards seq_ (enqueue may run on several subscription threads).
+  std::uint64_t seq_{ 0 };
+};
+
+/// The queue's read half (dc_uploader's), plus the full queue for a single-process
+/// deployment: oldest-first scheduling with per-entry exponential backoff, so one
+/// permanently-failing intent can't starve the backlog behind it, and replay of every
+/// unacked intent a previous run left behind. Thread-safe: enqueue() is expected to run
+/// on the subscription callback's thread while next_ready()/ack()/record_failure() run on
+/// the uploader worker thread.
+class IntentQueue final : public IntentWriter
 {
 public:
   /// `dir` is created if missing. Every `*.json` file already there — a previous run's
@@ -64,10 +98,7 @@ public:
   explicit IntentQueue(std::string dir, std::chrono::milliseconds base_backoff = DEFAULT_BASE_BACKOFF,
                        std::chrono::milliseconds max_backoff = DEFAULT_MAX_BACKOFF);
 
-  /// Writes one intent — `{version: 1, tag, timestamp, payload}` — to disk via tmp+write
-  /// +rename (crash-atomic; no fsync, matching FLB's `storage.sync normal`) and makes it
-  /// immediately eligible for next_ready(). Returns its id.
-  std::string enqueue(const std::string& tag, const nlohmann::json& payload);
+  std::string enqueue(const std::string& tag, const nlohmann::json& payload) override;
 
   /// Unlinks the intent's file and drops it from scheduling. Idempotent: acking an id
   /// that's already gone (or was never known) is a no-op, never a thrown error.
@@ -91,18 +122,18 @@ public:
   std::vector<Intent> pending() const;
 
   /// Number of intents currently pending on disk (ready or backing off).
-  std::size_t size() const;
+  std::size_t size() const override;
   bool empty() const;
 
   /// Picks up any `*.json` file that exists on disk but isn't yet known to this
   /// instance — the multi-process split (#446): a Bridge process enqueues intents while a
   /// separate Uploader process holds the read side (next_ready()/ack()/record_failure()),
-  /// each with its own IntentQueue instance over the same directory. enqueue() only
-  /// updates its own caller's in-memory view, so the Uploader's instance never otherwise
-  /// learns about an intent a different process wrote; this is what closes that gap.
-  /// Already-known entries are left untouched (so in-flight backoff state survives);
-  /// returns the number of newly discovered intents. Safe to call from the same loop that
-  /// already polls for next_ready(), same cost as the constructor's initial scan.
+  /// each with its own instance over the same directory. enqueue() only updates its own
+  /// caller's in-memory view, so the Uploader's instance never otherwise learns about an
+  /// intent a different process wrote; this is what closes that gap. Already-known
+  /// entries are left untouched (so in-flight backoff state survives); returns the number
+  /// of newly discovered intents. Safe to call from the same loop that already polls for
+  /// next_ready(), same cost as the constructor's initial scan.
   std::size_t rescan();
 
 private:
@@ -117,9 +148,6 @@ private:
   };
 
   std::string path_for(const std::string& id) const;
-  /// Every "*.json" filename currently on disk under `dir`, sorted oldest-first (ids sort
-  /// lexicographically in enqueue order — see intent_queue.cpp's make_id()).
-  static std::vector<std::string> list_json_names(const std::string& dir);
   /// Parses one intent file's body into an Entry, or nullopt if it can't be read/parsed (a
   /// "final" .json file should always be complete, since rename is atomic).
   static std::optional<Entry> load_entry(const std::string& dir, const std::string& name);

--- a/dc_bridge/include/dc_bridge/uploader/process_config.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/process_config.hpp
@@ -56,7 +56,8 @@ struct UploaderProcessConfig
   UploaderConfig uploader_config{ std::string(), false };
 
   /// The durable upload intent queue directory (DC_UPLOADER_QUEUE_DIR) — the Bridge
-  /// writes intents here; this process reads, acks, and replays them.
+  /// writes intents here; this process reads, acks, and replays them. dc_bringup sets it
+  /// to intent_queue_dir(uploader.data_dir), the path the Bridge itself derives.
   std::string queue_dir;
 
   /// Sanity-checked for existence at process startup only (DC_UPLOADER_FILES_DIR):

--- a/dc_bridge/include/dc_bridge/uploader/retention.hpp
+++ b/dc_bridge/include/dc_bridge/uploader/retention.hpp
@@ -57,7 +57,7 @@ struct SweepResult
 };
 
 /// One retention sweep: stats the on-disk pool of Files referenced by `queue`'s pending
-/// intents (every intent still in `<uploader.data_dir>/queue/upload/` — the Uploader hasn't
+/// intents (every intent still in intent_queue_dir()'s directory — the Uploader hasn't
 /// finished with it, so this excludes Records whose Files already uploaded, verified, and
 /// left the queue via ack()) and, while either configured limit is exceeded, sheds the
 /// oldest eligible intent's Files — File and intent removed together, never one without

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -224,6 +224,9 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
       records_destinations.push_back(std::move(d));
     }
   }
+  // Where the rest of the Destination rules live (render.hpp's validation) — not only in
+  // dc_bringup's launch translation, which is what enforced this before (#505).
+  validate_files_destinations(files_destinations);
 
   // --- raw / generic-subscription mode (#227) ---
   // Declared before render() below, because enabling it adds a routed Tag namespace to
@@ -303,10 +306,9 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
 
     // The durable intent queue (#265/#446): the Bridge writes an intent for every Record
     // a files-Destination's subscription receives and never reads it back — a separate
-    // dc_uploader process owns replay, backoff, and acking. Its own directory
-    // (uploader.data_dir's multipart-resume state) is dc_uploader's concern now, not the
-    // Bridge's.
-    intent_queue_ = std::make_unique<uploader::IntentQueue>(uploader_data_dir + "/queue/upload");
+    // dc_uploader process owns replay, backoff, and acking. Only the write half is
+    // constructed: no backlog scan, no payloads held, no read API to call by accident.
+    intent_queue_ = std::make_unique<uploader::IntentQueueWriter>(uploader::intent_queue_dir(uploader_data_dir));
   }
 
   RenderConfig render_config;

--- a/dc_bridge/src/render.cpp
+++ b/dc_bridge/src/render.cpp
@@ -538,6 +538,21 @@ Destination destination_from_raw(const std::string& name, const std::string& typ
   return dest;
 }
 
+void validate_files_destinations(const std::vector<Destination>& files_destinations)
+{
+  if (files_destinations.size() <= 1)
+  {
+    return;
+  }
+  std::string names;
+  for (const auto& dest : files_destinations)
+  {
+    names += (names.empty() ? "" : ", ") + dest.name;
+  }
+  throw RenderError(RenderErrorKind::TooManyFilesDestinations,
+                    "at most one `receives: files` destination is supported per deployment; found " + names, names);
+}
+
 std::string expand_env(const std::string& input,
                        const std::function<std::optional<std::string>(const std::string&)>& lookup)
 {

--- a/dc_bridge/src/uploader/intent_queue.cpp
+++ b/dc_bridge/src/uploader/intent_queue.cpp
@@ -69,9 +69,10 @@ std::chrono::system_clock::time_point enqueued_at_from_id(const std::string& id)
   }
 }
 
-}  // namespace
-
-std::vector<std::string> IntentQueue::list_json_names(const std::string& dir)
+// Every "*.json" filename currently on disk under `dir`, sorted oldest-first (ids sort
+// lexicographically in enqueue order — see make_id() above). Both halves of the queue
+// share it: the reader loads entries from it, the writer counts it.
+std::vector<std::string> list_json_names(const std::string& dir)
 {
   std::vector<std::string> names;
   for (const auto& e : std::filesystem::directory_iterator(dir))
@@ -84,6 +85,57 @@ std::vector<std::string> IntentQueue::list_json_names(const std::string& dir)
   }
   std::sort(names.begin(), names.end());
   return names;
+}
+
+// The one write path both halves share — IntentQueueWriter's enqueue() and IntentQueue's
+// are the same bytes on disk, which is what keeps the format (#265) single-owner. `seq`
+// is the caller's own per-instance counter (make_id() needs it for uniqueness within one
+// process).
+std::string write_intent_file(const std::string& dir, std::uint64_t seq, const std::string& tag,
+                              const nlohmann::json& payload)
+{
+  const std::uint64_t now_ns = static_cast<std::uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+  const std::string id = make_id(now_ns, seq);
+
+  nlohmann::json doc{ { "version", 1 }, { "tag", tag }, { "timestamp", iso8601_now() }, { "payload", payload } };
+  const std::string final_path = dir + "/" + id;
+  const std::string tmp_path = final_path + ".tmp";
+  {
+    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
+    out << doc.dump();
+  }
+  // No fsync (FLB `storage.sync normal` parity) — the rename itself is what makes the
+  // write crash-atomic; losing the last few milliseconds of writes on a hard power loss
+  // is an accepted, pre-existing tradeoff this queue doesn't change.
+  if (std::rename(tmp_path.c_str(), final_path.c_str()) != 0)
+  {
+    throw std::runtime_error("failed to rename intent queue entry into place: " + final_path);
+  }
+  return id;
+}
+
+}  // namespace
+
+std::string intent_queue_dir(const std::string& uploader_data_dir)
+{
+  return (std::filesystem::path(uploader_data_dir) / "queue" / "upload").string();
+}
+
+IntentQueueWriter::IntentQueueWriter(std::string dir) : dir_(std::move(dir))
+{
+  std::filesystem::create_directories(dir_);
+}
+
+std::string IntentQueueWriter::enqueue(const std::string& tag, const nlohmann::json& payload)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  return write_intent_file(dir_, seq_++, tag, payload);
+}
+
+std::size_t IntentQueueWriter::size() const
+{
+  return list_json_names(dir_).size();
 }
 
 std::optional<IntentQueue::Entry> IntentQueue::load_entry(const std::string& dir, const std::string& name)
@@ -166,36 +218,18 @@ std::string IntentQueue::path_for(const std::string& id) const
 
 std::string IntentQueue::enqueue(const std::string& tag, const nlohmann::json& payload)
 {
-  std::uint64_t now_ns = static_cast<std::uint64_t>(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count());
   std::uint64_t seq;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     seq = seq_++;
   }
-  const std::string id = make_id(now_ns, seq);
-
-  nlohmann::json doc{ { "version", 1 }, { "tag", tag }, { "timestamp", iso8601_now() }, { "payload", payload } };
-  const std::string final_path = path_for(id);
-  const std::string tmp_path = final_path + ".tmp";
-  {
-    std::ofstream out(tmp_path, std::ios::binary | std::ios::trunc);
-    out << doc.dump();
-  }
-  // No fsync (FLB `storage.sync normal` parity) — the rename itself is what makes the
-  // write crash-atomic; losing the last few milliseconds of writes on a hard power loss
-  // is an accepted, pre-existing tradeoff this queue doesn't change.
-  if (std::rename(tmp_path.c_str(), final_path.c_str()) != 0)
-  {
-    throw std::runtime_error("failed to rename intent queue entry into place: " + final_path);
-  }
+  const std::string id = write_intent_file(dir_, seq, tag, payload);
 
   std::lock_guard<std::mutex> lock(mutex_);
   Entry entry;
   entry.tag = tag;
   entry.payload = payload;
-  entry.enqueued_at =
-      std::chrono::system_clock::time_point(std::chrono::nanoseconds(static_cast<std::int64_t>(now_ns)));
+  entry.enqueued_at = enqueued_at_from_id(id);
   entries_.emplace(id, std::move(entry));
   order_.push_back(id);
   return id;

--- a/dc_bridge/test/intent_queue_test.cpp
+++ b/dc_bridge/test/intent_queue_test.cpp
@@ -274,3 +274,49 @@ TEST(IntentQueue, RecordsWithoutFilesNeverLingerInSteadyState)
   EXPECT_TRUE(q.empty());
   (void)id;
 }
+
+TEST(IntentQueue, QueueDirIsDerivedFromTheUploaderDataDirInOnePlace)
+{
+  EXPECT_EQ(intent_queue_dir("/data/uploader"), "/data/uploader/queue/upload");
+  EXPECT_EQ(intent_queue_dir("/data/uploader/"), "/data/uploader/queue/upload");
+}
+
+// #505: the Bridge holds the write half only. Its constructor loads nothing and its
+// size() is a count of what is on disk — so it stays true while the reader process acks
+// in its own address space, which an in-memory count copied at construction never was.
+TEST(IntentQueue, WriterCountsOnDiskIntentsItNeverLoaded)
+{
+  Fixture fx;
+  {
+    IntentQueue q(fx.dir.string());
+    q.enqueue("dc.measurement.camera", json{ { "seq", 1 } });
+    q.enqueue("dc.measurement.camera", json{ { "seq", 2 } });
+  }
+
+  IntentQueueWriter writer(fx.dir.string());
+  EXPECT_EQ(writer.size(), 2u);
+
+  IntentQueue reader(fx.dir.string());
+  reader.ack(reader.next_ready()->id);
+  EXPECT_EQ(writer.size(), 1u);
+}
+
+TEST(IntentQueue, WriterEnqueueIsVisibleToAReaderRescan)
+{
+  // The production split (#446): a Bridge process's IntentQueueWriter appends, a
+  // separate dc_uploader process's IntentQueue discovers the intent by rescanning.
+  Fixture fx;
+  IntentQueueWriter writer(fx.dir.string());
+  IntentQueue reader(fx.dir.string());
+  EXPECT_TRUE(reader.empty());
+
+  const std::string id = writer.enqueue("dc.measurement.camera", json{ { "name", "camera" } });
+  EXPECT_EQ(writer.size(), 1u);
+  EXPECT_TRUE(reader.empty());  // not yet rescanned
+
+  EXPECT_EQ(reader.rescan(), 1u);
+  auto ready = reader.next_ready();
+  ASSERT_TRUE(ready.has_value());
+  EXPECT_EQ(ready->id, id);
+  EXPECT_EQ(ready->payload["name"], "camera");
+}

--- a/dc_bridge/test/record_dispatch_test.cpp
+++ b/dc_bridge/test/record_dispatch_test.cpp
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // The per-Record dispatch (#494): the enqueue-vs-forward decision, the parse-or-wrap
-// rule, and the stamp/envelope assembly, against a real IntentQueue and a loopback
-// shipper ingest protocol peer — no ROS node.
+// rule, and the stamp/envelope assembly, against a real intent-queue writer (the Bridge's
+// write half) and a loopback shipper ingest protocol peer — no ROS node.
 #include "dc_bridge/record_dispatch.hpp"
 
 #include <arpa/inet.h>
@@ -185,13 +185,13 @@ const msgpack::object* wire_message_value(const msgpack::object& record)
   return &record.via.map.ptr[0].val;
 }
 
-// A dispatcher over a real intent queue and a real Forwarder. `want_peer` decides whether
-// the Shipper is a listening loopback peer or a port nothing accepts on, so both
+// A dispatcher over a real intent-queue writer and a real Forwarder. `want_peer` decides
+// whether the Shipper is a listening loopback peer or a port nothing accepts on, so both
 // "nothing was sent" and "the send failed" are observable.
 struct Harness
 {
   std::filesystem::path queue_dir;
-  std::unique_ptr<IntentQueue> queue;
+  std::unique_ptr<IntentQueueWriter> queue;
   std::unique_ptr<CapturedFrame> peer;
   std::unique_ptr<Forwarder> forwarder;
   std::mutex forwarder_mutex;
@@ -203,7 +203,7 @@ struct Harness
     if (want_queue)
     {
       std::filesystem::create_directories(queue_dir);
-      queue = std::make_unique<IntentQueue>(queue_dir.string());
+      queue = std::make_unique<IntentQueueWriter>(queue_dir.string());
     }
 
     ForwarderConfig fcfg;
@@ -262,7 +262,10 @@ TEST(RecordDispatch, FilesTopicRecordIsEnqueuedAndNotForwarded)
   h.dispatcher->dispatch(make_incoming("/dc/camera/image", R"({"path": "/files/img.jpg"})"));
 
   ASSERT_EQ(h.queue->size(), 1u);
-  const Intent intent = h.queue->pending().at(0);
+  // The writer half only appends, so the payload is read back through the reader half —
+  // the same hand-off the separate dc_uploader process makes.
+  IntentQueue reader(h.queue_dir.string());
+  const Intent intent = reader.pending().at(0);
   EXPECT_EQ(intent.tag, "dc.camera.image");
   EXPECT_EQ(intent.payload, json::parse(R"({"path": "/files/img.jpg"})"));
 

--- a/dc_bridge/test/render_test.cpp
+++ b/dc_bridge/test/render_test.cpp
@@ -54,6 +54,13 @@ VectorParams vector_kind()
   return VectorParams{ "dc-e2e-limits-agg", 6000 };
 }
 
+Destination files_destination(const std::string& name)
+{
+  Destination d = make_destination(name, {}, TimeFormat::EpochNanos, S3Params{});
+  d.receives = Receives::Files;
+  return d;
+}
+
 SocketSinkParams mcap_like_sink()
 {
   SocketSinkParams params;
@@ -529,6 +536,30 @@ TEST(Render, RejectsFilesDestinationReachingShipperConfig)
   {
     EXPECT_EQ(e.kind(), RenderErrorKind::FilesDestinationInShipperConfig);
   }
+}
+
+// #505: the intent queue is one store behind one dc_uploader process — the second
+// `receives: files` Destination is rejected where Destinations are validated, not only by
+// dc_bringup's launch translation.
+TEST(Render, RejectsTwoFilesDestinations)
+{
+  const std::vector<Destination> files{ files_destination("minio_a"), files_destination("minio_b") };
+  try
+  {
+    validate_files_destinations(files);
+    FAIL();
+  }
+  catch (const RenderError& e)
+  {
+    EXPECT_EQ(e.kind(), RenderErrorKind::TooManyFilesDestinations);
+    EXPECT_EQ(e.arg0(), "minio_a, minio_b");
+  }
+}
+
+TEST(Render, AcceptsZeroOrOneFilesDestination)
+{
+  EXPECT_NO_THROW(validate_files_destinations({}));
+  EXPECT_NO_THROW(validate_files_destinations({ files_destination("minio") }));
 }
 
 TEST(Render, ExtraTagsAreRoutedNormalizedAndConsumed)


### PR DESCRIPTION
Closes #505.

## What each side sees now

ADR-0014 says the queue *is* the interface between `dc_bridge` and `dc_uploader`. This makes that literal and typechecked: two classes over one store and one write path, each process holding only its own half.

**Writer — what the Bridge sees** (`uploader::IntentQueueWriter`, through the new abstract `uploader::IntentWriter`):

| | |
|---|---|
| `enqueue(tag, payload) -> id` | same bytes on disk as before: `{version: 1, tag, timestamp, payload}` via tmp+write+rename, no fsync |
| `size()` | `*.json` files on disk right now |

Nothing else is on the type. Replay, backoff, `rescan`, `pending`, `ack` are the reader's half, so writer-side code can no longer reach them.

**Reader — what `dc_uploader` sees** (`uploader::IntentQueue`, interface unchanged): constructor scan, `rescan()`, `next_ready()`, `pending()`, `ack()`, `record_failure()`, `size()`, `empty()`. It still implements `IntentWriter`, so a single-process deployment loses nothing.

## What shrank on each side

- **Bridge**: constructing the queue no longer scans the directory and loads every pending intent's payload it would never read back. Its `size()` — the readiness probe's "upload queue depth" — is now a live count of the store instead of an in-memory count copied at construction that never dropped when `dc_uploader` acked in another process.
- **`dc_uploader`**: nothing — its reader interface and its `uploader_main.cpp` are untouched.
- **`intent_queue.cpp`**: the two `enqueue`s collapse into one `write_intent_file`, so the on-disk format and the single-writer crash-atomicity (#265) stay single-owner. No migration; every existing file is read exactly as before.

## Also in here

- `uploader::intent_queue_dir(uploader_data_dir)` is the one C++ derivation of `<uploader.data_dir>/queue/upload`; `bridge_node.cpp` and the `process_config.hpp`/`retention.hpp` doc comments point at it.
- The "at most one `receives: files` Destination" rule is now `validate_files_destinations()` in the render module, beside the other Destination validation, with a `RenderErrorKind::TooManyFilesDestinations` and a Bridge call at startup — previously only `dc_bringup.launch.py` enforced it.

## Out of scope, left for the launch-file issue the original one blocks on

The queue path and the files-Destination rule still have copies outside `dc_bridge` that this PR deliberately does not touch: the `DC_UPLOADER_QUEUE_DIR` translation in `dc_bringup/launch/dc_bringup.launch.py` (re-derived under a "must agree" comment) and the hard-coded values in `deploy/robot/compose.yaml`, `deploy/robot/quadlet/dc-uploader.container`, `deploy/robot/kubernetes/robot-pod.yaml`, `deploy/robot/helm/dc-robot/templates/pod.yaml`, and `tools/e2e/compose.split.yaml`. Those are the "same launch files" the Shipper-config-generation issue owns; pointing them at `intent_queue_dir()` needs the `dc_render` CLI (or a generated manifest), which is that issue's shape. `DC_UPLOADER_STORAGE_NAME`'s stringly equality with the Bridge's Destination name is likewise untouched: the two processes share no address space, so the strongest available check remains the one-files-Destination rule added above.

## Tests

`dc_bridge`'s gtest definitions go 194 → 199 (+5):

- `intent_queue_test`: `QueueDirIsDerivedFromTheUploaderDataDirInOnePlace`, `WriterCountsOnDiskIntentsItNeverLoaded`, `WriterEnqueueIsVisibleToAReaderRescan`
- `render_test`: `RejectsTwoFilesDestinations`, `AcceptsZeroOrOneFilesDestination`
- `record_dispatch_test`: harness now wires the dispatcher to the write half the Bridge actually passes it, and reads enqueued payloads back through a reader over the same dir — the production hand-off.

## Verification

No local ROS toolchain here, so CI's `build-workspace` job is the authoritative check: it builds the workspace and runs `colcon test` through the same `tools/e2e/scripts/build.sh` a developer runs. `prek run --skip build-doc` passes on the changed files (clang-format included).

