### PR TITLE
fix(e2e): failed runs keep their evidence

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1039,6 +1039,8 @@ jobs:
         with:
           name: e2e-harness-logs
           path: tools/e2e/.run/**
+          # .run/ is hidden — upload-artifact skips hidden dirs by default (#517)
+          include-hidden-files: true
 
   e2e-split:
     needs: [build-workspace, build-e2e-image]
@@ -1085,3 +1087,5 @@ jobs:
         with:
           name: e2e-split-harness-logs
           path: tools/e2e/.run/**
+          # .run/ is hidden — upload-artifact skips hidden dirs by default (#517)
+          include-hidden-files: true

--- a/tools/e2e/scripts/lib/harness.sh
+++ b/tools/e2e/scripts/lib/harness.sh
@@ -135,6 +135,20 @@ harness_rm_networks() {
   done
 }
 
+# On a failed run, the reload/error tail of each captured container goes to stdout too:
+# CI's artifact upload can't see the run dir (a hidden directory), so the job log is the
+# only copy of the failure's evidence that survives.
+harness_failure_excerpts() {
+  local pair container
+  for pair in "${HARNESS_LOG_CAPTURES[@]}"; do
+    container="${pair%%:*}"
+    if podman container exists "$container"; then
+      log "--- $container: reload/error tail"
+      podman logs "$container" 2>&1 | grep -iE "reload|error|fatal" | tail -30 || true
+    fi
+  done
+}
+
 # Podman logs for every --log-captures pair, into the manifest's run dir.
 harness_capture_logs() {
   local pair container
@@ -161,6 +175,9 @@ harness_cleanup() {
   local exit_code=$?
   if [ -n "$HARNESS_STATS_PID" ] && kill -0 "$HARNESS_STATS_PID" 2>/dev/null; then
     kill "$HARNESS_STATS_PID"
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    harness_failure_excerpts
   fi
   if [ "$exit_code" -ne 0 ] && [ "${DC_E2E_KEEP:-false}" = "true" ]; then
     log "FAILED (exit $exit_code) — leaving the stack up (DC_E2E_KEEP=true) for debugging"


### PR DESCRIPTION
Closes #517

## What

Two changes, nothing else:

1. **`.github/workflows/ci.yaml`** — the `Upload E2E harness logs (on failure)` step in `e2e` and the `Upload split E2E harness logs (on failure)` step in `e2e-split` now set `include-hidden-files: true`. The harness writes to `tools/e2e/.run/`, a hidden directory, and `upload-artifact@v4` skips hidden dirs by default — so every failed run so far has uploaded nothing ("No files were found"). The one artifact that says why a run failed (vector.log) was thrown away every time.
2. **Cherry-pick of `11ef5e74`** from `feature/496-e2e-topology`, pushed 21 minutes after #511 was squash-merged — it never got CI and is not on `jazzy`. It makes the harness print a reload/error tail of each captured container to stdout on failure, so diagnosis survives in the job log even when artifacts break. Authorship and message are preserved as committed; it already carried the Co-Authored-By trailer.

## Deliberately not here

`--watch-config` stays in compose.split.yaml, dc_bridge's shipper-config write is untouched, and no e2e tolerance is widened. Whether the 26-Record gap [49..74] is (a) `--watch-config` reloading Vector on the Bridge's byte-identical shipper-config rewrite or (b) the postgres sink's disk-buffer handling across the outage is decided by the next failed run's vector.log — which this PR is what makes that next failed run actually produce.

## CI is authoritative

No local build was run; CI is the only verification for both changes. The YAML fix is only observable in a *failed* e2e run (a failed run must upload `e2e-harness-logs`/`e2e-split-harness-logs` with contents instead of "No files were found"), so a green CI run on this PR proves the cherry-picked harness change is healthy but not the artifact fix itself — that one lands with the PR and gets exercised by the next real failure.

Local checks before push: `prek run --skip build-doc` clean, `bash -n` and `shellcheck` clean on the cherry-picked `tools/e2e/scripts/lib/harness.sh`.