### PR TITLE
refactor(dc_measurements): split the Measurement framework into a ROS-free core and a thin ROS driver

### DIFF
--- a/dc_measurements/CMakeLists.txt
+++ b/dc_measurements/CMakeLists.txt
@@ -6,6 +6,7 @@ project(dc_measurements)
 
 set(dependencies
   action_msgs
+  ament_index_cpp
   controller_manager_msgs
   cv_bridge
   dc_common
@@ -113,6 +114,7 @@ function(dc_add_measurement_plugin name)
   set(dc_measurement_plugin_libs ${dc_measurement_plugin_libs} PARENT_SCOPE)
   ament_target_dependencies(${name} ${dependencies})
   target_link_libraries(${name}
+    dc_measurement_core
     nlohmann_json::nlohmann_json
     nlohmann_json_schema_validator
     yaml-cpp::yaml-cpp
@@ -141,6 +143,25 @@ set(system_sources
   plugins/measurements/system/process.cpp
   plugins/measurements/system/processor.cpp
   plugins/measurements/system/system.cpp
+)
+
+# The ROS-free Measurement pipeline (#499): one compiled framework shared by every plugin .so,
+# instead of a private header-only copy in each. The ROS wiring stays in the header-only
+# dc_measurements::Measurement (measurement.hpp); everything decidable without ROS is here.
+add_library(dc_measurement_core SHARED
+  src/measurement_core.cpp
+)
+
+ament_target_dependencies(dc_measurement_core
+  ament_index_cpp
+  dc_common
+  dc_core
+)
+
+target_link_libraries(
+  dc_measurement_core
+  nlohmann_json::nlohmann_json
+  nlohmann_json_schema_validator
 )
 
 
@@ -254,7 +275,8 @@ ament_target_dependencies(${executable_name}
 
 rclcpp_components_register_nodes(${library_name} "measurement_server::MeasurementServer")
 
-install(TARGETS ${library_name}
+install(TARGETS dc_measurement_core
+                ${library_name}
                 ${dc_measurement_plugin_libs}
                 ${dc_condition_plugin_libs}
   ARCHIVE DESTINATION lib
@@ -291,6 +313,7 @@ set(tests
   test_measurement_camera
   test_measurement_cmd_vel
   test_measurement_compare
+  test_measurement_core
   test_measurement_diagnostics
   test_measurement_distance_traveled
   test_measurement_driving_type
@@ -351,6 +374,7 @@ if(BUILD_TESTING)
     )
     target_link_libraries(
       ${PROJECT_NAME}_${test}
+      dc_measurement_core
       nlohmann_json::nlohmann_json
       nlohmann_json_schema_validator
       opencv_calib3d
@@ -367,7 +391,8 @@ if(BUILD_TESTING)
 endif()
 
 ament_export_include_directories(include)
-ament_export_libraries(${library_name}
+ament_export_libraries(dc_measurement_core
+  ${library_name}
   ${dc_measurement_plugin_libs}
   ${dc_condition_plugin_libs}
 )

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -6,32 +6,24 @@
 
 #include <yaml-cpp/yaml.h>
 
-#include <cctype>
 #include <chrono>
-#include <cmath>
 #include <ctime>
-#include <filesystem>
-#include <fstream>
+#include <iomanip>
+#include <map>
 #include <memory>
-#include <mutex>
-#include <nlohmann/json-schema.hpp>
-#include <nlohmann/json.hpp>
+#include <sstream>
 #include <string>
-#include <utility>
 #include <vector>
 
-#include "dc_common/file_scratch_ring.hpp"
-#include "dc_common/record_file_walk.hpp"
 #include "dc_core/condition.hpp"
-#include "dc_core/condition_set.hpp"
 #include "dc_core/measurement.hpp"
 #include "dc_interfaces/msg/condition.hpp"
 #include "dc_interfaces/msg/flush_event.hpp"
 #include "dc_interfaces/msg/string_stamped.hpp"
-#include "dc_measurements/incident_releaser.hpp"
-#include "dc_measurements/publish_gate.hpp"
-#include "dc_measurements/record_enricher.hpp"
+#include "dc_measurements/measurement_core.hpp"
 #include "rclcpp/rclcpp.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rclcpp_lifecycle/lifecycle_publisher.hpp"
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/create_timer_ros.h"
 #include "tf2_ros/transform_listener.h"
@@ -41,56 +33,23 @@
 #pragma GCC diagnostic pop
 
 using namespace std::chrono_literals;  // NOLINT
-using json = nlohmann::json;
-using nlohmann::json_schema::json_validator;
 
 namespace dc_measurements
 {
 
-enum class Status : int8_t
-{
-  SUCCEEDED = 1,
-  FAILED = 2,
-  RUNNING = 3,
-};
-
-// A json_validator schema_loader resolving a "$ref" naming a sibling file (e.g.
-// "mission_base.json") against `schema_dir` -- the directory the root schema itself was loaded
-// from. Every schema in this codebase but the Mission Measurement family keeps to same-file
-// "#/$defs/..." refs, which nlohmann_json_schema_validator resolves on its own; this loader is
-// only ever invoked for a schema that references another file, letting a family of adapters
-// (#305/ADR-0010's shared mission_start/mission_end contract) share one base schema instead of
-// duplicating its properties per adapter.
-inline nlohmann::json_schema::schema_loader makeSchemaFileLoader(const std::string& schema_dir)
-{
-  return [schema_dir](const nlohmann::json_uri& id, json& value) {
-    std::string filename = id.path();
-    if (!filename.empty() && filename.front() == '/')
-    {
-      filename.erase(0, 1);
-    }
-    std::ifstream f(schema_dir + "/" + filename);
-    if (!f)
-    {
-      throw std::runtime_error{ "could not load schema '" + filename + "' referenced from " + schema_dir };
-    }
-    value = json::parse(f);
-  };
-}
-
 /**
- * @class nav2_behaviors::Behavior
- * @brief An action server Behavior base class implementing the action server and basic factory.
+ * @class dc_measurements::Measurement
+ * @brief The ROS driver of a Measurement plugin: the thin half of the framework split (#499).
+ *
+ * Everything decidable without ROS lives in MeasurementCore (one compiled copy shared by every
+ * plugin, directly testable). This class owns the ROS wiring -- publisher, polling and release
+ * timers, flush subscription, lifecycle transitions, node parameters -- and the plugin-facing
+ * surface: plugins keep inheriting exactly this one class and overriding collect() plus the
+ * onConfigure/onCleanup/onFailedValidation hooks.
  */
-// template <typename ActionT>
 class Measurement : public dc_core::Measurement
 {
 public:
-  //   using ActionServer = nav2_util::SimpleActionServer<ActionT>;
-
-  /**
-   * @brief A Measurement constructor
-   */
   Measurement()
   {
   }
@@ -159,237 +118,38 @@ public:
 
   void validateSchema(const std::string& package_name, const std::string& json_filename)
   {
-    std::string package_share_directory = ament_index_cpp::get_package_share_directory(package_name);
-    std::string schema_dir = package_share_directory + "/plugins/measurements/json";
-    std::string path = schema_dir + "/" + json_filename;
-    std::ifstream f(path.c_str());
-    try
-    {
-      schema_ = json::parse(f);
-
-      RCLCPP_INFO_STREAM(logger_, "Looking for schema at " << path);
-
-      RCLCPP_INFO_STREAM(logger_, "schema: " << schema_);
-      try
-      {
-        validator_ = json_validator(makeSchemaFileLoader(schema_dir));
-        validator_.set_root_schema(schema_);
-      }
-      catch (const std::exception& e)
-      {
-        std::string err = std::string("Validation of schema failed: ") + e.what();
-        RCLCPP_ERROR(logger_, "%s", err.c_str());
-        throw std::runtime_error{ err.c_str() };
-      }
-    }
-    catch (json::parse_error& e)
-    {
-      RCLCPP_ERROR_STREAM(logger_, "Error parsing JSON from file path: " << schema_);
-    }
+    core_.validateSchema(package_name, json_filename);
   }
 
   void validateSchema(const std::string& json_schema_path)
   {
-    std::ifstream f(json_schema_path.c_str());
-    try
-    {
-      schema_ = json::parse(f);
-
-      RCLCPP_INFO_STREAM(logger_, "schema: " << schema_);
-      try
-      {
-        const std::string schema_dir = std::filesystem::path(json_schema_path).parent_path().string();
-        validator_ = json_validator(makeSchemaFileLoader(schema_dir));
-        validator_.set_root_schema(schema_);
-      }
-      catch (const std::exception& e)
-      {
-        std::string err = std::string("Validation of schema failed: ") + e.what();
-        RCLCPP_ERROR(logger_, "%s", err.c_str());
-        throw std::runtime_error{ err.c_str() };
-      }
-    }
-    catch (json::parse_error& e)
-    {
-      RCLCPP_ERROR_STREAM(logger_, "Error parsing JSON file json_schema_path: " << json_schema_path);
-    }
+    core_.validateSchema(json_schema_path);
   }
 
-  // CamelCase to snake_case, keeping an acronym run together with the word it precedes:
-  // TCPHealth -> tcp_health, Ros2ControlStatus -> ros2_control_status, OS -> os.
   static std::string snakeCase(const std::string& camel)
   {
-    std::string out;
-    for (size_t i = 0; i < camel.size(); i++)
-    {
-      const unsigned char c = static_cast<unsigned char>(camel[i]);
-      const unsigned char prev = i > 0 ? static_cast<unsigned char>(camel[i - 1]) : 0;
-      const unsigned char next = i + 1 < camel.size() ? static_cast<unsigned char>(camel[i + 1]) : 0;
-      const bool boundary = i > 0 && std::isupper(c) &&
-                            ((std::islower(prev) || std::isdigit(prev)) || (std::isupper(prev) && std::islower(next)));
-      if (boundary)
-      {
-        out += '_';
-      }
-      out += static_cast<char>(std::tolower(c));
-    }
-    return out;
+    return MeasurementCore::snakeCase(camel);
   }
 
-  // The schema file a plugin type validates against by default, relative to the registering
-  // package's plugins/measurements/json directory. Only the type after the '/' is converted:
-  // the package part is not a CamelCase word.
   static std::string defaultSchemaFile(const std::string& plugin_lookup_name)
   {
-    const size_t sep = plugin_lookup_name.find('/');
-    const std::string& plugin_type = sep == std::string::npos ? plugin_lookup_name : plugin_lookup_name.substr(sep + 1);
-    return snakeCase(plugin_type) + ".json";
-  }
-
-  // The schema a Measurement validates against when json_schema_path is unset: one file per
-  // plugin type, named after it, shipped by the package registering the plugin
-  // (dc_measurements/Camera -> dc_measurements/plugins/measurements/json/camera.json).
-  // Derived from the plugin type rather than the measurement name so an instance id like
-  // right_camera still finds the Camera schema.
-  void validateDefaultSchema()
-  {
-    const size_t sep = measurement_plugin_.find('/');
-    const std::string package =
-        sep == std::string::npos ? std::string("dc_measurements") : measurement_plugin_.substr(0, sep);
-    validateSchema(package, defaultSchemaFile(measurement_plugin_));
-  }
-
-  // Current state of one of the configured Conditions, as dc_core::ConditionSet asks for it.
-  // A name that is not a configured Condition reads as false rather than dereferencing a null
-  // plugin, which is what the previous conditions_[name]->getState(msg) did on a typo'd name.
-  bool getConditionState(const std::string& condition_name, const dc_interfaces::msg::StringStamped& msg)
-  {
-    auto condition_it = conditions_.find(condition_name);
-    if (condition_it == conditions_.end() || !condition_it->second)
-    {
-      RCLCPP_ERROR_STREAM(logger_, "Measurement " << measurement_name_ << ": '" << condition_name
-                                                  << "' is not a configured condition; treating it as false.");
-      return false;
-    }
-    return condition_it->second->getState(msg);
-  }
-
-  bool isConditionOn(const dc_interfaces::msg::StringStamped& msg)
-  {
-    // The if_all/if_any/if_none composition itself lives in dc_core so the Trigger plugins can
-    // compose Conditions the same way (#284); only the state lookup is Measurement's own.
-    const auto outcome = condition_set_.evaluate(dc_core::ConditionStateLookup{
-        [&](const std::string& condition_name) { return getConditionState(condition_name, msg); } });
-
-    RCLCPP_DEBUG(logger_, "all_conditions_res=%d, any_conditions_res=%d, none_conditions_res=%d",
-                 outcome.if_all_satisfied, outcome.if_any_satisfied, outcome.if_none_satisfied);
-
-    return outcome.satisfied();
-  }
-
-  bool isAnyConditionSet()
-  {
-    return !condition_set_.empty();
-  }
-
-  // Whether every collection should currently be held back by the gate condition.
-  //
-  // Semantics (distinct from if_all/if_any/if_none, which are re-evaluated on every collection):
-  // gate_condition_ names a Condition that must become true once; from then on the gate latches
-  // open permanently for the lifetime of this Measurement instance and the condition is never
-  // consulted again, even if it later becomes false again.
-  bool isGateArmed(const dc_interfaces::msg::StringStamped& msg)
-  {
-    // An open gate -- no gate_condition configured, or already latched -- is never re-consulted.
-    if (publish_gate_.gateOpen())
-    {
-      return true;
-    }
-
-    auto condition_it = conditions_.find(gate_condition_);
-    if (condition_it == conditions_.end())
-    {
-      RCLCPP_ERROR_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
-                                                  << "' is not a configured condition; holding all collection back.");
-      return false;
-    }
-
-    const bool open = publish_gate_.openGate(condition_it->second->getState(msg));
-    if (open)
-    {
-      RCLCPP_INFO_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
-                                                 << "' became true, collection will proceed normally from now on.");
-    }
-    return open;
-  }
-
-  // The validation step of the enrichment pipeline: a Record the schema rejects is logged and
-  // handed to the plugin hook, but still published, exactly as this chain always did.
-  void validateJSON(const json& data_json)
-  {
-    try
-    {
-      validator_.validate(data_json);
-    }
-    catch (const std::exception& e)
-    {
-      RCLCPP_ERROR_STREAM(logger_, "Validation failed: " << e.what() << "data=" << data_json.dump());
-      onFailedValidation(data_json);
-    }
-  }
-
-  // Applies the same enrichment publish() applies before publishing (validation, nesting/
-  // flattening, run_id, tags, measurement name/plugin, custom keys) without publishing --
-  // shared by publish() and bufferSample() so a Record released later from the ring buffer
-  // looks identical to one published live, modulo the incident_id onFlushEvent() adds (#287).
-  // One parse, one dump: the steps themselves live in RecordEnricher (#482).
-  void enrichMsg(dc_interfaces::msg::StringStamped& msg)
-  {
-    msg.data = record_enricher_.enrich(msg.data);
+    return MeasurementCore::defaultSchemaFile(plugin_lookup_name);
   }
 
   void publish(dc_interfaces::msg::StringStamped msg)
   {
     auto msg_copy = msg;
-    if (!msg.data.empty() && msg.data != "null")
+    core_.publish(msg.data, msg.group_key, rclcpp::Time(msg.header.stamp).nanoseconds(), gateLookup(msg_copy),
+                  conditionLookup(msg_copy), std::chrono::system_clock::now());
+    if (core_.collectionFinished())
     {
-      enrichMsg(msg);
-    }
-    if (!msg.data.empty() && msg.data != "null")
-    {
-      if (!isGateArmed(msg_copy))
-      {
-        RCLCPP_DEBUG_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << gate_condition_
-                                                    << "' not yet true, dropping collection.");
-        return;
-      }
-
-      if (publish_gate_.offer(isAnyConditionSet() && isConditionOn(msg_copy)))
-      {
-        data_pub_->publish(msg);
-      }
-
-      if (publish_gate_.collectionFinished())
-      {
-        collect_timer_.reset();
-      }
-    }
-    else
-    {
-      // Not necessarily a fault: a Measurement that found nothing to report
-      // returns an empty message on purpose -- Camera does exactly that on every
-      // frame with no barcode in view, which is most frames of the QR-code demo.
-      // Throttled and worded accordingly, because at the polling rate this used
-      // to read like a broken pipeline and sent #279 chasing one that was fine.
-      RCLCPP_WARN_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
-                                  "No data collected from measurement "
-                                      << measurement_name_ << " (nothing to report, or it is not receiving input)");
+      collect_timer_.reset();
     }
   }
 
   void publishFromMsg(const dc_interfaces::msg::StringStamped& msg)
   {
-    if (enabled_)
+    if (core_.collectible())
     {
       publish(msg);
     }
@@ -398,208 +158,16 @@ public:
   void collectAndPublish()
   {
     dc_interfaces::msg::StringStamped msg = collect();
-    if (enabled_)
+    if (core_.collectible())
     {
-      if (releaser_)
+      if (core_.hasReleaser())
       {
-        offerSample(msg);
+        core_.offerSample(msg.data, std::chrono::system_clock::now());
       }
       else
       {
         publish(msg);
       }
-    }
-  }
-
-  // With incident capture configured, collectAndPublish() calls this instead of publish(): the
-  // sample is enriched exactly as a live Record would be, then handed to the IncidentReleaser,
-  // which buffers it or (during post-roll) publishes it live through publishIncidentRecord() (#288).
-  void offerSample(dc_interfaces::msg::StringStamped msg)
-  {
-    const auto now = std::chrono::system_clock::now();
-    if (msg.data.empty() || msg.data == "null")
-    {
-      // Nothing to offer, but the phase deadlines and a rate-limited release still need driving.
-      const std::lock_guard<std::mutex> lock(releaser_mutex_);
-      releaser_->tick(now);
-      return;
-    }
-    enrichMsg(msg);
-    const std::lock_guard<std::mutex> lock(releaser_mutex_);
-    // Drive the phase transitions before deciding what to do with this sample's Files: during
-    // post-roll the Record is published live and its Files are left exactly where the Measurement
-    // wrote them, which is what the Bridge has always picked up.
-    releaser_->tick(now);
-    if (releaser_->state() != IncidentState::PostRoll)
-    {
-      stageSampleFiles(msg, now);
-    }
-    releaser_->offer(msg.data, now);
-  }
-
-  // A buffered Record's Files, staged (#290). Called for every sample the releaser is about to
-  // buffer rather than publish: each File the Record references is moved into the scratch ring and
-  // the Record rewritten to point at the staged copy, then the ring is aged like the Record ring
-  // buffer it shadows, so an armed Measurement's Files stay bounded by buffer_duration_sec instead
-  // of piling up in the save path with no Record to ever carry them to the Bridge.
-  //
-  // Caller holds releaser_mutex_.
-  void stageSampleFiles(dc_interfaces::msg::StringStamped& msg, const std::chrono::system_clock::time_point& now)
-  {
-    json data_json;
-    try
-    {
-      data_json = json::parse(msg.data);
-    }
-    catch (json::parse_error& e)
-    {
-      // enrichMsg() already logged whatever made this unparsable; buffer it as-is.
-      return;
-    }
-    if (stageRecordFiles(data_json, now))
-    {
-      msg.data = data_json.dump(-1, ' ', true);
-    }
-    // Rolling deletion of the aged-out staged Files -- the disk-backed half of the same eviction
-    // the ring buffer does to their Records, driven with the same `now` and the same window, so
-    // the two stay in step. Safe to run mid-release: onFlushEvent() released the window being
-    // drained out of the ring's ownership before the drain started.
-    if (file_scratch_ring_)
-    {
-      file_scratch_ring_->evict(now);
-    }
-  }
-
-  // Stage every File `value` references, rewriting each local_paths entry to its staged copy.
-  // Returns whether anything was staged. The Record walk itself is owned by dc_common's
-  // record_file_walk (#479) -- the same one dc_bridge's parse_file_group() goes through, so
-  // exactly the paths the Bridge would have uploaded are the ones that move, in either written
-  // form (nested local_paths objects, or a flattened Record's JSON-pointer keys).
-  bool stageRecordFiles(json& value, const std::chrono::system_clock::time_point& stamp)
-  {
-    return dc_common::record_file_walk::rewrite_local_paths(value, [&](std::string& path) {
-      return stageOneFile(path, stamp);
-    });
-  }
-
-  // Move one File into the scratch ring and rewrite `path` to the staged copy. The walk hands
-  // over non-empty local-path strings only.
-  bool stageOneFile(std::string& path, const std::chrono::system_clock::time_point& stamp)
-  {
-    const std::string original = path;
-
-    try
-    {
-      const auto staged_path = scratchRing()->stage(original, stamp);
-      // Staging *moves* the File: the Record referencing the original is buffered, not published,
-      // so nothing will ever pick that original up -- neither the Bridge (which never sees the
-      // Record) nor its retention sweep. Leaving it behind would grow the save path without bound
-      // for as long as the Measurement stays armed, which is exactly what the bounded ring exists
-      // to prevent. The copy the ring made is what the released Record points at, and it uploads
-      // to the unchanged remote_paths key the Measurement computed at collection time.
-      std::error_code ec;
-      std::filesystem::remove(original, ec);
-      path = staged_path.string();
-      return true;
-    }
-    catch (const std::filesystem::filesystem_error& e)
-    {
-      RCLCPP_ERROR_STREAM_THROTTLE(logger_, *getNode()->get_clock(), 10000,
-                                   "Measurement " << measurement_name_ << ": could not stage File " << original
-                                                  << " into the incident scratch ring (" << e.what()
-                                                  << "); buffering the Record with the File left in place.");
-      return false;
-    }
-  }
-
-  // The scratch ring, created on the first Record that actually references a File so the many
-  // Measurements that produce none never grow a scratch directory. Caller holds releaser_mutex_.
-  const std::shared_ptr<dc_common::FileScratchRing>& scratchRing()
-  {
-    if (!file_scratch_ring_)
-    {
-      file_scratch_ring_ =
-          std::make_shared<dc_common::FileScratchRing>(scratchDir(), durationFromSeconds(buffer_duration_sec_));
-    }
-    return file_scratch_ring_;
-  }
-
-  // Where staged Files live: one stable directory per Measurement, next to the Files themselves
-  // (same filesystem, so staging is a cheap local move) but outside the dated save tree. The
-  // literal prefix of save_local_base_path is used -- everything up to its first strftime token --
-  // so the scratch directory doesn't roll over every hour the way the save path does.
-  std::filesystem::path scratchDir() const
-  {
-    std::string base = save_local_base_path_expanded_;
-    const auto token = base.find('%');
-    if (token != std::string::npos)
-    {
-      const auto slash = base.rfind('/', token);
-      base = (slash == std::string::npos) ? std::string() : base.substr(0, slash);
-    }
-    if (base.empty())
-    {
-      base = std::filesystem::temp_directory_path().string();
-    }
-    return std::filesystem::path(base) / ".dc_incident_scratch" / measurement_name_;
-  }
-
-  // Emits one Record belonging to an incident -- either released from the pre-roll buffer (stamped
-  // with when it was collected, not when it was released) or collected live during post-roll.
-  // Publishes straight through data_pub_, bypassing publish()'s gate/counter logic: a Record
-  // captured for an incident was already unconditionally collected and isn't re-filtered on the
-  // way out.
-  void publishIncidentRecord(const std::string& record_json, const std::chrono::system_clock::time_point& stamp,
-                             const std::string& incident_id)
-  {
-    dc_interfaces::msg::StringStamped out;
-    out.group_key = group_key_;
-    out.header.stamp =
-        rclcpp::Time(std::chrono::duration_cast<std::chrono::nanoseconds>(stamp.time_since_epoch()).count());
-    try
-    {
-      json data_json = json::parse(record_json);
-      data_json["incident_id"] = incident_id;
-      out.data = data_json.dump(-1, ' ', true);
-    }
-    catch (json::parse_error& e)
-    {
-      RCLCPP_ERROR_STREAM(logger_,
-                          "Error parsing Record JSON while releasing incident " << incident_id << ": " << record_json);
-      return;
-    }
-    data_pub_->publish(out);
-  }
-
-  // A Trigger fired somewhere in the system: hand the event to the state machine, which releases
-  // the buffered window under this incident_id when armed and ignores the event otherwise (#288).
-  void onFlushEvent(const dc_interfaces::msg::FlushEvent& event)
-  {
-    if (!releaser_)
-    {
-      return;
-    }
-    const auto now = std::chrono::system_clock::now();
-    const std::lock_guard<std::mutex> lock(releaser_mutex_);
-    releaser_->tick(now);
-    // Whether this event starts a cycle has to be read before onFlush() acts on it, since acting
-    // on it is exactly what makes isArmed() false.
-    const bool starts_cycle = releaser_->isArmed();
-    if (file_scratch_ring_ && starts_cycle)
-    {
-      // Staged Files that have aged out are not part of the window this incident releases (their
-      // Records were evicted from the ring buffer too): delete them first, so what survives to
-      // release() below is exactly what the released Records reference.
-      file_scratch_ring_->evict(now);
-    }
-    releaser_->onFlush(event.incident_id, now);
-    if (file_scratch_ring_ && starts_cycle)
-    {
-      // The released Records are on their way to the Bridge, which owns their Files from here
-      // (intent queue, upload, retention sweep, delete_when_sent). Stop tracking them so no later
-      // evict() can delete a File out from under an upload in flight -- #290's whole point being
-      // that the Bridge needs no change to ingest them, however old their timestamps are.
-      file_scratch_ring_->release();
     }
   }
 
@@ -625,7 +193,6 @@ public:
     polling_interval_ = config.polling_interval;
     debug_ = config.debug;
     enable_validator_ = config.enable_validator;
-    json_schema_path_ = config.json_schema_path;
     group_key_ = config.group_key;
     init_collect_ = config.init_collect;
     remote_keys_ = config.remote_keys;
@@ -635,37 +202,36 @@ public:
     save_local_base_path_ = config.save_local_base_path;
     save_local_base_path_expanded_ = config.save_local_base_path_expanded;
 
-    condition_set_ =
-        dc_core::ConditionSet(config.if_all_conditions, config.if_any_conditions, config.if_none_conditions);
-
-    gate_condition_ = config.gate_condition;
-
-    // The publish decision -- gate latch, init quota, condition cap -- is state the ROS layer
-    // only feeds and reads back (#482).
-    PublishGate::Config gate_config;
-    gate_config.init_max = config.init_max_measurements;
-    gate_config.condition_max = config.condition_max_measurements;
-    gate_config.has_conditions = !condition_set_.empty();
-    gate_config.gate_enabled = !gate_condition_.empty();
-    publish_gate_ = PublishGate(gate_config);
-
-    RecordEnricher::Config enricher_config;
-    enricher_config.measurement_name = measurement_name_;
-    enricher_config.measurement_plugin = measurement_plugin_;
-    enricher_config.nested = config.nested;
-    enricher_config.flatten = config.flatten;
-    enricher_config.run_id_enabled = config.run_id_enabled;
-    enricher_config.run_id = config.run_id;
-    enricher_config.include_measurement_name = config.include_measurement_name;
-    enricher_config.include_measurement_plugin = config.include_measurement_plugin;
-    enricher_config.tags = config.tags;
-    enricher_config.custom_keys = config.custom_keys;
-    enricher_config.enable_validator = config.enable_validator;
-    record_enricher_ = RecordEnricher(
-        enricher_config, [this](const json& data_json) { validateJSON(data_json); },
-        [this](const std::string& data) {
-          RCLCPP_ERROR_STREAM(logger_, "Error parsing JSON while enriching: " << data);
-        });
+    // The pipeline runs ROS-free in MeasurementCore; this wiring builds its inputs and outputs.
+    MeasurementCore::Config core_config;
+    core_config.measurement_name = measurement_name_;
+    core_config.measurement_plugin = measurement_plugin_;
+    core_config.group_key = group_key_;
+    core_config.enable_validator = enable_validator_;
+    core_config.json_schema_path = config.json_schema_path;
+    core_config.save_local_base_path_expanded = save_local_base_path_expanded_;
+    core_config.if_all_conditions = config.if_all_conditions;
+    core_config.if_any_conditions = config.if_any_conditions;
+    core_config.if_none_conditions = config.if_none_conditions;
+    core_config.gate_condition = config.gate_condition;
+    core_config.init_max_measurements = config.init_max_measurements;
+    core_config.condition_max_measurements = config.condition_max_measurements;
+    core_config.nested = config.nested;
+    core_config.flatten = config.flatten;
+    core_config.run_id_enabled = config.run_id_enabled;
+    core_config.run_id = config.run_id;
+    core_config.include_measurement_name = config.include_measurement_name;
+    core_config.include_measurement_plugin = config.include_measurement_plugin;
+    core_config.tags = config.tags;
+    core_config.custom_keys = config.custom_keys;
+    core_config.buffer_duration_sec = config.buffer_duration_sec;
+    core_config.post_roll_duration_sec = config.post_roll_duration_sec;
+    core_config.cooldown_sec = config.cooldown_sec;
+    core_config.max_flush_rate_hz = config.max_flush_rate_hz;
+    core_.configure(
+        core_config, [this](const RecordOut& out) { publishOut(out); },
+        [this](const json& data_json) { onFailedValidation(data_json); },
+        [this](LogLevel level, const std::string& message) { log(level, message); });
 
     if (topic_output_.empty())
     {
@@ -677,35 +243,21 @@ public:
     collect_timer_ = node->create_wall_timer(
         std::chrono::milliseconds(polling_interval_), [this] { collectAndPublish(); }, client_cb_group_);
 
-    buffer_duration_sec_ = config.buffer_duration_sec;
-    post_roll_duration_sec_ = config.post_roll_duration_sec;
-    cooldown_sec_ = config.cooldown_sec;
-    max_flush_rate_hz_ = config.max_flush_rate_hz;
-    flush_topic_ = config.flush_topic.empty() ? std::string("/dc/flush") : config.flush_topic;
-    if (buffer_duration_sec_ > 0.0)
+    if (core_.hasReleaser())
     {
-      releaser_ = std::make_shared<IncidentReleaser>(
-          durationFromSeconds(buffer_duration_sec_), durationFromSeconds(post_roll_duration_sec_),
-          durationFromSeconds(cooldown_sec_), max_flush_rate_hz_,
-          [this](const std::string& record_json, const std::chrono::system_clock::time_point& stamp,
-                 const std::string& incident_id) { publishIncidentRecord(record_json, stamp, incident_id); });
       flush_sub_ = node->create_subscription<dc_interfaces::msg::FlushEvent>(
-          flush_topic_, 10, std::bind(&Measurement::onFlushEvent, this, std::placeholders::_1));
-      if (max_flush_rate_hz_ > 0.0)
+          config.flush_topic.empty() ? std::string("/dc/flush") : config.flush_topic, 10,
+          [this](const dc_interfaces::msg::FlushEvent& event) {
+            core_.onFlushEvent(event.incident_id, std::chrono::system_clock::now());
+          });
+      if (config.max_flush_rate_hz > 0.0)
       {
         // A rate-limited release is drained by tick(), and the polling timer alone would drain it
         // at the polling rate -- in bursts, and never faster than collection however high
         // max_flush_rate_hz is. This timer paces the release properly (#289).
         release_timer_ = node->create_wall_timer(
-            durationFromSeconds(1.0 / max_flush_rate_hz_),
-            [this] {
-              const std::lock_guard<std::mutex> lock(releaser_mutex_);
-              if (releaser_)
-              {
-                releaser_->tick(std::chrono::system_clock::now());
-              }
-            },
-            client_cb_group_);
+            durationFromSeconds(1.0 / config.max_flush_rate_hz),
+            [this] { core_.tickRelease(std::chrono::system_clock::now()); }, client_cb_group_);
       }
     }
 
@@ -713,13 +265,13 @@ public:
 
     if (enable_validator_)
     {
-      if (json_schema_path_.empty())
+      if (config.json_schema_path.empty())
       {
-        validateDefaultSchema();
+        core_.validateDefaultSchema();
       }
       else
       {
-        validateSchema(json_schema_path_);
+        core_.validateSchema(config.json_schema_path);
       }
     }
     // If error during measurement initialization, stop it from publishing
@@ -729,11 +281,11 @@ public:
     }
     catch (std::runtime_error& error)
     {
-      enabled_ = false;
+      core_.markConfigureFailed();
       collect_timer_.reset();
     }
 
-    if (enable_validator_ && schema_.empty())
+    if (enable_validator_ && core_.schemaEmpty())
     {
       throw std::runtime_error{ "Enabled validation but didn't configure schema!" };
     }
@@ -744,20 +296,9 @@ public:
   {
     data_pub_.reset();
     flush_sub_.reset();
-    // Before the releaser it ticks, so the timer can't fire on a null one.
+    // Before the core's releaser it ticks, so the timer can't fire on a null one.
     release_timer_.reset();
-    {
-      const std::lock_guard<std::mutex> lock(releaser_mutex_);
-      releaser_.reset();
-      if (file_scratch_ring_)
-      {
-        // The buffered Records go with the releaser, so the Files they referenced would be
-        // orphaned in the scratch directory: nothing is left to publish them. Released ones are
-        // untracked by now (onFlushEvent()) and are the Bridge's, so purge() can't touch them.
-        file_scratch_ring_->purge();
-        file_scratch_ring_.reset();
-      }
-    }
+    core_.teardown();
     onCleanup();
   }
 
@@ -767,8 +308,12 @@ public:
     RCLCPP_INFO(logger_, "Activating measurement %s", measurement_name_.c_str());
 
     data_pub_->on_activate();
+    // Re-enable collection: deactivate() cleared it, and a deactivate -> activate cycle resumes
+    // where the old never-reset flag silenced the Measurement permanently (#499). A Measurement
+    // whose onConfigure() hook failed stays silent regardless -- see MeasurementCore::collectible().
+    core_.setEnabled(true);
 
-    if (enabled_ && init_collect_)
+    if (core_.collectible() && init_collect_)
     {
       collectAndPublish();
     }
@@ -778,7 +323,7 @@ public:
   void deactivate() override
   {
     data_pub_->on_deactivate();
-    enabled_ = false;
+    core_.setEnabled(false);
   }
 
 protected:
@@ -786,7 +331,7 @@ protected:
 
   std::string measurement_name_;
   std::string measurement_plugin_;
-  bool enabled_{ true };
+  std::string group_key_;
   bool debug_;
   std::shared_ptr<tf2_ros::Buffer> tf_;
   rclcpp::CallbackGroup::SharedPtr client_cb_group_;
@@ -796,7 +341,6 @@ protected:
   rclcpp_lifecycle::LifecyclePublisher<dc_interfaces::msg::StringStamped>::SharedPtr data_pub_;
   rclcpp::TimerBase::SharedPtr collect_timer_;
   std::string topic_output_;
-  std::string group_key_;
 
   // Parameters
   bool init_collect_;
@@ -807,47 +351,84 @@ protected:
   std::string save_local_base_path_;
   std::string save_local_base_path_expanded_;
 
-  // Conditions
+  // Conditions, resolved per collection into the lookups the core's gate and ConditionSet consume
   std::map<std::string, std::shared_ptr<dc_core::Condition>> conditions_;
-  dc_core::ConditionSet condition_set_;
-  std::string gate_condition_;
-
-  // The publish decision (gate latch, init quota, condition cap) and the Record shaping,
-  // both ROS-free and directly tested (#482).
-  PublishGate publish_gate_;
-  RecordEnricher record_enricher_{ RecordEnricher::Config{}, {}, {} };
 
   // Logger
   rclcpp::Logger logger_{ rclcpp::get_logger("dc_measurements") };
 
   // Validation
   bool enable_validator_;
-  std::string json_schema_path_;
-  json_validator validator_;
-  json schema_;
 
-  // Incident capture: pre-event circular-buffer capture (#287) driven by the IncidentReleaser
-  // state machine (#288). releaser_ is only created when buffer_duration_sec_ > 0; while it
-  // exists, collected samples go to it instead of publish(), and a FlushEvent on flush_topic_
-  // starts one buffer-release / post-roll / cooldown / re-arm cycle.
-  double buffer_duration_sec_{ 0.0 };
-  double post_roll_duration_sec_{ 0.0 };
-  double cooldown_sec_{ 0.0 };
-  double max_flush_rate_hz_{ 0.0 };
-  std::string flush_topic_;
-  std::shared_ptr<IncidentReleaser> releaser_;
+  // The pipeline, ROS-free and shared by every plugin (#499)
+  MeasurementCore core_;
+
+private:
+  // State of one configured Condition, as dc_core::ConditionSet asks for it. A name that is not a
+  // configured Condition reads as false rather than dereferencing a null plugin, which is what
+  // the previous conditions_[name]->getState(msg) did on a typo'd name.
+  dc_core::ConditionStateLookup conditionLookup(const dc_interfaces::msg::StringStamped& msg) const
+  {
+    return [this, &msg](const std::string& condition_name) {
+      const auto condition_it = conditions_.find(condition_name);
+      if (condition_it == conditions_.end() || !condition_it->second)
+      {
+        RCLCPP_ERROR_STREAM(logger_, "Measurement " << measurement_name_ << ": '" << condition_name
+                                                    << "' is not a configured condition; treating it as false.");
+        return false;
+      }
+      return condition_it->second->getState(msg);
+    };
+  }
+
+  // Same lookup, worded for the gate: a gate_condition naming nothing holds all collection back.
+  dc_core::ConditionStateLookup gateLookup(const dc_interfaces::msg::StringStamped& msg) const
+  {
+    return [this, &msg](const std::string& condition_name) {
+      const auto condition_it = conditions_.find(condition_name);
+      if (condition_it == conditions_.end() || !condition_it->second)
+      {
+        RCLCPP_ERROR_STREAM(logger_, "Measurement " << measurement_name_ << ": gate_condition '" << condition_name
+                                                    << "' is not a configured condition; holding all collection back.");
+        return false;
+      }
+      return condition_it->second->getState(msg);
+    };
+  }
+
+  // PublishFn target: every Record the pipeline emits -- live or released from the incident
+  // buffer -- goes out through the one lifecycle publisher.
+  void publishOut(const RecordOut& out)
+  {
+    dc_interfaces::msg::StringStamped msg;
+    msg.data = out.data;
+    msg.group_key = out.group_key;
+    msg.header.stamp = rclcpp::Time(out.stamp_ns);
+    data_pub_->publish(msg);
+  }
+
+  void log(LogLevel level, const std::string& message)
+  {
+    switch (level)
+    {
+      case LogLevel::Debug:
+        RCLCPP_DEBUG(logger_, "%s", message.c_str());
+        break;
+      case LogLevel::Info:
+        RCLCPP_INFO(logger_, "%s", message.c_str());
+        break;
+      case LogLevel::Warn:
+        RCLCPP_WARN(logger_, "%s", message.c_str());
+        break;
+      case LogLevel::Error:
+        RCLCPP_ERROR(logger_, "%s", message.c_str());
+        break;
+    }
+  }
+
   rclcpp::Subscription<dc_interfaces::msg::FlushEvent>::SharedPtr flush_sub_;
-  // Paces a rate-limited release; only created when max_flush_rate_hz_ > 0 (#289).
+  // Paces a rate-limited release; only created when max_flush_rate_hz > 0 (#289).
   rclcpp::TimerBase::SharedPtr release_timer_;
-  // The Files half of incident capture (#290): while the releaser buffers a Record instead of
-  // publishing it, the Files that Record references are moved in here and the Record rewritten to
-  // point at the staged copies, which age out on the same window as the Records themselves.
-  // Created lazily by scratchRing(), on the first Record that references a File at all.
-  std::shared_ptr<dc_common::FileScratchRing> file_scratch_ring_;
-  // The releaser is reached from three concurrent paths -- the polling timer, the FlushEvent
-  // subscription and release_timer_ -- so every entry into it, and into the scratch ring that
-  // shadows it, is serialized here.
-  std::mutex releaser_mutex_;
 };
 
 }  // namespace dc_measurements

--- a/dc_measurements/include/dc_measurements/measurement_core.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_core.hpp
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#ifndef DC_MEASUREMENTS__MEASUREMENT_CORE_HPP_
+#define DC_MEASUREMENTS__MEASUREMENT_CORE_HPP_
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <nlohmann/json-schema.hpp>
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+#include "dc_common/file_scratch_ring.hpp"
+#include "dc_core/condition_set.hpp"
+#include "dc_measurements/incident_releaser.hpp"
+#include "dc_measurements/publish_gate.hpp"
+#include "dc_measurements/record_enricher.hpp"
+
+using json = nlohmann::json;                  // NOLINT
+using nlohmann::json_schema::json_validator;  // NOLINT
+
+namespace dc_measurements
+{
+
+enum class Status : int8_t
+{
+  SUCCEEDED = 1,
+  FAILED = 2,
+  RUNNING = 3,
+};
+
+/// Severity of a message a ROS-free module reports through its log callback.
+enum class LogLevel
+{
+  Debug,
+  Info,
+  Warn,
+  Error,
+};
+
+/// One Record on its way out of the pipeline: the finished payload, the Group merge key, and the
+/// collection timestamp in nanoseconds since the epoch.
+struct RecordOut
+{
+  std::string data;
+  std::string group_key;
+  std::int64_t stamp_ns{ 0 };
+};
+
+// A json_validator schema_loader resolving a "$ref" naming a sibling file (e.g.
+// "mission_base.json") against `schema_dir` -- the directory the root schema itself was loaded
+// from. Every schema in this codebase but the Mission Measurement family keeps to same-file
+// "#/$defs/..." refs, which nlohmann_json_schema_validator resolves on its own; this loader is
+// only ever invoked for a schema that references another file, letting a family of adapters
+// (#305/ADR-0010's shared mission_start/mission_end contract) share one base schema instead of
+// duplicating its properties per adapter.
+nlohmann::json_schema::schema_loader makeSchemaFileLoader(const std::string& schema_dir);
+
+/**
+ * @class dc_measurements::MeasurementCore
+ * @brief The Measurement pipeline without ROS (#499): the gate latch, the publish counters, Record
+ * enrichment with schema validation, incident buffering, File staging and the scratch ring.
+ *
+ * This used to live in the header-only dc_measurements::Measurement, where every plugin .so
+ * compiled a private copy and nothing was instantiable without a LifecycleNode. The core owns the
+ * decisions; the ROS driver (measurement.hpp) owns the publisher, timers, subscription and
+ * lifecycle wiring that feed it.
+ *
+ * Every boundary is injected, so the whole pipeline is testable with no rclcpp type anywhere:
+ * - time enters through the `now` argument of each entry point;
+ * - Conditions enter as a dc_core::ConditionStateLookup -- the caller resolves names against its
+ *   live Condition plugins;
+ * - Records leave through PublishFn, diagnostics through LogFn, and a schema-rejected Record
+ *   reaches the plugin's hook through ValidationFailureFn.
+ */
+class MeasurementCore
+{
+public:
+  using TimePoint = std::chrono::system_clock::time_point;
+  using ConditionStateLookup = dc_core::ConditionStateLookup;
+
+  /// Emits one Record, live or released from the incident buffer.
+  using PublishFn = std::function<void(const RecordOut&)>;
+  /// Reports a schema-rejected Record; owns the plugin hook, and does not stop publication.
+  using ValidationFailureFn = std::function<void(const json&)>;
+  /// Reports a pipeline diagnostic.
+  using LogFn = std::function<void(LogLevel, const std::string&)>;
+
+  /// The pure pipeline settings; the ROS wiring around them stays in the driver.
+  struct Config
+  {
+    std::string measurement_name;
+    std::string measurement_plugin;  ///< Schema file and default package are derived from the type
+    std::string group_key;           ///< Key stamped on Records released from the incident buffer
+    bool enable_validator{ true };
+    std::string json_schema_path;               ///< Explicit schema file; empty means the default one
+    std::string save_local_base_path_expanded;  ///< Scratch ring lives next to this, outside the
+                                                ///< dated save tree
+
+    // Conditions and gating
+    std::vector<std::string> if_all_conditions;
+    std::vector<std::string> if_any_conditions;
+    std::vector<std::string> if_none_conditions;
+    std::string gate_condition;
+    int init_max_measurements{ 0 };
+    int condition_max_measurements{ 0 };
+
+    // Record shaping, forwarded to the RecordEnricher (#482)
+    bool nested{ false };
+    bool flatten{ false };
+    bool run_id_enabled{ true };
+    std::string run_id;
+    bool include_measurement_name{ true };
+    bool include_measurement_plugin{ false };
+    std::vector<std::string> tags;
+    std::vector<json> custom_keys;
+
+    // Incident capture (#287/#288/#289)
+    double buffer_duration_sec{ 0.0 };
+    double post_roll_duration_sec{ 0.0 };
+    double cooldown_sec{ 0.0 };
+    double max_flush_rate_hz{ 0.0 };
+  };
+
+  MeasurementCore();
+  ~MeasurementCore();
+
+  MeasurementCore(const MeasurementCore&) = delete;
+  MeasurementCore& operator=(const MeasurementCore&) = delete;
+
+  /**
+   * @brief Build the pipeline from `config`; Records go out through `publish`, a schema-rejected
+   * Record reaches `on_validation_failure`, diagnostics through `log`.
+   */
+  void configure(const Config& config, PublishFn publish, ValidationFailureFn on_validation_failure, LogFn log);
+
+  /**
+   * @brief The live publish path: enrich, gate, count, emit.
+   *
+   * Empty and "null" payloads are dropped with a throttled warning -- a Measurement that found
+   * nothing to report (Camera on a frame with no barcode) is not a fault. `gate_state` is
+   * consulted only until the gate latches open; `conditions` only while the set is non-empty, so
+   * Conditions with side effects are polled exactly when the old chain polled them.
+   */
+  void publish(const std::string& data, const std::string& group_key, std::int64_t stamp_ns,
+               const ConditionStateLookup& gate_state, const ConditionStateLookup& conditions, const TimePoint& now);
+
+  /**
+   * @brief Hand one collected sample to the incident state machine instead of publish().
+   *
+   * The sample is enriched like a live Record, its Files staged (#290), then buffered or (during
+   * post-roll) released live. Empty and "null" payloads still tick the phase deadlines along.
+   */
+  void offerSample(const std::string& data, const TimePoint& now);
+
+  /// A Trigger fired somewhere in the system: releases the buffered window under `incident_id`
+  /// when armed, ignored otherwise (#288).
+  void onFlushEvent(const std::string& incident_id, const TimePoint& now);
+
+  /// Advance a rate-limited release to `now`; safe and cheap to call at any rate (#289).
+  void tickRelease(const TimePoint& now);
+
+  /// Whether incident capture is configured (the driver subscribes to the flush topic when it is).
+  bool hasReleaser() const;
+
+  /// Whether the init quota is spent with no condition publishing configured; the driver stops
+  /// the polling timer when this turns true.
+  bool collectionFinished() const;
+
+  /**
+   * @brief The publish-enabling state machine, owned explicitly (#499).
+   *
+   * enabled_ is the lifecycle gate: the driver clears it on deactivate() and restores it on
+   * activate(), so a deactivate -> activate cycle resumes collection where the old flag -- set to
+   * false and never reset -- silenced the Measurement permanently. configure_failed_ is
+   * permanent: an onConfigure() hook that threw keeps the Measurement silent for its lifetime,
+   * however many activate() cycles follow.
+   */
+  bool collectible() const;
+  void setEnabled(bool enabled);
+  void markConfigureFailed();
+
+  /// Load the schema from `package_name`'s plugins/measurements/json directory.
+  void validateSchema(const std::string& package_name, const std::string& json_filename);
+  /// Load the schema from an explicit path; sibling "$ref" files resolve next to it.
+  void validateSchema(const std::string& json_schema_path);
+  /// The schema a Measurement validates against when json_schema_path is unset: one file per
+  /// plugin type, named after it, shipped by the package registering the plugin
+  /// (dc_measurements/Camera -> dc_measurements/plugins/measurements/json/camera.json).
+  void validateDefaultSchema();
+  /// Whether no schema is loaded; with the validator enabled that is a configuration error.
+  bool schemaEmpty() const;
+
+  // CamelCase to snake_case, keeping an acronym run together with the word it precedes:
+  // TCPHealth -> tcp_health, Ros2ControlStatus -> ros2_control_status, OS -> os.
+  static std::string snakeCase(const std::string& camel);
+
+  // The schema file a plugin type validates against by default, relative to the registering
+  // package's plugins/measurements/json directory. Only the type after the '/' is converted:
+  // the package part is not a CamelCase word.
+  static std::string defaultSchemaFile(const std::string& plugin_lookup_name);
+
+  /// Frees the incident state: the buffered Records go with the releaser, so the Files they
+  /// referenced are purged from the scratch ring rather than orphaned there.
+  void teardown();
+
+private:
+  // The enrichment step of the pipeline (#482): one parse, one dump, shared by publish() and
+  // offerSample() so a released Record looks identical to a live one, modulo the incident_id.
+  void enrich(std::string& data);
+
+  // The validation step: a Record the schema rejects is logged and handed to the plugin hook,
+  // but still published, exactly as this chain always did.
+  void validateJSON(const json& data_json);
+
+  // Whether every collection should currently be held back by the gate condition. Distinct from
+  // if_all/if_any/if_none, which are re-evaluated on every collection: gate_condition_ names a
+  // Condition that must become true once; from then on the gate latches open permanently for the
+  // lifetime of this instance and the condition is never consulted again.
+  bool gateOpen(const ConditionStateLookup& gate_state);
+
+  // The condition-composition half of the publish decision; false when no Condition is
+  // configured, matching the short-circuit the old isAnyConditionSet() && isConditionOn() had.
+  bool conditionSetOn(const ConditionStateLookup& conditions);
+
+  // A buffered Record's Files, staged (#290): each File the Record references is moved into the
+  // scratch ring, the Record rewritten to point at the staged copy, and the ring aged like the
+  // Record ring buffer it shadows. Caller holds releaser_mutex_.
+  void stageSampleFiles(std::string& data, const TimePoint& now);
+  bool stageRecordFiles(json& value, const TimePoint& stamp);
+  bool stageOneFile(std::string& path, const TimePoint& stamp);
+
+  // The scratch ring, created on the first Record that actually references a File so the many
+  // Measurements that produce none never grow a scratch directory. Caller holds releaser_mutex_.
+  const std::shared_ptr<dc_common::FileScratchRing>& scratchRing();
+
+  // Where staged Files live: one stable directory per Measurement, next to the Files themselves
+  // (same filesystem, so staging is a cheap local move) but outside the dated save tree.
+  std::filesystem::path scratchDir() const;
+
+  // Emits one Record belonging to an incident -- either released from the pre-roll buffer (stamped
+  // with when it was collected, not when it was released) or collected live during post-roll.
+  // Goes straight out through publish_, bypassing publish()'s gate/counter logic: a Record
+  // captured for an incident was already unconditionally collected and isn't re-filtered.
+  void publishIncidentRecord(const std::string& record_json, const TimePoint& stamp, const std::string& incident_id);
+
+  // Logs `message` through log_ unless `last` is less than one throttle period old, then stamps
+  // it. Stands in for the RCLCPP_*_THROTTLE calls this module cannot use.
+  void logThrottled(LogLevel level, TimePoint& last, const TimePoint& now, const std::string& message);
+
+  Config config_;
+  PublishFn publish_;
+  ValidationFailureFn on_validation_failure_;
+  LogFn log_;
+
+  dc_core::ConditionSet condition_set_;
+  // The publish decision (gate latch, init quota, condition cap) and the Record shaping, both
+  // ROS-free and directly tested (#482).
+  PublishGate publish_gate_;
+  RecordEnricher record_enricher_{ RecordEnricher::Config{}, {}, {} };
+
+  // Validation
+  bool enable_validator_{ true };
+  json_validator validator_;
+  json schema_;
+
+  // Publish-enabling state, see collectible() (#499)
+  bool enabled_{ true };
+  bool configure_failed_{ false };
+
+  // Incident capture: pre-event circular-buffer capture (#287) driven by the IncidentReleaser
+  // state machine (#288). releaser_ is only created when buffer_duration_sec_ > 0; while it
+  // exists, collected samples go to it instead of publish(), and a flush event starts one
+  // buffer-release / post-roll / cooldown / re-arm cycle.
+  std::shared_ptr<IncidentReleaser> releaser_;
+  // The Files half of incident capture (#290): while the releaser buffers a Record instead of
+  // publishing it, the Files that Record references are moved in here and the Record rewritten to
+  // point at the staged copies, which age out on the same window as the Records themselves.
+  // Created lazily by scratchRing(), on the first Record that references a File at all.
+  std::shared_ptr<dc_common::FileScratchRing> file_scratch_ring_;
+  // The releaser is reached from three concurrent paths -- the polling timer, the flush
+  // subscription and the release timer -- so every entry into it, and into the scratch ring that
+  // shadows it, is serialized here.
+  std::mutex releaser_mutex_;
+
+  // Throttle bookkeeping for the two log sites that had one, 10 s like the RCLCPP_*_THROTTLE
+  // calls this module cannot use.
+  TimePoint last_empty_warn_;
+  TimePoint last_stage_error_;
+};
+
+}  // namespace dc_measurements
+
+#endif  // DC_MEASUREMENTS__MEASUREMENT_CORE_HPP_

--- a/dc_measurements/package.xml
+++ b/dc_measurements/package.xml
@@ -16,6 +16,7 @@ SPDX-License-Identifier: MPL-2.0
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>action_msgs</depend>
+  <depend>ament_index_cpp</depend>
   <depend>controller_manager_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>dc_common</depend>

--- a/dc_measurements/src/measurement_core.cpp
+++ b/dc_measurements/src/measurement_core.cpp
@@ -1,0 +1,478 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include "dc_measurements/measurement_core.hpp"
+
+#include <cctype>
+#include <utility>
+
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "dc_common/record_file_walk.hpp"
+
+namespace dc_measurements
+{
+namespace
+{
+// The two throttled log sites the RCLCPP_*_THROTTLE calls used to own.
+constexpr std::chrono::milliseconds kThrottlePeriod{ 10000 };
+}  // namespace
+
+MeasurementCore::MeasurementCore() = default;
+
+MeasurementCore::~MeasurementCore() = default;
+
+nlohmann::json_schema::schema_loader makeSchemaFileLoader(const std::string& schema_dir)
+{
+  return [schema_dir](const nlohmann::json_uri& id, json& value) {
+    std::string filename = id.path();
+    if (!filename.empty() && filename.front() == '/')
+    {
+      filename.erase(0, 1);
+    }
+    std::ifstream f(schema_dir + "/" + filename);
+    if (!f)
+    {
+      throw std::runtime_error{ "could not load schema '" + filename + "' referenced from " + schema_dir };
+    }
+    value = json::parse(f);
+  };
+}
+
+void MeasurementCore::configure(const Config& config, PublishFn publish, ValidationFailureFn on_validation_failure,
+                                LogFn log)
+{
+  config_ = config;
+  publish_ = std::move(publish);
+  on_validation_failure_ = std::move(on_validation_failure);
+  log_ = std::move(log);
+
+  condition_set_ = dc_core::ConditionSet(config.if_all_conditions, config.if_any_conditions, config.if_none_conditions);
+
+  // The publish decision -- gate latch, init quota, condition cap -- is state the ROS layer only
+  // feeds and reads back (#482).
+  PublishGate::Config gate_config;
+  gate_config.init_max = config.init_max_measurements;
+  gate_config.condition_max = config.condition_max_measurements;
+  gate_config.has_conditions = !condition_set_.empty();
+  gate_config.gate_enabled = !config.gate_condition.empty();
+  publish_gate_ = PublishGate(gate_config);
+
+  RecordEnricher::Config enricher_config;
+  enricher_config.measurement_name = config.measurement_name;
+  enricher_config.measurement_plugin = config.measurement_plugin;
+  enricher_config.nested = config.nested;
+  enricher_config.flatten = config.flatten;
+  enricher_config.run_id_enabled = config.run_id_enabled;
+  enricher_config.run_id = config.run_id;
+  enricher_config.include_measurement_name = config.include_measurement_name;
+  enricher_config.include_measurement_plugin = config.include_measurement_plugin;
+  enricher_config.tags = config.tags;
+  enricher_config.custom_keys = config.custom_keys;
+  enricher_config.enable_validator = config.enable_validator;
+  record_enricher_ = RecordEnricher(
+      enricher_config, [this](const json& data_json) { validateJSON(data_json); },
+      [this](const std::string& data) { log_(LogLevel::Error, "Error parsing JSON while enriching: " + data); });
+
+  if (config.buffer_duration_sec > 0.0)
+  {
+    releaser_ = std::make_shared<IncidentReleaser>(
+        durationFromSeconds(config.buffer_duration_sec), durationFromSeconds(config.post_roll_duration_sec),
+        durationFromSeconds(config.cooldown_sec), config.max_flush_rate_hz,
+        [this](const std::string& record_json, const TimePoint& stamp, const std::string& incident_id) {
+          publishIncidentRecord(record_json, stamp, incident_id);
+        });
+  }
+}
+
+void MeasurementCore::publish(const std::string& data, const std::string& group_key, std::int64_t stamp_ns,
+                              const ConditionStateLookup& gate_state, const ConditionStateLookup& conditions,
+                              const TimePoint& now)
+{
+  if (data.empty() || data == "null")
+  {
+    // Not necessarily a fault: a Measurement that found nothing to report returns an empty
+    // message on purpose -- Camera does exactly that on every frame with no barcode in view,
+    // which is most frames of the QR-code demo. Throttled and worded accordingly, because at the
+    // polling rate this used to read like a broken pipeline and sent #279 chasing one that was
+    // fine.
+    logThrottled(LogLevel::Warn, last_empty_warn_, now,
+                 "No data collected from measurement " + config_.measurement_name +
+                     " (nothing to report, or it is not receiving input)");
+    return;
+  }
+
+  std::string enriched = data;
+  enrich(enriched);
+
+  if (!gateOpen(gate_state))
+  {
+    log_(LogLevel::Debug, "Measurement " + config_.measurement_name + ": gate_condition '" + config_.gate_condition +
+                              "' not yet true, dropping collection.");
+    return;
+  }
+
+  if (publish_gate_.offer(conditionSetOn(conditions)))
+  {
+    publish_(RecordOut{ enriched, group_key, stamp_ns });
+  }
+}
+
+void MeasurementCore::offerSample(const std::string& data, const TimePoint& now)
+{
+  if (!releaser_)
+  {
+    return;
+  }
+  if (data.empty() || data == "null")
+  {
+    // Nothing to offer, but the phase deadlines and a rate-limited release still need driving.
+    const std::lock_guard<std::mutex> lock(releaser_mutex_);
+    releaser_->tick(now);
+    return;
+  }
+  std::string enriched = data;
+  enrich(enriched);
+  const std::lock_guard<std::mutex> lock(releaser_mutex_);
+  // Drive the phase transitions before deciding what to do with this sample's Files: during
+  // post-roll the Record is published live and its Files are left exactly where the Measurement
+  // wrote them, which is what the Bridge has always picked up.
+  releaser_->tick(now);
+  if (releaser_->state() != IncidentState::PostRoll)
+  {
+    stageSampleFiles(enriched, now);
+  }
+  releaser_->offer(enriched, now);
+}
+
+void MeasurementCore::onFlushEvent(const std::string& incident_id, const TimePoint& now)
+{
+  if (!releaser_)
+  {
+    return;
+  }
+  const std::lock_guard<std::mutex> lock(releaser_mutex_);
+  releaser_->tick(now);
+  // Whether this event starts a cycle has to be read before onFlush() acts on it, since acting
+  // on it is exactly what makes isArmed() false.
+  const bool starts_cycle = releaser_->isArmed();
+  if (file_scratch_ring_ && starts_cycle)
+  {
+    // Staged Files that have aged out are not part of the window this incident releases (their
+    // Records were evicted from the ring buffer too): delete them first, so what survives to
+    // release() below is exactly what the released Records reference.
+    file_scratch_ring_->evict(now);
+  }
+  releaser_->onFlush(incident_id, now);
+  if (file_scratch_ring_ && starts_cycle)
+  {
+    // The released Records are on their way to the Bridge, which owns their Files from here
+    // (intent queue, upload, retention sweep, delete_when_sent). Stop tracking them so no later
+    // evict() can delete a File out from under an upload in flight -- #290's whole point being
+    // that the Bridge needs no change to ingest them, however old their timestamps are.
+    file_scratch_ring_->release();
+  }
+}
+
+void MeasurementCore::tickRelease(const TimePoint& now)
+{
+  const std::lock_guard<std::mutex> lock(releaser_mutex_);
+  if (releaser_)
+  {
+    releaser_->tick(now);
+  }
+}
+
+void MeasurementCore::teardown()
+{
+  const std::lock_guard<std::mutex> lock(releaser_mutex_);
+  releaser_.reset();
+  if (file_scratch_ring_)
+  {
+    // The buffered Records go with the releaser, so the Files they referenced would be orphaned
+    // in the scratch directory: nothing is left to publish them. Released ones are untracked by
+    // now (onFlushEvent()) and are the Bridge's, so purge() can't touch them.
+    file_scratch_ring_->purge();
+    file_scratch_ring_.reset();
+  }
+}
+
+bool MeasurementCore::hasReleaser() const
+{
+  return releaser_ != nullptr;
+}
+
+bool MeasurementCore::collectionFinished() const
+{
+  return publish_gate_.collectionFinished();
+}
+
+bool MeasurementCore::collectible() const
+{
+  return enabled_ && !configure_failed_;
+}
+
+void MeasurementCore::setEnabled(bool enabled)
+{
+  enabled_ = enabled;
+}
+
+void MeasurementCore::markConfigureFailed()
+{
+  configure_failed_ = true;
+}
+
+void MeasurementCore::validateSchema(const std::string& package_name, const std::string& json_filename)
+{
+  const std::string package_share_directory = ament_index_cpp::get_package_share_directory(package_name);
+  const std::string schema_dir = package_share_directory + "/plugins/measurements/json";
+  validateSchema(schema_dir + "/" + json_filename);
+}
+
+void MeasurementCore::validateSchema(const std::string& json_schema_path)
+{
+  std::ifstream f(json_schema_path);
+  try
+  {
+    schema_ = json::parse(f);
+
+    log_(LogLevel::Info, "Looking for schema at " + json_schema_path);
+    log_(LogLevel::Info, "schema: " + schema_.dump());
+    try
+    {
+      const std::string schema_dir = std::filesystem::path(json_schema_path).parent_path().string();
+      validator_ = json_validator(makeSchemaFileLoader(schema_dir));
+      validator_.set_root_schema(schema_);
+    }
+    catch (const std::exception& e)
+    {
+      const std::string err = std::string("Validation of schema failed: ") + e.what();
+      log_(LogLevel::Error, err);
+      throw std::runtime_error{ err };
+    }
+  }
+  catch (json::parse_error& e)
+  {
+    log_(LogLevel::Error, "Error parsing JSON file json_schema_path: " + json_schema_path);
+  }
+}
+
+void MeasurementCore::validateDefaultSchema()
+{
+  const size_t sep = config_.measurement_plugin.find('/');
+  const std::string package =
+      sep == std::string::npos ? std::string("dc_measurements") : config_.measurement_plugin.substr(0, sep);
+  validateSchema(package, defaultSchemaFile(config_.measurement_plugin));
+}
+
+bool MeasurementCore::schemaEmpty() const
+{
+  return schema_.empty();
+}
+
+std::string MeasurementCore::snakeCase(const std::string& camel)
+{
+  std::string out;
+  for (size_t i = 0; i < camel.size(); i++)
+  {
+    const unsigned char c = static_cast<unsigned char>(camel[i]);
+    const unsigned char prev = i > 0 ? static_cast<unsigned char>(camel[i - 1]) : 0;
+    const unsigned char next = i + 1 < camel.size() ? static_cast<unsigned char>(camel[i + 1]) : 0;
+    const bool boundary = i > 0 && std::isupper(c) &&
+                          ((std::islower(prev) || std::isdigit(prev)) || (std::isupper(prev) && std::islower(next)));
+    if (boundary)
+    {
+      out += '_';
+    }
+    out += static_cast<char>(std::tolower(c));
+  }
+  return out;
+}
+
+std::string MeasurementCore::defaultSchemaFile(const std::string& plugin_lookup_name)
+{
+  const size_t sep = plugin_lookup_name.find('/');
+  const std::string& plugin_type = sep == std::string::npos ? plugin_lookup_name : plugin_lookup_name.substr(sep + 1);
+  return snakeCase(plugin_type) + ".json";
+}
+
+void MeasurementCore::enrich(std::string& data)
+{
+  data = record_enricher_.enrich(data);
+}
+
+void MeasurementCore::validateJSON(const json& data_json)
+{
+  try
+  {
+    validator_.validate(data_json);
+  }
+  catch (const std::exception& e)
+  {
+    log_(LogLevel::Error, "Validation failed: " + std::string(e.what()) + "data=" + data_json.dump());
+    if (on_validation_failure_)
+    {
+      on_validation_failure_(data_json);
+    }
+  }
+}
+
+bool MeasurementCore::gateOpen(const ConditionStateLookup& gate_state)
+{
+  // An open gate -- no gate_condition configured, or already latched -- is never re-consulted.
+  if (publish_gate_.gateOpen())
+  {
+    return true;
+  }
+
+  const bool open = publish_gate_.openGate(gate_state(config_.gate_condition));
+  if (open)
+  {
+    log_(LogLevel::Info, "Measurement " + config_.measurement_name + ": gate_condition '" + config_.gate_condition +
+                             "' became true, collection will proceed normally from now on.");
+  }
+  return open;
+}
+
+bool MeasurementCore::conditionSetOn(const ConditionStateLookup& conditions)
+{
+  if (condition_set_.empty())
+  {
+    return false;
+  }
+
+  // The if_all/if_any/if_none composition itself lives in dc_core so the Trigger plugins can
+  // compose Conditions the same way (#284); the state lookup stays with the ROS driver.
+  const auto outcome = condition_set_.evaluate(conditions);
+
+  log_(LogLevel::Debug, "all_conditions_res=" + std::to_string(outcome.if_all_satisfied) +
+                            ", any_conditions_res=" + std::to_string(outcome.if_any_satisfied) +
+                            ", none_conditions_res=" + std::to_string(outcome.if_none_satisfied));
+
+  return outcome.satisfied();
+}
+
+void MeasurementCore::stageSampleFiles(std::string& data, const TimePoint& now)
+{
+  json data_json;
+  try
+  {
+    data_json = json::parse(data);
+  }
+  catch (json::parse_error& e)
+  {
+    // enrich() already logged whatever made this unparsable; buffer it as-is.
+    return;
+  }
+  if (stageRecordFiles(data_json, now))
+  {
+    data = data_json.dump(-1, ' ', true);
+  }
+  // Rolling deletion of the aged-out staged Files -- the disk-backed half of the same eviction
+  // the ring buffer does to their Records, driven with the same `now` and the same window, so
+  // the two stay in step. Safe to run mid-release: onFlushEvent() released the window being
+  // drained out of the ring's ownership before the drain started.
+  if (file_scratch_ring_)
+  {
+    file_scratch_ring_->evict(now);
+  }
+}
+
+bool MeasurementCore::stageRecordFiles(json& value, const TimePoint& stamp)
+{
+  // The Record walk itself is owned by dc_common's record_file_walk (#479) -- the same one
+  // dc_bridge's parse_file_group() goes through, so exactly the paths the Bridge would have
+  // uploaded are the ones that move, in either written form (nested local_paths objects, or a
+  // flattened Record's JSON-pointer keys).
+  return dc_common::record_file_walk::rewrite_local_paths(value,
+                                                          [&](std::string& path) { return stageOneFile(path, stamp); });
+}
+
+bool MeasurementCore::stageOneFile(std::string& path, const TimePoint& stamp)
+{
+  const std::string original = path;
+
+  try
+  {
+    const auto staged_path = scratchRing()->stage(original, stamp);
+    // Staging *moves* the File: the Record referencing the original is buffered, not published,
+    // so nothing will ever pick that original up -- neither the Bridge (which never sees the
+    // Record) nor its retention sweep. Leaving it behind would grow the save path without bound
+    // for as long as the Measurement stays armed, which is exactly what the bounded ring exists
+    // to prevent. The copy the ring made is what the released Record points at, and it uploads
+    // to the unchanged remote_paths key the Measurement computed at collection time.
+    std::error_code ec;
+    std::filesystem::remove(original, ec);
+    path = staged_path.string();
+    return true;
+  }
+  catch (const std::filesystem::filesystem_error& e)
+  {
+    logThrottled(LogLevel::Error, last_stage_error_, stamp,
+                 "Measurement " + config_.measurement_name + ": could not stage File " + original +
+                     " into the incident scratch ring (" + e.what() +
+                     "); buffering the Record with the File left "
+                     "in place.");
+    return false;
+  }
+}
+
+const std::shared_ptr<dc_common::FileScratchRing>& MeasurementCore::scratchRing()
+{
+  if (!file_scratch_ring_)
+  {
+    file_scratch_ring_ =
+        std::make_shared<dc_common::FileScratchRing>(scratchDir(), durationFromSeconds(config_.buffer_duration_sec));
+  }
+  return file_scratch_ring_;
+}
+
+std::filesystem::path MeasurementCore::scratchDir() const
+{
+  // The literal prefix of save_local_base_path_expanded is used -- everything up to its first
+  // strftime token -- so the scratch directory doesn't roll over every hour the way the save
+  // path does.
+  std::string base = config_.save_local_base_path_expanded;
+  const auto token = base.find('%');
+  if (token != std::string::npos)
+  {
+    const auto slash = base.rfind('/', token);
+    base = (slash == std::string::npos) ? std::string() : base.substr(0, slash);
+  }
+  if (base.empty())
+  {
+    base = std::filesystem::temp_directory_path().string();
+  }
+  return std::filesystem::path(base) / ".dc_incident_scratch" / config_.measurement_name;
+}
+
+void MeasurementCore::publishIncidentRecord(const std::string& record_json, const TimePoint& stamp,
+                                            const std::string& incident_id)
+{
+  RecordOut out;
+  out.group_key = config_.group_key;
+  out.stamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(stamp.time_since_epoch()).count();
+  try
+  {
+    json data_json = json::parse(record_json);
+    data_json["incident_id"] = incident_id;
+    out.data = data_json.dump(-1, ' ', true);
+  }
+  catch (json::parse_error& e)
+  {
+    log_(LogLevel::Error, "Error parsing Record JSON while releasing incident " + incident_id + ": " + record_json);
+    return;
+  }
+  publish_(out);
+}
+
+void MeasurementCore::logThrottled(LogLevel level, TimePoint& last, const TimePoint& now, const std::string& message)
+{
+  if (now < last + kThrottlePeriod)
+  {
+    return;
+  }
+  last = now;
+  log_(level, message);
+}
+
+}  // namespace dc_measurements

--- a/dc_measurements/test/test_measurement_core.cpp
+++ b/dc_measurements/test/test_measurement_core.cpp
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: 2022-2026 David Bensoussan
+// SPDX-License-Identifier: MPL-2.0
+
+#include <gtest/gtest.h>
+#include <unistd.h>
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "dc_measurements/measurement_core.hpp"
+
+using dc_measurements::LogLevel;
+using dc_measurements::MeasurementCore;
+using dc_measurements::RecordOut;
+
+// Exercises the ROS-free Measurement pipeline (#499) the way test_incident_releaser.cpp exercises
+// the state machine: no rclcpp, no node -- time is passed in, Records come back through a
+// callback, Conditions are stand-in lookups.
+
+namespace
+{
+
+// Seconds after the epoch, so throttle windows are plain arithmetic.
+MeasurementCore::TimePoint at(const double seconds)
+{
+  return MeasurementCore::TimePoint{} +
+         std::chrono::duration_cast<MeasurementCore::TimePoint::duration>(std::chrono::duration<double>(seconds));
+}
+
+// Everything the core reports, standing in for the ROS driver's publisher and logger.
+struct Captured
+{
+  std::vector<RecordOut> records;
+  std::vector<std::pair<LogLevel, std::string>> logs;
+  int validation_failures{ 0 };
+
+  MeasurementCore::PublishFn publishFn()
+  {
+    return [this](const RecordOut& out) { records.push_back(out); };
+  }
+
+  MeasurementCore::LogFn logFn()
+  {
+    return [this](const LogLevel level, const std::string& message) { logs.emplace_back(level, message); };
+  }
+
+  MeasurementCore::ValidationFailureFn failureFn()
+  {
+    return [this](const json&) { validation_failures++; };
+  }
+
+  int countLevel(const LogLevel level) const
+  {
+    int count = 0;
+    for (const auto& [logged_level, message] : logs)
+    {
+      (void)message;
+      if (logged_level == level)
+      {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  bool sawMessage(const std::string& needle) const
+  {
+    for (const auto& [level, message] : logs)
+    {
+      (void)level;
+      if (message.find(needle) != std::string::npos)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+// A counting stand-in for the driver's Condition resolution.
+struct FakeConditions
+{
+  bool state{ false };
+  int calls{ 0 };
+
+  MeasurementCore::ConditionStateLookup lookup()
+  {
+    return [this](const std::string&) {
+      calls++;
+      return state;
+    };
+  }
+};
+
+MeasurementCore::Config baseConfig()
+{
+  MeasurementCore::Config config;
+  config.measurement_name = "dummy";
+  config.measurement_plugin = "dc_measurements/Dummy";
+  config.group_key = "gk";
+  config.run_id = "run-1";
+  config.include_measurement_name = true;
+  return config;
+}
+
+class MeasurementCoreTest : public ::testing::Test
+{
+protected:
+  void TearDown() override
+  {
+    std::error_code ec;
+    std::filesystem::remove_all(tmp_, ec);
+  }
+
+  std::filesystem::path tmp_ =
+      std::filesystem::temp_directory_path() / ("dc_measurement_core_test_" + std::to_string(::getpid()));
+};
+
+TEST_F(MeasurementCoreTest, PublishesTheEnrichedRecord)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  FakeConditions conditions;
+  core.publish(R"({"message":"hi"})", "gk", 42, [](const std::string&) { return true; }, conditions.lookup(), at(100.0));
+
+  ASSERT_EQ(captured.records.size(), 1u);
+  const RecordOut& out = captured.records[0];
+  EXPECT_EQ(out.group_key, "gk");
+  EXPECT_EQ(out.stamp_ns, 42);
+  const json record = json::parse(out.data);
+  EXPECT_EQ(record["message"], "hi");
+  EXPECT_EQ(record["name"], "dummy");
+  EXPECT_EQ(record["run_id"], "run-1");
+  // No Condition is configured: the lookup is never consulted, exactly like the old
+  // isAnyConditionSet() && isConditionOn() short-circuit.
+  EXPECT_EQ(conditions.calls, 0);
+}
+
+TEST_F(MeasurementCoreTest, DropsEmptyPayloadsWithAThrottledWarning)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  const MeasurementCore::ConditionStateLookup no_gate = [](const std::string&) { return true; };
+  FakeConditions conditions;
+
+  core.publish("", "gk", 0, no_gate, conditions.lookup(), at(100.0));
+  core.publish("null", "gk", 0, no_gate, conditions.lookup(), at(105.0));
+  core.publish("", "gk", 0, no_gate, conditions.lookup(), at(109.0));
+  core.publish("", "gk", 0, no_gate, conditions.lookup(), at(111.0));
+
+  EXPECT_TRUE(captured.records.empty());
+  EXPECT_EQ(captured.countLevel(LogLevel::Warn), 2);
+  EXPECT_TRUE(captured.sawMessage("No data collected from measurement dummy"));
+}
+
+TEST_F(MeasurementCoreTest, ReportsUnparsablePayloadsAndPublishesThemAsTheyCame)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  core.publish(
+      "not json", "gk", 7, [](const std::string&) { return true; }, [](const std::string&) { return false; }, at(100.0));
+
+  ASSERT_EQ(captured.records.size(), 1u);
+  EXPECT_EQ(captured.records[0].data, "not json");
+  EXPECT_TRUE(captured.sawMessage("Error parsing JSON while enriching: not json"));
+}
+
+TEST_F(MeasurementCoreTest, GateLatchesOpenAndStopsConsultingTheCondition)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  FakeConditions gate;  // the gate condition reads false to start with
+  const auto publish_once = [&](const MeasurementCore::TimePoint& now) {
+    core.publish(R"({"message":"x"})", "gk", 0, gate.lookup(), [](const std::string&) { return false; }, now);
+  };
+
+  publish_once(at(100.0));
+  EXPECT_TRUE(captured.records.empty());
+  EXPECT_EQ(gate.calls, 1);
+
+  // The gate latches on the first true reading...
+  gate.state = true;
+  publish_once(at(101.0));
+  ASSERT_EQ(captured.records.size(), 1u);
+  EXPECT_TRUE(captured.sawMessage("gate_condition 'go' became true"));
+
+  // ...and from then on the condition is never consulted again, even reading false.
+  gate.state = false;
+  const int calls_before = gate.calls;
+  publish_once(at(102.0));
+  ASSERT_EQ(captured.records.size(), 2u);
+  EXPECT_EQ(gate.calls, calls_before);
+}
+
+TEST_F(MeasurementCoreTest, UnknownGateConditionHoldsAllCollectionBack)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  // What the driver's lookup does for a gate_condition naming no configured Condition: report
+  // false, so the gate never opens.
+  const MeasurementCore::ConditionStateLookup unknown = [](const std::string&) { return false; };
+
+  core.publish(R"({"message":"x"})", "gk", 0, unknown, [](const std::string&) { return false; }, at(100.0));
+  core.publish(R"({"message":"x"})", "gk", 0, unknown, [](const std::string&) { return false; }, at(101.0));
+
+  EXPECT_TRUE(captured.records.empty());
+}
+
+TEST_F(MeasurementCoreTest, InitQuotaPublishesUnconditionallyThenConditionsCap)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.init_max_measurements = 1;
+  config.condition_max_measurements = 2;
+  config.if_any_conditions = { "moving" };
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  FakeConditions conditions;
+  conditions.state = true;
+  const auto publish_once = [&] {
+    core.publish(R"({"message":"x"})", "gk", 0, [](const std::string&) { return true; }, conditions.lookup(), at(100.0));
+  };
+
+  publish_once();  // the init quota, unconditional
+  EXPECT_EQ(captured.records.size(), 1u);
+  EXPECT_GT(conditions.calls, 0);
+
+  publish_once();
+  publish_once();  // within the condition cap
+  publish_once();  // over it
+  EXPECT_EQ(captured.records.size(), 3u);
+
+  // A false reading resets the cap for the next true stretch.
+  conditions.state = false;
+  publish_once();
+  EXPECT_EQ(captured.records.size(), 3u);
+  conditions.state = true;
+  publish_once();
+  publish_once();
+  publish_once();
+  EXPECT_EQ(captured.records.size(), 5u);
+}
+
+TEST_F(MeasurementCoreTest, CollectionFinishedAfterTheQuotaWithNoConditionPublishing)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.init_max_measurements = 2;
+  config.condition_max_measurements = -1;
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  const MeasurementCore::ConditionStateLookup no_gate = [](const std::string&) { return true; };
+  EXPECT_FALSE(core.collectionFinished());
+  core.publish(R"({"message":"x"})", "gk", 0, no_gate, [](const std::string&) { return false; }, at(100.0));
+  EXPECT_FALSE(core.collectionFinished());
+  core.publish(R"({"message":"x"})", "gk", 0, no_gate, [](const std::string&) { return false; }, at(101.0));
+  EXPECT_TRUE(core.collectionFinished());
+  EXPECT_EQ(captured.records.size(), 2u);
+}
+
+TEST_F(MeasurementCoreTest, EnabledStateMachineOwnsCollectionExplicitly)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  EXPECT_TRUE(core.collectible());
+  core.setEnabled(false);
+  EXPECT_FALSE(core.collectible());
+  core.setEnabled(true);
+  EXPECT_TRUE(core.collectible());
+
+  // A failed onConfigure() hook is permanent: however many activate() cycles follow, the
+  // Measurement stays silent.
+  core.markConfigureFailed();
+  EXPECT_FALSE(core.collectible());
+  core.setEnabled(true);
+  EXPECT_FALSE(core.collectible());
+}
+
+TEST_F(MeasurementCoreTest, IncidentBufferReleasesOnFlush)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.buffer_duration_sec = 60.0;
+  config.cooldown_sec = 50.0;
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  EXPECT_TRUE(core.hasReleaser());
+  core.offerSample(R"({"message":"a"})", at(100.0));
+  core.offerSample(R"({"message":"b"})", at(101.0));
+  EXPECT_TRUE(captured.records.empty());
+
+  core.onFlushEvent("inc-1", at(102.0));
+  ASSERT_EQ(captured.records.size(), 2u);
+  for (const RecordOut& out : captured.records)
+  {
+    const json record = json::parse(out.data);
+    EXPECT_EQ(record["incident_id"], "inc-1");
+    EXPECT_EQ(out.group_key, "gk");
+    // Released Records are stamped with when they were collected, not when they were released.
+    EXPECT_NE(out.stamp_ns, std::chrono::duration_cast<std::chrono::nanoseconds>(at(102.0).time_since_epoch()).count());
+  }
+  EXPECT_EQ(json::parse(captured.records[0].data)["message"], "a");
+  EXPECT_EQ(json::parse(captured.records[1].data)["message"], "b");
+
+  // Cooldown: a flapping Trigger's second event starts no new cycle.
+  core.offerSample(R"({"message":"c"})", at(103.0));
+  core.onFlushEvent("inc-2", at(104.0));
+  EXPECT_EQ(captured.records.size(), 2u);
+}
+
+TEST_F(MeasurementCoreTest, PostRollPublishesLiveThenReArms)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.buffer_duration_sec = 60.0;
+  config.post_roll_duration_sec = 30.0;
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  core.onFlushEvent("inc-1", at(100.0));  // empty buffer, straight into post-roll
+  core.offerSample(R"({"message":"live"})", at(110.0));
+  ASSERT_EQ(captured.records.size(), 1u);
+  const json record = json::parse(captured.records[0].data);
+  EXPECT_EQ(record["message"], "live");
+  EXPECT_EQ(record["incident_id"], "inc-1");
+
+  // Past the post-roll deadline the next sample buffers again.
+  core.offerSample(R"({"message":"buffered"})", at(131.0));
+  EXPECT_EQ(captured.records.size(), 1u);
+}
+
+TEST_F(MeasurementCoreTest, StagesRecordFilesIntoTheScratchRing)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.measurement_name = "camera";
+  config.buffer_duration_sec = 60.0;
+  // A dated save tree: the scratch ring sits on its literal prefix, outside the rolling part.
+  config.save_local_base_path_expanded = (tmp_ / "%Y/%M/%D/%H").string();
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  const auto produced = tmp_ / "%Y/%M/%D/%H" / "frame.jpg";
+  std::filesystem::create_directories(produced.parent_path());
+  {
+    std::ofstream f(produced);
+    f << "jpeg-bytes";
+  }
+
+  core.offerSample(R"({"local_paths":{"jpeg":")" + produced.string() +
+                       R"("},"remote_paths":{"minio":{"jpeg":"cam/frame.jpg"}}})",
+                   at(100.0));
+
+  // Staging *moves* the File...
+  EXPECT_FALSE(std::filesystem::exists(produced));
+  const auto scratch_root = tmp_ / ".dc_incident_scratch" / "camera";
+  ASSERT_TRUE(std::filesystem::exists(scratch_root));
+  const auto staged = *(std::filesystem::directory_iterator(scratch_root));
+  EXPECT_EQ(staged.path().filename().string().find("frame.jpg") != std::string::npos, true);
+
+  // ...and the buffered Record is rewritten to point at the staged copy, remote key untouched.
+  core.onFlushEvent("inc-1", at(101.0));
+  ASSERT_EQ(captured.records.size(), 1u);
+  const json record = json::parse(captured.records[0].data);
+  EXPECT_EQ(record["local_paths"]["jpeg"].get<std::string>(), staged.path().string());
+  EXPECT_EQ(record["remote_paths"]["minio"]["jpeg"], "cam/frame.jpg");
+}
+
+TEST_F(MeasurementCoreTest, TeardownPurgesStagedFilesOfBufferedRecords)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.buffer_duration_sec = 60.0;
+  config.save_local_base_path_expanded = tmp_.string();
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  const auto produced = tmp_ / "frame.jpg";
+  {
+    std::ofstream f(produced);
+    f << "jpeg-bytes";
+  }
+  core.offerSample(R"({"local_paths":{"jpeg":")" + produced.string() + R"("}})", at(100.0));
+
+  const auto scratch_root = tmp_ / ".dc_incident_scratch" / "dummy";
+  ASSERT_TRUE(std::filesystem::exists(scratch_root));
+  core.teardown();
+  // The buffered Record is gone with the releaser, so its staged File would be orphaned there.
+  EXPECT_TRUE(std::filesystem::is_empty(scratch_root));
+}
+
+TEST_F(MeasurementCoreTest, SchemaValidationFeedsThePluginHookAndStillPublishes)
+{
+  Captured captured;
+  auto config = baseConfig();
+  config.enable_validator = true;
+  MeasurementCore core;
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  const auto schema = tmp_ / "dummy.json";
+  std::filesystem::create_directories(tmp_);
+  {
+    std::ofstream f(schema);
+    f << R"({"type":"object","required":["name"]})";
+  }
+  core.validateSchema(schema.string());
+  EXPECT_FALSE(core.schemaEmpty());
+
+  // A Record the schema rejects is reported through the hook, but still published, exactly as
+  // this chain always did.
+  core.publish(R"({"other":1})", "gk", 0, [](const std::string&) { return true; },
+               [](const std::string&) { return false; }, at(100.0));
+  EXPECT_EQ(captured.validation_failures, 1);
+  EXPECT_TRUE(captured.sawMessage("Validation failed:"));
+  EXPECT_EQ(captured.records.size(), 1u);
+
+  core.publish(R"({"name":"dummy"})", "gk", 0, [](const std::string&) { return true; },
+               [](const std::string&) { return false; }, at(101.0));
+  EXPECT_EQ(captured.validation_failures, 1);
+  EXPECT_EQ(captured.records.size(), 2u);
+}
+
+TEST_F(MeasurementCoreTest, ValidateSchemaResolvesSiblingRefsAndReportsBadOnes)
+{
+  Captured captured;
+  MeasurementCore core;
+  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+
+  std::filesystem::create_directories(tmp_);
+  {
+    std::ofstream f(tmp_ / "common.json");
+    f << R"({"type":"object"})";
+  }
+  const auto root = tmp_ / "root.json";
+  {
+    std::ofstream f(root);
+    f << R"({"$ref":"common.json"})";
+  }
+  core.validateSchema(root.string());
+  EXPECT_FALSE(core.schemaEmpty());
+
+  const auto broken = tmp_ / "broken.json";
+  {
+    std::ofstream f(broken);
+    f << R"({"$ref":"missing.json"})";
+  }
+  EXPECT_THROW(core.validateSchema(broken.string()), std::runtime_error);
+
+  const auto unparsable = tmp_ / "unparsable.json";
+  {
+    std::ofstream f(unparsable);
+    f << "not json";
+  }
+  core.validateSchema(unparsable.string());
+  EXPECT_TRUE(captured.sawMessage("Error parsing JSON file json_schema_path"));
+}
+
+TEST(MeasurementCoreNamingTest, SnakeCaseKeepsAcronymsWithTheWordTheyPrecede)
+{
+  EXPECT_EQ(MeasurementCore::snakeCase("OS"), "os");
+  EXPECT_EQ(MeasurementCore::snakeCase("TCPHealth"), "tcp_health");
+  EXPECT_EQ(MeasurementCore::snakeCase("Ros2ControlStatus"), "ros2_control_status");
+  EXPECT_EQ(MeasurementCore::snakeCase("MissionNav2ThroughPoses"), "mission_nav2_through_poses");
+}
+
+TEST(MeasurementCoreNamingTest, DefaultSchemaFileTakesTheTypeNotTheWholeLookupName)
+{
+  EXPECT_EQ(MeasurementCore::defaultSchemaFile("dc_measurements/Battery"), "battery.json");
+  EXPECT_EQ(MeasurementCore::defaultSchemaFile("dc_measurements/TCPHealth"), "tcp_health.json");
+  EXPECT_EQ(MeasurementCore::defaultSchemaFile("dc_demos/UptimeCustom"), "uptime_custom.json");
+}
+
+}  // namespace

