### PR TITLE
Type the Incident on the Record envelope

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,9 +33,10 @@ _Avoid_: flush signal, flush command
 
 **Incident**:
 One flush cycle: the pre-event window a FlushEvent released, plus the post-roll collected
-after it. Every Record and File of one cycle carries that event's `incident_id` — a top-level
-field of the Record envelope beside Tags, and its own column in a PostgreSQL Destination — so
-"everything from this one event" is a query, not a timestamp range reconstructed by hand.
+after it. Every Record and File of one cycle carries that event's `incident_id` — a typed
+field of the StringStamped Record envelope beside `group_key`, lifted into the payload's top
+level by the Bridge, and its own column in a PostgreSQL Destination — so "everything from
+this one event" is a query, not a timestamp range reconstructed by hand.
 _Avoid_: event (a Record is not an event), alert, incident report
 
 **Manipulation**:

--- a/dc_bridge/include/dc_bridge/record_dispatch.hpp
+++ b/dc_bridge/include/dc_bridge/record_dispatch.hpp
@@ -21,8 +21,9 @@ namespace dc_bridge
 {
 
 /// One Record arriving on a subscribed topic, as the ROS subscription hands it over: the
-/// topic, the header stamp, and the payload bytes verbatim. No rclcpp/dc_interfaces types
-/// — the Bridge node's subscription callback is the only thing that sees StringStamped.
+/// topic, the header stamp, the envelope's incident_id, and the payload bytes verbatim. No
+/// rclcpp/dc_interfaces types — the Bridge node's subscription callback is the only thing
+/// that sees StringStamped.
 struct IncomingRecord
 {
   std::string topic;
@@ -30,6 +31,8 @@ struct IncomingRecord
   /// is clamped to 0 when the forwarded Record is built.
   std::int32_t stamp_secs{ 0 };
   std::uint32_t stamp_nanos{ 0 };
+  /// The StringStamped envelope's incident_id (#506): empty outside an Incident.
+  std::string incident_id;
   std::string data;
 };
 

--- a/dc_bridge/src/bridge_node.cpp
+++ b/dc_bridge/src/bridge_node.cpp
@@ -437,6 +437,7 @@ BridgeNode::BridgeNode(const rclcpp::NodeOptions& options) : rclcpp::Node("dc_br
           incoming.topic = topic;
           incoming.stamp_secs = msg.header.stamp.sec;
           incoming.stamp_nanos = msg.header.stamp.nanosec;
+          incoming.incident_id = msg.incident_id;
           incoming.data = msg.data;
           dispatcher_->dispatch(incoming);
         });

--- a/dc_bridge/src/record_dispatch.cpp
+++ b/dc_bridge/src/record_dispatch.cpp
@@ -53,6 +53,16 @@ void RecordDispatcher::dispatch(const IncomingRecord& incoming) const
 
   nlohmann::json payload = parse_payload(incoming.data);
 
+  // The incident_id rides the StringStamped envelope (#506), but everything downstream of
+  // the Bridge — the Uploader's payload and the Shipper's Record — only ever sees the
+  // payload JSON, so lift it to a top-level key: the same place the pre-#506 injection put
+  // it, and all a `postgres` sink maps onto a column. A payload that is not an object has
+  // no top level to receive it and keeps as it is.
+  if (!incoming.incident_id.empty() && payload.is_object())
+  {
+    payload["incident_id"] = incoming.incident_id;
+  }
+
   if (routing.enqueue_intent)
   {
     // Durable enqueue (#265): the intent lands on disk before this returns, so it

--- a/dc_bridge/test/record_dispatch_test.cpp
+++ b/dc_bridge/test/record_dispatch_test.cpp
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 // The per-Record dispatch (#494): the enqueue-vs-forward decision, the parse-or-wrap
-// rule, and the stamp/envelope assembly, against a real intent-queue writer (the Bridge's
-// write half) and a loopback shipper ingest protocol peer — no ROS node.
+// rule, the stamp/envelope assembly, and the envelope incident_id's lift into the payload
+// (#506), against a real intent-queue writer (the Bridge's write half) and a loopback
+// shipper ingest protocol peer — no ROS node.
 #include "dc_bridge/record_dispatch.hpp"
 
 #include <arpa/inet.h>
@@ -42,12 +43,13 @@ std::filesystem::path unique_dir()
 }
 
 IncomingRecord make_incoming(const std::string& topic, const std::string& data, std::int32_t secs = 1700000000,
-                             std::uint32_t nanos = 123456789)
+                             std::uint32_t nanos = 123456789, const std::string& incident_id = std::string())
 {
   IncomingRecord in;
   in.topic = topic;
   in.stamp_secs = secs;
   in.stamp_nanos = nanos;
+  in.incident_id = incident_id;
   in.data = data;
   return in;
 }
@@ -379,6 +381,89 @@ TEST(RecordDispatch, ArrayPayloadIsNotCoercedIntoAnObject)
   ASSERT_EQ(message->type, msgpack::type::ARRAY);
   ASSERT_EQ(message->via.array.size, 3u);
   EXPECT_EQ(message->via.array.ptr[2].as<std::uint64_t>(), 3u);
+}
+
+// #506: the incident_id rides the StringStamped envelope; dispatch lifts it to a top-level
+// payload key, the only place the Destinations downstream of the Bridge can map it from.
+
+// The wire record's "incident_id" value, or nullptr when the record has no such key.
+const msgpack::object* wire_incident_id(const msgpack::object& record)
+{
+  if (record.type != msgpack::type::MAP)
+  {
+    return nullptr;
+  }
+  for (std::uint32_t i = 0; i < record.via.map.size; ++i)
+  {
+    if (record.via.map.ptr[i].key.as<std::string>() == "incident_id")
+    {
+      return &record.via.map.ptr[i].val;
+    }
+  }
+  return nullptr;
+}
+
+TEST(RecordDispatch, EnvelopeIncidentIdIsLiftedToAPayloadTopLevelKey)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/uptime" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/uptime", R"({"uptime_s": 42})", 1700000000, 0, "incident-42"));
+
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  const msgpack::object* incident_id = wire_incident_id(wire_record_map(oh.get()));
+  ASSERT_NE(incident_id, nullptr);
+  EXPECT_EQ(incident_id->as<std::string>(), "incident-42");
+}
+
+TEST(RecordDispatch, AnEmptyEnvelopeIncidentIdAddsNoPayloadKey)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/uptime" };
+  Harness h(std::move(topics));
+
+  // The default make_incoming() incident_id: empty, as on every Record collected outside
+  // an incident. The Record must reach the Shipper exactly as it was published.
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/uptime", R"({"uptime_s": 42})"));
+
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  EXPECT_EQ(wire_incident_id(wire_record_map(oh.get())), nullptr);
+}
+
+TEST(RecordDispatch, EnvelopeIncidentIdReachesTheUploadIntentPayload)
+{
+  RecordDispatcher::Topics topics;
+  topics.files = { "/dc/camera/image" };
+  Harness h(std::move(topics));
+
+  h.dispatcher->dispatch(
+      make_incoming("/dc/camera/image", R"({"path": "/files/img.jpg"})", 1700000000, 0, "incident-42"));
+
+  ASSERT_EQ(h.queue->size(), 1u);
+  IntentQueue reader(h.queue_dir.string());
+  const Intent intent = reader.pending().at(0);
+  EXPECT_EQ(intent.payload, json::parse(R"({"path": "/files/img.jpg", "incident_id": "incident-42"})"));
+}
+
+TEST(RecordDispatch, ANonObjectPayloadCarriesNoIncidentIdKey)
+{
+  RecordDispatcher::Topics topics;
+  topics.records = { "/dc/measurement/array" };
+  Harness h(std::move(topics));
+
+  // No top level to receive the key: the payload keeps as it is, wrapped, not coerced
+  // into an object for the id's sake.
+  h.dispatcher->dispatch(make_incoming("/dc/measurement/array", "[1, 2, 3]", 1700000000, 0, "incident-42"));
+
+  ASSERT_TRUE(h.peer->read_frame(std::chrono::seconds(2)));
+  msgpack::object_handle oh = unpack_frame(h.peer->frame());
+  const msgpack::object* message = wire_message_value(wire_record_map(oh.get()));
+  ASSERT_NE(message, nullptr);
+  ASSERT_EQ(message->type, msgpack::type::ARRAY);
+  EXPECT_EQ(wire_incident_id(wire_record_map(oh.get())), nullptr);
 }
 
 TEST(RecordDispatch, NegativeStampSecondsClampToZeroAndNanosecondsSurvive)

--- a/dc_bridge/test/uploader_test.cpp
+++ b/dc_bridge/test/uploader_test.cpp
@@ -930,8 +930,8 @@ TEST(Uploader, IncidentReleasedScratchFilesAreIngestedUnmodified)
   const auto collected_at = std::chrono::system_clock::now() - std::chrono::minutes(5);
   auto staged = ring.stage(produced, collected_at);
   auto payload = camera_payload(staged.string(), { "minio" });
-  // What measurement.hpp's publishIncidentRecord() adds on the way out; nothing in the Files
-  // pipeline knows or cares about it.
+  // What the Bridge's dispatch lifts off the StringStamped envelope (#506); nothing in the
+  // Files pipeline knows or cares about it.
   payload["incident_id"] = "incident-42";
   // Releasing hands the staged copies to the Bridge: the ring stops tracking them, so its rolling
   // eviction can no longer delete one out from under an upload in flight.

--- a/dc_group/dc_group/group_merge.py
+++ b/dc_group/dc_group/group_merge.py
@@ -8,8 +8,10 @@ at the edges and hands over already-parsed payloads, so these rules are testable
 ROS install.
 
 A member payload is whatever `json.loads` made of its Record — object, array, or bare