--- a/dc_measurements/test/test_measurement_core.cpp
+++ b/dc_measurements/test/test_measurement_core.cpp
@@ -179,7 +179,9 @@ TEST_F(MeasurementCoreTest, GateLatchesOpenAndStopsConsultingTheCondition)
 {
   Captured captured;
   MeasurementCore core;
-  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+  auto config = baseConfig();
+  config.gate_condition = "go";
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
 
   FakeConditions gate;  // the gate condition reads false to start with
   const auto publish_once = [&](const MeasurementCore::TimePoint& now) {
@@ -208,7 +210,9 @@ TEST_F(MeasurementCoreTest, UnknownGateConditionHoldsAllCollectionBack)
 {
   Captured captured;
   MeasurementCore core;
-  core.configure(baseConfig(), captured.publishFn(), captured.failureFn(), captured.logFn());
+  auto config = baseConfig();
+  config.gate_condition = "go";
+  core.configure(config, captured.publishFn(), captured.failureFn(), captured.logFn());
 
   // What the driver's lookup does for a gate_condition naming no configured Condition: report
   // false, so the gate never opens.


### PR DESCRIPTION
Closes #499.

## What each side owns now

`measurement.hpp` was header-only (~770 lines) holding the entire framework: Record shaping, Condition gating, the polling timer, lifecycle, incident capture, File staging, scratch-ring eviction. Each of the 33 plugins compiled a private copy of all of it, and nothing was instantiable without a LifecycleNode. This splits it along the ROS boundary:

**The core** — `MeasurementCore` (`measurement_core.hpp`/`.cpp`, compiled once into the new `dc_measurement_core` SHARED library) owns everything decidable without ROS:

| | |
|---|---|
| publish path | enrich (RecordEnricher + schema validation, #482) → gate latch → init quota / condition cap (PublishGate) → emit |
| incident capture | IncidentReleaser driving (#288), File staging into the scratch ring (#290), rate-limited release ticks (#289) |
| naming | `snakeCase`, `defaultSchemaFile` (the fix from #483's review, preserved) |

Every boundary is injected, so nothing in the core names an rclcpp type: time enters through a `now` argument on each entry point, Conditions enter as `ConditionStateLookup` lambdas (the same `std::function` shape `dc_core::ConditionSet` already takes), Records leave through `PublishFn`, diagnostics through `LogFn`, schema-rejected Records through `ValidationFailureFn`, and the two throttled log sites the `RCLCPP_*_THROTTLE` calls owned become explicit 10 s throttle state.

**The driver** — `Measurement` (`measurement.hpp`, now thin) owns the ROS wiring: the lifecycle publisher, polling and release timers, flush subscription, parameter plumbing, lifecycle transitions, and the two `ConditionStateLookup` builders with their distinct unknown-condition wordings ("treating it as false" for if_all/if_any/if_none, "holding all collection back" for gate_condition — both preserved).

**The plugin-facing API is unchanged.** Plugins keep inheriting exactly one `Measurement` class and overriding `collect()` plus the `onConfigure`/`onCleanup`/`onFailedValidation` hooks; the protected members they reach for (`measurement_name_`, `logger_`, `getNode()`, `getSavePath()`, `group_key_`, `tf_`, …) are untouched. `MeasurementCore core_` is a protected member the driver delegates to.

## The one behavior change (sanctioned by the issue)

The state machine now owns the enabled state explicitly:

- `enabled_` follows the lifecycle — `deactivate()` clears it, `activate()` restores it. **Today a deactivate → activate cycle permanently silences a Measurement** (the flag was set false and never reset); it now resumes collection. The issue asked for exactly this: "fix or file separately, but make the state machine own it explicitly".
- `configure_failed_` is permanent: an `onConfigure()` hook that threw keeps the Measurement silent for its lifetime, however many `activate()` cycles follow — the old behavior for failed configuration is kept, just no longer conflated with deactivation.

`collectible() == enabled_ && !configure_failed_`, and `publishFromMsg`/`collectAndPublish`/`activate` consult it where the old code consulted the single flag.

## Also

- `dc_measurement_core` is exported and linked into every measurement plugin through the `dc_add_measurement_plugin` CMake function (condition plugins excluded — they never inherited the framework), so there is one framework `.o` per workspace instead of 33 header copies.
- The global `using json`/`using json_validator` aliases stay in `measurement_core.hpp`: several plugins rely on them transitively through `measurement.hpp`.

## Tests

New `test_measurement_core.cpp` (16 test cases) exercises the whole pipeline with no rclcpp type anywhere, the way `test_incident_releaser.cpp` exercises the state machine: enriched Record shape, throttled empty-payload warning, unparsable payloads, gate latch + condition-consultation counts, unknown gate condition, init quota + condition cap + cap reset, `collectionFinished()`, the enabled/configure-failed state machine, buffer release on FlushEvent with cooldown flapping, post-roll live publish + re-arm, File staging into the scratch ring (move, Record rewrite, remote key untouched), teardown purge, schema validation feeding the plugin hook while still publishing, sibling-`$ref` schema loading, and the naming helpers.

The ~60 existing plugin suites are untouched and remain the compatibility check for the preserved API.

## Verification

No local build for this one — the container build was OOM-killed with three other workspaces building concurrently, so per instruction this leans on CI entirely: the `build-workspace` job builds the workspace and runs `colcon test` through the same `tools/e2e/scripts/build.sh` a developer runs, and is authoritative for both the compile and the ~60 suites. `prek run --all-files --skip build-doc` passes locally (clang-format included).