-scalar (#514). Only an object can carry the envelope fields, so a non-object member is
-merged as its value under its `group_key`, the same never-raise, never-drop rule as #508.
+scalar (#514). Only an object can carry envelope data (`tags`, `plugin`), so a non-object
+member is merged as its value under its `group_key`, the same never-raise, never-drop rule
+as #508. The `incident_id` envelope field never passes through here: it rides the
+`StringStamped` envelope (#506), and `GroupServer` lifts it from the members' envelopes.
 """
 
 from fnmatch import fnmatchcase
@@ -71,31 +73,19 @@ def merge_records(
     """
     data_dict = {}
     plugins_list = []
-    incident_id = None
     for payload in parsed_payloads:
         m_data = payload["data"]
         if isinstance(m_data, dict):
-            # A copy: the pops below must not reach back into the caller's payload.
+            # A copy: the pop below must not reach back into the caller's payload.
             m_data = dict(m_data)
             m_data.pop("tags", None)
-            # `incident_id` is an envelope field, not measurement data (#291): merged under a
-            # member's `group_key` it would become `<group_key>.incident_id`, which is no
-            # column any Destination table has and so is silently dropped by the Postgres
-            # sink. Lifted to the merged Record's top level instead, the same way `tags` is,
-            # so a grouped incident stays queryable as `WHERE incident_id = ...`. One
-            # FlushEvent mints one id for every Measurement listening, so the members of a
-            # released window all carry the same one — first non-null wins, and a partial
-            # Record built from a mix of released and live members still carries it.
-            member_incident_id = m_data.pop("incident_id", None)
-            if incident_id is None:
-                incident_id = member_incident_id
             if collect_plugins and "plugin" in m_data:
                 plugins_list.append(m_data["plugin"])
         # else: a payload that is not an object (#514) — a bare scalar or an array. It has
-        # no `tags`, `incident_id` or `plugin` to lift, and `dict()` on it is what used to
-        # raise from the callback. It goes under the member's `group_key` as it is: the
-        # same never-raise, never-drop rule as #508, and the flatten round trip below
-        # already brings a scalar or an array back unchanged.
+        # no `tags` or `plugin` to lift, and `dict()` on it is what used to raise from the
+        # callback. It goes under the member's `group_key` as it is: the same never-raise,
+        # never-drop rule as #508, and the flatten round trip below already brings a scalar
+        # or an array back unchanged.
         data_dict = data_dict | flatten(
             nested_dict={payload["group_key"]: m_data}, separator=SEPARATOR
         )
@@ -106,17 +96,13 @@ def merge_records(
         data_dict = unflatten_list(flat_dict=data_dict, separator=SEPARATOR)
         if not isinstance(data_dict, dict):
             # Every group_key is numeric, so the merged Record unflattened into a JSON array.
-            # A Record is an object: its envelope (`tags`, `incident_id`, `plugins`) is made of
-            # top-level keys, and a top-level key is all a `postgres` sink maps onto a column,
-            # so an array would land in no column at all. The members stay nested under their
+            # A Record is an object: its envelope (`tags`, `plugins`) is made of top-level
+            # keys, and a top-level key is all a `postgres` sink maps onto a column, so an
+            # array would land in no column at all. The members stay nested under their
             # numeric group_key instead, keeping the rest of the Record intact.
             data_dict = unflatten(flat_data, separator=SEPARATOR)
     # A member's own Tags are dropped above: the Record carries the group's.
     data_dict["tags"] = group_cfg["tags"]
-    # Only when a member actually carried one: a Record collected outside an incident must
-    # leave the column NULL rather than write an explicit null into every grouped Record.
-    if incident_id is not None:
-        data_dict["incident_id"] = incident_id
     if collect_plugins and plugins_list:
         data_dict["plugins"] = plugins_list
 

--- a/dc_group/dc_group/group_server.py
+++ b/dc_group/dc_group/group_server.py
@@ -71,12 +71,20 @@ class GroupServer(Node):
         """
         collected_time = self.get_clock().now()
         parsed_payloads = []
+        incident_id = ""
         for measurement in measurements:
             # https://github.com/ros2/rosidl_python/blob/0f5c8f360be92566ad86f4b29f3db1febfca2242/rosidl_generator_py/resource/_msg.py.em#L187-L189
             measurement_dict = message_converter.convert_ros_message_to_dictionary(measurement)
             parsed_payloads.append(
                 {"group_key": measurement_dict["group_key"], "data": json.loads(measurement.data)}
             )
+            # `incident_id` rides the envelope (#506), not the payload: one FlushEvent mints
+            # one id for every Measurement listening, so the members of a released window all
+            # carry the same one — first non-empty wins, and a partial Record built from a mix
+            # of released and live members still carries it. Empty outside an incident, so a
+            # Record collected outside one leaves the column NULL rather than writing "".
+            if not incident_id and measurement.incident_id:
+                incident_id = measurement.incident_id
 
         data_dict = merge_records(
             parsed_payloads,
@@ -90,6 +98,7 @@ class GroupServer(Node):
         msg.data = json.dumps(data_dict)
         msg.header.stamp = collected_time.to_msg()
         msg.group_key = self.params[group]["group_key"]
+        msg.incident_id = incident_id
         self.publishers_[group].publish(msg)
 
     def init_parameters(self):

--- a/dc_group/test/test_group_merge.py
+++ b/dc_group/test/test_group_merge.py
@@ -144,14 +144,12 @@ def test_a_non_object_member_carries_no_envelope_field():
     record = merge(
         [
             payload("a", "hi"),
-            payload("b", {"plugin": "memory", "free": 1.0, "incident_id": "incident-42"}),
+            payload("b", {"plugin": "memory", "free": 1.0}),
         ]
     )
 
-    # Nothing to lift off a scalar: no plugin of its own in the list, and the incident id
-    # comes from the member that actually carried one.
+    # Nothing to lift off a scalar: no plugin of its own in the list.
     assert record["plugins"] == ["memory"]
-    assert record["incident_id"] == "incident-42"
 
 
 def test_merge_does_not_mutate_a_non_object_payload():
@@ -308,59 +306,24 @@ def test_tags_key_is_present_even_when_the_group_declares_none():
 
 
 # --- incident_id ----------------------------------------------------------------------------
+# `incident_id` rides the StringStamped envelope (#506), not the payload: GroupServer lifts
+# it from the members' envelopes, and the merge neither sees nor lifts a payload key of that
+# name — one inside a member's data is measurement data like any other.
 
 
-def test_incident_id_is_lifted_to_the_records_top_level():
-    # Nested under the member's `group_key` it would become `a.incident_id`, which is no
-    # column any Destination table has — the Postgres sink drops it silently (#291).
+def test_a_payload_level_incident_id_is_member_data_not_envelope():
+    # Was lifted to the Record's top level when it lived inside the payload (#291); the
+    # envelope field never enters the merge, so a key of that name in a member's data stays
+    # under the member's group_key.
     record = merge(
         [
             payload("a", {"used": 12.0, "incident_id": "incident-42"}),
-            payload("b", {"free": 34.0, "incident_id": "incident-42"}),
+            payload("b", {"free": 34.0}),
         ]
     )
 
-    assert record["incident_id"] == "incident-42"
-    # Lifted, not copied: it must not also stay behind inside the members' own data.
-    assert record["a"] == {"used": 12.0}
-    assert record["b"] == {"free": 34.0}
-
-
-@pytest.mark.parametrize(
-    ("member_ids", "expected"),
-    [
-        # One FlushEvent mints one id for every Measurement listening: all agree.
-        (["incident-42", "incident-42"], "incident-42"),
-        # First non-null wins, so a partial Record built from a mix of released and live
-        # members still carries the id of the one that arrived.
-        ([None, "incident-42"], "incident-42"),
-        (["incident-42", None], "incident-42"),
-    ],
-)
-def test_first_non_null_incident_id_wins(member_ids, expected):
-    payloads = [
-        payload(group_key, {"incident_id": incident_id} if incident_id else {})
-        for group_key, incident_id in zip(["a", "b"], member_ids, strict=True)
-    ]
-
-    assert merge(payloads)["incident_id"] == expected
-
-
-def test_incident_id_is_absent_when_no_member_carries_one():
-    # A Record collected outside an incident leaves the column NULL, not empty or null.
-    record = merge([payload("a", {"used": 12.0}), payload("b", {"free": 34.0})])
-
+    assert record["a"] == {"used": 12.0, "incident_id": "incident-42"}
     assert "incident_id" not in record
-
-
-def test_an_empty_string_incident_id_is_still_lifted():
-    # Pinning current behaviour: the lift is on `is None`, so an empty string counts as an
-    # id and shadows a real one arriving from a later member.
-    record = merge(
-        [payload("a", {"incident_id": ""}), payload("b", {"incident_id": "incident-42"})]
-    )
-
-    assert record["incident_id"] == ""
 
 
 # --- the envelope ---------------------------------------------------------------------------
@@ -432,8 +395,9 @@ def test_serialized_record_is_stable():
     )
 
     assert json.dumps(record) == (
-        '{"a": {"plugin": "cpu", "used": 12.0}, "b": {"free": 34.0}, "tags": ["robot-7"], '
-        '"incident_id": "incident-42", "plugins": ["cpu"], "name": "test_group"}'
+        '{"a": {"incident_id": "incident-42", "plugin": "cpu", "used": 12.0}, '
+        '"b": {"free": 34.0, "incident_id": "incident-42"}, "tags": ["robot-7"], '
+        '"plugins": ["cpu"], "name": "test_group"}'
     )
 
 
@@ -546,8 +510,8 @@ def test_unflatten_list_rebuilds_a_top_level_list():
 
 def test_a_record_whose_group_keys_are_all_numeric_stays_an_object():
     # Numeric group_keys would unflatten the merged Record into a JSON array. A Record is an
-    # object — `tags`, `incident_id` and `plugins` are top-level keys, which is all a `postgres`
-    # sink maps onto columns — so the members stay nested under their group_key instead (#508).
+    # object — `tags` and `plugins` are top-level keys, which is all a `postgres` sink maps
+    # onto columns — so the members stay nested under their group_key instead (#508).
     record = merge([payload("0", {"used": 1.0}), payload("1", {"free": 2.0})])
 
     assert record == {"0": {"used": 1.0}, "1": {"free": 2.0}, "tags": ["dc"], "name": GROUP}

--- a/dc_group/test/test_group_sync_timeout.py
+++ b/dc_group/test/test_group_sync_timeout.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 """Tests for the Group node's sync-timeout drop/emit_partial behaviour (#126), plus the
-envelope fields a merged Record has to carry through at top level (`incident_id`, #291).
+envelope fields a merged Record has to carry through (`incident_id`, #291/#506).
 
 Every test drives a real `GroupServer` through a real executor against real DDS topics —
 `message_filters` has no timeout of its own, so what is under test is precisely the
@@ -113,10 +113,11 @@ class GroupHarness:
         )
         assert matched, "the Group node's subscriptions/publisher never matched the test node"
 
-    def publish(self, index, data):
+    def publish(self, index, data, incident_id=""):
         msg = StringStamped()
         msg.data = json.dumps(data)
         msg.group_key = self.inputs[index].rsplit("/", 1)[-1]
+        msg.incident_id = incident_id
         msg.header.stamp = self.server.get_clock().now().to_msg()
         self.input_publishers[index].publish(msg)
 
@@ -337,42 +338,44 @@ def test_throttle_of_zero_logs_every_timeout(harness):
     assert len(group.sync_timeout_warnings()) == len(group.records)
 
 
-def test_incident_id_is_lifted_to_the_merged_records_top_level(harness):
-    """#291: a released member's incident_id survives merging as a first-class field."""
-    # Nested under the member's `group_key` it would be `<group_key>.incident_id`, which no
-    # Destination table has a column for and the Postgres sink therefore drops.
+def test_incident_id_is_carried_from_the_member_envelopes(harness):
+    """#291: a released member's incident_id survives merging as the output's envelope field."""
+    # One FlushEvent mints one id for every Measurement listening, so the members of a
+    # released window all carry the same one on their `StringStamped` envelope (#506).
     group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
-    group.publish(0, {"used": 12.0, "incident_id": "incident-42"})
-    group.publish(1, {"free": 34.0, "incident_id": "incident-42"})
+    group.publish(0, {"used": 12.0}, incident_id="incident-42")
+    group.publish(1, {"free": 34.0}, incident_id="incident-42")
 
     assert group.wait_for_records(1), "no Record published for a complete set"
+    record = group.records[0]
     payload = group.payloads()[0]
 
-    assert payload["incident_id"] == "incident-42"
-    # Lifted, not copied: it must not also stay behind inside the members' own data.
+    assert record.incident_id == "incident-42"
+    # The payload carries no copy of it: the id lives on the envelope alone.
     assert payload["a"] == {"used": 12.0}
     assert payload["b"] == {"free": 34.0}
+    assert "incident_id" not in payload
 
 
-def test_incident_id_is_absent_when_no_member_carries_one(harness):
+def test_incident_id_is_empty_when_no_member_carries_one(harness):
     """A Record collected outside an incident leaves the column NULL, not empty-string."""
     group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
     group.publish(0, {"used": 12.0})
     group.publish(1, {"free": 34.0})
 
     assert group.wait_for_records(1), "no Record published for a complete set"
-    assert "incident_id" not in group.payloads()[0]
+    assert group.records[0].incident_id == ""
 
 
 def test_partial_record_keeps_the_incident_id_of_the_member_that_arrived(harness):
     """A window released by one Measurement while another is silent is still an incident."""
     group = harness(sync_timeout=SYNC_TIMEOUT, on_sync_timeout="emit_partial")
-    group.publish(0, {"used": 12.0, "incident_id": "incident-7"})
+    group.publish(0, {"used": 12.0}, incident_id="incident-7")
 
     assert group.wait_for_records(1), "no partial Record published for the incomplete set"
     payload = group.payloads()[0]
 
-    assert payload["incident_id"] == "incident-7"
+    assert group.records[0].incident_id == "incident-7"
     assert payload["partial"] is True
 
 

--- a/dc_interfaces/CMakeLists.txt
+++ b/dc_interfaces/CMakeLists.txt
@@ -6,7 +6,6 @@ project(dc_interfaces)
 
 
 set(dependencies
-  builtin_interfaces
   rosidl_default_generators
   sensor_msgs
   std_msgs

--- a/dc_interfaces/msg/FlushEvent.msg
+++ b/dc_interfaces/msg/FlushEvent.msg
@@ -3,4 +3,3 @@
 # SPDX-License-Identifier: MPL-2.0
 
 string incident_id
-builtin_interfaces/Time stamp

--- a/dc_interfaces/msg/StringStamped.msg
+++ b/dc_interfaces/msg/StringStamped.msg
@@ -6,3 +6,5 @@ std_msgs/Header header
 
 string data
 string group_key
+# The Incident a released Record belongs to (#291); empty outside an Incident
+string incident_id

--- a/dc_interfaces/package.xml
+++ b/dc_interfaces/package.xml
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MPL-2.0
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>

--- a/dc_measurements/include/dc_measurements/measurement.hpp
+++ b/dc_measurements/include/dc_measurements/measurement.hpp
@@ -403,6 +403,7 @@ private:
     dc_interfaces::msg::StringStamped msg;
     msg.data = out.data;
     msg.group_key = out.group_key;
+    msg.incident_id = out.incident_id;
     msg.header.stamp = rclcpp::Time(out.stamp_ns);
     data_pub_->publish(msg);
   }

--- a/dc_measurements/include/dc_measurements/measurement_core.hpp
+++ b/dc_measurements/include/dc_measurements/measurement_core.hpp
@@ -44,12 +44,14 @@ enum class LogLevel
   Error,
 };
 
-/// One Record on its way out of the pipeline: the finished payload, the Group merge key, and the
-/// collection timestamp in nanoseconds since the epoch.
+/// One Record on its way out of the pipeline: the finished payload, the Group merge key, the
+/// collection timestamp in nanoseconds since the epoch, and the Incident it belongs to (empty
+/// outside one).
 struct RecordOut
 {
   std::string data;
   std::string group_key;
+  std::string incident_id;
   std::int64_t stamp_ns{ 0 };
 };
 

--- a/dc_measurements/src/measurement_core.cpp
+++ b/dc_measurements/src/measurement_core.cpp
@@ -113,7 +113,7 @@ void MeasurementCore::publish(const std::string& data, const std::string& group_
 
   if (publish_gate_.offer(conditionSetOn(conditions)))
   {
-    publish_(RecordOut{ enriched, group_key, stamp_ns });
+    publish_(RecordOut{ enriched, group_key, {}, stamp_ns });
   }
 }
 
@@ -448,20 +448,13 @@ std::filesystem::path MeasurementCore::scratchDir() const
 void MeasurementCore::publishIncidentRecord(const std::string& record_json, const TimePoint& stamp,
                                             const std::string& incident_id)
 {
+  // The Incident rides the typed envelope field, not a key injected into the payload (#506): no
+  // serialize / re-parse / re-dump round trip, and the payload stays pure member data.
   RecordOut out;
+  out.data = record_json;
   out.group_key = config_.group_key;
+  out.incident_id = incident_id;
   out.stamp_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(stamp.time_since_epoch()).count();
-  try
-  {
-    json data_json = json::parse(record_json);
-    data_json["incident_id"] = incident_id;
-    out.data = data_json.dump(-1, ' ', true);
-  }
-  catch (json::parse_error& e)
-  {
-    log_(LogLevel::Error, "Error parsing Record JSON while releasing incident " + incident_id + ": " + record_json);
-    return;
-  }
   publish_(out);
 }
 

--- a/dc_measurements/test/test_measurement_buffering.cpp
+++ b/dc_measurements/test/test_measurement_buffering.cpp
@@ -52,6 +52,7 @@ protected:
   {
     (void)measurement;
     received_.push_back(msg.data);
+    incident_ids_.push_back(msg.incident_id);
     // When each Record actually landed, for the rate-limited release (#289).
     arrivals_.push_back(std::chrono::steady_clock::now());
   }
@@ -74,14 +75,13 @@ protected:
     flush_pub_->publish(flush_msg);
   }
 
-  // How many received Records carry this incident_id.
+  // How many received Records carry this incident_id on the envelope.
   int countTaggedWith(const std::string& incident_id) const
   {
     int count = 0;
-    for (const auto& data : received_)
+    for (const auto& id : incident_ids_)
     {
-      json data_json = json::parse(data);
-      if (data_json.contains("incident_id") && data_json["incident_id"] == incident_id)
+      if (id == incident_id)
       {
         count++;
       }
@@ -156,6 +156,7 @@ protected:
 
 public:
   std::vector<std::string> received_;
+  std::vector<std::string> incident_ids_;
   std::vector<std::chrono::steady_clock::time_point> arrivals_;
 };
 
@@ -169,6 +170,8 @@ TEST_F(MeasurementBufferingTest, ZeroBufferDurationPublishesLiveAsBefore)
 
   ASSERT_TRUE(spinUntil([this] { return !received_.empty(); }, 5000)) << "no Record was ever published";
 
+  // Outside an incident the envelope field stays empty, and the payload carries no copy of it.
+  EXPECT_TRUE(incident_ids_.front().empty());
   json data_json = json::parse(received_.front());
   EXPECT_FALSE(data_json.contains("incident_id"));
 }

--- a/dc_measurements/test/test_measurement_core.cpp
+++ b/dc_measurements/test/test_measurement_core.cpp
@@ -317,7 +317,9 @@ TEST_F(MeasurementCoreTest, IncidentBufferReleasesOnFlush)
   for (const RecordOut& out : captured.records)
   {
     const json record = json::parse(out.data);
-    EXPECT_EQ(record["incident_id"], "inc-1");
+    // The Incident rides the typed envelope field (#506); the payload carries no such key.
+    EXPECT_EQ(out.incident_id, "inc-1");
+    EXPECT_FALSE(record.contains("incident_id"));
     EXPECT_EQ(out.group_key, "gk");
     // Released Records are stamped with when they were collected, not when they were released.
     EXPECT_NE(out.stamp_ns, std::chrono::duration_cast<std::chrono::nanoseconds>(at(102.0).time_since_epoch()).count());
@@ -345,7 +347,8 @@ TEST_F(MeasurementCoreTest, PostRollPublishesLiveThenReArms)
   ASSERT_EQ(captured.records.size(), 1u);
   const json record = json::parse(captured.records[0].data);
   EXPECT_EQ(record["message"], "live");
-  EXPECT_EQ(record["incident_id"], "inc-1");
+  EXPECT_EQ(captured.records[0].incident_id, "inc-1");
+  EXPECT_FALSE(record.contains("incident_id"));
 
   // Past the post-roll deadline the next sample buffers again.
   core.offerSample(R"({"message":"buffered"})", at(131.0));

--- a/dc_measurements/test/test_measurement_shared_flush.cpp
+++ b/dc_measurements/test/test_measurement_shared_flush.cpp
@@ -49,6 +49,7 @@ protected:
   void onRecord(const std::string& measurement, const dc_interfaces::msg::StringStamped& msg) override
   {
     received_[measurement].push_back(msg.data);
+    incident_ids_[measurement].push_back(msg.incident_id);
   }
 
   void declareMeasurement(const std::string& name, const int polling_interval)
@@ -67,14 +68,13 @@ protected:
     flush_pub_->publish(flush_msg);
   }
 
-  // How many of this Measurement's Records carry exactly this incident_id.
+  // How many of this Measurement's Records carry exactly this incident_id on the envelope.
   int countTaggedWith(const std::string& name, const std::string& incident_id)
   {
     int count = 0;
-    for (const auto& data : received_[name])
+    for (const auto& id : incident_ids_[name])
     {
-      nlohmann::json data_json = nlohmann::json::parse(data);
-      if (data_json.contains("incident_id") && data_json["incident_id"].get<std::string>() == incident_id)
+      if (id == incident_id)
       {
         count++;
       }
@@ -97,9 +97,9 @@ protected:
   int countCarryingAnIncident(const std::string& name)
   {
     int count = 0;
-    for (const auto& data : received_[name])
+    for (const auto& id : incident_ids_[name])
     {
-      if (nlohmann::json::parse(data).contains("incident_id"))
+      if (!id.empty())
       {
         count++;
       }
@@ -111,6 +111,7 @@ protected:
 
 public:
   std::map<std::string, std::vector<std::string>> received_;
+  std::map<std::string, std::vector<std::string>> incident_ids_;
 };
 
 // Acceptance criterion: a single FlushEvent releases the buffered window of every Measurement

--- a/dc_triggers/src/trigger_broadcast_node.cpp
+++ b/dc_triggers/src/trigger_broadcast_node.cpp
@@ -105,7 +105,6 @@ void TriggerBroadcastNode::checkTrigger()
 
   dc_interfaces::msg::FlushEvent msg;
   msg.incident_id = mintIncidentId();
-  msg.stamp = get_clock()->now();
 
   RCLCPP_INFO_STREAM(get_logger(), "Trigger '" << trigger_id_ << "' fired, incident_id=" << msg.incident_id);
 

--- a/doc/src/dc/concepts.md
+++ b/doc/src/dc/concepts.md
@@ -72,6 +72,8 @@ The `StringStamped` message carries:
 1. **header**: ROS timestamp as `std_msgs/Header`
 2. **data**: the Record, as a JSON string
 3. **group_key**: the key this Record is nested under when merged into a Group
+4. **incident_id**: the [Incident](#triggers-and-incidents) a released Record belongs to;
+   empty outside an incident
 
 The `data` string **must** be valid JSON:
 

--- a/doc/src/dc/destinations.md
+++ b/doc/src/dc/destinations.md
@@ -207,9 +207,10 @@ The destination's own column type can truncate independently of `time_format`. A
 ### `incident_id`
 
 A Measurement configured for [incident capture](./measurements.md) tags every Record it
-releases with the `incident_id` of the `FlushEvent` that released it. That field is part
-of the Record envelope, so it is already a top-level key of the JSON every Destination
-receives — no Bridge-side templating is needed to expose it. A `postgres` sink (via the
+releases with the `incident_id` of the `FlushEvent` that released it. That field is typed on
+the `StringStamped` Record envelope (#506), and the Bridge lifts it into a top-level key of
+the payload JSON before handing a Record to its Destinations — no per-Destination
+configuration is needed to expose it. A `postgres` sink (via the
 [passthrough recipe](#recipes-postgres-s3-console-via-passthrough) below) can therefore
 write it straight into its own **`incident_id` column** with no extra mapping —
 "everything from this one event" is a plain `WHERE incident_id = '…'` query — since
@@ -222,7 +223,8 @@ and `tools/infrastructure/docker/config/postgresql/init.sql` both carry it):
 ALTER TABLE dc ADD COLUMN incident_id text;
 ```
 
-Records collected outside an incident have no `incident_id` and leave the column NULL.
+Records collected outside an incident carry an empty `incident_id`, and an empty envelope
+field is never lifted, leaving the column NULL.
 
 ```admonish note
 Through [#471](https://github.com/minipada/ros2_data_collection/issues/471), the blessed

--- a/doc/src/dc/groups.md
+++ b/doc/src/dc/groups.md
@@ -17,11 +17,14 @@ A merged Record is an ordinary Record from there on: it carries the Tag derived 
 output topic, and a Destination receives it by listing that topic in `inputs`.
 
 Envelope fields do not get nested under a member's key: a member's `tags` is replaced by the
-Group's own, and its `incident_id` — the id a Measurement stamps on a Record it released as
-part of an [incident](./measurements.md) — is lifted to the merged Record's top level, where
-a `postgres` Destination has a column for it. Buried under `<group_key>.incident_id` it would
-simply be dropped by that sink. A member payload that is not a JSON object — a bare scalar or
-an array — has no such fields to lift, and is merged as it is under its `group_key`.
+Group's own, and the `incident_id` on its envelope — the id a Measurement stamps on a Record
+it released as part of an [incident](./measurements.md) — is carried onto the merged Record's
+own envelope (first non-empty wins, so a partial Record built from a mix of released and live
+members still carries it). The Bridge lifts that envelope field into the payload's top level,
+where a `postgres` Destination has a column for it; buried under `<group_key>.incident_id` it
+would simply be dropped by that sink. A member payload that is not a JSON object — a bare
+scalar or an array — has no such fields to lift, and is merged as it is under its
+`group_key`.
 
 ```admonish info
 The Group node is written in Python: allocating and passing a variable number of inputs to

--- a/doc/src/dc/triggers.md
+++ b/doc/src/dc/triggers.md
@@ -51,7 +51,7 @@ publishes a `FlushEvent` on a configurable topic (`/dc/flush` by default) each t
                     ┌──────────▼───────────┐
                     │  Trigger (EdgeTrigger)│  false → true?
                     └──────────┬───────────┘
-                               │ FlushEvent { incident_id, stamp }
+                               │ FlushEvent { incident_id }
                     ┌──────────▼───────────┐
                     │      /dc/flush       │
                     └───┬──────────────┬───┘
@@ -95,17 +95,16 @@ Measurement side:
 | Field         | Type                     | Description                                                        |
 | ------------- | ------------------------ | ------------------------------------------------------------------ |
 | `incident_id` | string                   | UUID minted by the broadcast node, one per firing                  |
-| `stamp`       | builtin_interfaces/Time  | When the Trigger fired                                             |
 
 A Measurement adopts the `incident_id` it receives; it never generates its own. An event that
 arrives while a Measurement is already flushing, in post-roll, or in cooldown is ignored.
 
 ## `incident_id`
 
-`incident_id` is a top-level field of the Record envelope, beside `tags`, `run_id` and `name`
-— not a key nested inside the measurement's own data. Every Record and File released by one
-flush cycle carries the same value, so "everything from this one event" is a single query
-rather than a timestamp range reconstructed by hand:
+`incident_id` is a typed field of the `dc_interfaces/msg/StringStamped` Record envelope,
+beside `group_key` — not a key nested inside the measurement's own data. Every Record and
+File released by one flush cycle carries the same value, so "everything from this one event"
+is a single query rather than a timestamp range reconstructed by hand:
 
 ```sql
 SELECT * FROM dc_records WHERE incident_id = '3f2b1c7e-…' ORDER BY date;
@@ -113,12 +112,12 @@ SELECT * FROM dc_records WHERE incident_id = '3f2b1c7e-…' ORDER BY date;
 
 - A `postgres` Destination writes it to its own **`incident_id` column** — the column must
   exist in the table beforehand; see [Destinations](./destinations.md#incident_id).
-- A Record collected outside an incident carries no `incident_id` at all, leaving the column
+- A Record collected outside an incident carries an empty `incident_id`, leaving the column
   NULL.
-- A [Group](./groups.md) lifts a member's `incident_id` onto the merged Record the same way it
-  does `tags`, so grouping does not bury it.
-- Other Destination types need no configuration: `incident_id` is already a top-level key of
-  the JSON they receive.
+- A [Group](./groups.md) carries a member's envelope `incident_id` onto its own output
+  envelope, so grouping does not bury it.
+- Every Destination receives it as a top-level key of the JSON the Bridge ships: the Bridge
+  lifts the envelope field into the payload before handing a Record to its Destinations.
 
 ## Available plugins
 

--- a/tools/e2e/README.md
+++ b/tools/e2e/README.md
@@ -172,12 +172,12 @@ Same `dc-e2e` image and env vars again, this time against
 `params/e2e_incident_params.yaml`: an `uptime` Measurement armed with
 `buffer_duration_sec` beside a `memory` Measurement collecting live, both routed to one
 `postgres` Destination. The scenario publishes a single `FlushEvent` onto `/dc/flush`
-with a known id and asserts: (1) `dc_records.incident_id` exists as a real `text`
-column; (2) while armed, the buffered Measurement ships *nothing* while the live one
-keeps landing rows; (3) after the event, the released window is reachable as `WHERE
-incident_id = '…'` — a column predicate, which is the whole point of #291, since the
-same data buried in the JSON payload would not be; (4) the id is on the released window
-only, and the never-armed Measurement's rows keep `incident_id IS NULL`.
+with a known id and asserts: (1) while armed, the buffered Measurement ships *nothing*
+while the live one keeps landing rows; (2) after the event, the released window is
+reachable as `WHERE incident_id = '…'` — a column predicate, which is the whole point
+of #291, since the same data buried in the JSON payload would not be; (3) the id is on
+the released window only, and the never-armed Measurement's rows keep
+`incident_id IS NULL`.
 
 The `FlushEvent` is published with `ros2 topic pub` rather than by a `dc_triggers`
 broadcast node: that topic is the contract Measurements subscribe to, `dc_triggers` has

--- a/tools/e2e/params/e2e_incident_pgsql_sink.toml
+++ b/tools/e2e/params/e2e_incident_pgsql_sink.toml
@@ -5,10 +5,10 @@
 # #472 — see doc/src/dc/destinations.md's "Recipes: postgres, s3, console via
 # passthrough". `pgsql_records` in e2e_incident_params.yaml is now a `type: file` anchor
 # only; the real delivery to Postgres (including the `incident_id` column
-# run_incident.sh asserts on) happens here. `incident_id` needs no special handling from
-# dc_bridge: it is already a top-level key of every Record's JSON payload, so Vector's
-# `postgres` sink maps it straight onto the `incident_id` column the same as any other
-# column — see destinations.md's `incident_id` section for what changed with #472.
+# run_incident.sh asserts on) happens here. `incident_id` reaches the sink as a top-level
+# key of the Record payload — dc_bridge lifts it off the typed StringStamped envelope
+# (#506) — so Vector's `postgres` sink maps it onto the same-named column like any other
+# column.
 
 [sinks.pgsql_records_store]
 type = "postgres"

--- a/tools/e2e/scripts/run_incident.sh
+++ b/tools/e2e/scripts/run_incident.sh
@@ -98,8 +98,6 @@ podman run -d --network host --name "$DC_C" \
   "$DC_IMAGE" >/dev/null
 
 # --- 1. armed means silent, live means flowing -------------------------------------------
-# Also where dc_records.incident_id is asserted to be a column at all: without it, nothing
-# below could mean what it claims to.
 log "waiting up to ${LIVE_TIMEOUT_SECONDS}s for the live Measurement's first rows, then asserting the armed one shipped nothing"
 python3 "$SCRIPT_DIR/verify_zero_loss.py" \
   --postgres-container "$PG_C" \

--- a/tools/e2e/scripts/verify_zero_loss.py
+++ b/tools/e2e/scripts/verify_zero_loss.py
@@ -62,11 +62,11 @@ Profiles (#496). `--profile` selects which set of checks runs, so a scenario's R
 assertions all live here instead of as inline SQL in its bash script:
 
   - `zero-loss` (the default): the checks above, as run.sh and its siblings invoke them.
-  - `incident`: run_incident.sh's assertions (#291) — that `incident_id` really is a
-    column, that a Measurement armed with `buffer_duration_sec` ships nothing while a
-    live one flows, and that after one FlushEvent the released window is queryable by
-    column and carries no other Measurement's rows. Two stages, because a FlushEvent is
-    published between them: `--stage armed`, then `--stage released`.
+  - `incident`: run_incident.sh's assertions (#291) — that a Measurement armed with
+    `buffer_duration_sec` ships nothing while a live one flows, and that after one
+    FlushEvent the released window is queryable by `incident_id` column and carries no
+    other Measurement's rows. Two stages, because a FlushEvent is published between
+    them: `--stage armed`, then `--stage released`.
   - `retention`: run_retention.sh's assertions (#267) — that a File is shed without upload
     once the pool exceeds `files.retention.max_bytes` against a down store, and that a
     later File uploads normally once the store is back. One stage per half, `--stage
@@ -332,26 +332,6 @@ INCIDENT_STAGES = (INCIDENT_STAGE_ARMED, INCIDENT_STAGE_RELEASED)
 RETENTION_STAGE_SHED = "shed"
 RETENTION_STAGE_UPLOADED = "uploaded"
 RETENTION_STAGES = (RETENTION_STAGE_SHED, RETENTION_STAGE_UPLOADED)
-
-
-def check_incident_column(column_type: str, violations: list, details: dict) -> None:
-    """Assert dc_records.incident_id is a column, before anything queries it.
-
-    The point of #291 is that a released window is reachable by *column* predicate. A
-    table without the column would make every later assertion fail for a reason that has
-    nothing to do with the pipeline, so say so instead.
-
-    Args:
-        column_type: information_schema's data_type for the column, "" if absent.
-        violations: hard failures, appended to in place.
-        details: counters for the JSON report, populated in place.
-    """
-    details["incident_id_column"] = {"data_type": column_type or None}
-    if column_type != "text":
-        violations.append(
-            f"incident: dc_records has no text incident_id column (got "
-            f"'{column_type or 'none'}') — check sql/init.sql"
-        )
 
 
 def check_live_flowing(
@@ -998,14 +978,6 @@ def verify_incident(args, violations: list, notes: list, details: dict) -> None:
     pg = args.postgres_container
 
     if args.stage == INCIDENT_STAGE_ARMED:
-        column_type = psql(
-            pg,
-            "SELECT data_type FROM information_schema.columns "
-            "WHERE table_name = 'dc_records' AND column_name = 'incident_id'",
-        )
-        check_incident_column(column_type, violations, details)
-        if violations:
-            return
         live_count = wait_for_count(
             pg,
             f"SELECT count(*) FROM dc_records WHERE tag = '{args.live_tag}'",

--- a/tools/e2e/test/test_verify_profiles.py
+++ b/tools/e2e/test/test_verify_profiles.py
@@ -21,20 +21,6 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "scr
 import verify_zero_loss as vzl
 
 
-def test_incident_column_is_required_to_be_text():
-    violations = []
-    details = {}
-    vzl.check_incident_column("text", violations, details)
-    assert violations == []
-
-
-def test_a_missing_incident_column_fails_and_names_init_sql():
-    violations = []
-    vzl.check_incident_column("", violations, {})
-    assert len(violations) == 1
-    assert "init.sql" in violations[0]
-
-
 def test_the_live_measurement_must_be_actually_delivering():
     violations = []
     vzl.check_live_flowing(vzl.MIN_LIVE_ROWS, "dc.measurement.memory", 180, violations, {})


### PR DESCRIPTION
Closes #506

`incident_id` becomes a typed field of the `StringStamped` Record envelope, beside `group_key`, instead of a JSON key injected into the payload after the fact.

## What changes

- **`dc_interfaces`**: `StringStamped` gains `string incident_id` — set by the Measurement that releases an Incident, empty outside one. `FlushEvent` loses `stamp`, which was written but never read, and `builtin_interfaces` leaves the package deps.
- **`dc_measurements`**: `publishIncidentRecord` publishes the envelope field directly. The serialize / re-parse / re-dump injection of `incident_id` into the payload JSON is gone. The buffering and shared-flush tests assert the envelope id (empty outside an Incident, set on release) and that the payload no longer carries the key.
- **`dc_group`**: the merge knows nothing about `incident_id` — a payload-level `incident_id` key is just member data. `GroupServer` picks the first non-empty member *envelope* id for the merged output.
- **`dc_bridge`**: `dispatch()` lifts the envelope `incident_id` into the payload's top level (JSON-object payloads only), because everything downstream of the Bridge — the Uploader's intent payloads and the Shipper's Records — only ever sees the payload. An empty id adds no key, so non-Incident Records still land with the column NULL.
- **`tools/e2e`**: the zero-loss verify's `information_schema` pre-check for the `incident_id` column retires — the column's existence was only ever a guard on the old payload plumbing. The sink params header and run script comments follow.
- **docs**: concepts, triggers, groups, destinations, and `CONTEXT.md` describe the typed envelope and the Bridge's lift.

## Validation

- `TARGET=workspace CCOV=false ./tools/e2e/scripts/build.sh` (the same script CI runs): 17 packages, **820 tests, 0 errors, 0 failures, 0 skipped**
- `prek run --all-files --skip build-doc`: all hooks pass

Co-Authored-By: Claude Code <noreply@anthropic.com>